### PR TITLE
Recognize LinearAttentionGate as a pass-through for LinearAttention decay/beta

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -1425,7 +1425,7 @@ was:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import (
     Any,
     Callable,
@@ -21145,6 +21145,15 @@ class _GQAChain:
     # `MultiHeadAttention` node whose own `bias` input is absent/empty --
     # both exactly as before this field existed.
     mha_bias: Optional[str] = None
+    # Set only for a matched ``LinearAttention`` node whose own `decay`/`beta`
+    # inputs (indices 4/5) are fed by a recognized ``com.microsoft::
+    # LinearAttentionGate`` node -- see :func:`_match_linear_attention_gate`
+    # (what's matched and why) and :class:`_LinearAttentionGatePassThrough`
+    # (what gets sliced at apply time). ``None`` (the default) for every
+    # other matched op, and for a `LinearAttention` chain whose `decay`/
+    # `beta` are absent or genuine constants -- both exactly as before this
+    # field existed.
+    linear_attention_gate: Optional["_LinearAttentionGatePassThrough"] = None
 
 
 # Either kind of matched attention block, sharing enough of a common shape
@@ -22516,46 +22525,65 @@ def _match_paged_attention_producer(
 #   or `attn_mask`).
 #
 #   **Scope boundary, declined rather than guessed at: a *dynamic*
-#   `decay`/`beta` declines the whole match outright**, unlike
-#   `GroupQueryAttention`'s own dynamic `past_key`/`past_value`/`attention_bias`
-#   (left alone, matched anyway) -- a deliberately narrower bar than the rest
-#   of this family, for a reason specific to these two inputs: `past_key`/
-#   `past_value`/`attention_bias`, when dynamic, are either an ordinary graph
-#   input (a caller free to supply a differently-sized tensor after this
-#   pass shrinks `kv_num_heads`) or, in an unrolled autoregressive loop,
-#   loop-carried from that *same op's own* `present_key`/`present_value`
-#   output -- which this pass's own `kv_num_heads` rewrite already narrows in
-#   step. `decay`/`beta` have no such self-consistent path: `LinearAttention`
-#   has no `decay`/`beta` *output* at all (only `output`/`present_state`), so
-#   a dynamic one can only come from a genuine graph input (in which case the
+#   `decay`/`beta` declines the whole match outright UNLESS it is fed by one
+#   specific, recognized producer shape**, unlike `GroupQueryAttention`'s own
+#   dynamic `past_key`/`past_value`/`attention_bias` (left alone, matched
+#   anyway) -- a deliberately narrower bar than the rest of this family, for
+#   a reason specific to these two inputs: `past_key`/`past_value`/
+#   `attention_bias`, when dynamic, are either an ordinary graph input (a
+#   caller free to supply a differently-sized tensor after this pass shrinks
+#   `kv_num_heads`) or, in an unrolled autoregressive loop, loop-carried from
+#   that *same op's own* `present_key`/`present_value` output -- which this
+#   pass's own `kv_num_heads` rewrite already narrows in step. `decay`/`beta`
+#   have no such self-consistent path in general: `LinearAttention` has no
+#   `decay`/`beta` *output* at all (only `output`/`present_state`), so a
+#   dynamic one can only come from a genuine graph input (in which case the
 #   "caller supplies a narrower tensor" reasoning above would still hold) or
 #   -- the realistic, common shape for every actual gated/delta/gated_delta
-#   export -- an internal node's own computation (e.g. `com.microsoft::
-#   LinearAttentionGate`, this op's own documented companion, projecting from
-#   a `dt_bias`/`decay_scale` weight sized `(kv_num_heads,)`) that this pass
-#   never traces into or adjusts. Nothing here can tell those two cases
-#   apart from the tensor name alone, and leaving a genuinely internally-
-#   computed, still-old-width `decay`/`beta` connected to a node whose own
-#   `kv_num_heads` this pass just shrank is a real, silent correctness risk
-#   (a shape mismatch at best, a wrong-axis silent miscompute at worst) --
-#   not a risk this pass is willing to take on an unconfirmed guess. The
-#   practical consequence: this pass only ever prunes a `LinearAttention`
-#   chain whose `update_rule` is `"linear"` (needs neither `decay` nor
-#   `beta` at all) or one whose `decay`/`beta` happen to be genuine constants
-#   (a degenerate shape no real dynamic-decode export produces, but handled
-#   correctly rather than assumed away) -- a `gated`/`delta`/`gated_delta`
-#   chain fed by a real `LinearAttentionGate` (or equivalent) node is left
-#   completely unmatched, exactly the same "unmatched topology, not a silent
-#   gap" outcome this module holds everywhere else. Recognizing
-#   `LinearAttentionGate` as its own pass-through hop (slicing its own
-#   `dt_bias`/`decay_scale` per-head weights by `keep_groups`, mirroring how
-#   `_walk_back_through_qk_norm_rope` already recognizes a per-head Q/K-norm
-#   sandwich) would close this gap, but is genuinely new machinery beyond
-#   this feature's own scope -- left for a future pass, the same kind of
-#   scoped-out future work `GroupQueryAttention`'s own in-op
-#   `q_norm_weight`/`k_norm_weight` gap once was, before this module's
-#   `_match_gqa_producer`/`_find_gqa_chains` closed it (see this module's
-#   "Attention-head pruning" section comment for that wiring).
+#   export -- an internal node's own computation that this pass would
+#   otherwise never trace into or adjust. Nothing here can tell those two
+#   cases apart from the tensor name alone, and leaving a genuinely
+#   internally-computed, still-old-width `decay`/`beta` connected to a node
+#   whose own `kv_num_heads` this pass just shrank is a real, silent
+#   correctness risk (a shape mismatch at best, a wrong-axis silent
+#   miscompute at worst) -- not a risk this pass is willing to take on an
+#   unconfirmed guess.
+#
+#   Exactly one internal-node shape *does* have a self-consistent "narrower
+#   output implies narrower producer" story, and is recognized:
+#   `com.microsoft::LinearAttentionGate` (this op's own documented
+#   companion, schema confirmed live via
+#   ``onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()``
+#   against this environment's installed onnxruntime 1.29.0, `since_version`
+#   1) -- `decay = decay_scale * Softplus(a + dt_bias)`, `beta =
+#   Sigmoid(b)` (`b` "Required when the beta output is requested"), with
+#   `dt_bias`/`decay_scale` each a real `(kv_num_heads,)` float constant and
+#   `a`/`b` each a plain `(B, T, kv_num_heads)` MatMul/vanilla-Gemm
+#   activation. `dt_bias`/`decay_scale` are sliced directly (axis 0, by
+#   `keep_groups`) -- :func:`_apply_one_gqa_chain`'s own genuinely new
+#   per-tensor edit for this feature; `a`/`b` themselves need no slicing at
+#   all -- narrowing `a`'s/`b`'s own producer weight's output columns by the
+#   identical `keep_groups` (exactly how Q's/K's/V's own producer weight
+#   already gets narrowed) narrows `a`/`b` "for free", the same way this
+#   module never explicitly slices Q's/K's/V's own activation either. See
+#   :func:`_match_linear_attention_gate` (what's matched, and the
+#   single-consumer/not-a-graph-output bar every crossed edge is held to,
+#   mirroring `_walk_back_through_qk_norm_rope`'s own per-head Q/K-norm
+#   sandwich) and :class:`_LinearAttentionGatePassThrough` (what gets sliced)
+#   for the full mechanics. The practical consequence: this pass prunes a
+#   `LinearAttention` chain whose `update_rule` is `"linear"` (needs neither
+#   `decay` nor `beta` at all), one whose `decay`/`beta` happen to be genuine
+#   constants (a degenerate shape no real dynamic-decode export produces, but
+#   handled correctly rather than assumed away), AND -- since this fix -- a
+#   `gated`/`delta`/`gated_delta` chain fed by a real `LinearAttentionGate`
+#   node, the realistic shape every actual dynamic-decode export uses; a
+#   `decay`/`beta` fed by anything else dynamic (a bare graph input, any
+#   other node, a gate whose own `a`/`b` don't resolve to a plain constant-
+#   weight producer) is still left completely unmatched, exactly the same
+#   "unmatched topology, not a silent gap" outcome this module holds
+#   everywhere else -- deliberately NOT a general "any dynamic decay is now
+#   fine" relaxation, since no other shape has this one gate node's own
+#   self-consistent story.
 # - `scale` (float, default 0.0 -- "derives d_k... and uses 1/sqrt(d_k)")
 #   and `chunk_size` (int, "tuning hint; does not affect output correctness")
 #   are both entirely head-count-independent -- neither is ever read or
@@ -22608,12 +22636,18 @@ def _match_linear_attention_producer(
     rank-4 `(*, kv_num_heads, *, *)` shape (dynamic needs no check, left
     alone entirely -- the caller's own runtime data), and `decay`/`beta`
     (indices 4/5) -- see this section's own comment for the full reasoning
-    -- decline the whole match outright whenever either is connected but
-    *not* a constant, since nothing here can confirm a dynamic one's own
-    producer will still emit the correct post-pruning width. `beta`'s own
-    exact-shape check (its two documented shapes don't need `head_size` to
-    tell apart) runs here; `decay`'s own (which does) is deferred to
-    :func:`_find_linear_attention_chains`. This op has no
+    -- get their *constant*-shape checks here (a genuine constant not
+    exactly one of `decay`'s/`beta`'s own documented shapes declines the
+    whole match outright); a *dynamic* one is neither checked nor declined
+    here at all -- entirely deferred to :func:`_find_linear_attention_chains`
+    (via :func:`_match_linear_attention_gate`), which alone has the
+    graph-wide consumer/producer maps needed to tell a recognized
+    `com.microsoft::LinearAttentionGate` pass-through apart from anything
+    else dynamic (declined there instead). `beta`'s own exact-shape check
+    (its two documented shapes don't need `head_size` to tell apart) runs
+    here; `decay`'s own (which does) is deferred to
+    :func:`_find_linear_attention_chains` regardless of whether it is
+    constant or gate-fed. This op has no
     `attention_bias`/`attn_mask`-equivalent input at all on its own schema
     (confirmed off the same live schema dump the rest of this section was
     built from) -- `value_info_by_name` is accepted, unused, purely for
@@ -22652,9 +22686,13 @@ def _match_linear_attention_producer(
         if len(node.input) > idx and node.input[idx]:
             extra_init = initializer_map.get(node.input[idx])
             if extra_init is None:
-                return (
-                    None  # dynamic decay/beta -- declined, see this section's comment
-                )
+                # Dynamic decay/beta -- no longer declined right here: might
+                # be the one recognized `LinearAttentionGate` pass-through
+                # shape, checked later, once graph-wide consumer/producer
+                # maps are available, by :func:`_find_linear_attention_chains`
+                # (via :func:`_match_linear_attention_gate`) -- see this
+                # section's own comment for the full reasoning either way.
+                continue
             if (
                 not _is_supported_float_dtype(extra_init.data_type)
                 or len(extra_init.dims) != 3
@@ -24546,6 +24584,211 @@ def _find_paged_attention_chains(
     )
 
 
+@dataclass(frozen=True)
+class _LinearAttentionGatePassThrough:
+    """A ``com.microsoft::LinearAttentionGate`` node recognized, by
+    :func:`_match_linear_attention_gate`, as a safe pass-through producer
+    for a matched ``LinearAttention`` chain's own dynamic `decay`/`beta`
+    inputs -- see this module's own "Attention-head pruning" section
+    comment, the `LinearAttention` bullet's own `decay`/`beta` scope-boundary
+    paragraph, for the full empirical schema findings (`decay = decay_scale
+    * Softplus(a + dt_bias)`, `beta = Sigmoid(b)`, confirmed live via
+    ``onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()``)
+    and why this one op shape -- and only this one -- has a self-consistent
+    "narrower output implies narrower producer" story.
+
+    `dt_bias`/`decay_scale` (this node's own inputs 1/2, each a real
+    per-KV-head `(kv_num_heads,)` float constant) are sliced directly, axis
+    0, by the chain's own `keep_groups` -- :func:`_apply_one_gqa_chain`'s own
+    genuinely new per-tensor edit for this feature, mirroring how a
+    *constant* `decay`/`beta` already gets sliced elsewhere in that same
+    function.
+
+    `a`/`b` (this node's own inputs 0/3 -- `a` always present and always
+    resolved, since `decay` is this op's own required output, always
+    computed regardless of whether `LinearAttention` actually consumes it;
+    `b` only present/resolved when `beta` is *also* wired to the matched
+    chain's own `LinearAttention` node) need no slicing of their own: each
+    is itself a plain MatMul/vanilla-Gemm activation, exactly
+    `kv_num_heads`-wide, so narrowing that producer's own output columns by
+    the identical `keep_groups` -- recorded here as `a_weight`/`a_bias`/
+    `a_weight_transposed` (always set) and `b_weight`/`b_bias`/
+    `b_weight_transposed` (set only when `b` needs narrowing too) -- narrows
+    `a`/`b` themselves "for free", the same way slicing Q's/K's/V's own
+    producer weight already narrows their own activation with no separate
+    step. `b_weight` is left ``None`` whenever `beta` isn't wired to the
+    matched chain at all (the gate's own `beta` output, if present, is then
+    simply unused, so `b`'s own width is immaterial and left completely
+    untouched).
+    """
+
+    node: onnx.NodeProto
+    dt_bias: str
+    decay_scale: str
+    a_weight: str
+    a_bias: Optional[str]
+    a_weight_transposed: bool
+    b_weight: Optional[str] = None
+    b_bias: Optional[str] = None
+    b_weight_transposed: bool = False
+
+
+def _match_linear_attention_gate(
+    node: onnx.NodeProto,
+    kv_num_heads: int,
+    initializer_map: Dict[str, onnx.TensorProto],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+    node_by_output: Dict[str, onnx.NodeProto],
+) -> Optional[_LinearAttentionGatePassThrough]:
+    """Recognizes exactly one dynamic-producer shape for a matched
+    ``LinearAttention`` `node`'s own `decay`/`beta` inputs (indices 4/5,
+    each already confirmed non-constant by the caller -- see
+    :func:`_match_linear_attention_producer`'s own docstring for why a
+    dynamic `decay`/`beta` is no longer declined right there, deferred here
+    instead, where the graph-wide consumer/producer maps this needs are
+    available): both fed, directly and exclusively, by the SAME
+    ``com.microsoft::LinearAttentionGate`` node's own `decay` (output 0)
+    and, when `beta` is also connected, `beta` (output 1) outputs -- this
+    op's own documented companion, confirmed live via
+    ``onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()``
+    against this environment's installed onnxruntime 1.29.0 (`since_version`
+    1): `decay = decay_scale * Softplus(a + dt_bias)`, `beta = Sigmoid(b)`
+    (`b` "Required when the beta output is requested"), `dt_bias`/
+    `decay_scale` "per-head float32 vectors of length H" (`H` ==
+    `kv_num_heads`). See this module's own "Attention-head pruning" section
+    comment, the `LinearAttention` bullet, for why this is deliberately the
+    ONLY dynamic `decay`/`beta` producer shape ever recognized -- anything
+    else (a bare graph input, any other node, a gate whose own `a`/`b` don't
+    resolve to a plain constant-weight producer) still declines the whole
+    match, exactly as before this function existed.
+
+    Every edge crossed -- `node`'s own `decay`/`beta` input(s), and the gate
+    node's own `a`/`b` input(s) -- is required to have exactly one consumer
+    and not be a graph output (the same "no other consumer along the way"
+    bar :func:`_walk_back_through_qk_norm_rope` already holds its own
+    crossed hops to): narrowing `dt_bias`'s/`decay_scale`'s/`a`'s-or-`b`'s
+    own producer weight in place would otherwise silently corrupt whatever
+    else reads that same tensor. `a`'s (always) and `b`'s (only when `beta`
+    is connected) own producer must independently resolve via
+    :func:`_match_producer` (a plain MatMul/vanilla-Gemm with a constant 2-D
+    float weight) to a `kv_num_heads`-wide output -- exactly the schema's
+    own `(B, T, H)` shape -- so :func:`_apply_one_gqa_chain` can narrow it
+    the same "slice the producer weight's own output columns by
+    `keep_groups`" way Q's/K's/V's own producer weight already gets
+    narrowed (see :class:`_LinearAttentionGatePassThrough`'s own docstring
+    for why `a`/`b` themselves never need touching beyond that). Anything
+    not matching this exact shape declines outright (returns ``None``)
+    rather than guessed at.
+    """
+
+    def _is_internal(name: str) -> bool:
+        return len(consumers_of.get(name, [])) == 1 and name not in graph_outputs
+
+    decay_name = node.input[4] if len(node.input) > 4 else ""
+    beta_name = node.input[5] if len(node.input) > 5 else ""
+    dyn_decay = bool(decay_name) and decay_name not in initializer_map
+    dyn_beta = bool(beta_name) and beta_name not in initializer_map
+    if not dyn_decay and not dyn_beta:
+        return None  # nothing dynamic here -- not this function's own case
+
+    dyn_names = [
+        n for n in (decay_name if dyn_decay else "", beta_name if dyn_beta else "") if n
+    ]
+    gate_node = node_by_output.get(dyn_names[0])
+    if gate_node is None:
+        return None
+    if any(node_by_output.get(n) is not gate_node for n in dyn_names):
+        return None  # both dynamic inputs must be this SAME gate node's own outputs
+    if (
+        gate_node.domain != "com.microsoft"
+        or gate_node.op_type != "LinearAttentionGate"
+    ):
+        return None
+    if dyn_decay and (
+        len(gate_node.output) < 1
+        or not gate_node.output[0]
+        or gate_node.output[0] != decay_name
+    ):
+        return None
+    if dyn_beta and (
+        len(gate_node.output) < 2
+        or not gate_node.output[1]
+        or gate_node.output[1] != beta_name
+    ):
+        return None
+    for n in dyn_names:
+        if not _is_internal(n):
+            return None
+
+    if (
+        len(gate_node.input) < 3
+        or not gate_node.input[0]
+        or not gate_node.input[1]
+        or not gate_node.input[2]
+    ):
+        return None
+    a_name, dt_bias_name, decay_scale_name = (
+        gate_node.input[0],
+        gate_node.input[1],
+        gate_node.input[2],
+    )
+    dt_bias_init = initializer_map.get(dt_bias_name)
+    decay_scale_init = initializer_map.get(decay_scale_name)
+    if dt_bias_init is None or decay_scale_init is None:
+        return None
+    for init in (dt_bias_init, decay_scale_init):
+        if not _is_supported_float_dtype(init.data_type) or list(init.dims) != [
+            kv_num_heads
+        ]:
+            return None
+
+    if not _is_internal(a_name):
+        return None
+    a_prod = node_by_output.get(a_name)
+    if a_prod is None:
+        return None
+    a_info = _match_producer(a_prod, initializer_map)
+    if a_info is None:
+        return None
+    a_weight, a_weight_t, a_bias, a_n = a_info
+    if a_n != kv_num_heads:
+        return None
+
+    b_weight: Optional[str] = None
+    b_bias: Optional[str] = None
+    b_weight_t = False
+    if dyn_beta:
+        if len(gate_node.input) < 4 or not gate_node.input[3]:
+            return None
+        b_name = gate_node.input[3]
+        if not _is_internal(b_name):
+            return None
+        b_prod = node_by_output.get(b_name)
+        if b_prod is None:
+            return None
+        b_info = _match_producer(b_prod, initializer_map)
+        if b_info is None:
+            return None
+        b_weight, b_weight_t, b_bias, b_n = b_info
+        if b_n != kv_num_heads:
+            return None
+        if b_weight == a_weight:
+            return None  # degenerate -- can't independently slice a shared producer
+
+    return _LinearAttentionGatePassThrough(
+        node=gate_node,
+        dt_bias=dt_bias_name,
+        decay_scale=decay_scale_name,
+        a_weight=a_weight,
+        a_bias=a_bias,
+        a_weight_transposed=a_weight_t,
+        b_weight=b_weight,
+        b_bias=b_bias,
+        b_weight_transposed=b_weight_t,
+    )
+
+
 def _find_linear_attention_chains(
     graph: onnx.GraphProto,
     value_info_by_name: Optional[Dict[str, onnx.ValueInfoProto]] = None,
@@ -24561,20 +24804,32 @@ def _find_linear_attention_chains(
     requirement the two agree), the same as the plain ai.onnx `Attention`
     op/`MultiHeadAttention`.
 
-    Performs the one deferred check :func:`_match_linear_attention_producer`
-    itself cannot -- it doesn't yet know `head_size` (resolved only here,
-    from Q's own producer weight, by :func:`_find_separate_qkv_chains`
-    itself): a connected constant `decay` (index 4) must be exactly one of
-    its own two documented shapes -- ``(*, *, kv_num_heads)`` (DeltaNet/
-    RetNet, per-head scalar decay) or ``(*, *, kv_num_heads * head_size)``
-    (GLA/RWKV-6, per-key-dimension decay, `head_size` being Q's/K's shared
-    per-head width -- *not* V's own, independent `v_head_size`) -- anything
-    else declines the whole chain here, the same "don't guess" bar every
-    other deferred shape check in this section already holds (mirroring
-    `PagedAttention`'s own deferred `q_norm_weight`/`k_norm_weight`
-    exact-shape check). A *dynamic* `decay`/`beta` was already declined
-    outright at match time (see :func:`_match_linear_attention_producer`'s
-    own docstring for why) -- nothing here is reachable for that case.
+    Performs two deferred checks :func:`_match_linear_attention_producer`
+    itself cannot:
+
+    - A connected constant `decay` (index 4) must be exactly one of its own
+      two documented shapes -- ``(*, *, kv_num_heads)`` (DeltaNet/RetNet,
+      per-head scalar decay) or ``(*, *, kv_num_heads * head_size)``
+      (GLA/RWKV-6, per-key-dimension decay, `head_size` being Q's/K's shared
+      per-head width -- *not* V's own, independent `v_head_size`) --
+      anything else declines the whole chain here, the same "don't guess"
+      bar every other deferred shape check in this section already holds
+      (mirroring `PagedAttention`'s own deferred `q_norm_weight`/
+      `k_norm_weight` exact-shape check); needs `head_size`, resolved only
+      here, from Q's own producer weight, by :func:`_find_separate_qkv_chains`
+      itself.
+    - A connected *dynamic* `decay`/`beta` (declined outright by
+      :func:`_match_linear_attention_producer` before this fix; now merely
+      deferred, since it might be the one recognized
+      `com.microsoft::LinearAttentionGate` pass-through shape) is resolved
+      here via :func:`_match_linear_attention_gate`, which needs the
+      graph-wide consumer/producer maps :func:`_match_linear_attention_producer`
+      itself is never given -- a chain whose dynamic `decay`/`beta` doesn't
+      resolve this way is dropped here (the same "unmatched topology"
+      outcome as any other declined chain), one that does is rewrapped
+      (:func:`dataclasses.replace`, since :class:`_GQAChain` is frozen) with
+      its own `.linear_attention_gate` set, for :func:`_apply_one_gqa_chain`
+      to slice at apply time.
     """
     chains = _find_separate_qkv_chains(
         graph,
@@ -24584,10 +24839,36 @@ def _find_linear_attention_chains(
         allow_differing_v_head_size=True,
     )
     initializer_map = _constant_map(graph)
+    consumers_of = _consumers_of(graph)
+    graph_outputs = {o.name for o in graph.output}
+    node_by_output = {out: node for node in graph.node for out in node.output}
     out = []
     for chain in chains:
         decay_name = chain.node.input[4] if len(chain.node.input) > 4 else ""
-        if decay_name:
+        beta_name = chain.node.input[5] if len(chain.node.input) > 5 else ""
+        decay_dynamic = bool(decay_name) and decay_name not in initializer_map
+        beta_dynamic = bool(beta_name) and beta_name not in initializer_map
+
+        gate: Optional[_LinearAttentionGatePassThrough] = None
+        if decay_dynamic or beta_dynamic:
+            gate = _match_linear_attention_gate(
+                chain.node,
+                chain.kv_num_heads,
+                initializer_map,
+                consumers_of,
+                graph_outputs,
+                node_by_output,
+            )
+            if gate is None:
+                continue  # dynamic decay/beta not the recognized
+                # LinearAttentionGate shape -- declined
+            if gate.a_weight in (chain.q_weight, chain.k_weight, chain.v_weight) or (
+                gate.b_weight is not None
+                and gate.b_weight in (chain.q_weight, chain.k_weight, chain.v_weight)
+            ):
+                continue  # degenerate -- can't independently slice a shared producer
+
+        if decay_name and not decay_dynamic:
             decay_init = initializer_map.get(decay_name)
             if decay_init is not None:
                 last = decay_init.dims[-1] if len(decay_init.dims) else -1
@@ -24596,7 +24877,10 @@ def _find_linear_attention_chains(
                     chain.kv_num_heads * chain.head_size,
                 ):
                     continue  # neither of decay's own two documented shapes
-        out.append(chain)
+
+        out.append(
+            chain if gate is None else replace(chain, linear_attention_gate=gate)
+        )
     return out
 
 
@@ -28008,24 +28292,27 @@ def _apply_one_gqa_chain(
 
     # `LinearAttention`'s own `past_state`/`decay`/`beta` (indices 3/4/5 --
     # see this module's own "Attention-head pruning" section comment, the
-    # `LinearAttention` bullet, for the full empirical schema findings and
-    # why a *dynamic* `decay`/`beta` already declined the whole match at
-    # :func:`_match_linear_attention_producer` time -- nothing reaches this
-    # block for that case). `past_state` (rank-4 `(B, kv_num_heads, d_k,
-    # d_v)`) is the closest analogue of `GroupQueryAttention`'s own
-    # `past_key`/`past_value`, sliced the identical axis-1 way when
-    # constant. `decay` (rank-3) is either `kv_num_heads`-wide (DeltaNet/
-    # RetNet, per-head scalar -- sliced directly by `keep_groups`, no
-    # `head_size` expansion) or `kv_num_heads * d`-wide (GLA/RWKV-6,
-    # per-key-dimension -- sliced by the same per-head *column* expansion
-    # K's own producer weight gets, :func:`_head_column_indices`); already
-    # confirmed to be exactly one of these two shapes, or dynamic, by
-    # :func:`_find_linear_attention_chains`'s own deferred check, so no
-    # `else` branch here needs to guess at a third shape. `beta` (rank-3,
-    # `kv_num_heads`-wide or a size-1 broadcast) is sliced only in the
-    # former case -- the latter needs no per-head slicing at all, the same
-    # "PER_TENSOR broadcast, left alone" reasoning as `k_scale`/`v_scale`
-    # above.
+    # `LinearAttention` bullet, for the full empirical schema findings). A
+    # *dynamic* `decay`/`beta` reaches this block only when
+    # `chain.linear_attention_gate` is set (see below) -- anything else
+    # dynamic already declined the whole match, in
+    # :func:`_find_linear_attention_chains` (via
+    # :func:`_match_linear_attention_gate`) or, before that, at
+    # :func:`_match_linear_attention_producer` time. `past_state` (rank-4
+    # `(B, kv_num_heads, d_k, d_v)`) is the closest analogue of
+    # `GroupQueryAttention`'s own `past_key`/`past_value`, sliced the
+    # identical axis-1 way when constant. `decay` (rank-3) is either
+    # `kv_num_heads`-wide (DeltaNet/RetNet, per-head scalar -- sliced
+    # directly by `keep_groups`, no `head_size` expansion) or `kv_num_heads
+    # * d`-wide (GLA/RWKV-6, per-key-dimension -- sliced by the same
+    # per-head *column* expansion K's own producer weight gets,
+    # :func:`_head_column_indices`); already confirmed, when constant, to be
+    # exactly one of these two shapes by :func:`_find_linear_attention_chains`'s
+    # own deferred check, so no `else` branch here needs to guess at a third
+    # shape. `beta` (rank-3, `kv_num_heads`-wide or a size-1 broadcast) is
+    # sliced only in the former case -- the latter needs no per-head slicing
+    # at all, the same "PER_TENSOR broadcast, left alone" reasoning as
+    # `k_scale`/`v_scale` above.
     if is_linear_attention:
         if len(chain.node.input) > 3 and chain.node.input[3]:
             past_state_init = initializer_map.get(chain.node.input[3])
@@ -28043,6 +28330,35 @@ def _apply_one_gqa_chain(
             beta_init = initializer_map.get(chain.node.input[5])
             if beta_init is not None and beta_init.dims[-1] == h:
                 _slice_last_axis(beta_init, keep_groups)
+
+        # A recognized ``com.microsoft::LinearAttentionGate`` pass-through
+        # (see :func:`_match_linear_attention_gate`,
+        # :class:`_LinearAttentionGatePassThrough`): `dt_bias`/`decay_scale`
+        # (both real `(kv_num_heads,)` constants) are sliced directly, axis
+        # 0 -- the one genuinely new per-tensor edit this feature adds.
+        # `a`'s (always) and `b`'s (only when `beta` was also wired to this
+        # chain) own producer weight -- resolved, at match time, to a plain
+        # MatMul/vanilla-Gemm output exactly `kv_num_heads` columns wide --
+        # is sliced the identical `keep_groups` way Q's/K's/V's own producer
+        # weight already is a few lines above, narrowing `a`/`b` themselves
+        # with no separate step (see that class's own docstring for why).
+        gate = chain.linear_attention_gate
+        if gate is not None:
+            _slice_last_axis(initializer_map[gate.dt_bias], keep_groups)
+            _slice_last_axis(initializer_map[gate.decay_scale], keep_groups)
+            _slice_producer_weight(
+                initializer_map[gate.a_weight], gate.a_weight_transposed, keep_groups
+            )
+            if gate.a_bias is not None:
+                _slice_last_axis(initializer_map[gate.a_bias], keep_groups)
+            if gate.b_weight is not None:
+                _slice_producer_weight(
+                    initializer_map[gate.b_weight],
+                    gate.b_weight_transposed,
+                    keep_groups,
+                )
+                if gate.b_bias is not None:
+                    _slice_last_axis(initializer_map[gate.b_bias], keep_groups)
 
     # `attention_bias`/`attn_mask` (index 10 for `GroupQueryAttention`, 3
     # for the plain ai.onnx op, 5 for `MultiHeadAttention`, 4 for
@@ -28186,8 +28502,20 @@ def _apply_one_gqa_chain(
         if hop is not None:
             stale.update(n.output[0] for n in hop.nodes if n.output and n.output[0])
             stale.update(hop.extra_stale_outputs)
+    producer_names = {chain.q_weight, chain.k_weight, chain.v_weight}
+    if chain.linear_attention_gate is not None:
+        # A recognized `LinearAttentionGate` pass-through node is a
+        # distinct node from `chain.node` (already covered by `stale`
+        # above), so its own `decay`/`beta` outputs need marking stale
+        # here too, and `a`'s/`b`'s own (now narrower) producer weight
+        # needs the same touched-producer bookkeeping every other producer
+        # weight in this chain already gets.
+        stale.update(chain.linear_attention_gate.node.output)
+        producer_names.add(chain.linear_attention_gate.a_weight)
+        if chain.linear_attention_gate.b_weight is not None:
+            producer_names.add(chain.linear_attention_gate.b_weight)
     return (
-        {chain.q_weight, chain.k_weight, chain.v_weight},
+        producer_names,
         chain.consumer_weight,
         stale,
     )
@@ -28249,6 +28577,15 @@ def _apply_attention_chains(
     for chain in chains:
         if isinstance(chain, (_GQAChain, _DecomposedGQAChain)):
             producer_names = {chain.q_weight, chain.k_weight, chain.v_weight}
+            if isinstance(chain, _GQAChain) and chain.linear_attention_gate is not None:
+                # See :func:`_apply_one_gqa_chain`'s own identical addition
+                # to its returned producer-name set -- checked here too so a
+                # `LinearAttentionGate`'s own `a`/`b` producer weight shared
+                # with an earlier chain is skipped up front, the same as
+                # Q's/K's/V's own already are.
+                producer_names.add(chain.linear_attention_gate.a_weight)
+                if chain.linear_attention_gate.b_weight is not None:
+                    producer_names.add(chain.linear_attention_gate.b_weight)
         else:
             producer_names = {chain.weight}
         if (
@@ -42665,6 +43002,12 @@ def _analyze_attention_chains(
         elif isinstance(chain, _GQAChain):
             label = _node_label(chain.node)
             producer_names = {chain.q_weight, chain.k_weight, chain.v_weight}
+            if chain.linear_attention_gate is not None:
+                # See :func:`_apply_one_gqa_chain`'s own identical addition
+                # to its returned producer-name set.
+                producer_names.add(chain.linear_attention_gate.a_weight)
+                if chain.linear_attention_gate.b_weight is not None:
+                    producer_names.add(chain.linear_attention_gate.b_weight)
             h = chain.kv_num_heads
             # True MQA (`kv_num_heads == 1`) fast path -- mirrors
             # :func:`_apply_one_gqa_chain`'s own `is_mqa` handling: KV-group

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -41188,6 +41188,358 @@ def test_analyze_attention_head_pruning_linear_attention_matches_real_call():
     assert dims_after["Wv"][1] == kept_groups * cfg["Dv"]
 
 
+# --- LinearAttentionGate-fed dynamic decay/beta pass-through --------------
+#
+# `LinearAttention`'s own `decay`/`beta` inputs (indices 4/5), when fed by a
+# genuine `com.microsoft::LinearAttentionGate` node (this op's own
+# documented companion -- `decay = decay_scale * Softplus(a + dt_bias)`,
+# `beta = Sigmoid(b)`, schema confirmed live via
+# `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()`
+# against this environment's installed onnxruntime 1.29.0), are recognized
+# as a safe pass-through: `dt_bias`/`decay_scale` (real `(kv_num_heads,)`
+# constants, this node's own inputs 1/2) are sliced directly, axis 0, and
+# `a`'s/`b`'s (inputs 0/3) own producer weight is sliced the identical
+# `keep_groups` way Q's/K's/V's own is -- see onnxsim/pruning.py's own
+# "Attention-head pruning" section comment, the `LinearAttention` bullet,
+# and `_match_linear_attention_gate`'s own docstring. This is the realistic
+# shape every actual gated/delta/gated_delta dynamic-decode export uses --
+# before this fix, a `decay`/`beta` fed this way declined the whole match
+# outright (see `test_linear_attention_pruning_dynamic_decay_is_declined`
+# above, which locks in the *general* dynamic-decay decline this fix
+# deliberately keeps for anything other than this one recognized shape).
+#
+# `LinearAttentionGate` itself has no CPU kernel in this environment's
+# onnxruntime (confirmed empirically -- attempting to run a model containing
+# it raises ``NOT_IMPLEMENTED: Could not find an implementation for
+# LinearAttentionGate``), so unlike every other `LinearAttention` test
+# above, the gate-bearing model itself can't be run end to end. The numeric
+# oracle check below instead "materializes" the gate's own well-known
+# formula to a constant decay/beta -- via the same, already
+# execution-verified constant-decay `LinearAttention` path those other
+# tests use -- on both the pruned side (using the pruned model's own sliced
+# `Wa`/`Wb`/`DtBias`/`DecayScale`) and an independently-built oracle side
+# (computing the identical formula at full width, then slicing its own
+# output by `keep_groups`), and confirms both give a bit-identical final
+# `Y` -- an end-to-end confirmation that slicing `Wa`/`Wb`/`DtBias`/
+# `DecayScale` the way this fix does is mathematically equivalent to
+# "compute at full width, then keep only the surviving heads' own output",
+# the same invariant every other oracle test in this file already checks.
+
+
+def _softplus(x):
+    return np.logaddexp(0.0, x)
+
+
+def _sigmoid(x):
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def _linear_attention_gate_model(Hkv=4, K=16, seed=0, decay_only=False):
+    """The exact `com.microsoft::LinearAttentionGate`-fed `gated_delta`
+    topology from this fix's own confirmed real-tool repro: `q`/`k`/`v` each
+    `MatMul(X, W*)`, `a`/`b_in` each `MatMul(X, Wa/Wb)` (also `Hkv`-wide --
+    per-head scalar `a`/`b`, this op's own documented shape), gated into
+    `decay`/`beta` by the gate node, consumed by
+    `LinearAttention<update_rule="gated_delta">`. `Hq == Hkv` (a plain,
+    non-GQA shape, `group_size == 1`) -- the KV-group-pruning formula itself
+    is already covered by every other `LinearAttention` test above; this
+    section is only about the new `decay`/`beta` producer recognition.
+    `decay_only=True` omits `b_in`/`beta` entirely (the `"gated"`-mode
+    shape, `beta` never requested), exercising this fix's own `b_weight is
+    None` branch.
+    """
+    rng = np.random.default_rng(seed)
+    D = 4
+    N = Hkv * D
+    wq = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    wk = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    wv = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    wo = rng.standard_normal((N, K)).astype(np.float32) * 0.3
+    wa = rng.standard_normal((K, Hkv)).astype(np.float32) * 0.3
+    dt_bias = rng.standard_normal((Hkv,)).astype(np.float32)
+    decay_scale = -np.abs(rng.standard_normal((Hkv,))).astype(np.float32)
+    cfg = dict(
+        Hq=Hkv,
+        Hkv=Hkv,
+        D=D,
+        K=K,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wo=wo,
+        wa=wa,
+        dt_bias=dt_bias,
+        decay_scale=decay_scale,
+    )
+    initializer = [
+        _f32(wq, "Wq"),
+        _f32(wk, "Wk"),
+        _f32(wv, "Wv"),
+        _f32(wo, "Wo"),
+        _f32(wa, "Wa"),
+        _f32(dt_bias, "DtBias"),
+        _f32(decay_scale, "DecayScale"),
+    ]
+    if decay_only:
+        gate_line = "decay = com.microsoft.LinearAttentionGate(a, DtBias, DecayScale)"
+        la_args = "q, k, v, , decay"
+        update_rule = "gated"
+    else:
+        wb = rng.standard_normal((K, Hkv)).astype(np.float32) * 0.3
+        cfg["wb"] = wb
+        initializer.append(_f32(wb, "Wb"))
+        gate_line = (
+            "decay, beta = com.microsoft.LinearAttentionGate"
+            "(a, DtBias, DecayScale, b_in)"
+        )
+        la_args = "q, k, v, , decay, beta"
+        update_rule = "gated_delta"
+    b_line = "" if decay_only else "b_in = MatMul(X, Wb)"
+
+    body = f"""
+        <
+          ir_version: 10,
+          opset_import: ["" : 27, "com.microsoft" : 1]
+        >
+        g (float[1,3,{K}] X) => (float[1,3,{K}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          a = MatMul(X, Wa)
+          {b_line}
+          {gate_line}
+          attn_out, ps = LinearAttention<q_num_heads={Hkv}, kv_num_heads={Hkv}, update_rule="{update_rule}">({la_args})
+          Y = MatMul(attn_out, Wo)
+        }}
+        """
+    model = parser.parse_model(body)
+    model.graph.initializer.extend(initializer)
+    return model, cfg
+
+
+def test_linear_attention_pruning_gate_fed_decay_and_beta_matches_oracle():
+    model, cfg = _linear_attention_gate_model(Hkv=4, K=16, seed=10)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _linear_attention_node(pruned)
+    q_attr = next(a.i for a in node.attribute if a.name == "q_num_heads")
+    kv_attr = next(a.i for a in node.attribute if a.name == "kv_num_heads")
+    assert kv_attr == 2
+    assert q_attr == 2  # group_size == 1 for this plain (non-GQA) shape
+
+    keep_groups = _linear_attention_keep_groups(
+        dict(
+            Hq=cfg["Hq"],
+            Hkv=cfg["Hkv"],
+            Dk=cfg["D"],
+            Dv=cfg["D"],
+            wq=cfg["wq"],
+            wk=cfg["wk"],
+            wv=cfg["wv"],
+        ),
+        sparsity=0.5,
+    )
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["DtBias"], cfg["dt_bias"][keep_groups])
+    np.testing.assert_array_equal(inits["DecayScale"], cfg["decay_scale"][keep_groups])
+    np.testing.assert_array_equal(inits["Wa"], cfg["wa"][:, keep_groups])
+    np.testing.assert_array_equal(inits["Wb"], cfg["wb"][:, keep_groups])
+
+    rng = np.random.default_rng(99)
+    x = rng.standard_normal((1, 3, cfg["K"])).astype(np.float32)
+    D = cfg["D"]
+    q_idx = np.concatenate([np.arange(h * D, (h + 1) * D) for h in keep_groups])
+
+    # Oracle: compute the gate's own formula at FULL width from the
+    # original weights, then slice its own output by `keep_groups`.
+    a_full = x @ cfg["wa"]
+    b_full = x @ cfg["wb"]
+    decay_full = cfg["decay_scale"] * _softplus(a_full + cfg["dt_bias"])
+    beta_full = _sigmoid(b_full)
+    oracle, _ = _linear_attention_model(
+        Hq=len(keep_groups),
+        Hkv=len(keep_groups),
+        Dk=D,
+        Dv=D,
+        K=cfg["K"],
+        update_rule="gated_delta",
+        decay=decay_full[:, :, keep_groups],
+        beta=beta_full[:, :, keep_groups],
+    )
+    oracle_vals = {
+        "Wq": cfg["wq"][:, q_idx],
+        "Wk": cfg["wk"][:, q_idx],
+        "Wv": cfg["wv"][:, q_idx],
+        "Wo": cfg["wo"][q_idx, :],
+        "Decay": decay_full[:, :, keep_groups],
+        "Beta": beta_full[:, :, keep_groups],
+    }
+    for init in oracle.graph.initializer:
+        init.CopyFrom(
+            onnx.numpy_helper.from_array(
+                np.ascontiguousarray(oracle_vals[init.name]), init.name
+            )
+        )
+    onnx.checker.check_model(oracle)
+
+    # Materialized pruned model: compute the identical formula, but from the
+    # PRUNED model's own already-sliced `Wa`/`Wb`/`DtBias`/`DecayScale`.
+    a_pruned = x @ inits["Wa"]
+    b_pruned = x @ inits["Wb"]
+    decay_pruned = inits["DecayScale"] * _softplus(a_pruned + inits["DtBias"])
+    beta_pruned = _sigmoid(b_pruned)
+    materialized, _ = _linear_attention_model(
+        Hq=len(keep_groups),
+        Hkv=len(keep_groups),
+        Dk=D,
+        Dv=D,
+        K=cfg["K"],
+        update_rule="gated_delta",
+        decay=decay_pruned,
+        beta=beta_pruned,
+    )
+    mat_vals = {
+        "Wq": inits["Wq"],
+        "Wk": inits["Wk"],
+        "Wv": inits["Wv"],
+        "Wo": inits["Wo"],
+        "Decay": decay_pruned,
+        "Beta": beta_pruned,
+    }
+    for init in materialized.graph.initializer:
+        init.CopyFrom(
+            onnx.numpy_helper.from_array(
+                np.ascontiguousarray(mat_vals[init.name]), init.name
+            )
+        )
+    onnx.checker.check_model(materialized)
+
+    y_oracle = _run27(oracle, {"X": x})[0]
+    y_pruned_materialized = _run27(materialized, {"X": x})[0]
+    np.testing.assert_array_equal(y_pruned_materialized, y_oracle)
+
+
+def test_linear_attention_pruning_gate_fed_decay_only_slices_wa_and_gate_weights():
+    # `"gated"` mode: `beta` never requested, so the gate node has no `b`
+    # input/`beta` output at all -- exercises this fix's own `b_weight is
+    # None` branch (nothing to slice for a `b` that was never connected).
+    model, cfg = _linear_attention_gate_model(Hkv=4, K=16, seed=13, decay_only=True)
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    keep_groups = _linear_attention_keep_groups(
+        dict(
+            Hq=cfg["Hq"],
+            Hkv=cfg["Hkv"],
+            Dk=cfg["D"],
+            Dv=cfg["D"],
+            wq=cfg["wq"],
+            wk=cfg["wk"],
+            wv=cfg["wv"],
+        ),
+        sparsity=0.5,
+    )
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert "Wb" not in inits
+    np.testing.assert_array_equal(inits["DtBias"], cfg["dt_bias"][keep_groups])
+    np.testing.assert_array_equal(inits["DecayScale"], cfg["decay_scale"][keep_groups])
+    np.testing.assert_array_equal(inits["Wa"], cfg["wa"][:, keep_groups])
+
+
+def test_linear_attention_pruning_constant_decay_beta_prunes_same_shapes_as_gate_fed():
+    # Regression guard: a genuine *constant* decay/beta (the shape this pass
+    # already supported before this fix) must keep pruning to the exact same
+    # shapes as the new gate-fed path, given the identical Wq/Wk/Wv/Wo (and
+    # therefore the identical importance ranking/`keep_groups`).
+    gate_model, cfg = _linear_attention_gate_model(Hkv=4, K=16, seed=12)
+
+    const_decay = np.broadcast_to(
+        (cfg["decay_scale"] * _softplus(cfg["dt_bias"]))[None, None, :],
+        (1, 3, cfg["Hkv"]),
+    )
+    const_beta = np.full((1, 3, cfg["Hkv"]), 0.5, dtype=np.float32)
+    const_model, _ = _linear_attention_model(
+        Hq=cfg["Hq"],
+        Hkv=cfg["Hkv"],
+        Dk=cfg["D"],
+        Dv=cfg["D"],
+        K=cfg["K"],
+        update_rule="gated_delta",
+        decay=const_decay,
+        beta=const_beta,
+    )
+    for init in const_model.graph.initializer:
+        if init.name in ("Wq", "Wk", "Wv", "Wo"):
+            init.CopyFrom(_f32(cfg[init.name.lower()], init.name))
+
+    pruned_gate = onnxsim.apply_attention_head_pruning(gate_model, sparsity=0.5)
+    pruned_const = onnxsim.apply_attention_head_pruning(const_model, sparsity=0.5)
+    onnx.checker.check_model(pruned_gate)
+    onnx.checker.check_model(pruned_const)
+
+    dims_gate = _initializer_dims(pruned_gate)
+    dims_const = _initializer_dims(pruned_const)
+    for name in ("Wq", "Wk", "Wv", "Wo"):
+        assert dims_gate[name] == dims_const[name]
+
+    node_gate = _linear_attention_node(pruned_gate)
+    node_const = _linear_attention_node(pruned_const)
+    for attr_name in ("q_num_heads", "kv_num_heads"):
+        assert next(a.i for a in node_gate.attribute if a.name == attr_name) == next(
+            a.i for a in node_const.attribute if a.name == attr_name
+        )
+
+
+def test_linear_attention_pruning_dynamic_decay_from_non_gate_node_still_declines():
+    # Same math as `LinearAttentionGate` (`decay_scale * Softplus(a +
+    # dt_bias)`) but decomposed into plain ops instead of the single
+    # recognized `com.microsoft::LinearAttentionGate` node -- still declines:
+    # this fix recognizes exactly one op shape, not a general "any dynamic
+    # decay computed from a per-head constant is fine" relaxation (see
+    # onnxsim/pruning.py's own docstring/section comment).
+    Hq, Hkv, Dk, Dv, K = 4, 2, 4, 4, 16
+    body = f"""
+        g (float[1,3,{K}] X) => (float[1,3,{K}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          a = MatMul(X, Wa)
+          ap = Add(a, DtBias)
+          sp = Softplus(ap)
+          decay = Mul(sp, DecayScale)
+          attn_out, ps = LinearAttention<q_num_heads={Hq}, kv_num_heads={Hkv}, update_rule="gated">(q, k, v, , decay)
+          Y = MatMul(attn_out, Wo)
+        }}
+        """
+    rng = np.random.default_rng(14)
+    wq = rng.standard_normal((K, Hq * Dk)).astype(np.float32) * 0.3
+    wk = rng.standard_normal((K, Hkv * Dk)).astype(np.float32) * 0.3
+    wv = rng.standard_normal((K, Hkv * Dv)).astype(np.float32) * 0.3
+    wo = rng.standard_normal((Hq * Dk, K)).astype(np.float32) * 0.3
+    wa = rng.standard_normal((K, Hkv)).astype(np.float32) * 0.3
+    dt_bias = rng.standard_normal((Hkv,)).astype(np.float32)
+    decay_scale = -np.abs(rng.standard_normal((Hkv,))).astype(np.float32)
+    model = _model(body, opset=27)
+    model.graph.initializer.extend(
+        [
+            _f32(wq, "Wq"),
+            _f32(wk, "Wk"),
+            _f32(wv, "Wv"),
+            _f32(wo, "Wo"),
+            _f32(wa, "Wa"),
+            _f32(dt_bias, "DtBias"),
+            _f32(decay_scale, "DecayScale"),
+        ]
+    )
+    pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    dims = _initializer_dims(pruned)
+    assert dims["Wq"] == (K, Hq * Dk)  # completely untouched -- no match
+
+
 # --- SparseAttention head pruning (com.microsoft, block-sparse-KV attention) ---
 #
 # Reuses the `GroupQueryAttention`-family's own whole-KV-group machinery


### PR DESCRIPTION
## Summary

`_match_linear_attention_producer` declined the entire `LinearAttention` attention-head-pruning chain whenever its `decay`/`beta` inputs (indices 4/5) were connected but not a constant. In practice, every real `gated`/`delta`/`gated_delta`-mode `LinearAttention` export computes `decay`/`beta` **dynamically** via `com.microsoft::LinearAttentionGate` — a real, live-confirmed `onnxruntime` 1.29.0 contrib op (`decay = decay_scale * Softplus(a + dt_bias)`, `beta = Sigmoid(b)`) — so this was the realistic shape, not an edge case, and `apply_attention_head_pruning` silently left the whole Q/K/V/output-projection chain unpruned whenever it was encountered. This gap was explicitly documented as "left for a future pass" in the module's own "Attention-head pruning" section comment.

## Empirically confirmed facts

- `com.microsoft::LinearAttentionGate`'s schema confirmed live via `onnxruntime.capi.onnxruntime_pybind11_state.get_all_operator_schema()`: inputs `a, dt_bias, decay_scale, b`, outputs `decay, beta`; `dt_bias`/`decay_scale` are real per-KV-head `(kv_num_heads,)` float constants; `a`/`b` are plain `(B, T, kv_num_heads)` activations.
- Built via `onnx.parser`: a `LinearAttention` chain (`update_rule="gated_delta"`) whose `decay`/`beta` are fed by a real `LinearAttentionGate` node. On the pre-fix code, `apply_attention_head_pruning(model, sparsity=0.5)` left `Wq` at `(16,16)` and `q_num_heads`/`kv_num_heads` at `4`/`4` — chain fully declined, zero pruning.
- The identical topology with `decay`/`beta` swapped for genuine rank-3 constant tensors (the one shape the matcher already accepted) pruned correctly (`Wq` → `(16,8)`, head counts → `2`/`2`), confirming the gap was specifically the `LinearAttentionGate` producer case, not a general failure of `LinearAttention` head-pruning.

## What's added

- New `_match_linear_attention_gate` + `_LinearAttentionGatePassThrough`: recognizes a `LinearAttentionGate` node feeding a matched chain's `decay`/`beta` (both from the SAME gate node), requiring every crossed edge (the gate's own `decay`/`beta` outputs, and its `a`/`b` inputs) to have exactly one consumer and not be a graph output — mirroring the existing `_walk_back_through_qk_norm_rope`'s own per-head Q/K-norm sandwich bar. `dt_bias`/`decay_scale` are sliced directly (axis 0, by `keep_groups`); `a`/`b` need no slicing of their own — each resolves (via the existing `_match_producer`) to a plain MatMul/vanilla-Gemm activation exactly `kv_num_heads`-wide, so narrowing that producer's own output columns by the same `keep_groups` narrows `a`/`b` "for free," the same way Q's/K's/V's own producer weight already narrows their activations with no separate step.
- `_find_linear_attention_chains` now defers (rather than declines outright) a dynamic `decay`/`beta` to this new matcher, since it needs graph-wide consumer/producer maps `_match_linear_attention_producer` itself doesn't have.
- `_apply_one_gqa_chain` slices `dt_bias`/`decay_scale`/`a`'s-and-`b`'s producer weight when a chain carries a recognized gate; `_apply_attention_chains`/`_analyze_attention_chains` bookkeeping (touched-producer sets, stale value_info) extended accordingly.
- **Deliberately narrow scope**: only this one exact op shape is recognized. A `decay`/`beta` fed by anything else dynamic (a bare graph input, any other node, a gate whose own `a`/`b` don't resolve to a plain constant-weight producer) still declines the whole match, exactly as before — not a general "any dynamic decay is now fine" relaxation, since no other shape has this one gate node's own self-consistent "narrower output implies narrower producer" story.

## Test plan

- 4 new regression tests: gate-fed decay+beta with a numeric oracle (materializing the gate's own formula to an equivalent constant decay/beta on both sides, since `LinearAttentionGate` has no CPU kernel in this environment — confirmed via a direct `onnxruntime.InferenceSession` probe returning `NOT_IMPLEMENTED`), a decay-only partial-wiring case (`beta` not connected), a same-shape regression check confirming the gate-fed and constant-decay/beta paths prune to identical shapes, and a decline check for a decomposed (non-gate) dynamic decay that must keep declining.
- Verified via a stash-based before/after check: reverting `onnxsim/pruning.py` to the pre-fix commit while keeping the new tests reproduces the bug (3 tests fail with genuine shape mismatches, e.g. `Wq` staying `(16,16)` unpruned); restoring the fix makes all 12 `linear_attention`-related tests pass.
- `pytest tests/test_pruning.py -k linear_attention` → 12 passed (8 pre-existing + 4 new).
- `ruff format --check`, `ruff check`, `mypy onnxsim/pruning.py` — all clean.
- Full suite: 164 failed (pre-existing, unrelated — stale-compiled-C++-extension test failures from concurrent unrelated automation porting Python functions to C++, confirmed identical failure set before and after this change), 841 passed.

## Risks for reviewer

- This is the first genuinely new piece of matcher machinery in this series of rounds (not a mechanical mirror of an existing hop) — the main risk surface is `_match_linear_attention_gate`'s own shape-recognition correctness, which the tied-tensor/single-consumer guards and the four new tests are specifically designed to exercise.
- `LinearAttentionGate` has no CPU execution kernel in this environment, so the oracle comparison materializes the gate's own documented formula to an equivalent constant tensor rather than running the gate node itself — the formula itself is taken directly from the live schema dump, not assumed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_