### PR TITLE
Port per-head optional-input slicing (mask/KV-cache/head_sink) across fused attention-pruning families

### DIFF
--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -1568,47 +1568,84 @@ def apply_attention_head_pruning_cpp(
     """
     C++-backed port of :func:`onnxsim.apply_attention_head_pruning`: removes
     whole attention heads -- or, for grouped-query attention, whole KV
-    groups -- from every matched ``com.microsoft::Attention``,
-    ``com.microsoft::GroupQueryAttention``, or plain ``ai.onnx::Attention``
-    node whose output feeds, optionally through a single shape-preserving
-    ``Reshape``, exactly one downstream MatMul/vanilla-Gemm's reduction
-    dimension (the output projection) -- the attention analogue of
+    groups -- from every matched fused self-attention block whose output
+    feeds, optionally through a single shape-preserving ``Reshape``, exactly
+    one downstream MatMul/vanilla-Gemm's reduction dimension (the output
+    projection) -- the attention analogue of
     :func:`onnxsim.apply_structured_pruning_cpp`, at head (or KV-group)
-    instead of single-channel granularity.
+    instead of single-channel granularity. Every matched producer/consumer
+    weight (and bias) may be FLOAT, FLOAT16, or BFLOAT16 -- read/ranked/
+    sliced in double precision and written back down to its own original
+    dtype, so a surviving entry's exact bit pattern is preserved.
 
-    For each matched plain ``com.microsoft::Attention`` block (a single
-    merged QKV weight/bias): ranks every head by the combined Frobenius norm
-    of its own Q, K, and V weight columns, drops the lowest-``sparsity``-
-    fraction of heads (at least one head is always kept), and removes the
-    corresponding column blocks from the merged QKV weight (and bias, if
-    present), decrementing ``num_heads``/``qkv_hidden_sizes`` accordingly,
-    and the matching row block from the output projection's weight.
+    Three families of fused op are matched:
 
-    For each matched ``GroupQueryAttention`` or plain ``ai.onnx::Attention``
-    block (separate, un-merged Q/K/V producers): ranks every *KV group* (a
-    KV head and the ``num_heads / kv_num_heads`` query heads the kernel maps
-    to it) by the combined Frobenius norm of that group's own Q+K+V weight
-    block, drops the lowest-``sparsity``-fraction of groups (at least one
-    group is always kept), and removes the corresponding column blocks from
-    all three producers (and their biases, if present) together with the
-    matching row block from the output projection's weight, decrementing the
-    query head count and ``kv_num_heads`` by the number of groups dropped --
-    so their ratio (query heads per KV head) is unchanged. An individual
-    query head is never dropped on its own: only a whole group, since
-    neither kernel has a way to keep a KV head alive for some, but not all,
-    of the query heads that shared it.
+    * A single merged QKV weight/bias -- ``com.microsoft::Attention``,
+      ``DecoderMaskedSelfAttention``, or ``PackedAttention`` (the three share
+      ``Attention``'s own weight/bias input positions and are matched
+      identically, net of ``DecoderMaskedSelfAttention``'s own schema
+      quirks -- no ``qkv_hidden_sizes`` attribute, a required, must-stay-
+      dynamic ``past`` input, no fused ``do_rotary``). Ranks every head by
+      the combined Frobenius norm of its own Q, K, and V weight columns,
+      drops the lowest-``sparsity``-fraction of heads (at least one head is
+      always kept), and removes the corresponding column blocks from the
+      merged QKV weight (and bias, if present), decrementing
+      ``num_heads``/``qkv_hidden_sizes`` accordingly (the latter left alone
+      for ``DecoderMaskedSelfAttention``, which has no such attribute), and
+      the matching row block from the output projection's weight.
+    * Separate, un-merged Q/K/V producers -- ``GroupQueryAttention``, plain
+      ``ai.onnx::Attention`` (opset 24+), ``MultiHeadAttention``,
+      ``PackedMultiHeadAttention``, ``DecoderMaskedMultiHeadAttention``,
+      ``PagedAttention``, ``LinearAttention``, or ``SparseAttention``. Ranks
+      every *KV group* (a KV head and the ``num_heads / kv_num_heads`` query
+      heads the kernel maps to it) by the combined Frobenius norm of that
+      group's own Q+K+V weight block, drops the lowest-``sparsity``-fraction
+      of groups (at least one group is always kept), and removes the
+      corresponding column blocks from all three producers (and their
+      biases, or a ``MultiHeadAttention``-style single combined Q+K+V bias,
+      if present) together with the matching row block from the output
+      projection's weight, decrementing the query head count and
+      ``kv_num_heads`` by the number of groups dropped -- so their ratio
+      (query heads per KV head) is unchanged. An individual query head is
+      never dropped on its own: only a whole group, since neither kernel has
+      a way to keep a KV head alive for some, but not all, of the query
+      heads that shared it.
+    * The fully decomposed ("eager SDPA export") shape -- separate Q/K/V
+      Linear producers (or one shared packed-QKV-then-``Split`` producer)
+      each reshaped/transposed to BNSH, an optional ``repeat_kv``
+      (``Unsqueeze``/``Expand``/``Reshape``) broadcast of K/V up to the full
+      query head count, optional decomposed RoPE and/or Q/K-norm pass-
+      throughs, ``MatMul(Q, K^T)`` -> scale -> optional additive mask ->
+      ``Softmax`` -> ``MatMul(., V)`` -> transpose/reshape back, feeding the
+      output projection. Ranked and pruned the same KV-group way as the
+      separate-producer family above (or, for true MQA -- a single shared KV
+      head -- by individual query head instead, since group-granularity
+      ranking can never distinguish anything when there is only one group).
 
-    The calibration-driven Wanda upgrade of this same matching/ranking
+    Also prunes ``com.microsoft::MatMulNBitsQkv`` (a block-quantized,
+    weight-only int4/int8 fused QKV projection) at whole-KV-group
+    granularity, reusing this function's own GQA/plain-Attention head-count-
+    matching machinery -- the C++ port's counterpart of
+    :func:`onnxsim.apply_structured_pruning_matmul_nbits`'s own
+    ``MatMulNBitsQkv`` handling (deliberately consolidated here rather than
+    in :func:`onnxsim.apply_structured_pruning_cpp`, which explicitly defers
+    to this function for that one op -- see that function's own docstring).
+
+    The calibration-driven Wanda upgrade of the three fused-op families above
     (mirroring the pure-Python :func:`onnxsim.apply_attention_head_wanda_pruning`)
-    is :func:`onnxsim.apply_attention_head_wanda_pruning_cpp`.
+    is :func:`onnxsim.apply_attention_head_wanda_pruning_cpp` -- which does
+    NOT include the ``MatMulNBitsQkv`` family, mirroring pruning.py's own
+    scope (no calibration-driven counterpart of
+    :func:`onnxsim.apply_structured_pruning_matmul_nbits` exists there
+    either).
 
     This is a single, self-contained graph rewrite: unlike :func:`simplify`,
     it does not run shape inference, constant folding, or any other pass.
 
     :param model: the original onnx ModelProto or file path
     :param sparsity: target fraction of each matched block's heads (or, for
-            GroupQueryAttention/plain ai.onnx Attention, KV groups) to
-            remove (at least one is always kept); must be in ``[0, 1)``
+            the separate-producer/decomposed families, KV groups) to remove
+            (at least one is always kept); must be in ``[0, 1)``
     :param importance_norm: ``"l2"`` (default, unchanged from before this
             parameter existed) ranks by the combined Frobenius (L2) norm of
             each head's/KV group's own weight block, mirroring the
@@ -1617,13 +1654,13 @@ def apply_attention_head_pruning_cpp(
             across that same block instead.
     :returns: ``model`` with every matched block's tensors resized in
             place; anything not matching that exact topology (a
-            non-constant weight, a packed-QKV GroupQueryAttention node, a
-            GroupQueryAttention/plain ai.onnx Attention node with a
-            non-empty constant past-KV-cache or attention-mask input, an
-            ai.onnx Attention node with differing Q/K/V head sizes or
-            without explicit ``q_num_heads``/``kv_num_heads`` attributes, a
-            consumer whose reduction dimension doesn't line up, ...) is
-            left completely untouched
+            non-constant or unsupported-dtype weight, a packed-QKV
+            GroupQueryAttention node, a node with a non-empty constant
+            past-KV-cache or attention-mask input, an ai.onnx Attention node
+            with differing Q/K/V head sizes or without explicit
+            ``q_num_heads``/``kv_num_heads`` attributes, a consumer whose
+            reduction dimension doesn't line up, ...) is left completely
+            untouched
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -108,6 +108,45 @@
 // model happened to carry).
 #include "partial_shape_eval.h"
 
+// Forward declarations of this file's own generic per-head mask/bias slicing
+// infrastructure (SliceAxisGeneric/HeadBiasInputIsSafe/SliceOrGatherHeadBias)
+// and its own generic "every name already live in `graph`" helper
+// (ExistingGraphNames) -- all four defined much later in the file (the
+// decomposed-GQA additive-mask section and its own MintUniqueName/
+// InsertDynamicHeadBiasGather neighbors), but, like this file's own
+// IsSupportedFloatDtype/ReadTensorAsF64/WriteF64TensorAs trio below, at
+// GLOBAL scope, not inside the anonymous namespace this comment sits just
+// above -- that namespace is closed and reopened more than once across this
+// file, and every one of these four definitions happens to sit in the gap
+// between two of those reopenings. So these declarations must also live at
+// global scope, not be repeated inside the anonymous namespace itself: a
+// same-signature declaration placed in there would create a SECOND, distinct
+// (anonymous-namespace-linkage) entity, ambiguous against this one at every
+// call site inside that namespace. Needed here so
+// MatchDecoderMaskedMultiHeadAttentionProducer/ApplyOneGqaChain/
+// ApplyAttentionChains -- defined earlier in the file, inside the anonymous
+// namespace -- can reuse this section's existing per-head mask/bias/unique-
+// name machinery (closing this port's own DecoderMaskedMultiHeadAttention/
+// PagedAttention optional-per-head-input parity gap) rather than duplicating
+// any of it a second time.
+bool HeadBiasInputIsSafe(
+    const onnx::NodeProto& node, int idx,
+    const std::unordered_map<std::string, const onnx::TensorProto*>& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name,
+    int64_t num_heads);
+void SliceAxisGeneric(onnx::TensorProto* t, const std::vector<int64_t>& keep,
+                      int64_t axis);
+void SliceOrGatherHeadBias(
+    onnx::NodeProto* node, int idx,
+    std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    int64_t num_heads, const std::vector<int64_t>& keep,
+    onnx::GraphProto* graph, std::unordered_set<std::string>& used_names,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name);
+std::unordered_set<std::string> ExistingGraphNames(
+    const onnx::GraphProto& graph);
+
 namespace {
 
 constexpr int kMaxChainHops = 8;
@@ -403,6 +442,18 @@ std::optional<MatMulLikeMatch> MatchMatMulLikeRaw(const onnx::NodeProto& node) {
 using InitMap = std::unordered_map<std::string, const onnx::TensorProto*>;
 using ConsumerMap =
     std::unordered_map<std::string, std::vector<onnx::NodeProto*>>;
+
+// Forward declaration of this file's own FLOAT/FLOAT16/BFLOAT16 dtype gate --
+// defined much later in the file (the MoE/QMoE whole-expert pruning
+// section), but inside this SAME anonymous namespace, so an ordinary
+// same-scope forward declaration (unlike the cross-namespace ones just above
+// this namespace's own opening brace) suffices: needed here so
+// MatchDecoderMaskedMultiHeadAttentionProducer/MatchPagedAttentionProducer
+// and their own new PastKvConstantsAreSliceable/PagedKvScaleIsSliceable
+// helpers below -- defined earlier in the file, before that section -- can
+// reuse it rather than duplicating the same FLOAT16/BFLOAT16 dtype check a
+// second time.
+bool IsSupportedFloatDtype(int32_t data_type);
 
 ConsumerMap ConsumersOf(onnx::GraphProto* graph) {
   ConsumerMap out;
@@ -5442,8 +5493,11 @@ struct HeadCountsMatch {
 // safely act on (separate Q/K/V inputs -- rules out the op's packed-QKV
 // calling convention; no non-empty constant past_key/past_value), returns
 // (num_heads, kv_num_heads). Mirrors pruning.py's own _match_gqa_producer.
-std::optional<HeadCountsMatch> MatchGqaProducer(const onnx::NodeProto& node,
-                                                const InitMap& init_map) {
+std::optional<HeadCountsMatch> MatchGqaProducer(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "GroupQueryAttention") {
     return std::nullopt;
@@ -5491,7 +5545,10 @@ std::optional<HeadCountsMatch> MatchGqaProducer(const onnx::NodeProto& node,
 // pass can safely act on, returns (q_num_heads, kv_num_heads). Mirrors
 // pruning.py's own _match_onnx_attention_producer.
 std::optional<HeadCountsMatch> MatchOnnxAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (!node.domain().empty() || node.op_type() != "Attention") {
     return std::nullopt;
   }
@@ -5588,7 +5645,10 @@ bool NoNonEmptyConstantAt(const onnx::NodeProto& node, const InitMap& init_map,
 // already get -- this port doesn't slice either past_kv tensor for this op
 // either, the same gap GQA/OnnxAttention already have).
 std::optional<HeadCountsMatch> MatchMultiHeadAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "MultiHeadAttention") {
     return std::nullopt;
@@ -5628,7 +5688,10 @@ std::optional<HeadCountsMatch> MatchMultiHeadAttentionProducer(
 // all (packing mode is an encoder-only, non-incremental-decode
 // optimization), so there is no KV-cache pair to gate here.
 std::optional<HeadCountsMatch> MatchPackedMultiHeadAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "PackedMultiHeadAttention") {
     return std::nullopt;
@@ -5654,6 +5717,109 @@ std::optional<HeadCountsMatch> MatchPackedMultiHeadAttentionProducer(
   return HeadCountsMatch{num_heads, num_heads};
 }
 
+// The three quantized-cache dtypes GroupQueryAttention's own T_CACHE type
+// constraint allows for past_key/past_value beyond plain FLOAT/FLOAT16/
+// BFLOAT16 -- mirrors pruning.py's own `_QUANTIZED_KV_CACHE_DTYPES` exactly.
+// `DecoderMaskedMultiHeadAttentionProducer` below never passes
+// `scale_indices` to `PastKvConstantsAreSliceable` (its own schema has no
+// `k_scale`/`v_scale` inputs at all -- confirmed off the same live schema
+// dump pruning.py's own docstring cites), so this set is only ever consulted
+// there to correctly DECLINE a quantized cache (never to accept one) --
+// still ported here at the generic-helper level, rather than hand-inlined as
+// "never accept a non-float dtype", so `PastKvConstantsAreSliceable` itself
+// stays a faithful, directly reusable port of pruning.py's own function
+// signature (indices, kv_num_heads, optional scale_indices) for any future
+// GroupQueryAttention/PagedAttention-side port of this same past_key/
+// past_value gap.
+const std::unordered_set<int32_t>& QuantizedKvCacheDtypes() {
+  static const std::unordered_set<int32_t> kDtypes = {
+      onnx::TensorProto::UINT8, onnx::TensorProto::INT8,
+      onnx::TensorProto::FLOAT8E4M3FN};
+  return kDtypes;
+}
+
+// Shared safety gate for a matched node's optional past_key/past_value
+// inputs (at `indices`, a (past_key_idx, past_value_idx) pair) -- mirrors
+// pruning.py's own `_past_kv_constants_are_sliceable` exactly. Both ops'
+// schemas this port currently calls this for lay a connected past_key/
+// past_value out in BNSH format (batch_size, kv_num_heads,
+// past_sequence_length, head_size_or_v_head_size), so the kv_num_heads axis
+// sits at axis 1 of a rank-4 tensor -- exactly the axis
+// ApplyOneGqaChain's own `keep_groups`/`keep_q_heads` index set already
+// selects along K's/V's own producer weight. A *dynamic* (non-constant)
+// past_key/past_value is always left alone and never blocks a match: it is
+// the caller's own runtime data. A *constant* one is declined when its shape
+// isn't confidently this exact layout (not rank 4, or its axis-1 length
+// doesn't already match `kv_num_heads`); a plain FLOAT/FLOAT16/BFLOAT16
+// constant of that shape is always accepted (IsSupportedFloatDtype -- this
+// port's own bounded dtype scope, mirroring HeadBiasInputIsSafe's own
+// identical bound below, narrower than pruning.py's own dtype-agnostic
+// acceptance of ANY plain-float dtype including `double`, a dtype this
+// port's own generic slicing infrastructure has no support for anywhere).
+// A quantized (`float8e4m3fn`/`uint8`/`int8`, see QuantizedKvCacheDtypes
+// above) constant is only ever accepted when the caller passes
+// `scale_indices` naming its own `k_scale`/`v_scale` inputs, and even then
+// only when that scale itself resolves cleanly (a `"PER_TENSOR"` scalar
+// broadcast, needing no slicing at all, or a `"PER_CHANNEL"`
+// `[1, kv_num_heads, 1, head_size]` constant, sliceable along the identical
+// axis 1) -- `DecoderMaskedMultiHeadAttentionProducer` below never passes
+// `scale_indices` (no such inputs on its own schema), so a quantized
+// past_key/past_value there is always declined outright, exactly as
+// pruning.py's own analogous call does.
+bool PastKvConstantsAreSliceable(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    std::pair<int, int> indices, int64_t kv_num_heads,
+    std::optional<std::pair<int, int>> scale_indices = std::nullopt) {
+  const int idxs[2] = {indices.first, indices.second};
+  const int scale_idxs[2] = {scale_indices ? scale_indices->first : -1,
+                             scale_indices ? scale_indices->second : -1};
+  for (int i = 0; i < 2; ++i) {
+    const int idx = idxs[i];
+    const int scale_idx = scale_idxs[i];
+    if (node.input_size() <= idx || node.input(idx).empty()) {
+      continue;
+    }
+    auto past_it = init_map.find(node.input(idx));
+    if (past_it == init_map.end()) {
+      continue;  // dynamic -- the caller's own runtime data, left alone
+    }
+    const onnx::TensorProto& past_init = *past_it->second;
+    if (past_init.dims_size() != 4 || past_init.dims(1) != kv_num_heads) {
+      return false;  // not a shape this function can safely slice
+    }
+    if (IsSupportedFloatDtype(past_init.data_type())) {
+      continue;  // unquantized cache -- nothing else to check
+    }
+    if (scale_idx < 0 ||
+        !QuantizedKvCacheDtypes().count(past_init.data_type())) {
+      return false;  // quantized dtype with nowhere to locate its scale
+    }
+    if (node.input_size() <= scale_idx || node.input(scale_idx).empty()) {
+      return false;  // quantized cache with no k_scale/v_scale connected
+    }
+    auto scale_it = init_map.find(node.input(scale_idx));
+    if (scale_it == init_map.end()) {
+      continue;  // dynamic scale -- the caller's own runtime data
+    }
+    const onnx::TensorProto& scale_init = *scale_it->second;
+    if (scale_init.data_type() != onnx::TensorProto::FLOAT) {
+      return false;  // not T_KV_SCALE's own float-only constraint
+    }
+    int64_t prod = 1;
+    for (int64_t d : scale_init.dims()) {
+      prod *= d;
+    }
+    if (prod == 1) {
+      continue;  // PER_TENSOR: a single broadcast scalar, nothing to slice
+    }
+    if (scale_init.dims_size() != 4 || scale_init.dims(1) != kv_num_heads) {
+      return false;  // not the PER_CHANNEL [1, kv_num_heads, 1, head_size]
+                     // layout
+    }
+  }
+  return true;
+}
+
 // The com.microsoft::DecoderMaskedMultiHeadAttention analogue of
 // MatchMultiHeadAttentionProducer -- mirrors pruning.py's own
 // _match_decoder_masked_multi_head_attention_producer. Single `num_heads`
@@ -5661,13 +5827,25 @@ std::optional<HeadCountsMatch> MatchPackedMultiHeadAttentionProducer(
 // **4** (not 5), `past_key`/`past_value` at **5/6** (not 6/7) -- genuinely
 // different positions from MultiHeadAttention's own, confirmed off both the
 // live schema dump and ONNX Runtime's own `replace_mha_with_dmmha` rewrite
-// (see pruning.py's own docstring) -- gated the same
-// decline-if-non-empty-constant way as MultiHeadAttention's own analogous
-// inputs, for the identical reason (no slicing machinery ported for either).
-// This op's own combined `bias` moves to index **10**, the last input (see
-// FindDecoderMaskedMhaChains below).
+// (see pruning.py's own docstring). Unlike MultiHeadAttention/
+// PackedMultiHeadAttention above (whose own analogous inputs still decline
+// the whole match outright whenever non-empty -- a documented, narrower-
+// than-pruning.py gap left for a follow-up), `attention_bias` gets the exact
+// constant-resolves-cleanly-or-is-declined treatment
+// pruning.py's own `_head_bias_input_is_safe` gives it (HeadBiasInputIsSafe,
+// this port's own existing decomposed-GQA machinery, reused outright here),
+// and `past_key`/`past_value` get PastKvConstantsAreSliceable's own
+// identical BNSH-axis-1 treatment (no `scale_indices` -- this op's own
+// schema has no `k_scale`/`v_scale` inputs at all) -- ApplyOneGqaChain's own
+// `is_dmmha` branch performs the actual per-head slice(s)/Gather-insertion
+// of both once a match succeeds, mirroring pruning.py's own
+// `_apply_one_gqa_chain` exactly for this op (`mask_idx=4`,
+// `past_kv_indices=(5, 6)`). This op's own combined `bias` moves to index
+// **10**, the last input (see FindDecoderMaskedMhaChains below).
 std::optional<HeadCountsMatch> MatchDecoderMaskedMultiHeadAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "DecoderMaskedMultiHeadAttention") {
     return std::nullopt;
@@ -5687,10 +5865,58 @@ std::optional<HeadCountsMatch> MatchDecoderMaskedMultiHeadAttentionProducer(
   if (!has_nh || num_heads <= 0) {
     return std::nullopt;
   }
-  if (!NoNonEmptyConstantAt(node, init_map, {4, 5, 6})) {
-    return std::nullopt;  // attention_bias, past_key, past_value
+  if (node.input_size() > 4 && !node.input(4).empty()) {  // attention_bias
+    if (!HeadBiasInputIsSafe(node, 4, init_map, value_info_by_name,
+                             num_heads)) {
+      return std::nullopt;  // doesn't statically resolve -- decline rather
+                            // than guess
+    }
+  }
+  if (!PastKvConstantsAreSliceable(node, init_map, {5, 6}, num_heads)) {
+    return std::nullopt;
   }
   return HeadCountsMatch{num_heads, num_heads};
+}
+
+// Safety gate for one of PagedAttention's own k_scale/v_scale inputs
+// (indices 14/15 -- *not* the same positions GroupQueryAttention's own
+// analogous inputs sit at, 12/13) -- mirrors pruning.py's own
+// `_paged_kv_scale_is_sliceable` exactly. Unlike GroupQueryAttention's own
+// k_scale/v_scale (PastKvConstantsAreSliceable's own `scale_indices` branch,
+// shape [1, kv_num_heads, 1, head_size] when "PER_CHANNEL" -- the KV axis at
+// position 1 of a rank-4 tensor), PagedAttention's own doc gives its
+// analogous inputs a *different* shape: rank 3, (kv_num_heads, 1,
+// head_size) when "PER_CHANNEL" -- the KV axis at position *0*, not 1. A
+// constant one is accepted here at either shape ("PER_TENSOR", a single
+// broadcast scalar needing no slicing at all, or "PER_CHANNEL", sliceable
+// along axis 0 by the same `keep_groups` index set used everywhere else in
+// this chain); declined for any other constant shape; left alone when
+// unconnected or dynamic.
+bool PagedKvScaleIsSliceable(const onnx::NodeProto& node,
+                             const InitMap& init_map, int idx,
+                             int64_t kv_num_heads) {
+  if (node.input_size() <= idx || node.input(idx).empty()) {
+    return true;  // unconnected -- nothing to check
+  }
+  auto scale_it = init_map.find(node.input(idx));
+  if (scale_it == init_map.end()) {
+    return true;  // dynamic -- the caller's own runtime data, left alone
+  }
+  const onnx::TensorProto& scale_init = *scale_it->second;
+  if (scale_init.data_type() != onnx::TensorProto::FLOAT) {
+    return false;  // not T_KV_SCALE's own float-only constraint
+  }
+  int64_t prod = 1;
+  for (int64_t d : scale_init.dims()) {
+    prod *= d;
+  }
+  if (prod == 1) {
+    return true;  // PER_TENSOR: a single broadcast scalar, nothing to slice
+  }
+  if (scale_init.dims_size() != 3 || scale_init.dims(0) != kv_num_heads) {
+    return false;  // not the PER_CHANNEL (kv_num_heads, 1, head_size) layout
+  }
+  return true;
 }
 
 // If `node` is a com.microsoft::PagedAttention node (kv_cache_layout ==
@@ -5706,17 +5932,38 @@ std::optional<HeadCountsMatch> MatchDecoderMaskedMultiHeadAttentionProducer(
 // declined outright whenever either resolves to a constant (this op's own
 // cache is "updated in place" by a real continuous-batching serving
 // harness -- a constant one is not a real export this pass has any
-// execution-verified story for, per pruning.py's own docstring).
+// execution-verified story for, per pruning.py's own docstring) -- a
+// *dynamic* one is always left alone and never sliced, the identical "no
+// analogue of PastKvConstantsAreSliceable's own slicing here" scope
+// pruning.py's own matcher documents (this op's own cache buffer is
+// "updated in place" by the serving harness, never a captured weight the
+// way GroupQueryAttention's own optional past_key/past_value legitimately
+// can be).
 //
-// Narrower than pruning.py's own matcher in one deliberate way: `head_sink`
-// (11), `q_norm_weight`/`k_norm_weight` (12/13), and `k_scale`/`v_scale`
-// (14/15) are none of them ever sliced by this port (no analogue of
-// pruning.py's own deferred-shape-check/slicing machinery for any of the
-// three), so a match here requires every one of them absent, rather than
-// risk a present-and-genuinely-per-head/per-KV-group one silently going
-// unsliced after `num_heads`/`kv_num_heads` shrink underneath it.
+// `head_sink` (index 11, documented shape (num_heads,)) is accepted here at
+// either a genuine (num_heads,) constant -- sliced by ApplyOneGqaChain's own
+// `is_paged` branch along its sole axis by `keep_q_heads`, bounded to
+// FLOAT/FLOAT16/BFLOAT16 (IsSupportedFloatDtype) the same way
+// HeadBiasInputIsSafe already bounds its own per-head constant -- unlike
+// pruning.py's own dtype-agnostic acceptance of any constant dtype there;
+// this port's own SliceAxisGeneric, its apply-time rewrite for this case,
+// only handles those three encodings) -- or dynamic (left alone
+// unconditionally, no check at all, exactly mirroring pruning.py's own
+// `_match_paged_attention_producer`, which only ever inspects a *constant*
+// `head_sink`'s own shape). `q_norm_weight`/`k_norm_weight` (12/13) are
+// validated here only for the schema's own paired-presence rule ("must be
+// provided together") -- the deferred exact-(head_size,)-shape half of that
+// check, run once `head_size` is known, is FindSeparateQkvChains' own job
+// (its `qk_norm_weight_indices` parameter, which FindPagedAttentionChains
+// passes `(12, 13)`) -- neither is ever sliced (a (head_size,)-shaped tensor
+// never needs touching under whole-head/KV-group pruning), mirroring
+// pruning.py's own identical two-stage validation split exactly. `k_scale`/
+// `v_scale` (14/15) get PagedKvScaleIsSliceable's own treatment above.
 std::optional<HeadCountsMatch> MatchPagedAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "PagedAttention") {
     return std::nullopt;
@@ -5761,10 +6008,28 @@ std::optional<HeadCountsMatch> MatchPagedAttentionProducer(
   if (init_map.count(node.input(3)) || init_map.count(node.input(4))) {
     return std::nullopt;  // constant key_cache/value_cache -- out of scope
   }
-  for (int idx : {11, 12, 13, 14, 15}) {  // head_sink, qk_norm, k/v_scale
-    if (node.input_size() > idx && !node.input(idx).empty()) {
-      return std::nullopt;
+  if (node.input_size() > 11 && !node.input(11).empty()) {  // head_sink
+    auto sink_it = init_map.find(node.input(11));
+    if (sink_it != init_map.end()) {
+      if (sink_it->second->dims_size() != 1 ||
+          sink_it->second->dims(0) != num_heads) {
+        return std::nullopt;  // not the schema's own (num_heads,) shape
+      }
+      if (!IsSupportedFloatDtype(sink_it->second->data_type())) {
+        return std::nullopt;  // SliceAxisGeneric-bounded dtype scope, see
+                              // this function's own comment above
+      }
     }
+    // else: dynamic -- left alone, no check at all (mirrors pruning.py)
+  }
+  const bool has_q_norm = node.input_size() > 12 && !node.input(12).empty();
+  const bool has_k_norm = node.input_size() > 13 && !node.input(13).empty();
+  if (has_q_norm != has_k_norm) {
+    return std::nullopt;  // schema: "must be provided together"
+  }
+  if (!PagedKvScaleIsSliceable(node, init_map, 14, kv_num_heads) ||
+      !PagedKvScaleIsSliceable(node, init_map, 15, kv_num_heads)) {
+    return std::nullopt;
   }
   return HeadCountsMatch{num_heads, kv_num_heads};
 }
@@ -5789,7 +6054,10 @@ std::optional<HeadCountsMatch> MatchPagedAttentionProducer(
 // matcher/finder pair uses -- gives up essentially nothing over the
 // realistic export shape while avoiding new, unverified slicing machinery.
 std::optional<HeadCountsMatch> MatchLinearAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& /*init_map*/) {
+    const onnx::NodeProto& node, const InitMap& /*init_map*/,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (!node.domain().empty() || node.op_type() != "LinearAttention") {
     return std::nullopt;
   }
@@ -5839,7 +6107,10 @@ std::optional<HeadCountsMatch> MatchLinearAttentionProducer(
 // `key_total_sequence_lengths` (7/8) required present (pure bookkeeping,
 // checked only for presence -- a genuinely incomplete node otherwise).
 std::optional<HeadCountsMatch> MatchSparseAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "SparseAttention") {
     return std::nullopt;
@@ -5914,9 +6185,14 @@ std::optional<HeadCountsMatch> MatchSparseAttentionProducer(
 std::vector<AttnChain> FindSeparateQkvChains(
     onnx::GraphProto* graph,
     const std::function<std::optional<HeadCountsMatch>(
-        const onnx::NodeProto&, const InitMap&)>& match_producer,
+        const onnx::NodeProto&, const InitMap&,
+        const std::unordered_map<std::string, const onnx::ValueInfoProto*>&)>&
+        match_producer,
     const std::string& num_heads_attr,
-    std::optional<int> combined_bias_input_index = std::nullopt) {
+    std::optional<int> combined_bias_input_index = std::nullopt,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {},
+    std::optional<std::pair<int, int>> qk_norm_weight_indices = std::nullopt) {
   InitMap init_map;
   for (const auto& t : graph->initializer()) {
     init_map[t.name()] = &t;
@@ -5940,7 +6216,7 @@ std::vector<AttnChain> FindSeparateQkvChains(
   std::vector<AttnChain> chains;
   for (int i = 0; i < graph->node_size(); ++i) {
     onnx::NodeProto* node = graph->mutable_node(i);
-    auto info = match_producer(*node, init_map);
+    auto info = match_producer(*node, init_map, value_info_by_name);
     if (!info) {
       continue;
     }
@@ -5981,6 +6257,36 @@ std::vector<AttnChain> FindSeparateQkvChains(
       // shared, uniform-head_size body declines that composition rather
       // than mis-slicing it.
       continue;
+    }
+
+    // PagedAttention-only (see MatchPagedAttentionProducer's own comment):
+    // its own q_norm_weight/k_norm_weight, when connected, are only ever
+    // validated for paired presence at match time (head_size isn't known
+    // yet there) -- the deferred exact-(head_size,)-shape half of that check
+    // runs here, now that head_size is settled, mirroring pruning.py's own
+    // `_find_separate_qkv_chains` `qk_norm_weight_indices` branch exactly. A
+    // connected constant not exactly (head_size,)-shaped declines the whole
+    // match outright; a dynamic one (or an unconnected pair) needs no check
+    // at all here -- neither is ever sliced regardless (a (head_size,)-
+    // shaped tensor never needs touching under whole-head/KV-group pruning).
+    if (qk_norm_weight_indices) {
+      bool bad_norm_shape = false;
+      for (int norm_idx :
+           {qk_norm_weight_indices->first, qk_norm_weight_indices->second}) {
+        if (node->input_size() <= norm_idx || node->input(norm_idx).empty()) {
+          continue;
+        }
+        auto norm_it = init_map.find(node->input(norm_idx));
+        if (norm_it != init_map.end() &&
+            (norm_it->second->dims_size() != 1 ||
+             norm_it->second->dims(0) != head_size)) {
+          bad_norm_shape = true;
+          break;
+        }
+      }
+      if (bad_norm_shape) {
+        continue;
+      }
     }
 
     // MultiHeadAttention/PackedMultiHeadAttention/
@@ -6079,17 +6385,33 @@ std::vector<AttnChain> FindPackedMhaChains(onnx::GraphProto* graph) {
 // FindMhaChains -- see MatchDecoderMaskedMultiHeadAttentionProducer's own
 // comment. `combined_bias_input_index = 10`: this op's own `bias` input,
 // moved to the *last* position (not index 3, MultiHeadAttention's own).
-std::vector<AttnChain> FindDecoderMaskedMhaChains(onnx::GraphProto* graph) {
-  return FindSeparateQkvChains(graph,
-                               MatchDecoderMaskedMultiHeadAttentionProducer,
-                               "num_heads", /*combined_bias_input_index=*/10);
+// `value_info_by_name`, defaulted to `{}` (see FindAttentionChains' own
+// analogous default's own reasoning), is threaded straight through to
+// MatchDecoderMaskedMultiHeadAttentionProducer's own
+// `match_producer(node, init_map, value_info_by_name)` call -- the one
+// matcher in this family whose own per-head `attention_bias` input needs it,
+// to classify a *dynamic* one's declared shape (HeadBiasInputIsSafe).
+std::vector<AttnChain> FindDecoderMaskedMhaChains(
+    onnx::GraphProto* graph,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
+  return FindSeparateQkvChains(
+      graph, MatchDecoderMaskedMultiHeadAttentionProducer, "num_heads",
+      /*combined_bias_input_index=*/10, value_info_by_name);
 }
 
 // The com.microsoft::PagedAttention analogue of FindGqaChains -- see
 // MatchPagedAttentionProducer's own comment. No combined bias input on this
-// op's own schema.
+// op's own schema (this op has no attention_bias/attn_mask-equivalent input
+// at all). `qk_norm_weight_indices=(12, 13)` -- this op's own
+// q_norm_weight/k_norm_weight input indices -- mirrors pruning.py's own
+// `_find_paged_attention_chains`, which passes the identical pair for the
+// identical deferred exact-(head_size,)-shape check (see
+// FindSeparateQkvChains' own comment on that branch).
 std::vector<AttnChain> FindPagedAttentionChains(onnx::GraphProto* graph) {
-  return FindSeparateQkvChains(graph, MatchPagedAttentionProducer, "num_heads");
+  return FindSeparateQkvChains(graph, MatchPagedAttentionProducer, "num_heads",
+                               /*combined_bias_input_index=*/std::nullopt, {},
+                               std::make_pair(12, 13));
 }
 
 // The plain ai.onnx::LinearAttention analogue of FindGqaChains -- see
@@ -6302,8 +6624,11 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     AttnChain& chain, double sparsity,
     const std::unordered_map<std::string, std::vector<double>>* act_norm =
         nullptr,
-    double epsilon = 1e-8,
-    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
+    double epsilon = 1e-8, ImportanceNorm importance_norm = ImportanceNorm::kL2,
+    onnx::GraphProto* graph = nullptr,
+    std::unordered_set<std::string>* used_names = nullptr,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   const int64_t h = chain.kv_num_heads;
   const int64_t keep_count =
       std::max<int64_t>(1, h - std::llround(static_cast<double>(h) * sparsity));
@@ -6476,6 +6801,69 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     SliceLastAxis(init_map.at(*chain.mha_bias), full_bias_idx);
   }
 
+  // DecoderMaskedMultiHeadAttention-only: attention_bias (index 4) and
+  // past_key/past_value (indices 5/6) -- mirrors pruning.py's own
+  // `_apply_one_gqa_chain` `is_dmmha` branch (`mask_idx=4`,
+  // `past_kv_indices=(5, 6)`) exactly. `graph`/`used_names` may be null when
+  // a caller has no dynamic-Gather-insertion machinery wired up (every
+  // ApplyAttentionChains call site does, so this is purely defensive) --
+  // SliceOrGatherHeadBias is never reached in that case, since a chain of
+  // this kind is only ever produced once MatchDecoderMaskedMultiHeadAttention
+  // Producer has already confirmed, at match time, that `attention_bias`
+  // resolves cleanly one way or another.
+  const bool is_dmmha =
+      chain.node->domain() == kComMicrosoftDomain &&
+      chain.node->op_type() == "DecoderMaskedMultiHeadAttention";
+  if (is_dmmha) {
+    if (graph != nullptr && used_names != nullptr) {
+      SliceOrGatherHeadBias(chain.node, 4, init_map, chain.num_heads,
+                            keep_q_heads, graph, *used_names,
+                            value_info_by_name);
+    }
+    for (int idx : {5, 6}) {  // past_key, past_value
+      if (chain.node->input_size() <= idx || chain.node->input(idx).empty()) {
+        continue;
+      }
+      auto past_it = init_map.find(chain.node->input(idx));
+      if (past_it != init_map.end()) {
+        SliceAxisGeneric(past_it->second, keep_groups, 1);
+      }
+    }
+  }
+
+  // PagedAttention-only: head_sink (index 11, sliced by `keep_q_heads` along
+  // its own sole axis, no head_size expansion needed) and k_scale/v_scale
+  // (indices 14/15, PER_CHANNEL only -- a PER_TENSOR broadcast scalar needs
+  // no slicing at all -- sliced along axis *0*, not axis 1, by
+  // `keep_groups`) -- mirrors pruning.py's own `_apply_one_gqa_chain`
+  // `is_paged` branch exactly (see MatchPagedAttentionProducer's own comment
+  // for why these positions/shapes differ from GroupQueryAttention's own
+  // analogous inputs).
+  const bool is_paged = chain.node->domain() == kComMicrosoftDomain &&
+                        chain.node->op_type() == "PagedAttention";
+  if (is_paged) {
+    if (chain.node->input_size() > 11 && !chain.node->input(11).empty()) {
+      auto sink_it = init_map.find(chain.node->input(11));
+      if (sink_it != init_map.end()) {
+        SliceAxisGeneric(sink_it->second, keep_q_heads, 0);
+      }
+    }
+    for (int idx : {14, 15}) {  // k_scale, v_scale
+      if (chain.node->input_size() <= idx || chain.node->input(idx).empty()) {
+        continue;
+      }
+      auto scale_it = init_map.find(chain.node->input(idx));
+      if (scale_it == init_map.end()) {
+        continue;  // dynamic -- caller's own runtime data, left alone
+      }
+      if (scale_it->second->dims_size() == 3 &&
+          scale_it->second->dims(0) == h) {
+        SliceAxisGeneric(scale_it->second, keep_groups, 0);
+      }
+      // else: PER_TENSOR broadcast scalar -- no per-head axis to slice
+    }
+  }
+
   const int64_t new_kv_num_heads = keep_count;
   const int64_t new_num_heads = keep_count * group_size;
   for (auto& attr : *chain.node->mutable_attribute()) {
@@ -6516,13 +6904,19 @@ void ApplyAttentionChains(
     onnx::GraphProto* graph, std::vector<AttnChain>& chains, double sparsity,
     const std::unordered_map<std::string, std::vector<double>>* act_norm =
         nullptr,
-    double epsilon = 1e-8,
-    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
+    double epsilon = 1e-8, ImportanceNorm importance_norm = ImportanceNorm::kL2,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   std::unordered_map<std::string, onnx::TensorProto*> init_map;
   for (int i = 0; i < graph->initializer_size(); ++i) {
     onnx::TensorProto* t = graph->mutable_initializer(i);
     init_map[t->name()] = t;
   }
+  // Seed set for DecoderMaskedMultiHeadAttention's own dynamic
+  // `attention_bias` Gather-insertion path (SliceOrGatherHeadBias ->
+  // InsertDynamicHeadBiasGather -> MintUniqueName) -- mirrors
+  // ApplyDecomposedGqaChains' own identical `used_names` seeding.
+  std::unordered_set<std::string> used_names = ExistingGraphNames(*graph);
   std::unordered_set<std::string> producer_touched, consumer_touched,
       stale_value_info;
 
@@ -6546,7 +6940,8 @@ void ApplyAttentionChains(
     std::optional<AppliedAttn> applied =
         chain.kind == AttnChainKind::kGqaLike
             ? ApplyOneGqaChain(init_map, chain, sparsity, act_norm, epsilon,
-                               importance_norm)
+                               importance_norm, graph, &used_names,
+                               value_info_by_name)
             : ApplyOnePlainAttentionChain(init_map, chain, sparsity, act_norm,
                                           epsilon, importance_norm);
     if (!applied) {
@@ -24891,6 +25286,16 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
   // Mirrors pruning.py's own apply_attention_head_pruning loop over
   // `_iter_subgraphs(out.graph)`.
   for (onnx::GraphProto* graph : IterSubgraphs(out.mutable_graph())) {
+    // This graph's own AS-DECLARED input/output/value_info (ValueInfoByName)
+    // -- computed once up front (rather than only ahead of the decomposed-GQA
+    // section below, its own original sole consumer) so
+    // FindDecoderMaskedMhaChains/ApplyAttentionChains can also thread it
+    // through to HeadBiasInputIsSafe/SliceOrGatherHeadBias for
+    // DecoderMaskedMultiHeadAttention's own per-head `attention_bias`
+    // classification, exactly the same "no real shape-inference pass backs
+    // it" convention FindDecomposedGqaChains' own section comment already
+    // documents.
+    auto value_info_by_name = ValueInfoByName(*graph);
     std::vector<AttnChain> chains = FindAttentionChains(graph);
     std::vector<AttnChain> gqa_chains = FindGqaChains(graph);
     std::vector<AttnChain> onnx_attn_chains = FindOnnxAttentionChains(graph);
@@ -24903,7 +25308,8 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
     // scope decisions).
     std::vector<AttnChain> mha_chains = FindMhaChains(graph);
     std::vector<AttnChain> packed_mha_chains = FindPackedMhaChains(graph);
-    std::vector<AttnChain> dmmha_chains = FindDecoderMaskedMhaChains(graph);
+    std::vector<AttnChain> dmmha_chains =
+        FindDecoderMaskedMhaChains(graph, value_info_by_name);
     std::vector<AttnChain> paged_chains = FindPagedAttentionChains(graph);
     std::vector<AttnChain> linear_attn_chains =
         FindLinearAttentionChains(graph);
@@ -24930,7 +25336,8 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
                   std::make_move_iterator(sparse_attn_chains.begin()),
                   std::make_move_iterator(sparse_attn_chains.end()));
     if (!chains.empty()) {
-      ApplyAttentionChains(graph, chains, sparsity, nullptr, 1e-8, norm);
+      ApplyAttentionChains(graph, chains, sparsity, nullptr, 1e-8, norm,
+                           value_info_by_name);
     }
     // The fully decomposed (un-fused, "eager SDPA export") shape
     // pruning.py's own `_find_decomposed_gqa_chains` additionally matches --
@@ -24943,17 +25350,13 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
     // touched bookkeeping (inside ApplyDecomposedGqaChains) is never shared
     // with ApplyAttentionChains's own above, the same "structurally
     // different node/weight shapes, always safe" reasoning this section's
-    // own MatMulNBitsQkv handling below already documents. `value_info_by_
-    // name` here is this graph's own AS-DECLARED input/output/value_info
-    // (ValueInfoByName) -- see FindDecomposedGqaChains' own section comment
-    // for why no real shape-inference pass backs it, here or at the top
-    // level, unlike pruning.py's own top-level-graph case.
-    auto decomposed_value_info_by_name = ValueInfoByName(*graph);
+    // own MatMulNBitsQkv handling below already documents. Reuses this
+    // graph's own `value_info_by_name`, computed once above.
     std::vector<DecomposedGqaChain> decomposed_gqa_chains =
-        FindDecomposedGqaChains(graph, decomposed_value_info_by_name);
+        FindDecomposedGqaChains(graph, value_info_by_name);
     if (!decomposed_gqa_chains.empty()) {
       ApplyDecomposedGqaChains(graph, decomposed_gqa_chains, sparsity, nullptr,
-                               1e-8, norm, decomposed_value_info_by_name);
+                               1e-8, norm, value_info_by_name);
     }
     // The fused `com.microsoft::MatMulNBitsQkv` variant -- see the
     // "MatMulNBitsMlp/MatMulNBitsQkv (fused block-quantized weight)
@@ -25008,6 +25411,15 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   // inputs).
   onnx::GraphProto* graph = out.mutable_graph();
 
+  // This graph's own AS-DECLARED input/output/value_info (ValueInfoByName)
+  // -- computed once up front (rather than only ahead of the decomposed-GQA
+  // section below, its own original sole consumer) so
+  // FindDecoderMaskedMhaChains/ApplyAttentionChains can also thread it
+  // through to HeadBiasInputIsSafe/SliceOrGatherHeadBias for
+  // DecoderMaskedMultiHeadAttention's own per-head `attention_bias`
+  // classification -- see ApplyAttentionHeadPruning's own identical comment.
+  auto value_info_by_name = ValueInfoByName(*graph);
+
   // Same chain-finding as ApplyAttentionHeadPruning's own nine matched
   // families -- deliberately excluding the fused `MatMulNBitsQkv` variant
   // that function additionally handles, since pruning.py's own
@@ -25018,7 +25430,8 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   std::vector<AttnChain> onnx_attn_chains = FindOnnxAttentionChains(graph);
   std::vector<AttnChain> mha_chains = FindMhaChains(graph);
   std::vector<AttnChain> packed_mha_chains = FindPackedMhaChains(graph);
-  std::vector<AttnChain> dmmha_chains = FindDecoderMaskedMhaChains(graph);
+  std::vector<AttnChain> dmmha_chains =
+      FindDecoderMaskedMhaChains(graph, value_info_by_name);
   std::vector<AttnChain> paged_chains = FindPagedAttentionChains(graph);
   std::vector<AttnChain> linear_attn_chains = FindLinearAttentionChains(graph);
   std::vector<AttnChain> sparse_attn_chains = FindSparseAttentionChains(graph);
@@ -25050,9 +25463,8 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   // ranked/sliced/probed entirely separately below, mirroring pruning.py's
   // own `chains: List[_AttnLikeChain]` union, which this port instead keeps
   // as two differently-typed collections threaded through in parallel.
-  auto decomposed_value_info_by_name = ValueInfoByName(*graph);
   std::vector<DecomposedGqaChain> decomposed_gqa_chains =
-      FindDecomposedGqaChains(graph, decomposed_value_info_by_name);
+      FindDecomposedGqaChains(graph, value_info_by_name);
 
   if (chains.empty() && decomposed_gqa_chains.empty()) {
     return out;  // Mirrors pruning.py's own early return.
@@ -25082,11 +25494,12 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
       WandaCalibrationStats(executor, out, probe_axis, calibration_data);
 
   if (!chains.empty()) {
-    ApplyAttentionChains(graph, chains, sparsity, &act_norm, epsilon, norm);
+    ApplyAttentionChains(graph, chains, sparsity, &act_norm, epsilon, norm,
+                         value_info_by_name);
   }
   if (!decomposed_gqa_chains.empty()) {
     ApplyDecomposedGqaChains(graph, decomposed_gqa_chains, sparsity, &act_norm,
-                             epsilon, norm, decomposed_value_info_by_name);
+                             epsilon, norm, value_info_by_name);
   }
   return out;
 }

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -124,6 +124,40 @@
 void SliceAxisGeneric(onnx::TensorProto* t, const std::vector<int64_t>& keep,
                       int64_t axis);
 
+// Forward declarations of three more of this file's own helpers, for the
+// identical global-scope reason SliceAxisGeneric's own declaration above
+// needs one: each one's real definition sits textually in the same
+// GLOBAL-scope gap SliceAxisGeneric's own does (the "Decomposed (un-fused)
+// GQA/MQA/plain-MHA attention head pruning" section, past this file's own
+// closing of the big anonymous namespace below), so a same-signature
+// declaration placed INSIDE that namespace would again create a second,
+// distinct (anonymous-namespace-linkage) entity rather than referring to the
+// real one. Needed here so GroupQueryAttention's/the plain ai.onnx::Attention
+// op's own MatchGqaProducer/MatchOnnxAttentionProducer/ApplyOneGqaChain --
+// defined earlier in the file, inside that namespace -- can reuse this exact
+// additive-mask safety/rewrite machinery for their own attention_bias/
+// attn_mask input (HeadBiasInputIsSafe/SliceOrGatherHeadBias, mirroring
+// pruning.py's own `_head_bias_input_is_safe`/`_slice_or_gather_head_bias`),
+// and this file's own pre-existing ExistingGraphNames (mirroring pruning.py's
+// own `_existing_graph_names`) to seed the same used-names set
+// InsertDynamicHeadBiasGather (reached transitively via SliceOrGatherHeadBias)
+// mints fresh Gather-node/indices-initializer names from.
+bool HeadBiasInputIsSafe(
+    const onnx::NodeProto& node, int idx,
+    const std::unordered_map<std::string, const onnx::TensorProto*>& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name,
+    int64_t num_heads);
+void SliceOrGatherHeadBias(
+    onnx::NodeProto* node, int idx,
+    std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    int64_t num_heads, const std::vector<int64_t>& keep,
+    onnx::GraphProto* graph, std::unordered_set<std::string>& used_names,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name);
+std::unordered_set<std::string> ExistingGraphNames(
+    const onnx::GraphProto& graph);
+
 namespace {
 
 constexpr int kMaxChainHops = 8;
@@ -436,6 +470,23 @@ std::vector<double> ReadTensorAsF64(const onnx::TensorProto& t);
 void WriteF64TensorAs(onnx::TensorProto* t, int32_t data_type,
                       const std::vector<int64_t>& dims,
                       const std::vector<double>& data);
+
+// Forward declarations of this file's own single-byte-dtype (UINT8/
+// FLOAT8E4M3FN) tensor <-> flat-buffer helpers -- defined later in the file
+// (the "MatMulNBits"/QMoE sections), but still inside this SAME anonymous
+// namespace (unlike the trio above and SliceAxisGeneric, so an ordinary
+// same-signature forward declaration here refers to those exact
+// definitions, no global-scope declaration needed). Needed here so
+// GroupQueryAttention's own MatchGqaProducer/ApplyOneGqaChain -- defined
+// earlier in the file -- can reuse them for a quantized (uint8/int8/
+// float8e4m3fn) `past_key`/`past_value` KV cache (see this file's own
+// SliceKvCacheAxis1, defined just above those matchers/appliers).
+std::vector<uint8_t> ReadUint8Tensor(const onnx::TensorProto& t);
+void SetUint8TensorData(onnx::TensorProto* t, const std::vector<int64_t>& dims,
+                        const std::vector<uint8_t>& data);
+void SetFloat8E4M3TensorData(onnx::TensorProto* t,
+                             const std::vector<int64_t>& dims,
+                             const std::vector<uint8_t>& data);
 
 ConsumerMap ConsumersOf(onnx::GraphProto* graph) {
   ConsumerMap out;
@@ -5562,12 +5613,196 @@ struct HeadCountsMatch {
   int64_t kv_num_heads;
 };
 
+// True for the three quantized-cache dtypes GroupQueryAttention's own
+// T_CACHE type constraint allows for `past_key`/`past_value` beyond plain
+// FLOAT -- mirrors pruning.py's own `_QUANTIZED_KV_CACHE_DTYPES` exactly
+// (`float16`/`bfloat16`, T_CACHE's other two members, are NOT quantized
+// dtypes and stay declined by the plain-FLOAT-family branch instead, same as
+// before this existed).
+bool IsQuantizedKvCacheDtype(int32_t data_type) {
+  return data_type == onnx::TensorProto::UINT8 ||
+         data_type == onnx::TensorProto::INT8 ||
+         data_type == onnx::TensorProto::FLOAT8E4M3FN;
+}
+
+// Shared safety gate for a matched node's optional `past_key`/`past_value`
+// inputs (at `indices`, a `(past_key_idx, past_value_idx)` pair -- `(3, 4)`
+// for GroupQueryAttention, `(4, 5)` for the plain ai.onnx::Attention op),
+// used by both MatchGqaProducer and MatchOnnxAttentionProducer. Mirrors
+// pruning.py's own `_past_kv_constants_are_sliceable` exactly: both ops lay a
+// connected `past_key`/`past_value` out in BNSH format (batch_size,
+// kv_num_heads, past_sequence_length, head_size_or_v_head_size), so
+// `kv_num_heads` sits at axis 1 of a rank-4 tensor -- the axis
+// ApplyOneGqaChain's own `keep_groups` index set already selects K's/V's own
+// producer weight by. A DYNAMIC (non-constant) past_key/past_value is always
+// left alone and never blocks a match -- the caller's own runtime data. A
+// CONSTANT one is declined (returns false) when its shape isn't confidently
+// this exact layout (not rank 4, or its axis-1 length doesn't match
+// `kv_num_heads`). A plain-FLOAT-family (IsSupportedFloatDtype) constant of
+// that shape is always accepted. A constant whose dtype is instead one of
+// IsQuantizedKvCacheDtype's own three is a quantized KV cache, only ever
+// accepted when the caller passes `scale_indices` (a `(k_scale_idx,
+// v_scale_idx)` pair GroupQueryAttention's own schema defines at (12, 13);
+// the plain ai.onnx::Attention op has no k_scale/v_scale inputs at all and
+// never passes `scale_indices`, so a quantized cache there is declined
+// outright, exactly as before). When `scale_indices` IS given and the cache
+// is quantized, the corresponding scale input is required to be connected
+// and, if itself a constant, must be exactly one of the schema's two
+// documented shapes: PER_TENSOR (a single scalar -- broadcasts identically
+// regardless of `kv_num_heads`, needs no slicing) or PER_CHANNEL
+// ([1, kv_num_heads, 1, head_size] -- the same axis-1 kv_num_heads layout as
+// the cache tensor itself, safe to slice the identical way); any other
+// constant scale shape is declined the same conservative way an unrecognized
+// cache shape already is, and a dynamic scale is left alone exactly like a
+// dynamic cache tensor.
+bool PastKvConstantsAreSliceable(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    std::pair<int, int> indices, int64_t kv_num_heads,
+    std::optional<std::pair<int, int>> scale_indices = std::nullopt) {
+  const std::pair<int, int> scale_idx =
+      scale_indices ? *scale_indices : std::pair<int, int>{-1, -1};
+  for (const auto& [idx, s_idx] :
+       {std::pair<int, int>{indices.first, scale_idx.first},
+        std::pair<int, int>{indices.second, scale_idx.second}}) {
+    if (node.input_size() <= idx || node.input(idx).empty()) {
+      continue;
+    }
+    auto it = init_map.find(node.input(idx));
+    if (it == init_map.end()) {
+      continue;  // Dynamic -- the caller's own runtime data, left alone.
+    }
+    const onnx::TensorProto& past = *it->second;
+    if (past.dims_size() != 4 || past.dims(1) != kv_num_heads) {
+      return false;  // Not a shape this function can safely slice.
+    }
+    if (IsSupportedFloatDtype(past.data_type())) {
+      continue;  // Unquantized cache -- nothing else to check.
+    }
+    if (s_idx < 0 || !IsQuantizedKvCacheDtype(past.data_type())) {
+      return false;  // Quantized dtype with nowhere to locate its scale.
+    }
+    if (node.input_size() <= s_idx || node.input(s_idx).empty()) {
+      return false;  // Quantized cache with no k_scale/v_scale connected.
+    }
+    auto sit = init_map.find(node.input(s_idx));
+    if (sit == init_map.end()) {
+      continue;  // Dynamic scale -- the caller's own runtime data.
+    }
+    const onnx::TensorProto& scale = *sit->second;
+    if (scale.data_type() != onnx::TensorProto::FLOAT) {
+      return false;  // Not T_KV_SCALE's own float-only constraint.
+    }
+    int64_t prod = 1;
+    for (int64_t d : scale.dims()) {
+      prod *= d;
+    }
+    if (prod == 1) {
+      continue;  // PER_TENSOR: a single broadcast scalar, nothing to slice.
+    }
+    if (scale.dims_size() != 4 || scale.dims(1) != kv_num_heads) {
+      return false;  // Not the PER_CHANNEL [1, kv_num_heads, 1, head_size].
+    }
+  }
+  return true;
+}
+
+// Slices a rank-4 BNSH-format `past_key`/`past_value`/PER_CHANNEL
+// `k_scale`/`v_scale` constant `t` along axis 1 (its own kv_num_heads axis)
+// by `keep`, preserving `t`'s own original dtype -- mirrors pruning.py's own
+// dtype-agnostic `_slice_axis(t, keep, axis=1)` used for these tensors (see
+// PastKvConstantsAreSliceable's own docstring). FLOAT/FLOAT16/BFLOAT16
+// (IsSupportedFloatDtype) reuse SliceAxisGeneric's own dtype-preserving
+// double round trip. UINT8/INT8/FLOAT8E4M3FN (GroupQueryAttention's own
+// T_CACHE quantized-cache dtypes) are single-byte encodings with no numeric
+// meaning to round-trip through double, so they get a plain raw-byte
+// index-select instead -- ReadUint8Tensor already reads any of the three
+// "regardless of the dtype tag" (that function's own comment); INT8 has no
+// dedicated Set*TensorData helper elsewhere in this file (unlike UINT8/
+// FLOAT8E4M3FN), so this function keeps its own inline raw_data write for
+// that one case.
+void SliceKvCacheAxis1(onnx::TensorProto* t, const std::vector<int64_t>& keep) {
+  if (IsSupportedFloatDtype(t->data_type())) {
+    SliceAxisGeneric(t, keep, 1);
+    return;
+  }
+  const std::vector<int64_t> dims(t->dims().begin(), t->dims().end());
+  int64_t inner = 1;
+  for (size_t i = 2; i < dims.size(); ++i) {
+    inner *= dims[i];
+  }
+  const int64_t axis_len = dims[1];
+  const std::vector<uint8_t> data = ReadUint8Tensor(*t);
+  std::vector<uint8_t> out;
+  out.reserve(static_cast<size_t>(dims[0]) * keep.size() *
+              static_cast<size_t>(inner));
+  for (int64_t o = 0; o < dims[0]; ++o) {
+    for (int64_t k : keep) {
+      const int64_t base = (o * axis_len + k) * inner;
+      out.insert(out.end(), data.begin() + base, data.begin() + base + inner);
+    }
+  }
+  std::vector<int64_t> new_dims = dims;
+  new_dims[1] = static_cast<int64_t>(keep.size());
+  switch (t->data_type()) {
+    case onnx::TensorProto::UINT8:
+      SetUint8TensorData(t, new_dims, out);
+      return;
+    case onnx::TensorProto::FLOAT8E4M3FN:
+      SetFloat8E4M3TensorData(t, new_dims, out);
+      return;
+    case onnx::TensorProto::INT8: {
+      const std::string name = t->name();
+      t->Clear();
+      t->set_name(name);
+      t->set_data_type(onnx::TensorProto::INT8);
+      for (int64_t d : new_dims) {
+        t->add_dims(d);
+      }
+      t->set_raw_data(
+          std::string(reinterpret_cast<const char*>(out.data()), out.size()));
+      return;
+    }
+    default:
+      throw std::runtime_error(
+          "SliceKvCacheAxis1: unsupported tensor dtype " +
+          std::to_string(static_cast<int>(t->data_type())));
+  }
+}
+
 // If `node` is a com.microsoft::GroupQueryAttention node this pass can
-// safely act on (separate Q/K/V inputs -- rules out the op's packed-QKV
-// calling convention; no non-empty constant past_key/past_value), returns
-// (num_heads, kv_num_heads). Mirrors pruning.py's own _match_gqa_producer.
-std::optional<HeadCountsMatch> MatchGqaProducer(const onnx::NodeProto& node,
-                                                const InitMap& init_map) {
+// safely act on, returns (num_heads, kv_num_heads). Mirrors pruning.py's own
+// _match_gqa_producer: separate, non-empty Q/K/V inputs (rules out the op's
+// packed-QKV calling convention), `num_heads`/`kv_num_heads` attributes with
+// `num_heads` a positive multiple of `kv_num_heads`, and a `past_key`/
+// `past_value` (indices 3/4) this pass can safely act on -- an absent or
+// dynamic one leaves the whole match unaffected, a constant one must be
+// safely sliceable (PastKvConstantsAreSliceable, passed `scale_indices =
+// (12, 13)` for GroupQueryAttention's own `k_scale`/`v_scale`) or the whole
+// match is declined. `attention_bias` (index 10), documented shape
+// `(batch_size or 1, num_heads or 1, sequence_length,
+// total_sequence_length)` -- addressed per QUERY head (this op's own
+// `num_heads`, not `kv_num_heads`) since it's added to Q*K' after GQA's own
+// internal K/V-repeat-to-query-head-count broadcast -- gets the same
+// constant-resolves-cleanly-or-is-declined treatment via HeadBiasInputIsSafe
+// the decomposed-GQA family's own additive mask already gets. `head_sink`
+// (index 11), documented shape `(num_heads,)`, is a genuine
+// one-scalar-per-query-head parameter, not a broadcastable mask -- a
+// constant one is only ever accepted at exactly that shape and a
+// FLOAT/FLOAT16/BFLOAT16 dtype (ApplyOneGqaChain's own SliceAxisGeneric,
+// unlike pruning.py's dtype-agnostic `_slice_last_axis`, only handles those
+// three -- a narrower-than-pruning.py scope decision analogous to
+// HeadBiasInputIsSafe's own identical one), declined otherwise; a dynamic
+// one is left alone as always. `q_norm_weight`/`k_norm_weight` (indices
+// 14/15), required by the schema to "be provided together", decline a match
+// where exactly one is connected (head_size itself never changes under this
+// pass' own whole-head/KV-group pruning, so neither ever needs slicing).
+// cos_cache/sin_cache (indices 7/8) are always left alone regardless -- both
+// are `[max_sequence_length, rotary_dim/2]`, broadcast identically across
+// every head.
+std::optional<HeadCountsMatch> MatchGqaProducer(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "GroupQueryAttention") {
     return std::nullopt;
@@ -5593,29 +5828,57 @@ std::optional<HeadCountsMatch> MatchGqaProducer(const onnx::NodeProto& node,
   if (num_heads % kv_num_heads != 0) {
     return std::nullopt;
   }
-  for (int idx : {3, 4}) {  // past_key, past_value.
-    if (node.input_size() <= idx || node.input(idx).empty()) {
-      continue;
+  if (!PastKvConstantsAreSliceable(node, init_map, {3, 4}, kv_num_heads,
+                                   std::pair<int, int>{12, 13})) {
+    return std::nullopt;
+  }
+  if (node.input_size() > 10 && !node.input(10).empty()) {  // attention_bias
+    if (!HeadBiasInputIsSafe(node, 10, init_map, value_info_by_name,
+                             num_heads)) {
+      return std::nullopt;  // doesn't statically resolve -- decline rather
+                            // than guess.
     }
-    auto it = init_map.find(node.input(idx));
+  }
+  if (node.input_size() > 11 && !node.input(11).empty()) {  // head_sink
+    auto it = init_map.find(node.input(11));
     if (it != init_map.end()) {
-      int64_t prod = 1;
-      for (int64_t d : it->second->dims()) {
-        prod *= d;
-      }
-      if (prod > 0) {
-        return std::nullopt;  // Non-empty KV-cache constant -- needs slicing.
+      if (it->second->dims_size() != 1 || it->second->dims(0) != num_heads ||
+          !IsSupportedFloatDtype(it->second->data_type())) {
+        return std::nullopt;  // Not the schema's own (num_heads,) shape, or
+                              // (this port's own narrowing) not a dtype
+                              // ApplyOneGqaChain's own SliceAxisGeneric can
+                              // slice.
       }
     }
+  }
+  const std::string q_norm_name =
+      node.input_size() > 14 ? node.input(14) : std::string();
+  const std::string k_norm_name =
+      node.input_size() > 15 ? node.input(15) : std::string();
+  if (q_norm_name.empty() != k_norm_name.empty()) {
+    return std::nullopt;  // schema: "must be provided together".
   }
   return HeadCountsMatch{num_heads, kv_num_heads};
 }
 
 // If `node` is a plain ai.onnx::Attention node (domain "", opset 24+) this
 // pass can safely act on, returns (q_num_heads, kv_num_heads). Mirrors
-// pruning.py's own _match_onnx_attention_producer.
+// pruning.py's own _match_onnx_attention_producer: separate, non-empty Q/K/V
+// inputs, `q_num_heads`/`kv_num_heads` attributes with `q_num_heads` a
+// positive multiple of `kv_num_heads`. The optional `attn_mask` input (index
+// 3) -- added against the `(batch, q_num_heads, q_seq, kv_seq)`
+// attention-score tensor via ordinary broadcasting, so a rank-3 mask's own
+// axis 0 lands on the q_num_heads slot too, not just a rank-4 mask's axis 1
+// -- gets the identical HeadBiasInputIsSafe treatment GroupQueryAttention's
+// own `attention_bias` gets above. `past_key`/`past_value` (indices 4/5 --
+// a different pair from GroupQueryAttention's own 3/4) get the same safety
+// gate via the same shared PastKvConstantsAreSliceable, but with no
+// `scale_indices` (this op's schema has no k_scale/v_scale inputs at all, so
+// a quantized cache here is declined outright by that shared function).
 std::optional<HeadCountsMatch> MatchOnnxAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   if (!node.domain().empty() || node.op_type() != "Attention") {
     return std::nullopt;
   }
@@ -5640,20 +5903,15 @@ std::optional<HeadCountsMatch> MatchOnnxAttentionProducer(
   if (q_num_heads % kv_num_heads != 0) {
     return std::nullopt;
   }
-  for (int idx : {3, 4, 5}) {  // attn_mask, past_key, past_value.
-    if (node.input_size() <= idx || node.input(idx).empty()) {
-      continue;
+  if (node.input_size() > 3 && !node.input(3).empty()) {  // attn_mask
+    if (!HeadBiasInputIsSafe(node, 3, init_map, value_info_by_name,
+                             q_num_heads)) {
+      return std::nullopt;  // doesn't statically resolve -- decline rather
+                            // than guess.
     }
-    auto it = init_map.find(node.input(idx));
-    if (it != init_map.end()) {
-      int64_t prod = 1;
-      for (int64_t d : it->second->dims()) {
-        prod *= d;
-      }
-      if (prod > 0) {
-        return std::nullopt;  // Non-empty constant -- would need slicing.
-      }
-    }
+  }
+  if (!PastKvConstantsAreSliceable(node, init_map, {4, 5}, kv_num_heads)) {
+    return std::nullopt;
   }
   return HeadCountsMatch{q_num_heads, kv_num_heads};
 }
@@ -6171,13 +6429,45 @@ std::vector<AttnChain> FindSeparateQkvChains(
   return chains;
 }
 
-std::vector<AttnChain> FindGqaChains(onnx::GraphProto* graph) {
-  return FindSeparateQkvChains(graph, MatchGqaProducer, "num_heads");
+// `value_info_by_name` (defaulted to `{}` -- every pre-existing call site
+// this port had before this attention_bias/attn_mask fix stays source
+// compatible) is this graph's own AS-DECLARED input/output/value_info
+// (ValueInfoByName), threaded down to MatchGqaProducer's own
+// HeadBiasInputIsSafe check for a dynamic `attention_bias` -- the same map
+// FindDecomposedGqaChains' own equivalent parameter already documents at its
+// own call sites for why no real shape-inference pass backs it. Wrapped in a
+// lambda (rather than passed directly, the way this function did before this
+// fix) since MatchGqaProducer's own third parameter, though defaulted, still
+// makes its real type a 3-argument function -- incompatible with
+// FindSeparateQkvChains' own fixed 2-argument `match_producer` callback type
+// without this adapter.
+std::vector<AttnChain> FindGqaChains(
+    onnx::GraphProto* graph,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
+  return FindSeparateQkvChains(
+      graph,
+      [&value_info_by_name](const onnx::NodeProto& node,
+                            const InitMap& init_map) {
+        return MatchGqaProducer(node, init_map, value_info_by_name);
+      },
+      "num_heads");
 }
 
-std::vector<AttnChain> FindOnnxAttentionChains(onnx::GraphProto* graph) {
-  return FindSeparateQkvChains(graph, MatchOnnxAttentionProducer,
-                               "q_num_heads");
+// The plain ai.onnx::Attention analogue of FindGqaChains -- see that
+// function's own comment for why `value_info_by_name` is threaded through a
+// wrapping lambda instead of passed directly.
+std::vector<AttnChain> FindOnnxAttentionChains(
+    onnx::GraphProto* graph,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
+  return FindSeparateQkvChains(
+      graph,
+      [&value_info_by_name](const onnx::NodeProto& node,
+                            const InitMap& init_map) {
+        return MatchOnnxAttentionProducer(node, init_map, value_info_by_name);
+      },
+      "q_num_heads");
 }
 
 // The com.microsoft::MultiHeadAttention analogue of FindGqaChains -- see
@@ -6449,12 +6739,15 @@ std::optional<AppliedAttn> ApplyOnePlainAttentionChain(
 // was observed. `nullptr` (the default) keeps this identically the plain
 // ``||W||_F``-only ranking it always was.
 std::optional<AppliedAttn> ApplyOneGqaChain(
+    onnx::GraphProto* graph,
     std::unordered_map<std::string, onnx::TensorProto*>& init_map,
-    AttnChain& chain, double sparsity,
+    std::unordered_set<std::string>& used_names, AttnChain& chain,
+    double sparsity,
     const std::unordered_map<std::string, std::vector<double>>* act_norm =
         nullptr,
-    double epsilon = 1e-8,
-    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
+    double epsilon = 1e-8, ImportanceNorm importance_norm = ImportanceNorm::kL2,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   const int64_t h = chain.kv_num_heads;
   const int64_t keep_count =
       std::max<int64_t>(1, h - std::llround(static_cast<double>(h) * sparsity));
@@ -6657,6 +6950,86 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     }
   }
 
+  // GroupQueryAttention/plain ai.onnx::Attention-only: past_key/past_value,
+  // k_scale/v_scale, attention_bias/attn_mask, and head_sink, each already
+  // confirmed at match time (MatchGqaProducer/MatchOnnxAttentionProducer, via
+  // PastKvConstantsAreSliceable/HeadBiasInputIsSafe) to be either absent/
+  // dynamic-and-left-alone, a provable broadcast needing no slicing, or a
+  // constant safe to slice -- mirrors pruning.py's own `_apply_one_gqa_chain`
+  // handling of these same four roles, scoped here to just these two op
+  // kinds (this port's own extended scope for this fix; every other chain
+  // kind sharing this function -- MultiHeadAttention/PackedMultiHeadAttention/
+  // DecoderMaskedMultiHeadAttention/PagedAttention/LinearAttention/
+  // SparseAttention -- keeps its own pre-existing, narrower-than-pruning.py
+  // scope untouched, per this file's own "Attention-head pruning" section
+  // comment).
+  const bool is_gqa = chain.node->domain() == kComMicrosoftDomain &&
+                      chain.node->op_type() == "GroupQueryAttention";
+  const bool is_onnx_attention =
+      chain.node->domain().empty() && chain.node->op_type() == "Attention";
+
+  if (is_gqa || is_onnx_attention) {
+    // past_key/past_value -- GroupQueryAttention's own at indices 3/4, the
+    // plain ai.onnx op's own at 4/5 -- sliced along axis 1 by the identical
+    // `keep_groups` K's/V's own producer weights are sliced by.
+    const int pk_idx = is_gqa ? 3 : 4;
+    const int pv_idx = is_gqa ? 4 : 5;
+    for (int idx : {pk_idx, pv_idx}) {
+      if (chain.node->input_size() <= idx || chain.node->input(idx).empty()) {
+        continue;
+      }
+      auto it = init_map.find(chain.node->input(idx));
+      if (it != init_map.end()) {
+        SliceKvCacheAxis1(it->second, keep_groups);
+      }
+    }
+  }
+
+  if (is_gqa) {
+    // k_scale/v_scale (indices 12/13, GroupQueryAttention-only -- the plain
+    // ai.onnx op's schema has no such inputs): a PER_CHANNEL
+    // [1, kv_num_heads, 1, head_size] float constant is sliced along axis 1
+    // the identical way; a PER_TENSOR scalar broadcast has no per-head axis
+    // and is left exactly as-is.
+    for (int idx : {12, 13}) {
+      if (chain.node->input_size() <= idx || chain.node->input(idx).empty()) {
+        continue;
+      }
+      auto it = init_map.find(chain.node->input(idx));
+      if (it == init_map.end()) {
+        continue;  // Dynamic -- the caller's own runtime data, left alone.
+      }
+      if (it->second->dims_size() == 4 && it->second->dims(1) == h) {
+        SliceAxisGeneric(it->second, keep_groups, 1);
+      }
+      // else: PER_TENSOR broadcast scalar -- no per-head axis to slice.
+    }
+  }
+
+  // attention_bias/attn_mask -- GroupQueryAttention's own at index 10, the
+  // plain ai.onnx op's own at index 3 -- handled by SliceOrGatherHeadBias
+  // along its own head axis by `keep_q_heads` (query-head granularity, not
+  // `keep_groups`' KV-group one: this input is added against Q*K' scores,
+  // laid out per query head).
+  const int mask_idx = is_gqa ? 10 : is_onnx_attention ? 3 : -1;
+  if (mask_idx >= 0) {
+    SliceOrGatherHeadBias(chain.node, mask_idx, init_map, chain.num_heads,
+                          keep_q_heads, graph, used_names, value_info_by_name);
+  }
+
+  // head_sink (index 11, GroupQueryAttention-only -- the plain ai.onnx op has
+  // no analogous input): a genuine (num_heads,) one-scalar-per-query-head
+  // constant, already confirmed at match time to be exactly that shape (and
+  // a FLOAT/FLOAT16/BFLOAT16 dtype) -- sliced directly by `keep_q_heads`, no
+  // head_size expansion needed.
+  if (is_gqa && chain.node->input_size() > 11 &&
+      !chain.node->input(11).empty()) {
+    auto it = init_map.find(chain.node->input(11));
+    if (it != init_map.end()) {
+      SliceAxisGeneric(it->second, keep_q_heads, 0);
+    }
+  }
+
   AppliedAttn out;
   out.producer_weights = {chain.q_weight, chain.k_weight, chain.v_weight};
   out.consumer_weight = chain.consumer_weight;
@@ -6674,17 +7047,29 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
 // ApplyAttentionHeadPruning call site is unchanged, are threaded straight
 // through to both -- see either's own doc comment for what they do; this
 // dispatcher itself has no importance computation of its own to touch.
+// `value_info_by_name` (defaulted to `{}`, likewise source-compatible with
+// every pre-existing call site) is threaded straight through to
+// ApplyOneGqaChain's own attention_bias/attn_mask handling -- see that
+// function's own comment. `used_names` (ExistingGraphNames -- mirrors
+// pruning.py's own `_existing_graph_names`, computed once here rather than
+// once per chain) seeds the same used-name set a dynamic attention_bias/
+// attn_mask's own freshly-inserted Gather node/indices initializer
+// (InsertDynamicHeadBiasGather, reached transitively via
+// SliceOrGatherHeadBias) mints unique names from -- mirrors
+// ApplyDecomposedGqaChains' own identical `used_names` bookkeeping.
 void ApplyAttentionChains(
     onnx::GraphProto* graph, std::vector<AttnChain>& chains, double sparsity,
     const std::unordered_map<std::string, std::vector<double>>* act_norm =
         nullptr,
-    double epsilon = 1e-8,
-    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
+    double epsilon = 1e-8, ImportanceNorm importance_norm = ImportanceNorm::kL2,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   std::unordered_map<std::string, onnx::TensorProto*> init_map;
   for (int i = 0; i < graph->initializer_size(); ++i) {
     onnx::TensorProto* t = graph->mutable_initializer(i);
     init_map[t->name()] = t;
   }
+  std::unordered_set<std::string> used_names = ExistingGraphNames(*graph);
   std::unordered_set<std::string> producer_touched, consumer_touched,
       stale_value_info;
 
@@ -6707,8 +7092,9 @@ void ApplyAttentionChains(
 
     std::optional<AppliedAttn> applied =
         chain.kind == AttnChainKind::kGqaLike
-            ? ApplyOneGqaChain(init_map, chain, sparsity, act_norm, epsilon,
-                               importance_norm)
+            ? ApplyOneGqaChain(graph, init_map, used_names, chain, sparsity,
+                               act_norm, epsilon, importance_norm,
+                               value_info_by_name)
             : ApplyOnePlainAttentionChain(init_map, chain, sparsity, act_norm,
                                           epsilon, importance_norm);
     if (!applied) {
@@ -10749,11 +11135,21 @@ void ApplyMatMulNBitsQkvChains(onnx::GraphProto* graph,
 
     const bool is_gqa = chain.attn_node->domain() == kComMicrosoftDomain &&
                         chain.attn_node->op_type() == "GroupQueryAttention";
-    // Constant past_key/past_value -- guaranteed EMPTY (product-of-dims-0)
-    // by MatchGqaProducer's own existing precondition whenever they're a
-    // constant at all, so this is purely a dim-count metadata fix, never a
-    // real data copy of any live cache values. Mirrors pruning.py's own
-    // identical `past_kv_indices` handling.
+    // Constant past_key/past_value -- guaranteed either EMPTY
+    // (product-of-dims-0) or a safely-sliceable BNSH-format cache (plain
+    // FLOAT/FLOAT16/BFLOAT16, or -- GQA only -- quantized with a
+    // schema-conforming k_scale/v_scale) by MatchGqaProducer's/
+    // MatchOnnxAttentionProducer's own existing precondition
+    // (PastKvConstantsAreSliceable) whenever they're a constant at all --
+    // sliced via SliceKvCacheAxis1 (the same dtype-dispatched helper
+    // ApplyOneGqaChain's own identical past_key/past_value handling uses),
+    // never a plain FLOAT-only slice: this dtype breadth was widened
+    // alongside MatchGqaProducer's/MatchOnnxAttentionProducer's own
+    // acceptance of a genuinely non-empty (not just guaranteed-empty) cache,
+    // so a FLOAT16/BFLOAT16 or quantized non-empty one reaching this apply
+    // function needs the identical real slice a FLOAT one does, not just a
+    // dim-count metadata fix. Mirrors pruning.py's own identical
+    // `past_kv_indices` handling.
     for (int idx :
          (is_gqa ? std::array<int, 2>{3, 4} : std::array<int, 2>{4, 5})) {
       if (chain.attn_node->input_size() <= idx ||
@@ -10761,14 +11157,16 @@ void ApplyMatMulNBitsQkvChains(onnx::GraphProto* graph,
         continue;
       }
       auto it = init_map.find(chain.attn_node->input(idx));
-      if (it != init_map.end() &&
-          it->second->data_type() == onnx::TensorProto::FLOAT) {
-        SliceFloatTensorAxis1(it->second, keep_groups);
+      if (it != init_map.end()) {
+        SliceKvCacheAxis1(it->second, keep_groups);
       }
     }
     // GQA's own `k_scale`/`v_scale` (indices 12/13), constant, per-KV-head
     // shaped `[.., kv_num_heads, .., 1]` -- mirrors pruning.py's own
-    // identical shape check.
+    // identical shape check. T_KV_SCALE is FLOAT-only per the schema (and
+    // PastKvConstantsAreSliceable's own match-time check already declined
+    // any other dtype), so this one stays a strict-FLOAT SliceAxisGeneric
+    // call, unlike the cache tensor itself just above.
     if (is_gqa) {
       for (int idx : {12, 13}) {
         if (chain.attn_node->input_size() <= idx ||
@@ -10781,7 +11179,7 @@ void ApplyMatMulNBitsQkvChains(onnx::GraphProto* graph,
           continue;
         }
         if (it->second->dims_size() == 4 && it->second->dims(1) == h) {
-          SliceFloatTensorAxis1(it->second, keep_groups);
+          SliceAxisGeneric(it->second, keep_groups, 1);
         }
       }
     }
@@ -25061,9 +25459,21 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
   // Mirrors pruning.py's own apply_attention_head_pruning loop over
   // `_iter_subgraphs(out.graph)`.
   for (onnx::GraphProto* graph : IterSubgraphs(out.mutable_graph())) {
+    // This graph's own AS-DECLARED input/output/value_info (ValueInfoByName)
+    // -- computed once per graph and reused below both by FindGqaChains'/
+    // FindOnnxAttentionChains' own MatchGqaProducer/MatchOnnxAttentionProducer
+    // dynamic-attention_bias/attn_mask check and by FindDecomposedGqaChains'
+    // own identical need further down (still named `decomposed_value_info_by_
+    // name` there for continuity with that section's own pre-existing
+    // comments) -- see FindDecomposedGqaChains' own section comment for why
+    // no real shape-inference pass backs it, here or at the top level, unlike
+    // pruning.py's own top-level-graph case.
+    auto decomposed_value_info_by_name = ValueInfoByName(*graph);
     std::vector<AttnChain> chains = FindAttentionChains(graph);
-    std::vector<AttnChain> gqa_chains = FindGqaChains(graph);
-    std::vector<AttnChain> onnx_attn_chains = FindOnnxAttentionChains(graph);
+    std::vector<AttnChain> gqa_chains =
+        FindGqaChains(graph, decomposed_value_info_by_name);
+    std::vector<AttnChain> onnx_attn_chains =
+        FindOnnxAttentionChains(graph, decomposed_value_info_by_name);
     // MultiHeadAttention/PackedMultiHeadAttention/
     // DecoderMaskedMultiHeadAttention/PagedAttention/LinearAttention/
     // SparseAttention -- six more matched families sharing the identical
@@ -25100,7 +25510,8 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
                   std::make_move_iterator(sparse_attn_chains.begin()),
                   std::make_move_iterator(sparse_attn_chains.end()));
     if (!chains.empty()) {
-      ApplyAttentionChains(graph, chains, sparsity, nullptr, 1e-8, norm);
+      ApplyAttentionChains(graph, chains, sparsity, nullptr, 1e-8, norm,
+                           decomposed_value_info_by_name);
     }
     // The fully decomposed (un-fused, "eager SDPA export") shape
     // pruning.py's own `_find_decomposed_gqa_chains` additionally matches --
@@ -25113,12 +25524,8 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
     // touched bookkeeping (inside ApplyDecomposedGqaChains) is never shared
     // with ApplyAttentionChains's own above, the same "structurally
     // different node/weight shapes, always safe" reasoning this section's
-    // own MatMulNBitsQkv handling below already documents. `value_info_by_
-    // name` here is this graph's own AS-DECLARED input/output/value_info
-    // (ValueInfoByName) -- see FindDecomposedGqaChains' own section comment
-    // for why no real shape-inference pass backs it, here or at the top
-    // level, unlike pruning.py's own top-level-graph case.
-    auto decomposed_value_info_by_name = ValueInfoByName(*graph);
+    // own MatMulNBitsQkv handling below already documents. Reuses this same
+    // graph's own `decomposed_value_info_by_name`, computed once above.
     std::vector<DecomposedGqaChain> decomposed_gqa_chains =
         FindDecomposedGqaChains(graph, decomposed_value_info_by_name);
     if (!decomposed_gqa_chains.empty()) {
@@ -25178,14 +25585,24 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   // inputs).
   onnx::GraphProto* graph = out.mutable_graph();
 
+  // This graph's own AS-DECLARED input/output/value_info (ValueInfoByName)
+  // -- computed once here (rather than down at its own pre-existing call
+  // site further below) and reused both by FindGqaChains'/
+  // FindOnnxAttentionChains' own MatchGqaProducer/MatchOnnxAttentionProducer
+  // dynamic-attention_bias/attn_mask check and by FindDecomposedGqaChains'
+  // own identical need further down.
+  auto decomposed_value_info_by_name = ValueInfoByName(*graph);
+
   // Same chain-finding as ApplyAttentionHeadPruning's own nine matched
   // families -- deliberately excluding the fused `MatMulNBitsQkv` variant
   // that function additionally handles, since pruning.py's own
   // apply_attention_head_wanda_pruning has no quantized-weight counterpart
   // either (see structured_pruning_entry.h's own declaration comment).
   std::vector<AttnChain> chains = FindAttentionChains(graph);
-  std::vector<AttnChain> gqa_chains = FindGqaChains(graph);
-  std::vector<AttnChain> onnx_attn_chains = FindOnnxAttentionChains(graph);
+  std::vector<AttnChain> gqa_chains =
+      FindGqaChains(graph, decomposed_value_info_by_name);
+  std::vector<AttnChain> onnx_attn_chains =
+      FindOnnxAttentionChains(graph, decomposed_value_info_by_name);
   std::vector<AttnChain> mha_chains = FindMhaChains(graph);
   std::vector<AttnChain> packed_mha_chains = FindPackedMhaChains(graph);
   std::vector<AttnChain> dmmha_chains = FindDecoderMaskedMhaChains(graph);
@@ -25220,7 +25637,8 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   // ranked/sliced/probed entirely separately below, mirroring pruning.py's
   // own `chains: List[_AttnLikeChain]` union, which this port instead keeps
   // as two differently-typed collections threaded through in parallel.
-  auto decomposed_value_info_by_name = ValueInfoByName(*graph);
+  // Reuses this same graph's own `decomposed_value_info_by_name`, computed
+  // once above.
   std::vector<DecomposedGqaChain> decomposed_gqa_chains =
       FindDecomposedGqaChains(graph, decomposed_value_info_by_name);
 
@@ -25252,7 +25670,8 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
       WandaCalibrationStats(executor, out, probe_axis, calibration_data);
 
   if (!chains.empty()) {
-    ApplyAttentionChains(graph, chains, sparsity, &act_norm, epsilon, norm);
+    ApplyAttentionChains(graph, chains, sparsity, &act_norm, epsilon, norm,
+                         decomposed_value_info_by_name);
   }
   if (!decomposed_gqa_chains.empty()) {
     ApplyDecomposedGqaChains(graph, decomposed_gqa_chains, sparsity, &act_norm,

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -5801,13 +5801,17 @@ std::optional<HeadCountsMatch> MatchOnnxAttentionProducer(
   return HeadCountsMatch{q_num_heads, kv_num_heads};
 }
 
-// Generic safety gate reused by every new "separate Q/K/V" matcher below
-// (MultiHeadAttention/PackedMultiHeadAttention/
-// DecoderMaskedMultiHeadAttention/SparseAttention): declines the whole match
+// Generic safety gate reused by MatchSparseAttentionProducer below (its own
+// `block_row_indices`/`block_col_indices` sit at fixed indices, but its own
+// past_key/past_value pair does not -- unlike MultiHeadAttention/
+// PackedMultiHeadAttention/DecoderMaskedMultiHeadAttention/GroupQueryAttention/
+// the plain ai.onnx::Attention op, all of which now validate-and-slice their
+// own analogous optional per-head inputs instead, via HeadBiasInputIsSafe/
+// PastKvConstantsAreSliceable -- this op's own past_key/past_value gap
+// remains a pre-existing, out-of-scope narrowing): declines the whole match
 // when any of `indices` resolves to a non-empty constant tensor -- mirrors
-// the identical "would need slicing, not attempted here" pattern
-// MatchGqaProducer/MatchOnnxAttentionProducer already use above for their
-// own past_key/past_value (and, for the latter, attn_mask) checks. An
+// the identical "would need slicing, not attempted here" pattern this port
+// used for every one of those other matchers before each one's own fix. An
 // absent, empty-string, or dynamic (unresolvable-to-constant) input at any
 // of `indices` is left completely alone -- nothing here ever slices any of
 // them either way, so a genuinely dynamic one is safe to leave connected
@@ -6515,8 +6519,7 @@ std::vector<AttnChain> FindOnnxAttentionChains(
     onnx::GraphProto* graph,
     const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
         value_info_by_name = {}) {
-  return FindSeparateQkvChains(graph, MatchOnnxAttentionProducer,
-                               "q_num_heads",
+  return FindSeparateQkvChains(graph, MatchOnnxAttentionProducer, "q_num_heads",
                                /*combined_bias_input_index=*/std::nullopt,
                                value_info_by_name);
 }
@@ -25931,8 +25934,7 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   // apply_attention_head_wanda_pruning has no quantized-weight counterpart
   // either (see structured_pruning_entry.h's own declaration comment).
   std::vector<AttnChain> chains = FindAttentionChains(graph);
-  std::vector<AttnChain> gqa_chains =
-      FindGqaChains(graph, value_info_by_name);
+  std::vector<AttnChain> gqa_chains = FindGqaChains(graph, value_info_by_name);
   std::vector<AttnChain> onnx_attn_chains =
       FindOnnxAttentionChains(graph, value_info_by_name);
   std::vector<AttnChain> mha_chains = FindMhaChains(graph, value_info_by_name);

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -108,6 +108,22 @@
 // model happened to carry).
 #include "partial_shape_eval.h"
 
+// Forward declaration of this file's own SliceAxisGeneric -- defined much
+// later in the file (the "attention_bias"-slicing section, reusing the
+// MoE/QMoE section's own ReadTensorAsF64/WriteF64TensorAs), but at GLOBAL
+// scope, not inside the anonymous namespace below (that namespace is closed
+// and reopened more than once across this file, and SliceAxisGeneric's own
+// definition happens to sit in one of the gaps between those reopenings) --
+// so this declaration must also be at global scope, not repeated inside the
+// anonymous namespace itself: a same-signature declaration placed in there
+// would create a SECOND, distinct (anonymous-namespace-linkage) entity,
+// ambiguous against this one at every call site inside that namespace.
+// Needed here so the Attention-head-pruning matchers/appliers -- defined
+// earlier in the file, inside the anonymous namespace -- can reuse it rather
+// than duplicating the same generic-axis-slice logic a second time.
+void SliceAxisGeneric(onnx::TensorProto* t, const std::vector<int64_t>& keep,
+                      int64_t axis);
+
 namespace {
 
 constexpr int kMaxChainHops = 8;
@@ -403,6 +419,23 @@ std::optional<MatMulLikeMatch> MatchMatMulLikeRaw(const onnx::NodeProto& node) {
 using InitMap = std::unordered_map<std::string, const onnx::TensorProto*>;
 using ConsumerMap =
     std::unordered_map<std::string, std::vector<onnx::NodeProto*>>;
+
+// Forward declarations for this file's own generic (FLOAT/FLOAT16/BFLOAT16)
+// dtype infrastructure -- defined much later in the file, inside this same
+// anonymous namespace (the "MoE/QMoE whole-expert pruning" section's own
+// IsSupportedFloatDtype/ReadTensorAsF64/WriteF64TensorAs), needed here so
+// the Attention-head-pruning matchers/appliers below -- defined earlier in
+// the file, before that section -- can reuse them rather than duplicating
+// the same FLOAT16/BFLOAT16 bit-conversion logic a second time. (This
+// file's own SliceAxisGeneric, which reuses that same trio, is declared
+// separately below, at global scope -- see that declaration's own comment
+// for why: its own definition, unlike these three, sits textually OUTSIDE
+// this anonymous namespace.)
+bool IsSupportedFloatDtype(int32_t data_type);
+std::vector<double> ReadTensorAsF64(const onnx::TensorProto& t);
+void WriteF64TensorAs(onnx::TensorProto* t, int32_t data_type,
+                      const std::vector<int64_t>& dims,
+                      const std::vector<double>& data);
 
 ConsumerMap ConsumersOf(onnx::GraphProto* graph) {
   ConsumerMap out;
@@ -755,6 +788,50 @@ std::optional<ProducerMatch> MatchProducer(const onnx::NodeProto& node,
   auto it = init_map.find(m->w_name);
   if (it == init_map.end() ||
       it->second->data_type() != onnx::TensorProto::FLOAT ||
+      it->second->dims_size() != 2) {
+    return std::nullopt;
+  }
+  std::optional<std::string> bias;
+  if (node.op_type() == "Gemm" && node.input_size() == 3) {
+    bias = node.input(2);
+    if (!init_map.count(*bias)) {
+      return std::nullopt;  // non-constant bias -- can't safely prune it.
+    }
+  }
+  const onnx::TensorProto* w = it->second;
+  const int64_t n_channels = m->weight_transposed ? w->dims(0) : w->dims(1);
+  return ProducerMatch{m->w_name, m->weight_transposed, bias, n_channels};
+}
+
+// Q/K/V producer matcher for the Attention-head-pruning section's own
+// separate-producer chain families (FindSeparateQkvChains/
+// FindDecomposedGqaChains/MatchPackedQkvSplit) ONLY -- mirrors MatchProducer
+// exactly, but widened to accept FLOAT16/BFLOAT16 in addition to FLOAT32 for
+// the weight, since pruning.py's own `_match_producer` -- shared by every ONE
+// of its own callers, unlike this file's own MatchProducer, which stays
+// FLOAT32-only for its OTHER callers -- already does. Deliberately a narrow,
+// LOCAL duplicate rather than a change to the shared MatchProducer itself:
+// that function backs a dozen OTHER chain families in this file (see
+// ApplyStructuredPruning's own six chain kinds), none of which has been
+// independently re-verified against a real FLOAT16/BFLOAT16 export -- exactly
+// the same reasoning as this file's own MatchMoeRouterProducer (MoE/QMoE
+// whole-expert pruning section, see that function's own comment). Unlike
+// MatchMoeRouterProducer, the Attention-head-pruning apply functions this
+// backs (ApplyOnePlainAttentionChain/ApplyOneGqaChain/
+// ApplyOneDecomposedGqaChain) HAVE been widened to FLOAT16/BFLOAT16 (see
+// their own comments -- ReadTensorAsF64/WriteF64TensorAs/SliceAxisGeneric
+// throughout), so this matcher's dtype gate is safe to widen. `bias` is
+// never dtype-checked at all, mirroring `_match_producer`'s/MatchProducer's
+// own identical lack of a bias dtype gate (only presence as a constant
+// initializer is required either way).
+std::optional<ProducerMatch> MatchProducerAnyFloat(const onnx::NodeProto& node,
+                                                   const InitMap& init_map) {
+  auto m = MatchMatMulLikeRaw(node);
+  if (!m) {
+    return std::nullopt;
+  }
+  auto it = init_map.find(m->w_name);
+  if (it == init_map.end() || !IsSupportedFloatDtype(it->second->data_type()) ||
       it->second->dims_size() != 2) {
     return std::nullopt;
   }
@@ -4425,10 +4502,17 @@ std::vector<int64_t> TopKIndicesAscending(const std::vector<double>& importance,
   return idx;
 }
 
-// Transposes a [dim0, dim1] row-major matrix into [dim1, dim0].
-std::vector<float> TransposeFlat(const std::vector<float>& data, int64_t dim0,
-                                 int64_t dim1) {
-  std::vector<float> out(data.size());
+// Transposes a [dim0, dim1] row-major matrix into [dim1, dim0]. Templated
+// (not just `float`) for the same reason SliceAxis0/SliceAxis1 above are --
+// so the Attention-head-pruning section's own FLOAT16/BFLOAT16-widened
+// `double` code path (ReadTensorAsF64/WriteF64TensorAs) can reuse this exact
+// same transpose via `TransposeFlat<double>` instead of a hand-duplicated
+// copy; every existing caller below still passes `std::vector<float>` and
+// gets the identical instantiation/behavior as before.
+template <typename T>
+std::vector<T> TransposeFlat(const std::vector<T>& data, int64_t dim0,
+                             int64_t dim1) {
+  std::vector<T> out(data.size());
   for (int64_t i = 0; i < dim0; ++i) {
     for (int64_t j = 0; j < dim1; ++j) {
       out[static_cast<size_t>(j * dim0 + i)] =
@@ -5186,9 +5270,21 @@ void ApplyChainsGlobal(
 //   of query heads mapped to it after pruning (FindSeparateQkvChains/
 //   ApplyOneGqaChain, shared between the two ops).
 
-// True for a com.microsoft::Attention node with a constant 2-D float32
-// merged QKV weight [K, Nq+Nk+Nv] (and, if present, a constant 1-D float32
-// merged bias). Mirrors pruning.py's own _match_attention_producer.
+// True for a com.microsoft::Attention/DecoderMaskedSelfAttention/
+// PackedAttention node with a constant 2-D FLOAT/FLOAT16/BFLOAT16 merged QKV
+// weight [K, Nq+Nk+Nv] (and, if present, a constant 1-D FLOAT/FLOAT16/
+// BFLOAT16 merged bias of the same dtype-class). Mirrors pruning.py's own
+// _match_attention_producer, including its own three-op-type scope: all
+// three share `Attention`'s exact input positions for everything this
+// matcher touches (weight/bias at 1/2), differing only as `is_dmsa` below
+// accounts for. `attention_bias` (input 5)'s own per-head-safety check
+// (pruning.py's own `_head_bias_input_is_safe`/`_slice_or_gather_head_bias`
+// dynamic-Gather-insertion machinery) is a separate, larger parity gap this
+// port does not yet close for ANY of its matched families -- see this
+// file's own "Attention-head pruning" section comment above for the
+// per-family scope, and tests/test_attention_head_pruning_cpp.py's own
+// top-of-file docstring for the exact, already-accepted divergence this
+// produces -- left untouched here exactly as before.
 struct AttentionProducerMatch {
   std::string weight;
   std::optional<std::string> bias;
@@ -5198,16 +5294,20 @@ struct AttentionProducerMatch {
 
 std::optional<AttentionProducerMatch> MatchAttentionProducer(
     const onnx::NodeProto& node, const InitMap& init_map) {
-  if (node.domain() != kComMicrosoftDomain || node.op_type() != "Attention") {
+  if (node.domain() != kComMicrosoftDomain ||
+      (node.op_type() != "Attention" &&
+       node.op_type() != "DecoderMaskedSelfAttention" &&
+       node.op_type() != "PackedAttention")) {
     return std::nullopt;
   }
+  const bool is_dmsa = node.op_type() == "DecoderMaskedSelfAttention";
   if (node.input_size() < 2) {
     return std::nullopt;
   }
   const std::string& w_name = node.input(1);
   auto wit = init_map.find(w_name);
   if (wit == init_map.end() ||
-      wit->second->data_type() != onnx::TensorProto::FLOAT ||
+      !IsSupportedFloatDtype(wit->second->data_type()) ||
       wit->second->dims_size() != 2) {
     return std::nullopt;
   }
@@ -5218,15 +5318,27 @@ std::optional<AttentionProducerMatch> MatchAttentionProducer(
     bias_name = node.input(2);
     auto bit = init_map.find(*bias_name);
     if (bit == init_map.end() ||
-        bit->second->data_type() != onnx::TensorProto::FLOAT ||
+        !IsSupportedFloatDtype(bit->second->data_type()) ||
         bit->second->dims_size() != 1 || bit->second->dims(0) != total_n) {
       return std::nullopt;
     }
   }
 
+  // DecoderMaskedSelfAttention-only: `past` (index 4) is required by this
+  // op's own schema and holds combined key+value runtime decode state -- a
+  // real export always leaves it dynamic; a constant here has no
+  // established/tested slicing path, so decline conservatively rather than
+  // leaving it silently stale. Mirrors pruning.py's own
+  // `_match_attention_producer`.
+  if (is_dmsa && node.input_size() > 4 && !node.input(4).empty() &&
+      init_map.count(node.input(4))) {
+    return std::nullopt;
+  }
+
   int64_t num_heads = 0;
   bool has_num_heads = false;
   std::optional<std::vector<int64_t>> qkv_hidden_sizes;
+  int64_t do_rotary = 0;
   for (const auto& attr : node.attribute()) {
     if (attr.name() == "num_heads") {
       num_heads = attr.i();
@@ -5234,10 +5346,22 @@ std::optional<AttentionProducerMatch> MatchAttentionProducer(
     } else if (attr.name() == "qkv_hidden_sizes") {
       qkv_hidden_sizes =
           std::vector<int64_t>(attr.ints().begin(), attr.ints().end());
+    } else if (attr.name() == "do_rotary") {
+      do_rotary = attr.i();
     }
   }
   if (!has_num_heads || num_heads <= 0) {
     return std::nullopt;
+  }
+  if (is_dmsa) {
+    if (do_rotary) {
+      return std::nullopt;  // fused RoPE -- no confirmed per-head-safe
+                            // execution path for this op in this environment.
+    }
+    if (qkv_hidden_sizes) {
+      return std::nullopt;  // not a real attribute on this op's own schema --
+                            // decline rather than guess at an uneven split.
+    }
   }
 
   int64_t nq, nk, nv;
@@ -5332,7 +5456,7 @@ WalkToAttentionConsumer(const std::string& start, const InitMap& init_map,
   }
   auto wit = init_map.find(cm->w_name);
   if (wit == init_map.end() ||
-      wit->second->data_type() != onnx::TensorProto::FLOAT ||
+      !IsSupportedFloatDtype(wit->second->data_type()) ||
       wit->second->dims_size() != 2) {
     return {std::nullopt, chain_ops};
   }
@@ -5961,9 +6085,9 @@ std::vector<AttnChain> FindSeparateQkvChains(
         vit == node_by_output.end()) {
       continue;
     }
-    auto pq = MatchProducer(*qit->second, init_map);
-    auto pk = MatchProducer(*kit->second, init_map);
-    auto pv = MatchProducer(*vit->second, init_map);
+    auto pq = MatchProducerAnyFloat(*qit->second, init_map);
+    auto pk = MatchProducerAnyFloat(*kit->second, init_map);
+    auto pv = MatchProducerAnyFloat(*vit->second, init_map);
     if (!pq || !pk || !pv) {
       continue;
     }
@@ -5999,7 +6123,7 @@ std::vector<AttnChain> FindSeparateQkvChains(
         const std::string& bias_name = node->input(idx);
         auto bit = init_map.find(bias_name);
         if (bit == init_map.end() ||
-            bit->second->data_type() != onnx::TensorProto::FLOAT ||
+            !IsSupportedFloatDtype(bit->second->data_type()) ||
             bit->second->dims_size() != 1 ||
             bit->second->dims(0) !=
                 pq->n_channels + pk->n_channels + pv->n_channels) {
@@ -6163,7 +6287,12 @@ std::optional<AppliedAttn> ApplyOnePlainAttentionChain(
   onnx::TensorProto* w_init = init_map.at(chain.weight);
   const int64_t K = w_init->dims(0);
   const int64_t total_n = w_init->dims(1);
-  std::vector<float> w = ReadFloatTensor(*w_init);  // [K, total_n] row-major.
+  // ReadTensorAsF64 (not ReadFloatTensor) -- FLOAT/FLOAT16/BFLOAT16 alike,
+  // upcast to double, mirroring pruning.py's own `_to_f64`, for the
+  // importance ranking below only: the actual slice further down
+  // (SliceAxisGeneric) reads/writes this same tensor completely
+  // independently, with its own dtype-preserving round trip.
+  std::vector<double> w = ReadTensorAsF64(*w_init);  // [K, total_n] row-major.
 
   // Combined importance of each head's full Q+K+V weight block -- for L2
   // that's the block's own Frobenius norm (sqrt of the sum of every entry
@@ -6230,11 +6359,20 @@ std::optional<AppliedAttn> ApplyOnePlainAttentionChain(
   all_idx.insert(all_idx.end(), k_idx.begin(), k_idx.end());
   all_idx.insert(all_idx.end(), v_idx.begin(), v_idx.end());
 
-  std::vector<float> sliced_w = SliceAxis1(w, K, total_n, 1, all_idx);
-  SetFloatTensorData(w_init, {K, static_cast<int64_t>(all_idx.size())},
-                     sliced_w);
+  // SliceAxisGeneric (axis 1 -- the merged QKV weight's own column/head
+  // axis) rather than a manual SliceAxis1 + WriteF64TensorAs pair: reuses
+  // this file's own pre-existing MoE/QMoE-section ReadTensorAsF64/
+  // WriteF64TensorAs machinery in one call, preserving `w_init`'s own
+  // original dtype.
+  SliceAxisGeneric(w_init, all_idx, 1);
   if (chain.bias) {
-    SliceLastAxis(init_map.at(*chain.bias), all_idx);
+    // SliceAxisGeneric (axis 0 -- this bias' own only axis, always the last
+    // one) rather than the shared, FLOAT32-only SliceLastAxis: reuses this
+    // file's own pre-existing MoE/QMoE-section ReadTensorAsF64/
+    // WriteF64TensorAs machinery, mirroring pruning.py's own dtype-agnostic
+    // `_slice_last_axis` (`onnx.numpy_helper.to_array`/`from_array` handle
+    // any dtype).
+    SliceAxisGeneric(init_map.at(*chain.bias), all_idx, 0);
   }
 
   bool found_qkv = false;
@@ -6249,7 +6387,16 @@ std::optional<AppliedAttn> ApplyOnePlainAttentionChain(
       attr.add_ints(keep_count * dv);
     }
   }
-  if (!found_qkv) {
+  // `DecoderMaskedSelfAttention` has no `qkv_hidden_sizes` attribute on its
+  // own schema at all (see MatchAttentionProducer's own comment) --
+  // `dq == dk == dv` is guaranteed for it (the matcher only ever accepts its
+  // own always-even 3-way split), so `keep_count * dq == keep_count * dk ==
+  // keep_count * dv` remains true after pruning too, and the kernel's own
+  // even-split default reproduces the right shape with no attribute needed.
+  // Writing one anyway would just be a dead, schema-unrecognized attribute on
+  // the node -- harmless but pointless. Mirrors pruning.py's own
+  // `_apply_one_plain_attention_chain` exactly.
+  if (!found_qkv && chain.node->op_type() != "DecoderMaskedSelfAttention") {
     onnx::AttributeProto* attr = chain.node->add_attribute();
     attr->set_name("qkv_hidden_sizes");
     attr->set_type(onnx::AttributeProto::INTS);
@@ -6258,8 +6405,12 @@ std::optional<AppliedAttn> ApplyOnePlainAttentionChain(
     attr->add_ints(keep_count * dv);
   }
 
-  SliceConsumerWeight(init_map.at(chain.consumer_weight),
-                      chain.consumer_weight_transposed, v_idx_local, false);
+  // SliceAxisGeneric (axis = transposed ? 1 : 0 -- the reduction/input-
+  // channel axis of a plain 2-D MatMul/Gemm consumer weight, never a Conv
+  // here) rather than the shared, FLOAT32-only SliceConsumerWeight -- see
+  // this function's own `w`/`chain.bias` comments above for why.
+  SliceAxisGeneric(init_map.at(chain.consumer_weight), v_idx_local,
+                   chain.consumer_weight_transposed ? 1 : 0);
 
   for (const auto& co : chain.chain_ops) {
     if (co.shape_name) {
@@ -6352,9 +6503,16 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
                                      wk_init->dims().end());
   const std::vector<int64_t> wv_dims(wv_init->dims().begin(),
                                      wv_init->dims().end());
-  std::vector<float> wq = ReadFloatTensor(*wq_init);
-  std::vector<float> wk = ReadFloatTensor(*wk_init);
-  std::vector<float> wv = ReadFloatTensor(*wv_init);
+  // ReadTensorAsF64 (not ReadFloatTensor) -- FLOAT/FLOAT16/BFLOAT16 alike,
+  // upcast to double, for the importance ranking below only: the actual
+  // producer-weight slicing further down reads/writes each tensor completely
+  // independently (SliceAxisGeneric, its own dtype-preserving round trip), so
+  // no dtype needs tracking here. See ApplyOnePlainAttentionChain's own
+  // identical comment for why this round trip never rounds a surviving
+  // entry's own bit pattern.
+  std::vector<double> wq = ReadTensorAsF64(*wq_init);
+  std::vector<double> wk = ReadTensorAsF64(*wk_init);
+  std::vector<double> wv = ReadTensorAsF64(*wv_init);
 
   // Bring each to [K, N] (reduction dim first, head columns last) -- the
   // *opposite* of SliceProducerWeight's "output channel first" convention,
@@ -6363,15 +6521,15 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
   const int64_t Nq = wq_dims[chain.q_weight_transposed ? 0 : 1];
   const int64_t Nk = wk_dims[chain.k_weight_transposed ? 0 : 1];
   const int64_t Nv = wv_dims[chain.v_weight_transposed ? 0 : 1];
-  std::vector<float> wq_kn = chain.q_weight_transposed
-                                 ? TransposeFlat(wq, wq_dims[0], wq_dims[1])
-                                 : wq;
-  std::vector<float> wk_kn = chain.k_weight_transposed
-                                 ? TransposeFlat(wk, wk_dims[0], wk_dims[1])
-                                 : wk;
-  std::vector<float> wv_kn = chain.v_weight_transposed
-                                 ? TransposeFlat(wv, wv_dims[0], wv_dims[1])
-                                 : wv;
+  std::vector<double> wq_kn = chain.q_weight_transposed
+                                  ? TransposeFlat(wq, wq_dims[0], wq_dims[1])
+                                  : wq;
+  std::vector<double> wk_kn = chain.k_weight_transposed
+                                  ? TransposeFlat(wk, wk_dims[0], wk_dims[1])
+                                  : wk;
+  std::vector<double> wv_kn = chain.v_weight_transposed
+                                  ? TransposeFlat(wv, wv_dims[0], wv_dims[1])
+                                  : wv;
 
   // Combined importance of each KV group's own Q+K+V weight block -- for L2
   // that's the block's own Frobenius norm; for L1 the sum of every entry's
@@ -6436,17 +6594,21 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
   std::vector<int64_t> q_idx = HeadColumnIndices(keep_q_heads, d);
   std::vector<int64_t> kv_idx = HeadColumnIndices(keep_groups, d);
 
-  SliceProducerWeight(wq_init, chain.q_weight_transposed, q_idx, false);
-  SliceProducerWeight(wk_init, chain.k_weight_transposed, kv_idx, false);
-  SliceProducerWeight(wv_init, chain.v_weight_transposed, kv_idx, false);
+  // SliceAxisGeneric (axis = transposed ? 0 : 1 -- the output-channel/head
+  // axis of a plain 2-D MatMul/Gemm producer weight, never a Conv here)
+  // rather than the shared, FLOAT32-only SliceProducerWeight -- see this
+  // function's own `wq`/`wk`/`wv` comment above for why.
+  SliceAxisGeneric(wq_init, q_idx, chain.q_weight_transposed ? 0 : 1);
+  SliceAxisGeneric(wk_init, kv_idx, chain.k_weight_transposed ? 0 : 1);
+  SliceAxisGeneric(wv_init, kv_idx, chain.v_weight_transposed ? 0 : 1);
   if (chain.q_bias) {
-    SliceLastAxis(init_map.at(*chain.q_bias), q_idx);
+    SliceAxisGeneric(init_map.at(*chain.q_bias), q_idx, 0);
   }
   if (chain.k_bias) {
-    SliceLastAxis(init_map.at(*chain.k_bias), kv_idx);
+    SliceAxisGeneric(init_map.at(*chain.k_bias), kv_idx, 0);
   }
   if (chain.v_bias) {
-    SliceLastAxis(init_map.at(*chain.v_bias), kv_idx);
+    SliceAxisGeneric(init_map.at(*chain.v_bias), kv_idx, 0);
   }
 
   // MultiHeadAttention/PackedMultiHeadAttention/
@@ -6473,7 +6635,7 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     for (int64_t x : kv_idx) {
       full_bias_idx.push_back(x + nq_orig + nk_orig);
     }
-    SliceLastAxis(init_map.at(*chain.mha_bias), full_bias_idx);
+    SliceAxisGeneric(init_map.at(*chain.mha_bias), full_bias_idx, 0);
   }
 
   const int64_t new_kv_num_heads = keep_count;
@@ -6486,8 +6648,8 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     }
   }
 
-  SliceConsumerWeight(init_map.at(chain.consumer_weight),
-                      chain.consumer_weight_transposed, q_idx, false);
+  SliceAxisGeneric(init_map.at(chain.consumer_weight), q_idx,
+                   chain.consumer_weight_transposed ? 1 : 0);
 
   for (const auto& co : chain.chain_ops) {
     if (co.shape_name) {
@@ -23172,7 +23334,7 @@ std::optional<PackedQkvSplitMatch> MatchPackedQkvSplit(
   if (pit == node_by_output.end()) {
     return std::nullopt;
   }
-  auto pinfo = MatchProducer(*pit->second, init_map);
+  auto pinfo = MatchProducerAnyFloat(*pit->second, init_map);
   if (!pinfo || pinfo->n_channels != nq + nk + nv) {
     return std::nullopt;
   }
@@ -24094,7 +24256,7 @@ std::vector<DecomposedGqaChain> FindDecomposedGqaChains(
     }
     auto cwit = init_map.find(cm->w_name);
     if (cwit == init_map.end() ||
-        cwit->second->data_type() != onnx::TensorProto::FLOAT ||
+        !IsSupportedFloatDtype(cwit->second->data_type()) ||
         cwit->second->dims_size() != 2) {
       continue;
     }
@@ -24201,9 +24363,9 @@ std::vector<DecomposedGqaChain> FindDecomposedGqaChains(
                k_prod_node == v_prod_node) {
       continue;  // degenerate -- shared producer, can't independently slice
     } else {
-      auto q_info = MatchProducer(*q_prod_node, init_map);
-      auto k_info = MatchProducer(*k_prod_node, init_map);
-      auto v_info = MatchProducer(*v_prod_node, init_map);
+      auto q_info = MatchProducerAnyFloat(*q_prod_node, init_map);
+      auto k_info = MatchProducerAnyFloat(*k_prod_node, init_map);
+      auto v_info = MatchProducerAnyFloat(*v_prod_node, init_map);
       if (!q_info || !k_info || !v_info) {
         continue;
       }
@@ -24373,12 +24535,17 @@ std::optional<AppliedDecomposedGqa> ApplyOneDecomposedGqaChain(
                                      wk_init->dims().end());
   const std::vector<int64_t> wv_dims(wv_init->dims().begin(),
                                      wv_init->dims().end());
-  std::vector<float> wq = ReadFloatTensor(*wq_init);
-  std::vector<float> wk = ReadFloatTensor(*wk_init);
-  std::vector<float> wv = ReadFloatTensor(*wv_init);
+  // ReadTensorAsF64 (not ReadFloatTensor) -- FLOAT/FLOAT16/BFLOAT16 alike,
+  // upcast to double, mirroring pruning.py's own `_to_f64`, for the
+  // importance ranking below only: the actual producer-weight slicing
+  // further down (SliceAxisGeneric) reads/writes each tensor completely
+  // independently, with its own dtype-preserving round trip.
+  std::vector<double> wq = ReadTensorAsF64(*wq_init);
+  std::vector<double> wk = ReadTensorAsF64(*wk_init);
+  std::vector<double> wv = ReadTensorAsF64(*wv_init);
 
   int64_t Nq, Nk, Nv, Kq, Kk, Kv;
-  std::vector<float> wq_kn, wk_kn, wv_kn;
+  std::vector<double> wq_kn, wk_kn, wv_kn;
   if (chain.packed_split_sizes) {
     // `chain.q_weight`/`.k_weight`/`.v_weight` all name the *same*
     // underlying packed tensor (`wq_init == wk_init == wv_init`), one
@@ -24391,12 +24558,12 @@ std::optional<AppliedDecomposedGqa> ApplyOneDecomposedGqaChain(
     // chain` packed branch exactly.
     const int64_t total_n = wq_dims[chain.q_weight_transposed ? 0 : 1];
     const int64_t k_dim = chain.q_weight_transposed ? wq_dims[1] : wq_dims[0];
-    const std::vector<float> w_kn =
+    const std::vector<double> w_kn =
         chain.q_weight_transposed ? TransposeFlat(wq, wq_dims[0], wq_dims[1])
                                   : wq;
     const int64_t nv_orig = total_n - nq_orig - nk_orig;
     auto column_slice = [&](int64_t col_lo, int64_t width) {
-      std::vector<float> out(static_cast<size_t>(k_dim * width));
+      std::vector<double> out(static_cast<size_t>(k_dim * width));
       for (int64_t r = 0; r < k_dim; ++r) {
         std::copy(w_kn.begin() + r * total_n + col_lo,
                   w_kn.begin() + r * total_n + col_lo + width,
@@ -24557,9 +24724,12 @@ std::optional<AppliedDecomposedGqa> ApplyOneDecomposedGqaChain(
     for (int64_t x : v_idx) {
       full_idx.push_back(x + nq_orig + nk_orig);
     }
-    SliceProducerWeight(wq_init, chain.q_weight_transposed, full_idx, false);
+    // SliceAxisGeneric (axis = transposed ? 0 : 1) rather than the shared,
+    // FLOAT32-only SliceProducerWeight -- see this function's own `wq`/`wk`/
+    // `wv` comment above for why.
+    SliceAxisGeneric(wq_init, full_idx, chain.q_weight_transposed ? 0 : 1);
     if (chain.q_bias) {
-      SliceLastAxis(init_map.at(*chain.q_bias), full_idx);
+      SliceAxisGeneric(init_map.at(*chain.q_bias), full_idx, 0);
     }
     onnx::TensorProto* sizes_init = init_map.at(*chain.packed_split_sizes);
     SetInt64TensorData(
@@ -24567,21 +24737,21 @@ std::optional<AppliedDecomposedGqa> ApplyOneDecomposedGqaChain(
         {static_cast<int64_t>(q_idx.size()), static_cast<int64_t>(k_idx.size()),
          static_cast<int64_t>(v_idx.size())});
   } else {
-    SliceProducerWeight(wq_init, chain.q_weight_transposed, q_idx, false);
-    SliceProducerWeight(wk_init, chain.k_weight_transposed, k_idx, false);
-    SliceProducerWeight(wv_init, chain.v_weight_transposed, v_idx, false);
+    SliceAxisGeneric(wq_init, q_idx, chain.q_weight_transposed ? 0 : 1);
+    SliceAxisGeneric(wk_init, k_idx, chain.k_weight_transposed ? 0 : 1);
+    SliceAxisGeneric(wv_init, v_idx, chain.v_weight_transposed ? 0 : 1);
     if (chain.q_bias) {
-      SliceLastAxis(init_map.at(*chain.q_bias), q_idx);
+      SliceAxisGeneric(init_map.at(*chain.q_bias), q_idx, 0);
     }
     if (chain.k_bias) {
-      SliceLastAxis(init_map.at(*chain.k_bias), k_idx);
+      SliceAxisGeneric(init_map.at(*chain.k_bias), k_idx, 0);
     }
     if (chain.v_bias) {
-      SliceLastAxis(init_map.at(*chain.v_bias), v_idx);
+      SliceAxisGeneric(init_map.at(*chain.v_bias), v_idx, 0);
     }
   }
-  SliceConsumerWeight(init_map.at(chain.consumer_weight),
-                      chain.consumer_weight_transposed, y_idx, false);
+  SliceAxisGeneric(init_map.at(chain.consumer_weight), y_idx,
+                   chain.consumer_weight_transposed ? 1 : 0);
 
   // `keep_q_heads.size()` rather than `keep_count * group_size`: identical
   // for the ordinary group-pruning path (`keep_q_heads` is built there as
@@ -25493,23 +25663,27 @@ onnx::ModelProto ApplyTransformerBlockPruning(
 
 // Attention QKV-weight matcher for ApplySparseGptPruning ONLY -- mirrors
 // MatchAttentionProducer (this file's "Attention-head pruning" section)
-// exactly, but widened to accept FLOAT16/BFLOAT16 in addition to FLOAT32 for
-// both the weight and (if present) bias, mirroring pruning.py's own
+// exactly for the plain-`Attention` case, accepting FLOAT/FLOAT16/BFLOAT16
+// for both the weight and (if present) bias, mirroring pruning.py's own
 // `_match_attention_producer`, which is itself already
 // `_is_supported_float_dtype`-widened (`_match_attention_weight_only` just
-// reuses it in full, dtype widening included). Deliberately a narrow, LOCAL
-// duplicate rather than a change to the shared MatchAttentionProducer
-// itself -- exactly the same reasoning as this file's own
+// reuses it in full, dtype widening included) -- the SAME dtype scope
+// MatchAttentionProducer itself now also accepts (it was independently
+// widened for the structural Attention-head-pruning family, once THAT
+// family's own downstream apply-time arithmetic was verified FLOAT16/
+// BFLOAT16-safe end to end; see that function's own comment). Still a
+// narrow, LOCAL duplicate rather than a repointed call to the shared
+// MatchAttentionProducer, though -- for a DIFFERENT reason now: op-type
+// scope. MatchAttentionProducer also recognizes `DecoderMaskedSelfAttention`/
+// `PackedAttention` (and the `is_dmsa`-only `past`/`do_rotary`/
+// `qkv_hidden_sizes` schema quirks that come with them), neither of which
+// SparseGPT's own Hessian-compensated column-pruning math has been
+// independently re-verified against, so repointing here would silently
+// widen candidate matching to two op types this pass has never been checked
+// against -- exactly the same reasoning as this file's own
 // MatchMoeRouterProducer (MoE/QMoE whole-expert pruning section, see that
-// function's own comment): MatchAttentionProducer also backs this file's
-// OWN structural Attention-head pruning (FindAttentionChains /
-// ApplyOnePlainAttentionChain), which has not been independently
-// re-verified against a real FLOAT16/BFLOAT16 export and stays FLOAT32-only
-// -- its own downstream weight/bias rewriting is still ReadFloatTensor/
-// SetFloatTensorData-based (FLOAT32 only), so widening the shared matcher
-// in place would silently let a FLOAT16/BFLOAT16 node through to code that
-// cannot correctly handle it. SparseGPT never touches bias, only the
-// weight, but bias dtype/shape is still validated here (mirroring
+// function's own comment). SparseGPT never touches bias, only the weight,
+// but bias dtype/shape is still validated here (mirroring
 // `_match_attention_producer`'s own checks, reused in full by
 // `_match_attention_weight_only` even though nothing there reads bias
 // either) so a node this file's own structural head-pruning would decline
@@ -26093,10 +26267,11 @@ onnx::ModelProto ApplySparseGptPruning(
   // original dtype, exactly like the MoE/QMoE FP16/BFLOAT16 widening this
   // mirrors), plus every matched `com.microsoft::Attention` node's constant
   // 2-D FLOAT/FLOAT16/BFLOAT16 merged QKV weight
-  // (MatchAttentionProducerAnyFloat -- a narrow local dtype-widened
-  // duplicate of MatchAttentionProducer, see that function's own comment
-  // for why MatchAttentionProducer itself is left untouched -- exactly
-  // mirroring pruning.py's own _match_attention_weight_only, which reuses
+  // (MatchAttentionProducerAnyFloat -- a narrow local duplicate of
+  // MatchAttentionProducer, see that function's own comment for why this
+  // call site isn't simply repointed at the shared matcher directly --
+  // exactly mirroring pruning.py's own _match_attention_weight_only, which
+  // reuses
   // _match_attention_producer's own identical (already dtype-widened)
   // validation, minus its bias handling: SparseGPT never touches bias, only
   // weight). `com.microsoft::GroupQueryAttention`'s separate Q/K/V
@@ -26338,15 +26513,19 @@ onnx::ModelProto ApplySparseGptPruning(
 // Attention candidate case -- MatchAttentionProducer's own dtype gate is
 // baked INSIDE the shared matcher itself (unlike MatchMatMulLikeRaw's), and
 // that matcher is also reused by FindAttentionChains (structured
-// Attention-head pruning) and ApplySparseGptPruning immediately above, both
-// deliberately FLOAT32-only per their own declaration comments -- widening
-// it in place would silently widen candidate matching for those two
-// unrelated, independently-verified-only-for-FLOAT32 passes too. Hence the
-// narrow, local duplicate instead, exactly the same "narrow, local
-// duplicate instead of a shared-code change" precedent this file's own
-// MoE/QMoE section top comment already established for the analogous
-// FLOAT32-only-elsewhere situation. The only genuinely new machinery here
-// (beyond the dtype widening) is the plain one-shot importance score
+// Attention-head pruning) and ApplySparseGptPruning immediately above.
+// MatchAttentionProducer's own dtype scope now matches this pass' (both
+// FLOAT/FLOAT16/BFLOAT16 -- see that function's own comment), but it ALSO
+// recognizes `DecoderMaskedSelfAttention`/`PackedAttention`, an op-type
+// widening neither this pass nor ApplySparseGptPruning has independently
+// re-verified its own math against -- widening the call site to the shared
+// matcher in place would silently widen candidate matching for both of
+// those unrelated passes too. Hence the narrow, local duplicate instead,
+// exactly the same "narrow, local duplicate instead of a shared-code
+// change" precedent this file's own MoE/QMoE section top comment already
+// established for the analogous FLOAT32-only-elsewhere situation. The only
+// genuinely new machinery here (beyond the dtype widening) is the plain
+// one-shot importance score
 // (`|W_ij| * ||X_j||_2`, WandaImportance below, no Hessian/Cholesky at all)
 // and its element-wise masking (WandaSparsityMaskNK/WandaNmMaskNK/the
 // `global_sparsity` pooling loop inside ApplyWandaPruning itself), mirroring
@@ -26685,25 +26864,29 @@ std::vector<uint8_t> WandaNmMaskNK(const std::vector<double>& importance,
   return mask;
 }
 
-// Local, dtype-widened copy of MatchAttentionProducer (structural logic
-// verbatim identical -- domain/op_type, weight/bias shape and dtype,
+// Local, narrowed copy of MatchAttentionProducer (structural logic verbatim
+// identical for the plain-`Attention` case -- weight/bias shape and dtype,
 // num_heads/qkv_hidden_sizes consistency), scoped to ApplyWandaPruning
-// alone: accepts FLOAT/FLOAT16/BFLOAT16 (IsSupportedFloatDtype) for both
-// the merged QKV weight and (if present) its merged bias, mirroring
-// pruning.py's own `_match_attention_producer`'s `_is_supported_float_dtype`
-// checks exactly (unlike MatchAttentionProducer's own hardcoded `==
-// onnx::TensorProto::FLOAT`). A genuinely separate copy rather than an
-// in-place widening of the shared MatchAttentionProducer -- see this file's
-// own "Wanda unstructured (element-wise) pruning" section top comment for
-// why: that function is also reused by FindAttentionChains (structured
-// Attention-head pruning) and ApplySparseGptPruning immediately above, both
-// deliberately FLOAT32-only per their own declaration comments, so widening
-// its dtype gate in place would silently widen candidate matching for those
-// two unrelated, independently-verified-only-for-FLOAT32 passes too --
-// exactly the MoE/QMoE section's own already-established "narrow, local
-// duplicate instead of a shared-code change" precedent. Bias dtype is
-// checked (though ApplyWandaPruning itself never reads bias) purely to
-// decline the same malformed-node shapes MatchAttentionProducer already
+// alone: accepts FLOAT/FLOAT16/BFLOAT16 (IsSupportedFloatDtype) for both the
+// merged QKV weight and (if present) its merged bias, mirroring pruning.py's
+// own `_match_attention_producer`'s `_is_supported_float_dtype` checks
+// exactly -- the SAME dtype scope MatchAttentionProducer itself now also
+// accepts (see that function's own comment: it was independently widened,
+// for the structural Attention-head-pruning family only, once that family's
+// own downstream apply-time arithmetic was verified FLOAT16/BFLOAT16-safe
+// end to end). A genuinely separate copy rather than a repointed call to the
+// shared MatchAttentionProducer remains warranted for a DIFFERENT reason
+// now: op-type scope, not dtype -- MatchAttentionProducer also recognizes
+// `DecoderMaskedSelfAttention`/`PackedAttention` (and the `is_dmsa`-only
+// `past`/`do_rotary`/`qkv_hidden_sizes` schema quirks that come with them),
+// none of which ApplySparseGptPruning immediately above or ApplyWandaPruning
+// here have been independently re-verified against, so repointing either to
+// the shared matcher would silently widen candidate matching for both to
+// two op types their own Hessian-compensated/masking math has never been
+// checked against -- exactly the MoE/QMoE section's own already-established
+// "narrow, local duplicate instead of a shared-code change" precedent. Bias
+// dtype is checked (though ApplyWandaPruning itself never reads bias) purely
+// to decline the same malformed-node shapes MatchAttentionProducer already
 // would, matching pruning.py's own `_match_attention_weight_only`'s full
 // reuse of `_match_attention_producer` (including its bias check) exactly.
 std::optional<AttentionProducerMatch> MatchAttentionProducerWideDtype(

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -5438,12 +5438,97 @@ struct HeadCountsMatch {
   int64_t kv_num_heads;
 };
 
+}  // namespace
+
+// Forward declarations, at GLOBAL scope (matching where they're actually
+// defined, further down this file, past the closing `}  // namespace` of
+// this same anonymous namespace -- unlike everything else declared inside
+// it, an anonymous-namespace declaration has internal linkage distinct from
+// an identically-named global one, so a forward declaration placed INSIDE
+// this namespace would silently name a different, never-defined entity and
+// make every call site below ambiguous between the two) -- HeadBiasInputIsSafe/
+// SliceOrGatherHeadBias and PastKvConstantsAreSliceable are defined later in
+// this file, in the decomposed-GQA section (the former pair alongside
+// HeadBiasAxis/ConstShapeDims/DynamicHeadBiasAxis, all of which they share;
+// the latter grouped with them for the same "shared per-head/per-KV-cache
+// safety net" reason), but MatchMultiHeadAttentionProducer/
+// MatchPackedMultiHeadAttentionProducer (match time) and ApplyOneGqaChain
+// (apply time), both still inside this anonymous namespace and well before
+// that section, need to call them before that point in the file. `InitMap`
+// (declared earlier in this same anonymous namespace) remains visible here
+// and below: an anonymous namespace's own members are found by ordinary
+// unqualified lookup from its enclosing scope for the rest of the
+// translation unit, exactly like a `using namespace` into that scope.
+bool HeadBiasInputIsSafe(
+    const onnx::NodeProto& node, int idx, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name,
+    int64_t num_heads);
+void SliceOrGatherHeadBias(
+    onnx::NodeProto* node, int idx,
+    std::unordered_map<std::string, onnx::TensorProto*>& init_map,
+    int64_t num_heads, const std::vector<int64_t>& keep,
+    onnx::GraphProto* graph, std::unordered_set<std::string>& used_names,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name);
+// ApplyOneGqaChain (below) also calls this directly, to slice a constant
+// MultiHeadAttention past_key/past_value in place along axis 1 (its own
+// kv_num_heads axis) once PastKvConstantsAreSliceable has confirmed it's
+// safe -- mirrors pruning.py's own `_slice_axis1` call there. Same
+// forward-declaration reasoning as HeadBiasInputIsSafe above.
+void SliceAxisGeneric(onnx::TensorProto* t, const std::vector<int64_t>& keep,
+                      int64_t axis);
+
+// Shared safety gate for a matched node's optional `past_key`/`past_value`
+// inputs (a `(past_key_idx, past_value_idx)` pair) -- mirrors pruning.py's
+// own `_past_kv_constants_are_sliceable` exactly (see that function's own
+// docstring for the full BNSH-layout/quantized-cache reasoning): both ops'
+// own schemas lay a connected `past_key`/`past_value` out in BNSH format
+// (`batch_size, kv_num_heads, past_sequence_length, head_size`), so the
+// `kv_num_heads` axis sits at axis 1 of a rank-4 tensor -- the same axis
+// SliceAxisGeneric(..., 1) slices K's/V's own producer weight by. A
+// *dynamic* (non-constant) past_key/past_value is always left alone and
+// never blocks a match -- the caller's own runtime data. A *constant* one is
+// declined (returns false) when its shape isn't confidently this exact
+// layout. A plain FLOAT/FLOAT16/BFLOAT16 constant of that shape
+// (IsSupportedFloatDtype) is always accepted. A constant whose dtype is
+// instead quantized (float8e4m3fn/uint8/int8, `kQuantizedKvCacheDtypes`) is
+// only ever accepted when the caller passes `scale_indices`, with a
+// connected `k_scale`/`v_scale` that is either dynamic, a `"PER_TENSOR"`
+// single-scalar broadcast (needs no slicing), or a `"PER_CHANNEL"`
+// `[1, kv_num_heads, 1, head_size]` FLOAT constant (the same axis-1 layout,
+// safe to slice by the identical index set) -- any other shape declines the
+// match. Forward-declared for the same reason as HeadBiasInputIsSafe above;
+// defined alongside it.
+bool PastKvConstantsAreSliceable(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    std::pair<int, int> indices, int64_t kv_num_heads,
+    std::optional<std::pair<int, int>> scale_indices = std::nullopt);
+
+// Also forward-declared for the same reason: ApplyAttentionChains (below)
+// needs a `used_names` seed set to hand SliceOrGatherHeadBias's own
+// MintUniqueName calls, the same way ApplyDecomposedGqaChains already does.
+std::unordered_set<std::string> ExistingGraphNames(
+    const onnx::GraphProto& graph);
+
+namespace {
+
 // If `node` is a com.microsoft::GroupQueryAttention node this pass can
 // safely act on (separate Q/K/V inputs -- rules out the op's packed-QKV
 // calling convention; no non-empty constant past_key/past_value), returns
 // (num_heads, kv_num_heads). Mirrors pruning.py's own _match_gqa_producer.
-std::optional<HeadCountsMatch> MatchGqaProducer(const onnx::NodeProto& node,
-                                                const InitMap& init_map) {
+// `value_info_by_name` accepted for FindSeparateQkvChains' own uniform
+// match_producer call signature (mirroring pruning.py's own identical
+// choice -- see that function's own docstring) but ignored here: this
+// port's own GQA matcher has no per-head attention_bias/attn_mask handling
+// at all yet (a separate, pre-existing, out-of-scope gap from this MHA/
+// PackedMultiHeadAttention fix -- see this file's own "Attention-head
+// pruning" section comment for scope).
+std::optional<HeadCountsMatch> MatchGqaProducer(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "GroupQueryAttention") {
     return std::nullopt;
@@ -5489,9 +5574,15 @@ std::optional<HeadCountsMatch> MatchGqaProducer(const onnx::NodeProto& node,
 
 // If `node` is a plain ai.onnx::Attention node (domain "", opset 24+) this
 // pass can safely act on, returns (q_num_heads, kv_num_heads). Mirrors
-// pruning.py's own _match_onnx_attention_producer.
+// pruning.py's own _match_onnx_attention_producer. `value_info_by_name`
+// accepted (see MatchGqaProducer's own comment) but ignored: this op's own
+// `attn_mask` handling is a separate, pre-existing, out-of-scope gap here
+// too.
 std::optional<HeadCountsMatch> MatchOnnxAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (!node.domain().empty() || node.op_type() != "Attention") {
     return std::nullopt;
   }
@@ -5575,20 +5666,26 @@ bool NoNonEmptyConstantAt(const onnx::NodeProto& node, const InitMap& init_map,
 // convention (`query` alone carrying a packed rank-5 tensor) -- the same
 // exclusion pruning.py's own matcher gives.
 //
-// Deliberately narrower than pruning.py's own matcher in one way, consistent
-// with this file's own pre-existing, already-accepted scope gap (see this
-// section's own top comment and the MatMulNBitsQkv section's own comment on
-// ApplyOneGqaChain's identical gap for the already-shipped GQA/OnnxAttention
-// families): this port has no analogue of pruning.py's own
-// `_head_bias_input_is_safe`/`_slice_or_gather_head_bias` dynamic-bias
-// machinery at all, so rather than reproduce that same silent-corruption
-// risk for a brand new op family, `attention_bias` (index 5) declines the
-// whole match outright whenever it resolves to a non-empty constant (the
-// same `NoNonEmptyConstantAt` gate `past_key`/`past_value`, indices 6/7,
-// already get -- this port doesn't slice either past_kv tensor for this op
-// either, the same gap GQA/OnnxAttention already have).
+// The optional `attention_bias` input (index 5), documented shape
+// `(batch_size or 1, num_heads or 1, sequence_length,
+// total_sequence_length)`, gets the identical
+// constant-resolves-cleanly-or-is-declined treatment via HeadBiasInputIsSafe
+// that GroupQueryAttention's own attention_bias and the plain ai.onnx op's
+// own attn_mask would (see this section's own top comment for their own
+// still-open, out-of-scope gap). `key_padding_mask` (index 4) has no
+// num_heads-sized axis on any of its own documented shapes, so it is never
+// inspected here. The optional `past_key`/`past_value` inputs (indices 6/7
+// -- a different pair of indices from GroupQueryAttention's own 3/4 and the
+// plain ai.onnx op's own 4/5) get the same safety gate via the shared
+// PastKvConstantsAreSliceable, called with no `scale_indices`: this op's own
+// schema has no `k_scale`/`v_scale` inputs at all, so a quantized cache here
+// is declined outright. ApplyOneGqaChain performs the actual slice(s) of
+// both once a match succeeds -- mirrors pruning.py's own
+// _match_multi_head_attention_producer exactly.
 std::optional<HeadCountsMatch> MatchMultiHeadAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "MultiHeadAttention") {
     return std::nullopt;
@@ -5608,8 +5705,14 @@ std::optional<HeadCountsMatch> MatchMultiHeadAttentionProducer(
   if (!has_nh || num_heads <= 0) {
     return std::nullopt;
   }
-  if (!NoNonEmptyConstantAt(node, init_map, {5, 6, 7})) {
-    return std::nullopt;  // attention_bias, past_key, past_value
+  if (node.input_size() > 5 && !node.input(5).empty()) {  // attention_bias
+    if (!HeadBiasInputIsSafe(node, 5, init_map, value_info_by_name,
+                             num_heads)) {
+      return std::nullopt;  // doesn't statically resolve -- decline
+    }
+  }
+  if (!PastKvConstantsAreSliceable(node, init_map, {6, 7}, num_heads)) {
+    return std::nullopt;
   }
   return HeadCountsMatch{num_heads, num_heads};
 }
@@ -5624,11 +5727,15 @@ std::optional<HeadCountsMatch> MatchMultiHeadAttentionProducer(
 // `token_offset`/`cumulative_sequence_length`, shifting everything after it
 // one position later, confirmed directly off ONNX Runtime's own
 // `_replace_attention_with_packing_attention` rewrite -- see pruning.py's
-// own docstring). This op's own schema has no `past_key`/`past_value` at
-// all (packing mode is an encoder-only, non-incremental-decode
-// optimization), so there is no KV-cache pair to gate here.
+// own docstring), gated by the same HeadBiasInputIsSafe treatment
+// MultiHeadAttention's own analogous input gets. This op's own schema has no
+// `past_key`/`past_value` at all (packing mode is an encoder-only,
+// non-incremental-decode optimization), so there is no KV-cache pair to
+// gate here.
 std::optional<HeadCountsMatch> MatchPackedMultiHeadAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "PackedMultiHeadAttention") {
     return std::nullopt;
@@ -5648,8 +5755,11 @@ std::optional<HeadCountsMatch> MatchPackedMultiHeadAttentionProducer(
   if (!has_nh || num_heads <= 0) {
     return std::nullopt;
   }
-  if (!NoNonEmptyConstantAt(node, init_map, {6})) {
-    return std::nullopt;  // attention_bias
+  if (node.input_size() > 6 && !node.input(6).empty()) {  // attention_bias
+    if (!HeadBiasInputIsSafe(node, 6, init_map, value_info_by_name,
+                             num_heads)) {
+      return std::nullopt;  // doesn't statically resolve -- decline
+    }
   }
   return HeadCountsMatch{num_heads, num_heads};
 }
@@ -5663,11 +5773,17 @@ std::optional<HeadCountsMatch> MatchPackedMultiHeadAttentionProducer(
 // live schema dump and ONNX Runtime's own `replace_mha_with_dmmha` rewrite
 // (see pruning.py's own docstring) -- gated the same
 // decline-if-non-empty-constant way as MultiHeadAttention's own analogous
-// inputs, for the identical reason (no slicing machinery ported for either).
-// This op's own combined `bias` moves to index **10**, the last input (see
-// FindDecoderMaskedMhaChains below).
+// inputs used to be (this port's own out-of-scope gap for THIS op family --
+// unlike MultiHeadAttention/PackedMultiHeadAttention above, not fixed by
+// this change; see this section's own top comment for scope). This op's own
+// combined `bias` moves to index **10**, the last input (see
+// FindDecoderMaskedMhaChains below). `value_info_by_name` accepted (see
+// MatchGqaProducer's own comment) but ignored, for the same reason.
 std::optional<HeadCountsMatch> MatchDecoderMaskedMultiHeadAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "DecoderMaskedMultiHeadAttention") {
     return std::nullopt;
@@ -5715,8 +5831,14 @@ std::optional<HeadCountsMatch> MatchDecoderMaskedMultiHeadAttentionProducer(
 // three), so a match here requires every one of them absent, rather than
 // risk a present-and-genuinely-per-head/per-KV-group one silently going
 // unsliced after `num_heads`/`kv_num_heads` shrink underneath it.
+// `value_info_by_name` accepted for FindSeparateQkvChains' own uniform
+// match_producer call signature but ignored: this op has no
+// attention_bias/attn_mask-equivalent input on its own schema at all.
 std::optional<HeadCountsMatch> MatchPagedAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "PagedAttention") {
     return std::nullopt;
@@ -5788,8 +5910,14 @@ std::optional<HeadCountsMatch> MatchPagedAttentionProducer(
 // deferred decay/beta shape-classification logic pruning.py's own
 // matcher/finder pair uses -- gives up essentially nothing over the
 // realistic export shape while avoiding new, unverified slicing machinery.
+// `value_info_by_name` accepted (see MatchPagedAttentionProducer's own
+// comment) but ignored: this op has no attention_bias/attn_mask-equivalent
+// input on its own schema either.
 std::optional<HeadCountsMatch> MatchLinearAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& /*init_map*/) {
+    const onnx::NodeProto& node, const InitMap& /*init_map*/,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (!node.domain().empty() || node.op_type() != "LinearAttention") {
     return std::nullopt;
   }
@@ -5838,8 +5966,14 @@ std::optional<HeadCountsMatch> MatchLinearAttentionProducer(
 // `is_sparse_attention` branch); `total_sequence_length`/
 // `key_total_sequence_lengths` (7/8) required present (pure bookkeeping,
 // checked only for presence -- a genuinely incomplete node otherwise).
+// `value_info_by_name` accepted (see MatchPagedAttentionProducer's own
+// comment) but ignored: this op has no attention_bias/attn_mask-equivalent
+// input on its own schema either.
 std::optional<HeadCountsMatch> MatchSparseAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& init_map) {
+    const onnx::NodeProto& node, const InitMap& init_map,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+    /*value_info_by_name*/
+    = {}) {
   if (node.domain() != kComMicrosoftDomain ||
       node.op_type() != "SparseAttention") {
     return std::nullopt;
@@ -5911,12 +6045,27 @@ std::optional<HeadCountsMatch> MatchSparseAttentionProducer(
 // required equal to Q's/K's shared one, never pruning.py's own
 // `allow_differing_v_head_size=True` composition for the plain ai.onnx op/
 // MultiHeadAttention/PackedMultiHeadAttention/LinearAttention.
+// `value_info_by_name` is threaded straight through to every node's own
+// `match_producer(node, init_map, value_info_by_name)` call -- built the
+// same way every "Attention-head pruning" family entry point builds one
+// (ValueInfoByName) -- purely so a matcher whose own op owns a per-head
+// attention_bias/attn_mask input (MatchMultiHeadAttentionProducer/
+// MatchPackedMultiHeadAttentionProducer, currently -- see each one's own
+// comment for this port's own narrower, per-op-family scope) can classify a
+// *dynamic* one's declared shape (HeadBiasInputIsSafe); every other matcher
+// accepts and ignores it. Defaults to `{}` so every pre-existing call site
+// below that has no dynamic-mask handling of its own to feed stays
+// unchanged.
 std::vector<AttnChain> FindSeparateQkvChains(
     onnx::GraphProto* graph,
     const std::function<std::optional<HeadCountsMatch>(
-        const onnx::NodeProto&, const InitMap&)>& match_producer,
+        const onnx::NodeProto&, const InitMap&,
+        const std::unordered_map<std::string, const onnx::ValueInfoProto*>&)>&
+        match_producer,
     const std::string& num_heads_attr,
-    std::optional<int> combined_bias_input_index = std::nullopt) {
+    std::optional<int> combined_bias_input_index = std::nullopt,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   InitMap init_map;
   for (const auto& t : graph->initializer()) {
     init_map[t.name()] = &t;
@@ -5940,7 +6089,7 @@ std::vector<AttnChain> FindSeparateQkvChains(
   std::vector<AttnChain> chains;
   for (int i = 0; i < graph->node_size(); ++i) {
     onnx::NodeProto* node = graph->mutable_node(i);
-    auto info = match_producer(*node, init_map);
+    auto info = match_producer(*node, init_map, value_info_by_name);
     if (!info) {
       continue;
     }
@@ -6059,20 +6208,33 @@ std::vector<AttnChain> FindOnnxAttentionChains(onnx::GraphProto* graph) {
 // The com.microsoft::MultiHeadAttention analogue of FindGqaChains -- see
 // MatchMultiHeadAttentionProducer's own comment. `combined_bias_input_index
 // = 3`: this op's own `bias` input, the combined-Q/K/V-bias shape AttnChain's
-// own `mha_bias` field documents.
-std::vector<AttnChain> FindMhaChains(onnx::GraphProto* graph) {
+// own `mha_bias` field documents. `value_info_by_name` (defaulted to `{}`,
+// the same default FindSeparateQkvChains' own parameter of that name has) is
+// forwarded straight through to MatchMultiHeadAttentionProducer, so a
+// dynamic (non-constant) attention_bias's own declared shape can be
+// classified via HeadBiasInputIsSafe.
+std::vector<AttnChain> FindMhaChains(
+    onnx::GraphProto* graph,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   return FindSeparateQkvChains(graph, MatchMultiHeadAttentionProducer,
-                               "num_heads", /*combined_bias_input_index=*/3);
+                               "num_heads", /*combined_bias_input_index=*/3,
+                               value_info_by_name);
 }
 
 // The com.microsoft::PackedMultiHeadAttention analogue of FindMhaChains --
 // see MatchPackedMultiHeadAttentionProducer's own comment.
 // `combined_bias_input_index = 3`: this op's own `bias` input sits at the
 // same index MultiHeadAttention's own does (unlike `attention_bias`, which
-// moves to 6).
-std::vector<AttnChain> FindPackedMhaChains(onnx::GraphProto* graph) {
+// moves to 6). `value_info_by_name` forwarded the same way FindMhaChains'
+// own is.
+std::vector<AttnChain> FindPackedMhaChains(
+    onnx::GraphProto* graph,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   return FindSeparateQkvChains(graph, MatchPackedMultiHeadAttentionProducer,
-                               "num_heads", /*combined_bias_input_index=*/3);
+                               "num_heads", /*combined_bias_input_index=*/3,
+                               value_info_by_name);
 }
 
 // The com.microsoft::DecoderMaskedMultiHeadAttention analogue of
@@ -6298,12 +6460,14 @@ std::optional<AppliedAttn> ApplyOnePlainAttentionChain(
 // was observed. `nullptr` (the default) keeps this identically the plain
 // ``||W||_F``-only ranking it always was.
 std::optional<AppliedAttn> ApplyOneGqaChain(
+    onnx::GraphProto* graph, std::unordered_set<std::string>& used_names,
     std::unordered_map<std::string, onnx::TensorProto*>& init_map,
     AttnChain& chain, double sparsity,
     const std::unordered_map<std::string, std::vector<double>>* act_norm =
         nullptr,
-    double epsilon = 1e-8,
-    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
+    double epsilon = 1e-8, ImportanceNorm importance_norm = ImportanceNorm::kL2,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   const int64_t h = chain.kv_num_heads;
   const int64_t keep_count =
       std::max<int64_t>(1, h - std::llround(static_cast<double>(h) * sparsity));
@@ -6476,6 +6640,59 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     SliceLastAxis(init_map.at(*chain.mha_bias), full_bias_idx);
   }
 
+  // MultiHeadAttention/PackedMultiHeadAttention-only: their own optional
+  // `attention_bias` input (index 5 for MultiHeadAttention, 6 for
+  // PackedMultiHeadAttention -- see MatchMultiHeadAttentionProducer's/
+  // MatchPackedMultiHeadAttentionProducer's own docstrings), already
+  // confirmed at match time (HeadBiasInputIsSafe) to resolve cleanly one way
+  // or another, is handled by SliceOrGatherHeadBias along its own head axis
+  // by `keep_q_heads` -- *query*-head granularity (this input is added
+  // against Q*K' scores, laid out per query head) -- mirrors pruning.py's
+  // own `_apply_one_gqa_chain` handling of its `mask_idx` exactly. Every
+  // other chain kind this shared function also applies (GQA/plain
+  // ai.onnx::Attention/DecoderMaskedMultiHeadAttention/PagedAttention/
+  // LinearAttention/SparseAttention) has no analogous per-op `mask_idx` here
+  // yet -- a separate, pre-existing, out-of-scope gap (see this file's own
+  // "Attention-head pruning" section comment for scope); left completely
+  // untouched for those, exactly as before.
+  const bool is_mha = chain.node->domain() == kComMicrosoftDomain &&
+                      chain.node->op_type() == "MultiHeadAttention";
+  const bool is_packed_mha =
+      chain.node->domain() == kComMicrosoftDomain &&
+      chain.node->op_type() == "PackedMultiHeadAttention";
+  std::optional<int> mask_idx;
+  if (is_mha) {
+    mask_idx = 5;
+  } else if (is_packed_mha) {
+    mask_idx = 6;
+  }
+  if (mask_idx) {
+    SliceOrGatherHeadBias(chain.node, *mask_idx, init_map, chain.num_heads,
+                          keep_q_heads, graph, used_names, value_info_by_name);
+  }
+
+  // MultiHeadAttention-only: its own optional `past_key`/`past_value`
+  // (indices 6/7), already confirmed at match time
+  // (PastKvConstantsAreSliceable) to be either absent/dynamic (nothing to do
+  // here) or a BNSH-format FLOAT/FLOAT16/BFLOAT16 constant, is sliced along
+  // its own `kv_num_heads` axis (axis 1) by `keep_groups` -- the same axis
+  // K's/V's own producer weight is sliced by -- mirrors pruning.py's own
+  // `_apply_one_gqa_chain` handling of its `past_kv_indices` exactly.
+  // PackedMultiHeadAttention has no `past_key`/`past_value` inputs at all on
+  // its own schema (packing mode is an encoder-only, non-incremental-decode
+  // optimization), so this is skipped for it outright.
+  if (is_mha) {
+    for (int idx : {6, 7}) {
+      if (chain.node->input_size() <= idx || chain.node->input(idx).empty()) {
+        continue;
+      }
+      auto past_it = init_map.find(chain.node->input(idx));
+      if (past_it != init_map.end()) {
+        SliceAxisGeneric(past_it->second, keep_groups, 1);
+      }
+    }
+  }
+
   const int64_t new_kv_num_heads = keep_count;
   const int64_t new_num_heads = keep_count * group_size;
   for (auto& attr : *chain.node->mutable_attribute()) {
@@ -6512,17 +6729,26 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
 // ApplyAttentionHeadPruning call site is unchanged, are threaded straight
 // through to both -- see either's own doc comment for what they do; this
 // dispatcher itself has no importance computation of its own to touch.
+// `value_info_by_name` (defaulted to `{}`, unused by
+// ApplyOnePlainAttentionChain, which has no dynamic-mask machinery of its own
+// -- see this section's own top comment for that still-open, out-of-scope gap)
+// is forwarded to ApplyOneGqaChain, alongside a freshly built `used_names` seed
+// set (ExistingGraphNames, the same one ApplyDecomposedGqaChains already
+// builds) so SliceOrGatherHeadBias can mint a fresh, collision-free name for
+// any dynamic attention_bias/attn_mask Gather it inserts.
 void ApplyAttentionChains(
     onnx::GraphProto* graph, std::vector<AttnChain>& chains, double sparsity,
     const std::unordered_map<std::string, std::vector<double>>* act_norm =
         nullptr,
-    double epsilon = 1e-8,
-    ImportanceNorm importance_norm = ImportanceNorm::kL2) {
+    double epsilon = 1e-8, ImportanceNorm importance_norm = ImportanceNorm::kL2,
+    const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
+        value_info_by_name = {}) {
   std::unordered_map<std::string, onnx::TensorProto*> init_map;
   for (int i = 0; i < graph->initializer_size(); ++i) {
     onnx::TensorProto* t = graph->mutable_initializer(i);
     init_map[t->name()] = t;
   }
+  std::unordered_set<std::string> used_names = ExistingGraphNames(*graph);
   std::unordered_set<std::string> producer_touched, consumer_touched,
       stale_value_info;
 
@@ -6545,8 +6771,9 @@ void ApplyAttentionChains(
 
     std::optional<AppliedAttn> applied =
         chain.kind == AttnChainKind::kGqaLike
-            ? ApplyOneGqaChain(init_map, chain, sparsity, act_norm, epsilon,
-                               importance_norm)
+            ? ApplyOneGqaChain(graph, used_names, init_map, chain, sparsity,
+                               act_norm, epsilon, importance_norm,
+                               value_info_by_name)
             : ApplyOnePlainAttentionChain(init_map, chain, sparsity, act_norm,
                                           epsilon, importance_norm);
     if (!applied) {
@@ -23596,6 +23823,74 @@ bool HeadBiasInputIsSafe(
   return DynamicHeadBiasAxis(name, value_info_by_name, num_heads).has_value();
 }
 
+// Quantized past_key/past_value cache dtypes (float8e4m3fn/uint8/int8) --
+// mirrors pruning.py's own `_QUANTIZED_KV_CACHE_DTYPES` exactly (confirmed
+// directly off the installed onnxruntime package's schema registry;
+// float16/bfloat16, T_CACHE's other two members, are not quantized dtypes
+// and stay handled by the plain IsSupportedFloatDtype branch below, same as
+// before this set existed).
+const std::unordered_set<int32_t> kQuantizedKvCacheDtypes = {
+    onnx::TensorProto::UINT8, onnx::TensorProto::INT8,
+    onnx::TensorProto::FLOAT8E4M3FN};
+
+// Forward-declared above (see that declaration's own comment for why) --
+// mirrors pruning.py's own `_past_kv_constants_are_sliceable` exactly (see
+// that function's own docstring for the full BNSH-layout/quantized-cache
+// reasoning this reproduces).
+bool PastKvConstantsAreSliceable(
+    const onnx::NodeProto& node, const InitMap& init_map,
+    std::pair<int, int> indices, int64_t kv_num_heads,
+    std::optional<std::pair<int, int>> scale_indices) {
+  const int idxs[2] = {indices.first, indices.second};
+  const int scale_idxs[2] = {scale_indices ? scale_indices->first : -1,
+                             scale_indices ? scale_indices->second : -1};
+  for (int i = 0; i < 2; ++i) {
+    const int idx = idxs[i];
+    if (node.input_size() <= idx || node.input(idx).empty()) {
+      continue;
+    }
+    auto past_it = init_map.find(node.input(idx));
+    if (past_it == init_map.end()) {
+      continue;  // dynamic -- the caller's own runtime data, left alone
+    }
+    const onnx::TensorProto* past_init = past_it->second;
+    if (past_init->dims_size() != 4 || past_init->dims(1) != kv_num_heads) {
+      return false;  // not a shape this function can safely slice
+    }
+    if (IsSupportedFloatDtype(past_init->data_type())) {
+      continue;  // unquantized cache -- nothing else to check
+    }
+    const int scale_idx = scale_idxs[i];
+    if (scale_idx < 0 ||
+        !kQuantizedKvCacheDtypes.count(past_init->data_type())) {
+      return false;  // quantized dtype with nowhere to locate its scale
+    }
+    if (node.input_size() <= scale_idx || node.input(scale_idx).empty()) {
+      return false;  // quantized cache with no k_scale/v_scale connected
+    }
+    auto scale_it = init_map.find(node.input(scale_idx));
+    if (scale_it == init_map.end()) {
+      continue;  // dynamic scale -- the caller's own runtime data
+    }
+    const onnx::TensorProto* scale_init = scale_it->second;
+    if (scale_init->data_type() != onnx::TensorProto::FLOAT) {
+      return false;  // not T_KV_SCALE's own float-only constraint
+    }
+    int64_t prod = 1;
+    for (int64_t d : scale_init->dims()) {
+      prod *= d;
+    }
+    if (prod == 1) {
+      continue;  // PER_TENSOR: a single broadcast scalar, nothing to slice
+    }
+    if (scale_init->dims_size() != 4 || scale_init->dims(1) != kv_num_heads) {
+      return false;  // not the PER_CHANNEL [1, kv_num_heads, 1, head_size]
+                     // layout
+    }
+  }
+  return true;
+}
+
 // Generic arbitrary-axis, arbitrary-rank slice of a FLOAT/FLOAT16/BFLOAT16
 // constant tensor `t` by `keep` (an ascending index set) along `axis` --
 // mirrors pruning.py's own `_slice_axis` (`onnx.numpy_helper.to_array`/
@@ -24891,6 +25186,15 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
   // Mirrors pruning.py's own apply_attention_head_pruning loop over
   // `_iter_subgraphs(out.graph)`.
   for (onnx::GraphProto* graph : IterSubgraphs(out.mutable_graph())) {
+    // This graph's own AS-DECLARED input/output/value_info (ValueInfoByName)
+    // -- see FindDecomposedGqaChains' own section comment for why no real
+    // shape-inference pass backs it, here or at the top level, unlike
+    // pruning.py's own top-level-graph case. Computed once up front (rather
+    // than only ahead of the decomposed-GQA family, as before) so
+    // FindMhaChains/FindPackedMhaChains can thread it into
+    // MatchMultiHeadAttentionProducer/MatchPackedMultiHeadAttentionProducer's
+    // own dynamic-attention_bias classification (HeadBiasInputIsSafe) too.
+    auto value_info_by_name = ValueInfoByName(*graph);
     std::vector<AttnChain> chains = FindAttentionChains(graph);
     std::vector<AttnChain> gqa_chains = FindGqaChains(graph);
     std::vector<AttnChain> onnx_attn_chains = FindOnnxAttentionChains(graph);
@@ -24901,8 +25205,10 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
     // already use above (see each Find*Chains function's own comment for
     // what's matched and this port's deliberate, narrower-than-pruning.py
     // scope decisions).
-    std::vector<AttnChain> mha_chains = FindMhaChains(graph);
-    std::vector<AttnChain> packed_mha_chains = FindPackedMhaChains(graph);
+    std::vector<AttnChain> mha_chains =
+        FindMhaChains(graph, value_info_by_name);
+    std::vector<AttnChain> packed_mha_chains =
+        FindPackedMhaChains(graph, value_info_by_name);
     std::vector<AttnChain> dmmha_chains = FindDecoderMaskedMhaChains(graph);
     std::vector<AttnChain> paged_chains = FindPagedAttentionChains(graph);
     std::vector<AttnChain> linear_attn_chains =
@@ -24930,7 +25236,8 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
                   std::make_move_iterator(sparse_attn_chains.begin()),
                   std::make_move_iterator(sparse_attn_chains.end()));
     if (!chains.empty()) {
-      ApplyAttentionChains(graph, chains, sparsity, nullptr, 1e-8, norm);
+      ApplyAttentionChains(graph, chains, sparsity, nullptr, 1e-8, norm,
+                           value_info_by_name);
     }
     // The fully decomposed (un-fused, "eager SDPA export") shape
     // pruning.py's own `_find_decomposed_gqa_chains` additionally matches --
@@ -24943,17 +25250,13 @@ onnx::ModelProto ApplyAttentionHeadPruning(const onnx::ModelProto& model,
     // touched bookkeeping (inside ApplyDecomposedGqaChains) is never shared
     // with ApplyAttentionChains's own above, the same "structurally
     // different node/weight shapes, always safe" reasoning this section's
-    // own MatMulNBitsQkv handling below already documents. `value_info_by_
-    // name` here is this graph's own AS-DECLARED input/output/value_info
-    // (ValueInfoByName) -- see FindDecomposedGqaChains' own section comment
-    // for why no real shape-inference pass backs it, here or at the top
-    // level, unlike pruning.py's own top-level-graph case.
-    auto decomposed_value_info_by_name = ValueInfoByName(*graph);
+    // own MatMulNBitsQkv handling below already documents. Reuses the same
+    // `value_info_by_name` computed above.
     std::vector<DecomposedGqaChain> decomposed_gqa_chains =
-        FindDecomposedGqaChains(graph, decomposed_value_info_by_name);
+        FindDecomposedGqaChains(graph, value_info_by_name);
     if (!decomposed_gqa_chains.empty()) {
       ApplyDecomposedGqaChains(graph, decomposed_gqa_chains, sparsity, nullptr,
-                               1e-8, norm, decomposed_value_info_by_name);
+                               1e-8, norm, value_info_by_name);
     }
     // The fused `com.microsoft::MatMulNBitsQkv` variant -- see the
     // "MatMulNBitsMlp/MatMulNBitsQkv (fused block-quantized weight)
@@ -25008,6 +25311,12 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   // inputs).
   onnx::GraphProto* graph = out.mutable_graph();
 
+  // This graph's own AS-DECLARED input/output/value_info -- see
+  // ApplyAttentionHeadPruning's own identical comment for why it's computed
+  // once up front and threaded into both FindMhaChains/FindPackedMhaChains
+  // and FindDecomposedGqaChains/ApplyDecomposedGqaChains below.
+  auto value_info_by_name = ValueInfoByName(*graph);
+
   // Same chain-finding as ApplyAttentionHeadPruning's own nine matched
   // families -- deliberately excluding the fused `MatMulNBitsQkv` variant
   // that function additionally handles, since pruning.py's own
@@ -25016,8 +25325,9 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   std::vector<AttnChain> chains = FindAttentionChains(graph);
   std::vector<AttnChain> gqa_chains = FindGqaChains(graph);
   std::vector<AttnChain> onnx_attn_chains = FindOnnxAttentionChains(graph);
-  std::vector<AttnChain> mha_chains = FindMhaChains(graph);
-  std::vector<AttnChain> packed_mha_chains = FindPackedMhaChains(graph);
+  std::vector<AttnChain> mha_chains = FindMhaChains(graph, value_info_by_name);
+  std::vector<AttnChain> packed_mha_chains =
+      FindPackedMhaChains(graph, value_info_by_name);
   std::vector<AttnChain> dmmha_chains = FindDecoderMaskedMhaChains(graph);
   std::vector<AttnChain> paged_chains = FindPagedAttentionChains(graph);
   std::vector<AttnChain> linear_attn_chains = FindLinearAttentionChains(graph);
@@ -25050,9 +25360,8 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
   // ranked/sliced/probed entirely separately below, mirroring pruning.py's
   // own `chains: List[_AttnLikeChain]` union, which this port instead keeps
   // as two differently-typed collections threaded through in parallel.
-  auto decomposed_value_info_by_name = ValueInfoByName(*graph);
   std::vector<DecomposedGqaChain> decomposed_gqa_chains =
-      FindDecomposedGqaChains(graph, decomposed_value_info_by_name);
+      FindDecomposedGqaChains(graph, value_info_by_name);
 
   if (chains.empty() && decomposed_gqa_chains.empty()) {
     return out;  // Mirrors pruning.py's own early return.
@@ -25082,11 +25391,12 @@ onnx::ModelProto ApplyAttentionHeadWandaPruning(
       WandaCalibrationStats(executor, out, probe_axis, calibration_data);
 
   if (!chains.empty()) {
-    ApplyAttentionChains(graph, chains, sparsity, &act_norm, epsilon, norm);
+    ApplyAttentionChains(graph, chains, sparsity, &act_norm, epsilon, norm,
+                         value_info_by_name);
   }
   if (!decomposed_gqa_chains.empty()) {
     ApplyDecomposedGqaChains(graph, decomposed_gqa_chains, sparsity, &act_norm,
-                             epsilon, norm, decomposed_value_info_by_name);
+                             epsilon, norm, value_info_by_name);
   }
   return out;
 }

--- a/onnxsim/structured_pruning_entry.h
+++ b/onnxsim/structured_pruning_entry.h
@@ -423,10 +423,16 @@ onnx::ModelProto ApplyTransformerBlockPruning(
 // mirroring pruning.py's own `_to_f64`/`_from_f64` convention), plus every
 // `com.microsoft::Attention` node's constant 2-D FLOAT/FLOAT16/BFLOAT16
 // merged QKV weight (MatchAttentionProducerAnyFloat -- a narrow, SparseGPT-
-// local dtype-widened duplicate of the shared, still-FLOAT32-only
-// MatchAttentionProducer, which also backs this file's own structural
-// Attention-head pruning and was deliberately left untouched -- see that
-// function's own comment in structured_pruning_entry.cpp), PLUS every 2-D
+// local duplicate of the shared MatchAttentionProducer, which also backs
+// this file's own structural Attention-head pruning and has SINCE been
+// independently widened to the identical FLOAT/FLOAT16/BFLOAT16 dtype scope
+// -- the two functions' remaining difference is op-type scope, not dtype:
+// MatchAttentionProducerAnyFloat still only recognizes plain `Attention`,
+// while MatchAttentionProducer also recognizes `DecoderMaskedSelfAttention`/
+// `PackedAttention` -- a widening SparseGPT weight-only pruning has not been
+// independently re-verified against, so this duplicate is deliberately left
+// as is rather than merged -- see that function's own comment in
+// structured_pruning_entry.cpp), PLUS every 2-D
 // `Conv`/`FusedConv` node (ordinary/depthwise/general-grouped alike) with a
 // constant 4-D FLOAT/FLOAT16/BFLOAT16 `[out_channels, in_channels/group,
 // kh, kw]` weight (`_match_conv_weight_only`'s own criteria: `group >= 1`,

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -38,16 +38,34 @@ remaining shape not covered by one of those still declines to match in this
 C++ port (never mis-sliced), so ``apply_attention_head_pruning``/
 ``apply_attention_head_wanda_pruning`` remain pure-Python (NOT yet aliased to
 this port) -- see that section's own tests for the exact, explicit divergence
-each remaining narrowing produces. The six newer fused-op families
-(everything past plain ``Attention``/``GroupQueryAttention``/the plain
-``ai.onnx::Attention`` op) share one more deliberate, narrower-than-pruning.py
-scope choice throughout: this port has no analogue of pruning.py's own
-dynamic-attention-bias-Gather-insertion machinery (``_head_bias_input_is_safe``/
-``_slice_or_gather_head_bias``) at all for THOSE families -- a pre-existing,
-already-accepted gap for the three original fused-op families too (only the
-decomposed-GQA family above has that machinery ported) -- so every new
-fused-op matcher declines the whole chain outright whenever an optional
-per-head bias/mask/sink/norm/scale input resolves to a non-empty constant,
+each remaining narrowing produces.
+
+``com.microsoft::MultiHeadAttention``/``com.microsoft::PackedMultiHeadAttention``
+now ALSO carry the dynamic-attention-bias-Gather-insertion machinery
+(``HeadBiasInputIsSafe``/``SliceOrGatherHeadBias`` -- this port's own analogue
+of pruning.py's ``_head_bias_input_is_safe``/``_slice_or_gather_head_bias``),
+via the same shared helpers the decomposed-GQA family above uses: their own
+optional ``attention_bias`` input (index 5 for ``MultiHeadAttention``, 6 for
+``PackedMultiHeadAttention``) is validated and, if genuinely per-head, sliced
+in place (a constant) or Gather-spliced (dynamic) rather than declining the
+whole match outright -- see the dedicated tests in each family's own section
+below. ``MultiHeadAttention``'s own optional ``past_key``/``past_value``
+(indices 6/7) are similarly now validated (``PastKvConstantsAreSliceable``,
+this port's own analogue of pruning.py's ``_past_kv_constants_are_sliceable``,
+called with no ``scale_indices`` since this op has no ``k_scale``/``v_scale``)
+and sliced along their own BNSH ``kv_num_heads`` axis when a constant of that
+exact shape; ``PackedMultiHeadAttention`` has no ``past_key``/``past_value``
+inputs on its own schema at all (packing mode is encoder-only).
+
+The four remaining newer fused-op families
+(``DecoderMaskedMultiHeadAttention``/``PagedAttention``/``LinearAttention``/
+``SparseAttention``) keep the prior, narrower-than-pruning.py scope choice:
+this port has no analogue of pruning.py's own dynamic-attention-bias-Gather-
+insertion machinery for THOSE families yet -- a pre-existing, already-accepted
+gap shared with ``GroupQueryAttention``/the plain ``ai.onnx::Attention`` op's
+own ``attention_bias``/``attn_mask`` handling (out of scope here) -- so their
+own matchers decline the whole chain outright whenever an optional per-head
+bias/mask/sink/norm/scale/past-KV input resolves to a non-empty constant,
 rather than risk leaving one silently stale after ``num_heads``/
 ``kv_num_heads`` shrink underneath it. See each new family's own model
 builder/test section below, and each ``Match*Producer`` function's own
@@ -1746,16 +1764,21 @@ def test_cpp_gqa_pruning_importance_norm_l1_matches_python_reference_and_differs
 # the IDENTICAL input model -- not merely "both produce a valid model", but
 # the same keep-set and the same sliced values.
 #
-# One deliberate, narrower-than-pruning.py scope choice threads through all
-# six (see MatchMultiHeadAttentionProducer's own comment in
-# structured_pruning_entry.cpp for the full reasoning): this port has no
-# analogue of pruning.py's own dynamic-attention-bias-Gather-insertion
-# machinery (`_head_bias_input_is_safe`/`_slice_or_gather_head_bias`) at
-# all -- a pre-existing, already-accepted gap for the GQA/OnnxAttention
-# families above too -- so every new matcher here declines the whole chain
-# outright whenever an optional per-head bias/mask/sink/norm/scale input
-# resolves to a non-empty constant, rather than risk leaving one silently
-# stale after `num_heads`/`kv_num_heads` shrink underneath it.
+# `MultiHeadAttention`/`PackedMultiHeadAttention` (the next two sections) now
+# carry the same dynamic-attention-bias-Gather-insertion machinery
+# (`HeadBiasInputIsSafe`/`SliceOrGatherHeadBias`) the decomposed-GQA family
+# already has, plus (`MultiHeadAttention` only) `PastKvConstantsAreSliceable`
+# for its own optional `past_key`/`past_value` -- see
+# MatchMultiHeadAttentionProducer's/MatchPackedMultiHeadAttentionProducer's
+# own comments in structured_pruning_entry.cpp. The remaining four families
+# below (`DecoderMaskedMultiHeadAttention`/`PagedAttention`/`LinearAttention`/
+# `SparseAttention`) keep the prior, narrower-than-pruning.py scope choice: no
+# analogue of that machinery yet -- a pre-existing, already-accepted gap
+# shared with the GQA/OnnxAttention families above -- so their own matchers
+# decline the whole chain outright whenever an optional per-head bias/mask/
+# sink/norm/scale/past-KV input resolves to a non-empty constant, rather than
+# risk leaving one silently stale after `num_heads`/`kv_num_heads` shrink
+# underneath it.
 
 
 # --- com.microsoft::MultiHeadAttention (separate Q/K/V producers, no --------
@@ -1771,7 +1794,10 @@ def _mha_model(
     batch=2,
     seq=5,
     combined_bias=False,
-    attention_bias=None,  # constant attention_bias array, or None (unconnected)
+    attention_bias=None,  # constant/declared-shape attention_bias array, or None
+    attention_bias_dynamic=False,  # declare AttentionBias as a graph INPUT instead
+    past_key=None,  # constant BNSH past_key array, or None (unconnected)
+    past_value=None,  # constant BNSH past_value array, or None (unconnected)
     wq=None,
     wk=None,
     wv=None,
@@ -1792,6 +1818,7 @@ def _mha_model(
         wout = rng.standard_normal((Nv, Out)).astype(np.float32)
 
     initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    extra_inputs = ""
     operands = ["q", "k", "v"]
     if combined_bias:
         if bq is None:
@@ -1806,16 +1833,34 @@ def _mha_model(
     else:
         operands.append("")
 
+    operands.append("")  # key_padding_mask (index 4) -- never touched by this pass
+
     if attention_bias is not None:
-        operands.append("")  # key_padding_mask -- never touched by this pass
-        initializer.append(_f32(np.asarray(attention_bias), "AttentionBias"))
+        if attention_bias_dynamic:
+            shape_str = ",".join(str(d) for d in np.asarray(attention_bias).shape)
+            extra_inputs += f", float[{shape_str}] AttentionBias"
+        else:
+            initializer.append(_f32(np.asarray(attention_bias), "AttentionBias"))
         operands.append("AttentionBias")
+    else:
+        operands.append("")
+
+    if past_key is not None:
+        initializer.append(_f32(np.asarray(past_key), "PastKey"))
+        operands.append("PastKey")
+    else:
+        operands.append("")
+    if past_value is not None:
+        initializer.append(_f32(np.asarray(past_value), "PastValue"))
+        operands.append("PastValue")
+    else:
+        operands.append("")
 
     while operands and operands[-1] == "":
         operands.pop()
 
     body = f"""
-        g (float[{batch},{seq},{K}] X) => (float[{batch},{seq},{Out}] Y)
+        g (float[{batch},{seq},{K}] X{extra_inputs}) => (float[{batch},{seq},{Out}] Y)
         {{
           q = MatMul(X, Wq)
           k = MatMul(X, Wk)
@@ -1916,24 +1961,188 @@ def test_cpp_mha_pruning_slices_combined_bias_matches_python_reference():
     assert list(inits["Bias"].dims) == [4 * 4 * 3]
 
 
-def test_cpp_mha_pruning_nonempty_attention_bias_constant_is_left_untouched():
-    model, _ = _mha_model(
-        K=8,
-        H=4,
-        D=4,
-        Out=6,
-        seed=24,
-        attention_bias=np.zeros((2, 4, 5, 5), dtype=np.float32),
-    )
-    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+def test_cpp_mha_pruning_broadcast_attention_bias_is_left_untouched():
+    # A genuinely BROADCAST attention_bias (dims[1] == 1, not num_heads) --
+    # HeadBiasAxis classifies this as "already correct for any head count",
+    # so the match succeeds (unlike the pre-fix behavior, which declined the
+    # whole chain outright for ANY non-empty constant here) and
+    # SliceOrGatherHeadBias leaves the tensor itself completely untouched
+    # while every other matched weight is still pruned normally.
+    bias = np.random.default_rng(24).standard_normal((1, 1, 5, 5)).astype(np.float32)
+    model, _ = _mha_model(K=8, H=4, D=4, Out=6, seed=24, attention_bias=bias)
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+
+    node = _mha_node(pruned_cpp)
+    assert _mha_num_heads(node) == 2
     inits_before = {
         t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
     }
     inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
     }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+    np.testing.assert_array_equal(
+        inits_before["AttentionBias"], inits_after["AttentionBias"]
+    )
+
+
+def test_cpp_mha_pruning_per_head_attention_bias_is_sliced_matches_python():
+    # A genuinely PER-HEAD constant attention_bias (dims[1] == num_heads) --
+    # HeadBiasInputIsSafe confirms it's safe, so SliceOrGatherHeadBias slices
+    # it in place along its own head axis by the kept query heads, exactly
+    # like every other per-head weight in the chain.
+    H = 4
+    bias = np.random.default_rng(25).standard_normal((2, H, 5, 5)).astype(np.float32)
+    model, cfg = _mha_model(K=8, H=H, D=4, Out=6, seed=25, attention_bias=bias)
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _mha_node(pruned_cpp)
+    num_heads = _mha_num_heads(node)
+    assert num_heads == 2
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], H, H, cfg["D"], num_heads
+    )
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
+    }
+    assert inits["AttentionBias"].shape == (2, num_heads, 5, 5)
+    np.testing.assert_array_equal(inits["AttentionBias"], bias[:, keep_heads, :, :])
+
+
+def test_cpp_mha_pruning_dynamic_per_head_attention_bias_gathers_matches_python():
+    # A genuinely PER-HEAD, but DYNAMIC (graph-input, not constant),
+    # attention_bias -- the one case that needs SliceOrGatherHeadBias's own
+    # Gather-insertion path (InsertDynamicHeadBiasGather), since the tensor's
+    # own real values aren't available at prune time.
+    H = 4
+    bias_shape = (1, H, 5, 5)
+    model, cfg = _mha_model(
+        K=8,
+        H=H,
+        D=4,
+        Out=6,
+        seed=27,
+        attention_bias=np.zeros(bias_shape, dtype=np.float32),
+        attention_bias_dynamic=True,
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+
+    gather_nodes = [n for n in pruned_cpp.graph.node if n.op_type == "Gather"]
+    assert len(gather_nodes) == 1
+    gather = gather_nodes[0]
+    assert gather.input[0] == "AttentionBias"
+    axis = next(a.i for a in gather.attribute if a.name == "axis")
+    assert axis == 1
+    indices_init = next(
+        t for t in pruned_cpp.graph.initializer if t.name == gather.input[1]
+    )
+    indices = onnx.numpy_helper.to_array(indices_init)
+
+    node = _mha_node(pruned_cpp)
+    num_heads = _mha_num_heads(node)
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], H, H, cfg["D"], num_heads
+    )
+    np.testing.assert_array_equal(indices, keep_heads)
+    # MHA's own attention_bias input (index 5) is rewired onto the new
+    # Gather's own output, not left pointing directly at "AttentionBias".
+    assert node.input[5] == gather.output[0]
+
+
+def test_cpp_mha_pruning_unsafe_attention_bias_shape_declines_match_matches_python():
+    # rank-4 with axis-1 length neither 1 (broadcast) nor num_heads
+    # (per-head) -- HeadBiasAxis can't resolve this either way, so
+    # HeadBiasInputIsSafe declines the whole match outright, exactly like
+    # pruning.py's own `_head_bias_input_is_safe`/`_match_multi_head_attention_producer`.
+    bias = np.random.default_rng(26).standard_normal((2, 3, 5, 5)).astype(np.float32)
+    model, _ = _mha_model(K=8, H=4, D=4, Out=6, seed=26, attention_bias=bias)
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    # Declined outright -- the whole model is left byte-for-byte unchanged.
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_mha_pruning_constant_past_kv_is_sliced_matches_python():
+    # A constant, BNSH-format (batch, kv_num_heads, past_seq, head_size)
+    # past_key/past_value -- PastKvConstantsAreSliceable confirms the shape,
+    # so both are sliced along their own kv_num_heads axis (axis 1) by the
+    # same kept-head index set K's/V's own producer weight is sliced by.
+    H, D, seq, batch, past_seq = 4, 4, 5, 2, 3
+    rng = np.random.default_rng(28)
+    past_key = rng.standard_normal((batch, H, past_seq, D)).astype(np.float32)
+    past_value = rng.standard_normal((batch, H, past_seq, D)).astype(np.float32)
+    model, cfg = _mha_model(
+        K=8,
+        H=H,
+        D=D,
+        Out=6,
+        seed=28,
+        batch=batch,
+        seq=seq,
+        past_key=past_key,
+        past_value=past_value,
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+
+    node = _mha_node(pruned_cpp)
+    num_heads = _mha_num_heads(node)
+    assert num_heads == 2
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], H, H, D, num_heads
+    )
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
+    }
+    assert inits["PastKey"].shape == (batch, num_heads, past_seq, D)
+    assert inits["PastValue"].shape == (batch, num_heads, past_seq, D)
+    np.testing.assert_array_equal(inits["PastKey"], past_key[:, keep_heads, :, :])
+    np.testing.assert_array_equal(inits["PastValue"], past_value[:, keep_heads, :, :])
+
+
+def test_cpp_mha_pruning_unsafe_past_key_shape_declines_match_matches_python():
+    # axis-1 length neither `kv_num_heads` nor otherwise resolvable --
+    # PastKvConstantsAreSliceable declines the whole match outright, exactly
+    # like pruning.py's own `_past_kv_constants_are_sliceable`.
+    H, D, seq, batch, past_seq = 4, 4, 5, 2, 3
+    rng = np.random.default_rng(29)
+    past_key = rng.standard_normal((batch, 3, past_seq, D)).astype(np.float32)
+    model, _ = _mha_model(
+        K=8, H=H, D=D, Out=6, seed=29, batch=batch, seq=seq, past_key=past_key
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
 
 
 # --- com.microsoft::PackedMultiHeadAttention --------------------------------
@@ -1948,6 +2157,7 @@ def _packed_mha_model(
     tok=5,
     combined_bias=False,
     attention_bias=None,
+    attention_bias_dynamic=False,  # declare AttentionBias as a graph INPUT instead
     wq=None,
     wk=None,
     wv=None,
@@ -1991,8 +2201,13 @@ def _packed_mha_model(
     else:
         operands.append("")
     operands += ["TokenOffset", "CumSeqLen"]
+    extra_inputs = ""
     if attention_bias is not None:
-        initializer.append(_f32(np.asarray(attention_bias), "AttentionBias"))
+        if attention_bias_dynamic:
+            shape_str = ",".join(str(d) for d in np.asarray(attention_bias).shape)
+            extra_inputs += f", float[{shape_str}] AttentionBias"
+        else:
+            initializer.append(_f32(np.asarray(attention_bias), "AttentionBias"))
         operands.append("AttentionBias")
 
     while operands and operands[-1] == "":
@@ -2000,7 +2215,7 @@ def _packed_mha_model(
     qkv_inputs = ", ".join(operands)
 
     body = f"""
-        g (float[{tok},{K}] X) => (float[{tok},{Out}] Y)
+        g (float[{tok},{K}] X{extra_inputs}) => (float[{tok},{Out}] Y)
         {{
           q = MatMul(X, Wq)
           k = MatMul(X, Wk)
@@ -2066,25 +2281,127 @@ def test_cpp_packed_mha_pruning_slices_combined_bias_matches_python_reference():
     assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
 
 
-def test_cpp_packed_mha_pruning_nonempty_attention_bias_constant_is_left_untouched():
-    model, cfg = _packed_mha_model(
-        K=8,
-        H=4,
-        D=4,
-        Out=6,
-        seed=33,
-        tok=5,
-        attention_bias=np.zeros((1, 4, 5, 5), dtype=np.float32),
+def test_cpp_packed_mha_pruning_broadcast_attention_bias_is_left_untouched():
+    # A genuinely BROADCAST attention_bias (dims[1] == 1) -- see
+    # test_cpp_mha_pruning_broadcast_attention_bias_is_left_untouched's own
+    # comment; identical reasoning, just at this op's own attention_bias
+    # index (6, not 5).
+    bias = np.random.default_rng(33).standard_normal((1, 1, 5, 5)).astype(np.float32)
+    model, _ = _packed_mha_model(
+        K=8, H=4, D=4, Out=6, seed=33, tok=5, attention_bias=bias
     )
-    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+
+    node = _packed_mha_node(pruned_cpp)
+    assert _mha_num_heads(node) == 2
     inits_before = {
         t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
     }
     inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
     }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+    np.testing.assert_array_equal(
+        inits_before["AttentionBias"], inits_after["AttentionBias"]
+    )
+
+
+def test_cpp_packed_mha_pruning_per_head_attention_bias_is_sliced_matches_python():
+    # A genuinely PER-HEAD constant attention_bias (dims[1] == num_heads) --
+    # see test_cpp_mha_pruning_per_head_attention_bias_is_sliced_matches_python's
+    # own comment; identical reasoning, just at index 6.
+    H = 4
+    bias = np.random.default_rng(34).standard_normal((1, H, 5, 5)).astype(np.float32)
+    model, cfg = _packed_mha_model(
+        K=8, H=H, D=4, Out=6, seed=34, tok=5, attention_bias=bias
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _packed_mha_node(pruned_cpp)
+    num_heads = _mha_num_heads(node)
+    assert num_heads == 2
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], H, H, cfg["D"], num_heads
+    )
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
+    }
+    assert inits["AttentionBias"].shape == (1, num_heads, 5, 5)
+    np.testing.assert_array_equal(inits["AttentionBias"], bias[:, keep_heads, :, :])
+
+
+def test_cpp_packed_mha_pruning_dynamic_per_head_attention_bias_gathers_matches_python():
+    # A genuinely PER-HEAD, but DYNAMIC, attention_bias -- see
+    # test_cpp_mha_pruning_dynamic_per_head_attention_bias_gathers_matches_python's
+    # own comment; identical reasoning, just at index 6.
+    H = 4
+    model, cfg = _packed_mha_model(
+        K=8,
+        H=H,
+        D=4,
+        Out=6,
+        seed=35,
+        tok=5,
+        attention_bias=np.zeros((1, H, 5, 5), dtype=np.float32),
+        attention_bias_dynamic=True,
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+
+    gather_nodes = [n for n in pruned_cpp.graph.node if n.op_type == "Gather"]
+    assert len(gather_nodes) == 1
+    gather = gather_nodes[0]
+    assert gather.input[0] == "AttentionBias"
+    axis = next(a.i for a in gather.attribute if a.name == "axis")
+    assert axis == 1
+    indices_init = next(
+        t for t in pruned_cpp.graph.initializer if t.name == gather.input[1]
+    )
+    indices = onnx.numpy_helper.to_array(indices_init)
+
+    node = _packed_mha_node(pruned_cpp)
+    num_heads = _mha_num_heads(node)
+    keep_heads = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], H, H, cfg["D"], num_heads
+    )
+    np.testing.assert_array_equal(indices, keep_heads)
+    # PackedMultiHeadAttention's own attention_bias input (index 6) is
+    # rewired onto the new Gather's own output.
+    assert node.input[6] == gather.output[0]
+
+
+def test_cpp_packed_mha_pruning_unsafe_attention_bias_shape_declines_match_matches_python():
+    # rank-4 with axis-1 length neither 1 nor num_heads -- HeadBiasAxis can't
+    # resolve this either way, so HeadBiasInputIsSafe declines the whole
+    # match outright, exactly like pruning.py's own
+    # `_match_packed_multi_head_attention_producer`.
+    bias = np.random.default_rng(36).standard_normal((1, 3, 5, 5)).astype(np.float32)
+    model, _ = _packed_mha_model(
+        K=8, H=4, D=4, Out=6, seed=36, tok=5, attention_bias=bias
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
 
 
 # --- com.microsoft::DecoderMaskedMultiHeadAttention -------------------------

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -54,6 +54,7 @@ builder/test section below, and each ``Match*Producer`` function's own
 comment in ``structured_pruning_entry.cpp``, for the exact narrowing.
 """
 
+import ml_dtypes
 import numpy as np
 import onnx
 import onnx.helper
@@ -68,6 +69,14 @@ ort = pytest.importorskip("onnxruntime")
 
 def _f32(array, name):
     return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _f16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float16), name)
+
+
+def _bf16(array, name):
+    return onnx.numpy_helper.from_array(array.astype(ml_dtypes.bfloat16), name)
 
 
 def _run(model, feeds):
@@ -4566,3 +4575,466 @@ def test_cpp_decomposed_gqa_qk_norm_pruning_matches_oracle_and_python_reference_
     (y_pruned,) = _run(pruned_cpp, {"X": x})
     (y_oracle,) = _run(oracle, {"X": x})
     np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+# --- FLOAT16 / BFLOAT16 weight support ---------------------------------------
+#
+# `_is_supported_float_dtype` (pruning.py) accepts FLOAT/FLOAT16/BFLOAT16
+# uniformly for every producer/consumer weight and bias across all matched
+# attention families; this port's own matchers (MatchAttentionProducer,
+# MatchProducerAnyFloat, WalkToAttentionConsumer, and every downstream
+# apply-time weight read/rank/slice/write) now mirror that exactly (see each
+# function's own comment in structured_pruning_entry.cpp). One FLOAT16 and
+# one BFLOAT16 case per major family group below (merged-QKV `Attention`,
+# separate-producer `GroupQueryAttention`, separate-producer
+# `MultiHeadAttention`, and the decomposed/un-fused shape), each checked
+# against the live pure-Python `apply_attention_head_pruning` reference
+# byte-for-byte (`SerializeToString()` equality) -- both `onnx.checker`
+# and this repo's own ONNX Runtime confirm FLOAT16 has a real CPU kernel for
+# every one of these ops in this environment, and BFLOAT16 at least passes
+# `onnx.checker.check_model` (its own schema's `T` type constraint includes
+# it) even where no CPU kernel exists, so both are exercised the same
+# structural way here -- via the graph-rewrite comparison alone, never a
+# real session run (mirroring this module's own decomposed-GQA/MQA tests'
+# "matches_python_reference_exactly" naming and style).
+
+
+@pytest.mark.parametrize(
+    "dtype,dtype_name",
+    [(np.float16, "float16"), (ml_dtypes.bfloat16, "bfloat16")],
+)
+def test_cpp_attention_head_pruning_widened_dtype_matches_python_reference_exactly(
+    dtype, dtype_name
+):
+    K, H, D, Out = 8, 4, 4, 6
+    Nq = Nk = Nv = H * D
+    rng = np.random.default_rng(301)
+    wqkv = (rng.standard_normal((K, Nq + Nk + Nv)) * 0.3).astype(dtype)
+    bqkv = (rng.standard_normal((Nq + Nk + Nv,)) * 0.1).astype(dtype)
+    wout = (rng.standard_normal((Nv, Out)) * 0.3).astype(dtype)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g ({dtype_name}[batch,seq,{K}] X) => ({dtype_name}[batch,seq,{Out}] Y)
+        {{
+          ctx = com.microsoft.Attention <num_heads={H}, qkv_hidden_sizes=[{Nq},{Nk},{Nv}]> (X, Wqkv, Bqkv)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(wqkv, "Wqkv"),
+            onnx.numpy_helper.from_array(bqkv, "Bqkv"),
+            onnx.numpy_helper.from_array(wout, "Wout"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    onnx_dtype = onnx.helper.np_dtype_to_tensor_dtype(np.dtype(dtype))
+    inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    assert inits["Wqkv"].data_type == onnx_dtype
+    assert list(inits["Wqkv"].dims) == [K, 6 * D]  # H=4 -> keep_count=2 heads
+
+
+@pytest.mark.parametrize(
+    "dtype,dtype_name",
+    [(np.float16, "float16"), (ml_dtypes.bfloat16, "bfloat16")],
+)
+def test_cpp_gqa_pruning_widened_dtype_matches_python_reference_exactly(
+    dtype, dtype_name
+):
+    K, H, KVH, D, Out, batch, seq = 8, 4, 2, 8, 6, 2, 5
+    Nq, Nkv = H * D, KVH * D
+    rng = np.random.default_rng(302)
+    wq = (rng.standard_normal((K, Nq)) * 0.3).astype(dtype)
+    wk = (rng.standard_normal((K, Nkv)) * 0.3).astype(dtype)
+    wv = (rng.standard_normal((K, Nkv)) * 0.3).astype(dtype)
+    wout = (rng.standard_normal((Nq, Out)) * 0.3).astype(dtype)
+    seqlens_k = np.full((batch,), seq - 1, dtype=np.int32)
+    total_seq = np.array(seq, dtype=np.int32)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g ({dtype_name}[{batch},{seq},{K}] X) => ({dtype_name}[{batch},{seq},{Out}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          ctx, pk, pv = com.microsoft.GroupQueryAttention <num_heads={H}, kv_num_heads={KVH}> (q, k, v, , , SeqLensK, TotalSeq)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(wq, "Wq"),
+            onnx.numpy_helper.from_array(wk, "Wk"),
+            onnx.numpy_helper.from_array(wv, "Wv"),
+            onnx.numpy_helper.from_array(wout, "Wout"),
+            onnx.numpy_helper.from_array(seqlens_k, "SeqLensK"),
+            onnx.numpy_helper.from_array(total_seq, "TotalSeq"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    onnx_dtype = onnx.helper.np_dtype_to_tensor_dtype(np.dtype(dtype))
+    inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    assert inits["Wq"].data_type == onnx_dtype
+    assert inits["Wk"].data_type == onnx_dtype
+    assert list(inits["Wk"].dims) == [K, D]  # KVH=2 -> keep_count=1 KV group
+
+
+@pytest.mark.parametrize(
+    "dtype,dtype_name",
+    [(np.float16, "float16"), (ml_dtypes.bfloat16, "bfloat16")],
+)
+def test_cpp_mha_pruning_widened_dtype_matches_python_reference_exactly(
+    dtype, dtype_name
+):
+    K, H, D, Out, batch, seq = 8, 8, 4, 6, 2, 5
+    Nq = Nk = Nv = H * D
+    rng = np.random.default_rng(303)
+    wq = (rng.standard_normal((K, Nq)) * 0.3).astype(dtype)
+    wk = (rng.standard_normal((K, Nk)) * 0.3).astype(dtype)
+    wv = (rng.standard_normal((K, Nv)) * 0.3).astype(dtype)
+    wout = (rng.standard_normal((Nv, Out)) * 0.3).astype(dtype)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g ({dtype_name}[{batch},{seq},{K}] X) => ({dtype_name}[{batch},{seq},{Out}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          ctx = com.microsoft.MultiHeadAttention <num_heads={H}> (q, k, v)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            onnx.numpy_helper.from_array(wq, "Wq"),
+            onnx.numpy_helper.from_array(wk, "Wk"),
+            onnx.numpy_helper.from_array(wv, "Wv"),
+            onnx.numpy_helper.from_array(wout, "Wout"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    onnx_dtype = onnx.helper.np_dtype_to_tensor_dtype(np.dtype(dtype))
+    inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    assert inits["Wq"].data_type == onnx_dtype
+    assert list(inits["Wq"].dims) == [K, 4 * D]  # H=8 -> keep_count=4 heads
+
+
+def _decomposed_gqa_model_dtype(dtype, dtype_name, seed):
+    """Trimmed, dtype-parametrized rebuild of `_decomposed_gqa_model`'s own
+    "plain" (bias=True, needs_repeat_kv, no mask/rope/qk_norm) shape --
+    covers this port's own downstream-arithmetic FLOAT16/BFLOAT16 widening
+    for `ApplyOneDecomposedGqaChain` (`ReadTensorAsF64`/`WriteF64TensorAs`/
+    `SliceAxisGeneric`/`TransposeFlat<double>` throughout).
+    """
+    K, H, KVH, D, Out, batch, seq = 32, 4, 2, 8, 16, 1, 4
+    Nq, Nk, Nv = H * D, KVH * D, KVH * D
+    rng = np.random.default_rng(seed)
+    wq = (rng.standard_normal((K, Nq)) * 0.3).astype(dtype)
+    wk = (rng.standard_normal((K, Nk)) * 0.3).astype(dtype)
+    wv = (rng.standard_normal((K, Nv)) * 0.3).astype(dtype)
+    wout = (rng.standard_normal((H * D, Out)) * 0.3).astype(dtype)
+    bq = (rng.standard_normal((Nq,)) * 0.1).astype(dtype)
+    bk = (rng.standard_normal((Nk,)) * 0.1).astype(dtype)
+    bv = (rng.standard_normal((Nv,)) * 0.1).astype(dtype)
+    bout = (rng.standard_normal((Out,)) * 0.1).astype(dtype)
+    scale = np.array(D**-0.5).astype(dtype)
+    n_rep = H // KVH
+
+    def _i64(arr, name):
+        return onnx.numpy_helper.from_array(np.array(arr, dtype=np.int64), name)
+
+    initializer = [
+        onnx.numpy_helper.from_array(wq, "Wq"),
+        onnx.numpy_helper.from_array(wk, "Wk"),
+        onnx.numpy_helper.from_array(wv, "Wv"),
+        onnx.numpy_helper.from_array(wout, "Wout"),
+        onnx.numpy_helper.from_array(bq, "Bq"),
+        onnx.numpy_helper.from_array(bk, "Bk"),
+        onnx.numpy_helper.from_array(bv, "Bv"),
+        onnx.numpy_helper.from_array(bout, "Bout"),
+        _i64([batch * seq, K], "XFlatShape"),
+        _i64([batch, seq, H, D], "Sq"),
+        _i64([batch, seq, KVH, D], "Sk"),
+        _i64([batch, seq, KVH, D], "Sv"),
+        _i64([2], "Ax2"),
+        _i64([batch, KVH, n_rep, seq, D], "KExpandShape"),
+        _i64([batch, H, seq, D], "KMergeShape"),
+        _i64([batch, KVH, n_rep, seq, D], "VExpandShape"),
+        _i64([batch, H, seq, D], "VMergeShape"),
+        onnx.numpy_helper.from_array(scale, "Scale"),
+        _i64([batch * seq, H * D], "OutShape"),
+        _i64([batch, seq, Out], "YShape"),
+    ]
+    body = f"""
+        g ({dtype_name}[{batch},{seq},{K}] X) => ({dtype_name}[{batch},{seq},{Out}] Y)
+        {{
+          xf = Reshape(X, XFlatShape)
+          q0 = Gemm(xf, Wq, Bq)
+          qr = Reshape(q0, Sq)
+          qt = Transpose<perm=[0,2,1,3]>(qr)
+          k0 = Gemm(xf, Wk, Bk)
+          kr = Reshape(k0, Sk)
+          kt0 = Transpose<perm=[0,2,1,3]>(kr)
+          ku = Unsqueeze(kt0, Ax2)
+          ke = Expand(ku, KExpandShape)
+          kre = Reshape(ke, KMergeShape)
+          kt = Transpose<perm=[0,1,3,2]>(kre)
+          v0 = Gemm(xf, Wv, Bv)
+          vr = Reshape(v0, Sv)
+          vt0 = Transpose<perm=[0,2,1,3]>(vr)
+          vu = Unsqueeze(vt0, Ax2)
+          ve = Expand(vu, VExpandShape)
+          vt = Reshape(ve, VMergeShape)
+          qk = MatMul(qt, kt)
+          scaled = Mul(qk, Scale)
+          attn = Softmax<axis=-1>(scaled)
+          ctx0 = MatMul(attn, vt)
+          ctx1 = Transpose<perm=[0,2,1,3]>(ctx0)
+          ctx2 = Reshape(ctx1, OutShape)
+          y0 = Gemm(ctx2, Wout, Bout)
+          Y = Reshape(y0, YShape)
+        }}
+        """
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(K=K, H=H, KVH=KVH, D=D, wq=wq, wk=wk, wv=wv)
+
+
+@pytest.mark.parametrize(
+    "dtype,dtype_name",
+    [(np.float16, "float16"), (ml_dtypes.bfloat16, "bfloat16")],
+)
+def test_cpp_decomposed_gqa_pruning_widened_dtype_matches_python_reference_exactly(
+    dtype, dtype_name
+):
+    model, cfg = _decomposed_gqa_model_dtype(dtype, dtype_name, seed=304)
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    onnx_dtype = onnx.helper.np_dtype_to_tensor_dtype(np.dtype(dtype))
+    inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    assert inits["Wq"].data_type == onnx_dtype
+    assert inits["Wk"].data_type == onnx_dtype
+    # KVH=2 -> keep_count=1 KV group -> Wk/Wv shrink to a single D-wide head;
+    # Wq shrinks to that group's own 2 (of 4) query heads.
+    assert list(inits["Wk"].dims) == [cfg["K"], cfg["D"]]
+    assert list(inits["Wq"].dims) == [cfg["K"], 2 * cfg["D"]]
+    # Value-preserving slice -- the surviving KV group's own column block
+    # (whichever of the two KVH=2 groups importance ranking kept) must
+    # reproduce the exact original fp16/bf16 bit pattern, not a re-rounded
+    # one -- checked against both candidate groups since which one survives
+    # is a ranking outcome, not fixed by construction.
+    d = cfg["D"]
+    kept_wk = onnx.numpy_helper.to_array(inits["Wk"]).view(np.uint16)
+    candidates = [
+        cfg["wk"][:, :d].view(np.uint16),
+        cfg["wk"][:, d : 2 * d].view(np.uint16),
+    ]
+    assert any(np.array_equal(kept_wk, c) for c in candidates)
+
+
+# --- com.microsoft::DecoderMaskedSelfAttention / PackedAttention producer
+# --- recognition (MatchAttentionProducer's own three-op-type scope) --------
+#
+# MatchAttentionProducer (structured_pruning_entry.cpp) now recognizes
+# `com.microsoft::DecoderMaskedSelfAttention` and `com.microsoft::
+# PackedAttention` as the same merged-QKV family plain `Attention` already
+# was -- mirroring pruning.py's own `_match_attention_producer`, including
+# `DecoderMaskedSelfAttention`'s own schema quirks (no `qkv_hidden_sizes`
+# attribute -- confirmed below -- and a required `past` input, left
+# untouched here since it's never a constant in this model). Both compared
+# against the live pure-Python reference byte-for-byte, same as every other
+# family above.
+
+
+def test_cpp_decoder_masked_self_attention_pruning_matches_python_reference_exactly():
+    K, H, D, Out, batch = 8, 4, 4, 6, 2
+    Nq = Nk = Nv = H * D
+    rng = np.random.default_rng(305)
+    wqkv = (rng.standard_normal((K, Nq + Nk + Nv)) * 0.3).astype(np.float32)
+    bqkv = (rng.standard_normal((Nq + Nk + Nv,)) * 0.1).astype(np.float32)
+    wout = (rng.standard_normal((Nv, Out)) * 0.3).astype(np.float32)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g (float[{batch},1,{K}] X) => (float[{batch},1,{Out}] Y)
+        {{
+          ctx = com.microsoft.DecoderMaskedSelfAttention <num_heads={H}> (X, Wqkv, Bqkv)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [_f32(wqkv, "Wqkv"), _f32(bqkv, "Bqkv"), _f32(wout, "Wout")]
+    )
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = next(
+        n for n in pruned_cpp.graph.node if n.op_type == "DecoderMaskedSelfAttention"
+    )
+    assert next(a.i for a in node.attribute if a.name == "num_heads") == 2
+    # No real `qkv_hidden_sizes` attribute on this op's own schema -- never
+    # added, mirroring pruning.py's own `_apply_one_plain_attention_chain`.
+    assert not any(a.name == "qkv_hidden_sizes" for a in node.attribute)
+    inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    assert list(inits["Wqkv"].dims) == [K, 6 * D]
+
+
+def test_cpp_packed_attention_pruning_matches_python_reference_exactly():
+    K, H, D, Out, batch = 8, 4, 4, 6, 2
+    Nq = Nk = Nv = H * D
+    rng = np.random.default_rng(306)
+    wqkv = (rng.standard_normal((K, Nq + Nk + Nv)) * 0.3).astype(np.float32)
+    bqkv = (rng.standard_normal((Nq + Nk + Nv,)) * 0.1).astype(np.float32)
+    wout = (rng.standard_normal((Nv, Out)) * 0.3).astype(np.float32)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        g (float[{batch * 3},{K}] X, int32[{batch},3] TokenOffset, int32[{batch + 1}] CumSeqLen) => (float[{batch * 3},{Out}] Y)
+        {{
+          ctx = com.microsoft.PackedAttention <num_heads={H}, qkv_hidden_sizes=[{Nq},{Nk},{Nv}]> (X, Wqkv, Bqkv, TokenOffset, CumSeqLen)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    )
+    model.graph.initializer.extend(
+        [_f32(wqkv, "Wqkv"), _f32(bqkv, "Bqkv"), _f32(wout, "Wout")]
+    )
+    onnx.checker.check_model(model)
+
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = next(n for n in pruned_cpp.graph.node if n.op_type == "PackedAttention")
+    assert next(a.i for a in node.attribute if a.name == "num_heads") == 2
+    qkv = next(list(a.ints) for a in node.attribute if a.name == "qkv_hidden_sizes")
+    assert qkv == [2 * D, 2 * D, 2 * D]
+    inits = {t.name: t for t in pruned_cpp.graph.initializer}
+    assert list(inits["Wqkv"].dims) == [K, 6 * D]
+
+
+# --- Gap C: `com.microsoft::MatMulNBitsQkv` scope -- `ApplyAttentionHead
+# --- Pruning` vs. `ApplyAttentionHeadWandaPruning` ---------------------------
+#
+# Investigated as part of this same round of parity fixes: unlike a
+# hypothetical accidental scope-creep, `ApplyAttentionHeadPruning`'s own
+# `FindMatMulNBitsQkvChains`/`ApplyMatMulNBitsQkvChains` call is a
+# DELIBERATE, documented consolidation -- see structured_pruning_entry.cpp's
+# own comment directly above that call site, and this file's own "com.
+# microsoft::MatMulNBitsQkv" section comment above `_matmul_nbits_qkv_model`
+# (which pruning.py's own `apply_structured_pruning_matmul_nbits` explicitly
+# defers to `apply_attention_head_pruning_cpp` for -- see
+# `onnxsim.apply_structured_pruning_cpp`'s own docstring). Removing it would
+# leave `MatMulNBitsQkv` with NO C++ pruning path anywhere (pure-Python's own
+# `apply_attention_head_pruning` never touches it either -- that's
+# `apply_structured_pruning_matmul_nbits`'s own job there), a real regression
+# against this module's own already-extensive `test_cpp_matmul_nbits_qkv_
+# pruning_*` coverage above -- so it is intentionally KEPT here, unlike
+# `ApplyAttentionHeadWandaPruning`, which correctly has no such call at all
+# (mirroring pruning.py's own scope: no calibration-driven counterpart of
+# `apply_structured_pruning_matmul_nbits` exists there either). This test
+# pins that asymmetry: the plain entry point prunes a `MatMulNBitsQkv` chain
+# (already proven above), the Wanda entry point leaves the identical chain
+# completely untouched.
+
+
+def test_cpp_attention_head_wanda_pruning_leaves_matmul_nbits_qkv_chains_untouched():
+    num_heads, kv_num_heads, d, K, block_size, N2 = 4, 2, 8, 32, 16, 24
+    rng = np.random.default_rng(307)
+    Nq, Nkv = num_heads * d, kv_num_heads * d
+    w_q = (rng.standard_normal((Nq, K)) * 0.3).astype(np.float32)
+    w_k = (rng.standard_normal((Nkv, K)) * 0.3).astype(np.float32)
+    w_v = (rng.standard_normal((Nkv, K)) * 0.3).astype(np.float32)
+    bias_q = (rng.standard_normal((Nq,)) * 0.1).astype(np.float32)
+    bias_k = (rng.standard_normal((Nkv,)) * 0.1).astype(np.float32)
+    bias_v = (rng.standard_normal((Nkv,)) * 0.1).astype(np.float32)
+    norm_scale = np.ones((K,), dtype=np.float32)
+    model, _info = _matmul_nbits_qkv_model(
+        num_heads,
+        kv_num_heads,
+        d,
+        K,
+        block_size,
+        N2,
+        w_q,
+        w_k,
+        w_v,
+        bias_q,
+        bias_k,
+        bias_v,
+        norm_scale,
+    )
+    onnx.checker.check_model(model)
+
+    calibration_data = [
+        {"A": rng.standard_normal((2, 5, K)).astype(np.float32)} for _ in range(2)
+    ]
+    pruned = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned)
+    assert pruned.SerializeToString() == model.SerializeToString()

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -38,20 +38,39 @@ remaining shape not covered by one of those still declines to match in this
 C++ port (never mis-sliced), so ``apply_attention_head_pruning``/
 ``apply_attention_head_wanda_pruning`` remain pure-Python (NOT yet aliased to
 this port) -- see that section's own tests for the exact, explicit divergence
-each remaining narrowing produces. The six newer fused-op families
-(everything past plain ``Attention``/``GroupQueryAttention``/the plain
-``ai.onnx::Attention`` op) share one more deliberate, narrower-than-pruning.py
-scope choice throughout: this port has no analogue of pruning.py's own
-dynamic-attention-bias-Gather-insertion machinery (``_head_bias_input_is_safe``/
-``_slice_or_gather_head_bias``) at all for THOSE families -- a pre-existing,
-already-accepted gap for the three original fused-op families too (only the
-decomposed-GQA family above has that machinery ported) -- so every new
-fused-op matcher declines the whole chain outright whenever an optional
-per-head bias/mask/sink/norm/scale input resolves to a non-empty constant,
-rather than risk leaving one silently stale after ``num_heads``/
-``kv_num_heads`` shrink underneath it. See each new family's own model
-builder/test section below, and each ``Match*Producer`` function's own
-comment in ``structured_pruning_entry.cpp``, for the exact narrowing.
+each remaining narrowing produces.
+
+``GroupQueryAttention``'s and the plain ``ai.onnx::Attention`` op's own
+optional per-head inputs -- ``attention_bias``/``attn_mask``,
+``past_key``/``past_value`` (plus, GQA-only, ``k_scale``/``v_scale`` and
+``head_sink``) -- now reuse this exact same ``HeadBiasInputIsSafe``/
+``SliceOrGatherHeadBias`` machinery (``MatchGqaProducer``/
+``MatchOnnxAttentionProducer``/``ApplyOneGqaChain``, plus this file's own new
+``PastKvConstantsAreSliceable``/``SliceKvCacheAxis1`` for the KV-cache pair):
+a constant that resolves to a genuine per-head/per-KV-group tensor is sliced
+in place, a constant that resolves to a broadcast is left untouched (without
+declining the match), a dynamic one gets a ``Gather`` node spliced in ahead of
+it when genuinely per-head, and only a shape that doesn't statically resolve
+either way declines the whole match -- see the dedicated tests in each
+family's own section below (the ``_gqa_model`` helper's own
+``attention_bias``/``head_sink``/``past_kv`` parameters, and
+``_onnx_attention_model``'s own ``attn_mask``/``past_kv`` parameters).
+
+The other six fused-op families (``MultiHeadAttention``,
+``PackedMultiHeadAttention``, ``DecoderMaskedMultiHeadAttention``,
+``PagedAttention``, ``LinearAttention``, ``SparseAttention``) still share one
+more deliberate, narrower-than-pruning.py scope choice, unaffected by the
+above: this port has no analogue of pruning.py's own dynamic-attention-bias-
+Gather-insertion machinery for THOSE families -- a pre-existing,
+already-accepted gap (only GroupQueryAttention/the plain ``ai.onnx::Attention``
+op and the decomposed-GQA family above have that machinery ported) -- so
+every one of those six matchers still declines the whole chain outright
+whenever an optional per-head bias/mask/sink/norm/scale input resolves to a
+non-empty constant, rather than risk leaving one silently stale after
+``num_heads``/``kv_num_heads`` shrink underneath it. See each of those
+family's own model builder/test section below, and each ``Match*Producer``
+function's own comment in ``structured_pruning_entry.cpp``, for the exact
+narrowing.
 """
 
 import ml_dtypes
@@ -351,6 +370,12 @@ def _gqa_model(
     bv=None,
     wout=None,
     past_kv=None,  # None (empty) | "nonempty" (constant) | "dynamic" (graph input)
+    #  | "unsafe" (constant, wrong kv_num_heads-axis length -- declines the match)
+    attention_bias=None,  # None | "broadcast" (rank-4, axis1 size 1) | "per_head"
+    #  (rank-4, axis1 == num_heads, sliced) | "dynamic_per_head" (graph input, same
+    #  shape -- Gather inserted) | "unsafe" (axis1 neither 1 nor num_heads)
+    head_sink=None,  # None | "nonempty" (constant (num_heads,), sliced)
+    #  | "dynamic" (graph input, left alone) | "wrong_shape" (declines the match)
 ):
     rng = np.random.default_rng(seed)
     Nq, Nkv = H * D, KVH * D
@@ -397,9 +422,58 @@ def _gqa_model(
             f", float[{batch},{KVH},1,{D}] PastKeyIn"
             f", float[{batch},{KVH},1,{D}] PastValueIn"
         )
+    elif past_kv == "unsafe":
+        # rank-4 but axis-1 length != kv_num_heads -- not a shape either port
+        # can safely slice, so the whole match is declined outright by both.
+        past_key = rng.standard_normal((batch, KVH + 1, 1, D)).astype(np.float32)
+        past_value = rng.standard_normal((batch, KVH + 1, 1, D)).astype(np.float32)
+        initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
+        operands += ["PastKey", "PastValue"]
     else:
         operands += ["", ""]
     operands += ["SeqLensK", "TotalSeq"]
+
+    # cos_cache/sin_cache/position_ids (indices 7/8/9) -- always left empty here
+    # (this test file's own GQA models never exercise rotary embedding), just
+    # placeholders so attention_bias/head_sink (indices 10/11) land correctly.
+    operands += ["", "", ""]
+
+    if attention_bias == "broadcast":
+        bias_t = rng.standard_normal((1, 1, seq, seq)).astype(np.float32)
+        initializer.append(_f32(bias_t, "AttnBias"))
+        operands.append("AttnBias")
+    elif attention_bias == "per_head":
+        bias_t = rng.standard_normal((1, H, seq, seq)).astype(np.float32)
+        initializer.append(_f32(bias_t, "AttnBias"))
+        operands.append("AttnBias")
+    elif attention_bias == "dynamic_per_head":
+        operands.append("AttnBiasIn")
+        extra_graph_inputs += f", float[1,{H},{seq},{seq}] AttnBiasIn"
+    elif attention_bias == "unsafe":
+        # axis-1 length neither 1 (broadcast) nor num_heads -- unresolvable,
+        # declines the whole match rather than guessing.
+        bias_t = rng.standard_normal((1, H + 1, seq, seq)).astype(np.float32)
+        initializer.append(_f32(bias_t, "AttnBias"))
+        operands.append("AttnBias")
+    else:
+        operands.append("")
+
+    if head_sink == "nonempty":
+        sink_t = rng.standard_normal((H,)).astype(np.float32)
+        initializer.append(_f32(sink_t, "HeadSink"))
+        operands.append("HeadSink")
+    elif head_sink == "dynamic":
+        operands.append("HeadSinkIn")
+        extra_graph_inputs += f", float[{H}] HeadSinkIn"
+    elif head_sink == "wrong_shape":
+        sink_t = rng.standard_normal((H + 1,)).astype(np.float32)
+        initializer.append(_f32(sink_t, "HeadSink"))
+        operands.append("HeadSink")
+    else:
+        operands.append("")
+
+    while operands and operands[-1] == "":
+        operands.pop()
 
     if with_reshape:
         shape = np.array([batch, seq, Nq], dtype=np.int64)
@@ -608,17 +682,43 @@ def test_cpp_gqa_pruning_reshape_hop_is_recognized_and_shape_updated():
     assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
 
 
-def test_cpp_gqa_pruning_nonempty_past_kv_constant_is_left_untouched():
+def test_cpp_gqa_pruning_nonempty_sliceable_past_kv_constant_is_sliced():
+    # A constant past_key/past_value in the schema's own BNSH layout, with its
+    # axis-1 length matching kv_num_heads, is now validated-and-sliced along
+    # that axis by `keep_groups` -- the same index set K's/V's own producer
+    # weights are sliced by -- rather than declining the whole match outright
+    # (this test used to be named `..._is_left_untouched`, covering the OLD,
+    # narrower C++ behavior; see `..._past_kv_constant_is_unsafe_and_declined`
+    # below for the shape that genuinely still declines). Byte-for-byte
+    # cross-check against the live pure-Python reference.
     model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=12, past_kv="nonempty")
-    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
-    inits_before = {
-        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _gqa_node(pruned_cpp)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1
+    assert num_heads == group_size
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
     }
-    inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
-    }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+    assert inits["PastKey"].shape == (cfg["batch"], kv_num_heads, 1, cfg["D"])
+    assert inits["PastValue"].shape == (cfg["batch"], kv_num_heads, 1, cfg["D"])
+
+
+def test_cpp_gqa_pruning_past_kv_constant_is_unsafe_and_declined():
+    # A constant past_key/past_value whose axis-1 length does NOT match
+    # kv_num_heads (rank-4, but not the schema's own BNSH layout) is not a
+    # shape either port can safely slice -- both decline the whole match
+    # outright, identically.
+    model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=75, past_kv="unsafe")
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
 
 
 def test_cpp_gqa_pruning_dynamic_past_kv_input_is_still_pruned():
@@ -630,6 +730,132 @@ def test_cpp_gqa_pruning_dynamic_past_kv_input_is_still_pruned():
     group_size = cfg["H"] // cfg["KVH"]
     assert kv_num_heads == 1
     assert num_heads == group_size
+
+
+def test_cpp_gqa_pruning_broadcast_attention_bias_is_left_untouched_block_still_pruned():
+    # A constant attention_bias whose axis-1 (num_heads) length is 1 is an
+    # unconditional broadcast -- it carries no per-head values at all, so it
+    # is left byte-for-byte untouched even though the rest of the block IS
+    # pruned (this does NOT decline the whole match, unlike the old,
+    # overly-conservative C++ behavior this fix replaces).
+    model, cfg = _gqa_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=31, attention_bias="broadcast"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _gqa_node(pruned_cpp)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1
+    assert num_heads == cfg["H"] // cfg["KVH"]
+    bias_before = onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == "AttnBias")
+    )
+    bias_after = onnx.numpy_helper.to_array(
+        next(t for t in pruned_cpp.graph.initializer if t.name == "AttnBias")
+    )
+    np.testing.assert_array_equal(bias_before, bias_after)
+
+
+def test_cpp_gqa_pruning_per_head_attention_bias_constant_is_sliced():
+    # A constant attention_bias whose axis-1 length equals num_heads is a
+    # genuine per-(query-)head tensor -- sliced in place by `keep_q_heads`,
+    # the same query-head granularity Q's own producer weight is sliced by.
+    model, cfg = _gqa_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=32, attention_bias="per_head"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _gqa_node(pruned_cpp)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    bias_after = onnx.numpy_helper.to_array(
+        next(t for t in pruned_cpp.graph.initializer if t.name == "AttnBias")
+    )
+    assert bias_after.shape == (1, num_heads, cfg["seq"], cfg["seq"])
+
+
+def test_cpp_gqa_pruning_dynamic_per_head_attention_bias_gets_gather_inserted():
+    # A DYNAMIC (graph-input) attention_bias whose declared shape resolves to
+    # a genuine per-head axis gets a new Gather node spliced in ahead of the
+    # GroupQueryAttention node, selecting the kept query heads' own slice at
+    # runtime, rather than being left stale or blocking the match.
+    model, cfg = _gqa_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=33, attention_bias="dynamic_per_head"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    gather_nodes = [n for n in pruned_cpp.graph.node if n.op_type == "Gather"]
+    assert len(gather_nodes) == 1
+    assert gather_nodes[0].input[0] == "AttnBiasIn"
+
+    node = _gqa_node(pruned_cpp)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert node.input[10] == gather_nodes[0].output[0]
+
+    rng = np.random.default_rng(34)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    attn_bias_in = rng.standard_normal((1, cfg["H"], cfg["seq"], cfg["seq"])).astype(
+        np.float32
+    )
+    (y,) = _run(pruned_cpp, {"X": x, "AttnBiasIn": attn_bias_in})
+    assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
+
+
+def test_cpp_gqa_pruning_unsafe_attention_bias_constant_is_declined():
+    # A constant attention_bias whose axis-1 length is neither 1 (broadcast)
+    # nor num_heads (genuine per-head) doesn't statically resolve -- declined
+    # rather than guessed at, by both ports identically.
+    model, cfg = _gqa_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=35, attention_bias="unsafe"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_gqa_pruning_head_sink_constant_is_sliced():
+    model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=36, head_sink="nonempty")
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _gqa_node(pruned_cpp)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    sink_after = onnx.numpy_helper.to_array(
+        next(t for t in pruned_cpp.graph.initializer if t.name == "HeadSink")
+    )
+    assert sink_after.shape == (num_heads,)
+
+
+def test_cpp_gqa_pruning_dynamic_head_sink_is_left_untouched_block_still_pruned():
+    model, cfg = _gqa_model(K=8, H=8, KVH=2, D=8, Out=6, seed=37, head_sink="dynamic")
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    node = _gqa_node(pruned_cpp)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    assert kv_num_heads == 1
+
+
+def test_cpp_gqa_pruning_wrong_shape_head_sink_constant_is_declined():
+    model, cfg = _gqa_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=38, head_sink="wrong_shape"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
 
 
 def test_cpp_attention_head_pruning_group_query_attention_missing_required_inputs_is_left_untouched():
@@ -692,8 +918,14 @@ def _onnx_attention_model(
     bk=None,
     bv=None,
     wout=None,
-    attn_mask=None,  # None (omitted) | "nonempty" (constant) | "dynamic" (graph input)
-    past_kv=None,  # None (omitted) | "nonempty" (constant) | "dynamic" (graph input)
+    attn_mask=None,  # None (omitted) | "nonempty" (constant, rank-2 broadcast)
+    #  | "dynamic" (graph input, rank-2 broadcast) | "per_head" (constant,
+    #  rank-3, axis0 == q_num_heads, sliced) | "dynamic_per_head" (graph
+    #  input, same shape -- Gather inserted) | "unsafe" (axis0 neither 1 nor
+    #  q_num_heads -- declines the match)
+    past_kv=None,  # None (omitted) | "nonempty" (constant, sliced) | "dynamic"
+    #  (graph input) | "unsafe" (constant, wrong kv_num_heads-axis length --
+    #  declines the match)
 ):
     rng = np.random.default_rng(seed)
     Nq, Nkv = H * D, KVH * D
@@ -728,6 +960,19 @@ def _onnx_attention_model(
     elif attn_mask == "dynamic":
         operands.append("AttnMaskIn")
         extra_graph_inputs += f", float[{seq},{seq}] AttnMaskIn"
+    elif attn_mask == "per_head":
+        mask = rng.standard_normal((H, seq, seq)).astype(np.float32)
+        initializer.append(_f32(mask, "AttnMask"))
+        operands.append("AttnMask")
+    elif attn_mask == "dynamic_per_head":
+        operands.append("AttnMaskIn")
+        extra_graph_inputs += f", float[{H},{seq},{seq}] AttnMaskIn"
+    elif attn_mask == "unsafe":
+        # axis0 length neither 1 (broadcast) nor q_num_heads -- unresolvable,
+        # declines the whole match rather than guessing.
+        mask = rng.standard_normal((H + 1, seq, seq)).astype(np.float32)
+        initializer.append(_f32(mask, "AttnMask"))
+        operands.append("AttnMask")
     else:
         operands.append("")
 
@@ -742,6 +987,11 @@ def _onnx_attention_model(
             f", float[{batch},{KVH},1,{D}] PastKeyIn"
             f", float[{batch},{KVH},1,{D}] PastValueIn"
         )
+    elif past_kv == "unsafe":
+        past_key = rng.standard_normal((batch, KVH + 1, 1, D)).astype(np.float32)
+        past_value = rng.standard_normal((batch, KVH + 1, 1, D)).astype(np.float32)
+        initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
+        operands += ["PastKey", "PastValue"]
     else:
         operands += ["", ""]
 
@@ -884,19 +1134,125 @@ def test_cpp_onnx_attention_pruning_slices_bias_when_producer_has_one():
     np.testing.assert_array_equal(inits["Bv"], cfg["bv"][kv_idx])
 
 
-def test_cpp_onnx_attention_pruning_nonempty_attn_mask_constant_is_left_untouched():
+def test_cpp_onnx_attention_pruning_nonempty_2d_attn_mask_constant_is_pruned():
+    # A rank-2 (seq, seq) attn_mask never has a q_num_heads axis at all -- an
+    # unconditional broadcast -- so it needs no slicing and is left
+    # byte-for-byte untouched, but (unlike the OLD, overly-conservative C++
+    # behavior this fix replaces -- this test used to be named
+    # `..._is_left_untouched` and asserted the WHOLE model was unchanged) the
+    # rest of the block IS still pruned.
     model, cfg = _onnx_attention_model(
         K=8, H=4, KVH=2, D=4, Out=6, seed=17, attn_mask="nonempty"
     )
-    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
-    inits_before = {
-        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _onnx_attention_node(pruned_cpp)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    assert kv_num_heads == 1
+    assert q_num_heads == kv_num_heads * (cfg["H"] // cfg["KVH"])
+    mask_before = onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == "AttnMask")
+    )
+    mask_after = onnx.numpy_helper.to_array(
+        next(t for t in pruned_cpp.graph.initializer if t.name == "AttnMask")
+    )
+    np.testing.assert_array_equal(mask_before, mask_after)
+
+
+def test_cpp_onnx_attention_pruning_per_head_attn_mask_constant_is_sliced():
+    model, cfg = _onnx_attention_model(
+        K=8, H=4, KVH=2, D=4, Out=6, seed=41, attn_mask="per_head"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _onnx_attention_node(pruned_cpp)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    mask_after = onnx.numpy_helper.to_array(
+        next(t for t in pruned_cpp.graph.initializer if t.name == "AttnMask")
+    )
+    assert mask_after.shape == (q_num_heads, cfg["seq"], cfg["seq"])
+
+
+def test_cpp_onnx_attention_pruning_dynamic_per_head_attn_mask_gets_gather_inserted():
+    model, cfg = _onnx_attention_model(
+        K=8, H=4, KVH=2, D=4, Out=6, seed=42, attn_mask="dynamic_per_head"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    gather_nodes = [n for n in pruned_cpp.graph.node if n.op_type == "Gather"]
+    assert len(gather_nodes) == 1
+    assert gather_nodes[0].input[0] == "AttnMaskIn"
+
+    node = _onnx_attention_node(pruned_cpp)
+    assert node.input[3] == gather_nodes[0].output[0]
+
+    rng = np.random.default_rng(43)
+    x = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(np.float32)
+    attn_mask_in = rng.standard_normal((cfg["H"], cfg["seq"], cfg["seq"])).astype(
+        np.float32
+    )
+    (y,) = _run(pruned_cpp, {"X": x, "AttnMaskIn": attn_mask_in})
+    assert y.shape == (cfg["batch"], cfg["seq"], cfg["Out"])
+
+
+def test_cpp_onnx_attention_pruning_unsafe_attn_mask_constant_is_declined():
+    model, cfg = _onnx_attention_model(
+        K=8, H=4, KVH=2, D=4, Out=6, seed=44, attn_mask="unsafe"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_onnx_attention_pruning_nonempty_sliceable_past_kv_constant_is_sliced():
+    model, cfg = _onnx_attention_model(
+        K=8, H=8, KVH=2, D=4, Out=6, seed=45, past_kv="nonempty"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _onnx_attention_node(pruned_cpp)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
     }
-    inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
-    }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+    assert inits["PastKey"].shape == (cfg["batch"], kv_num_heads, 1, cfg["D"])
+    assert inits["PastValue"].shape == (cfg["batch"], kv_num_heads, 1, cfg["D"])
+
+
+def test_cpp_onnx_attention_pruning_past_kv_constant_is_unsafe_and_declined():
+    model, cfg = _onnx_attention_model(
+        K=8, H=8, KVH=2, D=4, Out=6, seed=46, past_kv="unsafe"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_onnx_attention_pruning_dynamic_past_kv_input_is_still_pruned():
+    model, cfg = _onnx_attention_model(
+        K=8, H=8, KVH=2, D=4, Out=6, seed=47, past_kv="dynamic"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    node = _onnx_attention_node(pruned_cpp)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    assert kv_num_heads == 1
 
 
 def test_cpp_onnx_attention_pruning_diff_v_head_size_is_left_untouched():

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -2105,6 +2105,19 @@ def _dmmha_model(
     bk=None,
     bv=None,
     wout=None,
+    # attention_bias (index 4): None (unconnected) | "broadcast" (constant
+    # [1, 1, 1, total_seq]) | "per_head" (constant [1, H, 1, total_seq]) |
+    # "dynamic_per_head" (graph input [1, H, 1, total_seq]) | "bad" (constant
+    # [1, H + 1, 1, total_seq] -- neither a genuine broadcast nor exactly
+    # num_heads-wide) -- see HeadBiasInputIsSafe's own comment.
+    attention_bias=None,
+    attention_bias_array=None,
+    total_seq=5,
+    # past_key/past_value (indices 5/6): None (unconnected) | "nonempty"
+    # (constant BNSH [batch, H, past_seq, D]) | "dynamic" (graph input) --
+    # see PastKvConstantsAreSliceable's own comment.
+    past_kv=None,
+    past_seq=3,
 ):
     rng = np.random.default_rng(seed)
     Nq = Nk = Nv = H * D
@@ -2123,6 +2136,34 @@ def _dmmha_model(
     # cache_indirection, bias -- see MatchDecoderMaskedMultiHeadAttentionProducer's
     # own comment for why this differs from MultiHeadAttention's own layout.
     operands = ["q", "k", "v", "", "", "", "", "", "", "", ""]
+    extra_graph_inputs = ""
+
+    if attention_bias in ("broadcast", "per_head", "bad"):
+        bias_heads = {"broadcast": 1, "per_head": H, "bad": H + 1}[attention_bias]
+        if attention_bias_array is None:
+            attention_bias_array = rng.standard_normal(
+                (1, bias_heads, 1, total_seq)
+            ).astype(np.float32)
+        initializer.append(_f32(attention_bias_array, "AttnBias"))
+        operands[4] = "AttnBias"
+    elif attention_bias == "dynamic_per_head":
+        operands[4] = "AttnBiasIn"
+        extra_graph_inputs += f", float[1,{H},1,{total_seq}] AttnBiasIn"
+
+    if past_kv == "nonempty":
+        past_key = rng.standard_normal((batch, H, past_seq, D)).astype(np.float32)
+        past_value = rng.standard_normal((batch, H, past_seq, D)).astype(np.float32)
+        initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
+        operands[5] = "PastKey"
+        operands[6] = "PastValue"
+    elif past_kv == "dynamic":
+        operands[5] = "PastKeyIn"
+        operands[6] = "PastValueIn"
+        extra_graph_inputs += (
+            f", float[{batch},{H},{past_seq},{D}] PastKeyIn"
+            f", float[{batch},{H},{past_seq},{D}] PastValueIn"
+        )
+
     if combined_bias:
         if bq is None:
             bq = rng.standard_normal((Nq,)).astype(np.float32)
@@ -2137,7 +2178,7 @@ def _dmmha_model(
         operands.pop()
 
     body = f"""
-        g (float[{batch},1,{K}] X) => (float[{batch},1,{Out}] Y)
+        g (float[{batch},1,{K}] X{extra_graph_inputs}) => (float[{batch},1,{Out}] Y)
         {{
           q = MatMul(X, Wq)
           k = MatMul(X, Wk)
@@ -2172,6 +2213,7 @@ def _dmmha_model(
         bv=bv,
         wout=wout,
         batch=batch,
+        attention_bias_array=attention_bias_array,
     )
 
 
@@ -2203,6 +2245,185 @@ def test_cpp_dmmha_pruning_slices_combined_bias_matches_python_reference():
     pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned_cpp)
     assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+
+def test_cpp_dmmha_pruning_constant_broadcast_attention_bias_is_untouched_matches_python():
+    # A constant attention_bias of the schema-documented broadcastable shape
+    # ([1, 1, 1, total_seq], axis 1 -- the num_heads-aligned slot -- sized 1)
+    # is left completely untouched (HeadBiasAxis resolves -1: already correct
+    # for any head count), matching pruning.py's own
+    # `_head_bias_input_is_safe`/`_slice_or_gather_head_bias` exactly.
+    model, cfg = _dmmha_model(K=8, H=8, D=4, Out=6, seed=43, attention_bias="broadcast")
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    bias_after = next(
+        onnx.numpy_helper.to_array(t)
+        for t in pruned_cpp.graph.initializer
+        if t.name == "AttnBias"
+    )
+    np.testing.assert_array_equal(bias_after, cfg["attention_bias_array"])
+
+
+def test_cpp_dmmha_pruning_constant_per_head_attention_bias_sliced_matches_python():
+    # A constant attention_bias genuinely per-head-shaped ([1, H, 1,
+    # total_seq], axis 1 sized exactly num_heads) is sliced in place along
+    # axis 1 by the kept query heads -- HeadBiasAxis resolves 1,
+    # SliceAxisGeneric performs the slice -- matching pruning.py's own
+    # `_slice_axis` exactly.
+    H, D = 8, 4
+    model, cfg = _dmmha_model(K=8, H=H, D=D, Out=6, seed=44, attention_bias="per_head")
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    keep_heads = _oracle_keep_heads(
+        np.concatenate([cfg["wq"], cfg["wk"], cfg["wv"]], axis=1),
+        cfg["Nq"],
+        cfg["Nk"],
+        cfg["Nv"],
+        H,
+        H - round(H * 0.5),
+    )
+    bias_after = next(
+        onnx.numpy_helper.to_array(t)
+        for t in pruned_cpp.graph.initializer
+        if t.name == "AttnBias"
+    )
+    np.testing.assert_array_equal(
+        bias_after, cfg["attention_bias_array"][:, keep_heads, :, :]
+    )
+
+
+def test_cpp_dmmha_pruning_dynamic_per_head_attention_bias_gathers_matches_python():
+    # A genuinely dynamic (graph-input) per-head attention_bias -- the one
+    # case needing SliceOrGatherHeadBias's own `Gather`-insertion path
+    # (InsertDynamicHeadBiasGather), since its own real values aren't
+    # available to slice in place at prune time.
+    H, D = 8, 4
+    model, cfg = _dmmha_model(
+        K=8, H=H, D=D, Out=6, seed=45, attention_bias="dynamic_per_head"
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    gather_nodes = [n for n in pruned_cpp.graph.node if n.op_type == "Gather"]
+    assert len(gather_nodes) == 1
+    gather = gather_nodes[0]
+    assert gather.input[0] == "AttnBiasIn"
+    axis = next(a.i for a in gather.attribute if a.name == "axis")
+    assert axis == 1
+    indices_init = next(
+        t for t in pruned_cpp.graph.initializer if t.name == gather.input[1]
+    )
+    indices = onnx.numpy_helper.to_array(indices_init)
+    keep_heads = _oracle_keep_heads(
+        np.concatenate([cfg["wq"], cfg["wk"], cfg["wv"]], axis=1),
+        cfg["Nq"],
+        cfg["Nk"],
+        cfg["Nv"],
+        H,
+        H - round(H * 0.5),
+    )
+    np.testing.assert_array_equal(indices, np.sort(keep_heads))
+    node = _dmmha_node(pruned_cpp)
+    assert node.input[4] == gather.output[0]
+
+
+def test_cpp_dmmha_pruning_unresolvable_attention_bias_shape_declines_matches_python():
+    # An attention_bias whose own axis-1 size is neither a genuine broadcast
+    # (1) nor exactly num_heads (H + 1 here) -- HeadBiasAxis/
+    # `_head_bias_axis` decline to classify it either way, so BOTH ports
+    # must decline the WHOLE chain rather than guess.
+    model, _ = _dmmha_model(K=8, H=8, D=4, Out=6, seed=46, attention_bias="bad")
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_dmmha_pruning_constant_sliceable_past_kv_matches_python():
+    # A constant past_key/past_value of the schema-documented BNSH layout
+    # ([batch, num_heads, past_seq, head_size], axis 1 the num_heads axis) --
+    # now sliced along axis 1 by the kept query heads (PastKvConstantsAreSliceable
+    # confirms the shape, SliceAxisGeneric performs the slice), matching
+    # pruning.py's own `_past_kv_constants_are_sliceable`/`_slice_axis1` exactly.
+    H, D = 8, 4
+    model, cfg = _dmmha_model(K=8, H=H, D=D, Out=6, seed=47, past_kv="nonempty")
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    keep_heads = _oracle_keep_heads(
+        np.concatenate([cfg["wq"], cfg["wk"], cfg["wv"]], axis=1),
+        cfg["Nq"],
+        cfg["Nk"],
+        cfg["Nv"],
+        H,
+        H - round(H * 0.5),
+    )
+    past_key_before = next(
+        onnx.numpy_helper.to_array(t)
+        for t in model.graph.initializer
+        if t.name == "PastKey"
+    )
+    past_key_after = next(
+        onnx.numpy_helper.to_array(t)
+        for t in pruned_cpp.graph.initializer
+        if t.name == "PastKey"
+    )
+    np.testing.assert_array_equal(past_key_after, past_key_before[:, keep_heads, :, :])
+
+
+def test_cpp_dmmha_pruning_dynamic_past_kv_input_is_still_pruned_matches_python():
+    model, _ = _dmmha_model(K=8, H=8, D=4, Out=6, seed=48, past_kv="dynamic")
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    node = _dmmha_node(pruned_cpp)
+    assert _mha_num_heads(node) == 4
+
+
+def test_cpp_dmmha_pruning_nonsliceable_past_kv_shape_declines_matches_python():
+    # A constant past_key whose own axis-1 length doesn't match num_heads at
+    # all (a shape PastKvConstantsAreSliceable can't confidently confirm is
+    # the documented BNSH layout) declines the whole match outright, rather
+    # than guessed at -- matching pruning.py's own identical decline.
+    H, D, batch = 8, 4, 2
+    rng = np.random.default_rng(49)
+    model, _ = _dmmha_model(K=8, H=H, D=D, Out=6, seed=49, past_kv=None)
+    bad_past_key = rng.standard_normal((batch, H + 1, 3, D)).astype(np.float32)
+    bad_past_value = rng.standard_normal((batch, H + 1, 3, D)).astype(np.float32)
+    model.graph.initializer.append(_f32(bad_past_key, "PastKey"))
+    model.graph.initializer.append(_f32(bad_past_value, "PastValue"))
+    node = _dmmha_node(model)
+    del node.input[:]
+    node.input.extend(["q", "k", "v", "", "", "PastKey", "PastValue"])
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
 
 
 # --- com.microsoft::PagedAttention -------------------------------------------
@@ -2238,6 +2459,21 @@ def _paged_attention_model(
     wk=None,
     wv=None,
     wout=None,
+    # head_sink (index 11): None (unconnected) | "per_head" (constant
+    # (num_heads,)) | "bad" (constant (num_heads + 1,) -- not the schema's
+    # own documented shape) -- see MatchPagedAttentionProducer's own comment.
+    head_sink=None,
+    head_sink_array=None,
+    # q_norm_weight/k_norm_weight (indices 12/13): "both" connects a
+    # (head_size,) constant pair (the schema's own "must be provided
+    # together" rule); "only_q" connects just one, violating that rule.
+    qk_norm=None,
+    # k_scale/v_scale (indices 14/15): None (unconnected) | "broadcast"
+    # (constant [1], PER_TENSOR) | "per_channel" (constant (kv_num_heads, 1,
+    # D), PER_CHANNEL) -- see PagedKvScaleIsSliceable's own comment.
+    kv_scale=None,
+    k_scale_array=None,
+    v_scale_array=None,
 ):
     rng = np.random.default_rng(seed)
     Nq, Nkv = H * D, KVH * D
@@ -2267,6 +2503,10 @@ def _paged_attention_model(
         f", float[{num_blocks},{block_size},{KVH},{D}] KeyCache"
         f", float[{num_blocks},{block_size},{KVH},{D}] ValueCache"
     )
+    # Fixed-index layout: query, key, value, key_cache, value_cache,
+    # cumulative_sequence_length, past_seqlens, block_table, cos_cache,
+    # sin_cache, slot_mapping, head_sink, q_norm_weight, k_norm_weight,
+    # k_scale, v_scale -- see MatchPagedAttentionProducer's own comment.
     operands = [
         "q",
         "k",
@@ -2276,7 +2516,50 @@ def _paged_attention_model(
         "CumSeqLen",
         "PastSeqLens",
         "BlockTable",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
     ]
+
+    if head_sink in ("per_head", "bad"):
+        sink_len = H if head_sink == "per_head" else H + 1
+        if head_sink_array is None:
+            head_sink_array = rng.standard_normal((sink_len,)).astype(np.float32)
+        initializer.append(_f32(head_sink_array, "HeadSink"))
+        operands[11] = "HeadSink"
+
+    if qk_norm in ("both", "only_q"):
+        q_norm = rng.standard_normal((D,)).astype(np.float32)
+        initializer.append(_f32(q_norm, "QNorm"))
+        operands[12] = "QNorm"
+        if qk_norm == "both":
+            k_norm = rng.standard_normal((D,)).astype(np.float32)
+            initializer.append(_f32(k_norm, "KNorm"))
+            operands[13] = "KNorm"
+
+    if kv_scale in ("broadcast", "per_channel"):
+        if kv_scale == "broadcast":
+            if k_scale_array is None:
+                k_scale_array = np.array([2.0], dtype=np.float32)
+            if v_scale_array is None:
+                v_scale_array = np.array([3.0], dtype=np.float32)
+        else:
+            if k_scale_array is None:
+                k_scale_array = rng.standard_normal((KVH, 1, D)).astype(np.float32)
+            if v_scale_array is None:
+                v_scale_array = rng.standard_normal((KVH, 1, D)).astype(np.float32)
+        initializer.append(_f32(k_scale_array, "KScale"))
+        initializer.append(_f32(v_scale_array, "VScale"))
+        operands[14] = "KScale"
+        operands[15] = "VScale"
+
+    while operands and operands[-1] == "":
+        operands.pop()
 
     body = f"""
         g (float[{num_tokens},{K}] X{extra_inputs}) => (float[{num_tokens},{Out}] Y)
@@ -2311,6 +2594,9 @@ def _paged_attention_model(
         wv=wv,
         wout=wout,
         num_tokens=num_tokens,
+        head_sink_array=head_sink_array,
+        k_scale_array=k_scale_array,
+        v_scale_array=v_scale_array,
     )
 
 
@@ -2364,6 +2650,171 @@ def test_cpp_paged_attention_pruning_matches_oracle_exactly():
     np.testing.assert_array_equal(inits["Wk"], cfg["wk"][:, kv_idx])
     np.testing.assert_array_equal(inits["Wv"], cfg["wv"][:, kv_idx])
     np.testing.assert_array_equal(inits["Wout"], cfg["wout"][q_idx, :])
+
+
+def _paged_keep(cfg, sparsity=0.5):
+    group_size = cfg["H"] // cfg["KVH"]
+    new_kv = cfg["KVH"] - round(cfg["KVH"] * sparsity)
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], new_kv
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    return keep_groups, keep_q_heads
+
+
+def test_cpp_paged_attention_pruning_constant_head_sink_sliced_matches_python():
+    # A constant head_sink of the schema-documented (num_heads,) shape is
+    # sliced by the kept query heads -- matching pruning.py's own
+    # `_match_paged_attention_producer`/`_slice_last_axis` exactly. This also
+    # exercises the underlying parity gap this port closes: previously ANY
+    # non-empty head_sink declined the whole match outright.
+    model, cfg = _paged_attention_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=53, head_sink="per_head"
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    _, keep_q_heads = _paged_keep(cfg)
+    sink_after = next(
+        onnx.numpy_helper.to_array(t)
+        for t in pruned_cpp.graph.initializer
+        if t.name == "HeadSink"
+    )
+    np.testing.assert_array_equal(sink_after, cfg["head_sink_array"][keep_q_heads])
+
+
+def test_cpp_paged_attention_pruning_bad_head_sink_shape_declines_matches_python():
+    # A constant head_sink whose own shape isn't exactly (num_heads,) --
+    # neither port can confirm this is the documented layout, so both
+    # decline the whole match rather than guess.
+    model, _ = _paged_attention_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=54, head_sink="bad"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_paged_attention_pruning_qk_norm_paired_presence_now_matches_python():
+    # A connected q_norm_weight/k_norm_weight PAIR (the schema's own "must be
+    # provided together" rule satisfied) now matches and prunes -- neither is
+    # ever sliced (a (head_size,)-shaped tensor never needs touching), so
+    # both stay byte-identical across the prune. Previously this port
+    # declined the whole match whenever EITHER was present at all.
+    model, cfg = _paged_attention_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=55, qk_norm="both"
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    q_norm_before = next(
+        onnx.numpy_helper.to_array(t)
+        for t in model.graph.initializer
+        if t.name == "QNorm"
+    )
+    q_norm_after = next(
+        onnx.numpy_helper.to_array(t)
+        for t in pruned_cpp.graph.initializer
+        if t.name == "QNorm"
+    )
+    np.testing.assert_array_equal(q_norm_after, q_norm_before)
+
+
+def test_cpp_paged_attention_pruning_qk_norm_only_one_present_declines_matches_python():
+    # Only q_norm_weight connected, k_norm_weight absent -- violates the
+    # schema's own "must be provided together" rule, declined outright by
+    # both ports.
+    model, _ = _paged_attention_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=56, qk_norm="only_q"
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_paged_attention_pruning_bad_qk_norm_shape_declines_matches_python():
+    # A connected q_norm_weight/k_norm_weight pair whose own shape ISN'T
+    # exactly (head_size,) -- the deferred shape check FindSeparateQkvChains
+    # performs once head_size is known -- declines the whole match, matching
+    # pruning.py's own identical deferred check.
+    model, cfg = _paged_attention_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=57, qk_norm="both"
+    )
+    for i, t in enumerate(model.graph.initializer):
+        if t.name == "QNorm":
+            bad = np.zeros((cfg["D"] + 1,), dtype=np.float32)
+            model.graph.initializer[i].CopyFrom(_f32(bad, "QNorm"))
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
+
+
+def test_cpp_paged_attention_pruning_constant_broadcast_kv_scale_is_untouched_matches_python():
+    # A constant k_scale/v_scale of the schema's own "PER_TENSOR" broadcast
+    # shape ([1]) needs no slicing at all -- left completely untouched,
+    # matching pruning.py's own `_paged_kv_scale_is_sliceable` exactly.
+    model, cfg = _paged_attention_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=58, kv_scale="broadcast"
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    k_scale_after = next(
+        onnx.numpy_helper.to_array(t)
+        for t in pruned_cpp.graph.initializer
+        if t.name == "KScale"
+    )
+    np.testing.assert_array_equal(k_scale_after, cfg["k_scale_array"])
+
+
+def test_cpp_paged_attention_pruning_constant_per_channel_kv_scale_sliced_matches_python():
+    # A constant k_scale/v_scale of the schema's own "PER_CHANNEL"
+    # (kv_num_heads, 1, head_size) shape -- the KV axis at position *0*, not
+    # 1 the way GroupQueryAttention's own k_scale/v_scale is -- sliced along
+    # axis 0 by the kept KV groups, matching pruning.py's own
+    # `_paged_kv_scale_is_sliceable`/`_slice_axis` exactly.
+    model, cfg = _paged_attention_model(
+        K=8, H=8, KVH=2, D=8, Out=6, seed=59, kv_scale="per_channel"
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    keep_groups, _ = _paged_keep(cfg)
+    k_scale_after = next(
+        onnx.numpy_helper.to_array(t)
+        for t in pruned_cpp.graph.initializer
+        if t.name == "KScale"
+    )
+    v_scale_after = next(
+        onnx.numpy_helper.to_array(t)
+        for t in pruned_cpp.graph.initializer
+        if t.name == "VScale"
+    )
+    np.testing.assert_array_equal(k_scale_after, cfg["k_scale_array"][keep_groups])
+    np.testing.assert_array_equal(v_scale_after, cfg["v_scale_array"][keep_groups])
 
 
 # --- Plain ai.onnx::LinearAttention (opset 27+) -----------------------------

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -44,43 +44,63 @@ each remaining narrowing produces.
 optional per-head inputs -- ``attention_bias``/``attn_mask``,
 ``past_key``/``past_value`` (plus, GQA-only, ``k_scale``/``v_scale`` and
 ``head_sink``) -- as well as ``com.microsoft::MultiHeadAttention``'s/
-``com.microsoft::PackedMultiHeadAttention``'s own optional ``attention_bias``
-(and, ``MultiHeadAttention``-only, ``past_key``/``past_value``) now reuse this
-exact same ``HeadBiasInputIsSafe``/``SliceOrGatherHeadBias`` machinery
-(``MatchGqaProducer``/``MatchOnnxAttentionProducer``/
+``com.microsoft::PackedMultiHeadAttention``'s/
+``com.microsoft::DecoderMaskedMultiHeadAttention``'s own optional
+``attention_bias`` (and, ``MultiHeadAttention``'s/
+``DecoderMaskedMultiHeadAttention``'s own ``past_key``/``past_value``) now
+reuse this exact same ``HeadBiasInputIsSafe``/``SliceOrGatherHeadBias``
+machinery (``MatchGqaProducer``/``MatchOnnxAttentionProducer``/
 ``MatchMultiHeadAttentionProducer``/``MatchPackedMultiHeadAttentionProducer``/
-``ApplyOneGqaChain``, plus this file's own new
-``PastKvConstantsAreSliceable``/``SliceKvCacheAxis1`` for the KV-cache pair):
-a constant that resolves to a genuine per-head/per-KV-group tensor is sliced
-in place, a constant that resolves to a broadcast is left untouched (without
-declining the match), a dynamic one gets a ``Gather`` node spliced in ahead of
-it when genuinely per-head, and only a shape that doesn't statically resolve
-either way declines the whole match -- see the dedicated tests in each
-family's own section below (the ``_gqa_model`` helper's own
-``attention_bias``/``head_sink``/``past_kv`` parameters,
+``MatchDecoderMaskedMultiHeadAttentionProducer``/``ApplyOneGqaChain``, plus
+this file's own ``PastKvConstantsAreSliceable``/``SliceKvCacheAxis1`` for the
+KV-cache pair): a constant that resolves to a genuine per-head/per-KV-group
+tensor is sliced in place, a constant that resolves to a broadcast is left
+untouched (without declining the match), a dynamic one gets a ``Gather``
+node spliced in ahead of it when genuinely per-head, and only a shape that
+doesn't statically resolve either way declines the whole match -- see the
+dedicated tests in each family's own section below (the ``_gqa_model``
+helper's own ``attention_bias``/``head_sink``/``past_kv`` parameters,
 ``_onnx_attention_model``'s own ``attn_mask``/``past_kv`` parameters, and
-``MultiHeadAttention``'s/``PackedMultiHeadAttention``'s own model builders'
-``attention_bias``/``past_kv`` parameters). ``MultiHeadAttention``'s own
-optional ``past_key``/``past_value`` (indices 6/7) are validated with
-``PastKvConstantsAreSliceable`` called with no ``scale_indices`` (this op has
-no ``k_scale``/``v_scale``) and sliced along their own BNSH ``kv_num_heads``
-axis when a constant of that exact shape; ``PackedMultiHeadAttention`` has no
-``past_key``/``past_value`` inputs on its own schema at all (packing mode is
-encoder-only).
+``MultiHeadAttention``'s/``PackedMultiHeadAttention``'s/
+``DecoderMaskedMultiHeadAttention``'s own model builders' own
+``attention_bias``/``past_kv`` parameters). Each of ``MultiHeadAttention``'s
+(indices 6/7) and ``DecoderMaskedMultiHeadAttention``'s (indices 5/6) own
+optional ``past_key``/``past_value`` are validated with
+``PastKvConstantsAreSliceable`` called with no ``scale_indices`` (neither op
+has ``k_scale``/``v_scale``) and sliced along their own BNSH
+``kv_num_heads`` axis when a constant of that exact shape;
+``PackedMultiHeadAttention`` has no ``past_key``/``past_value`` inputs on its
+own schema at all (packing mode is encoder-only).
 
-The other four fused-op families (``DecoderMaskedMultiHeadAttention``,
-``PagedAttention``, ``LinearAttention``, ``SparseAttention``) still share one
-more deliberate, narrower-than-pruning.py scope choice, unaffected by the
-above: this port has no analogue of pruning.py's own dynamic-attention-bias-
-Gather-insertion machinery for THOSE families -- a pre-existing,
-already-accepted gap (only the families named above have that machinery
-ported) -- so every one of those four matchers still declines the whole chain
-outright whenever an optional per-head bias/mask/sink/norm/scale input
-resolves to a non-empty constant, rather than risk leaving one silently stale
-after ``num_heads``/``kv_num_heads`` shrink underneath it. See each of those
-family's own model builder/test section below, and each ``Match*Producer``
-function's own comment in ``structured_pruning_entry.cpp``, for the exact
-narrowing.
+``com.microsoft::PagedAttention`` -- the one remaining separate-Q/K/V family
+with a per-head optional input beyond a combined bias -- has no
+``attention_bias``/``attn_mask``-equivalent input on its own schema at all,
+but its own ``head_sink`` (index 11, a genuine ``(num_heads,)`` constant),
+``q_norm_weight``/``k_norm_weight`` (indices 12/13, paired-presence only --
+neither ever sliced, since a ``(head_size,)`` shape never changes under
+whole-head/KV-group pruning), and ``k_scale``/``v_scale`` (indices 14/15,
+``PagedKvScaleIsSliceable`` -- a *different*, rank-3/axis-0
+``(kv_num_heads, 1, head_size)`` PER_CHANNEL layout from every other family's
+own rank-4/axis-1 one, since this op's own schema documents it that way) are
+now all validated/sliced too, via ``FindSeparateQkvChains``'s own new
+``qk_norm_weight_indices`` parameter and ``ApplyOneGqaChain``'s own
+``is_paged`` branch -- see the dedicated PagedAttention tests below and
+``MatchPagedAttentionProducer``'s/``PagedKvScaleIsSliceable``'s own comments
+in ``structured_pruning_entry.cpp``.
+
+The two remaining fused-op families (``LinearAttention``, ``SparseAttention``)
+still share one more deliberate, narrower-than-pruning.py scope choice,
+unaffected by the above: ``SparseAttention``'s own optional
+``past_key``/``past_value`` (indices 3/4) still decline the whole chain
+outright whenever non-empty and constant (``NoNonEmptyConstantAt``, this
+port's own pre-existing, already-accepted gap -- no analogue of
+``PastKvConstantsAreSliceable``'s own validate-and-slice treatment for THIS
+op yet), rather than risk leaving one silently stale after
+``num_heads``/``kv_num_heads`` shrink underneath it; ``LinearAttention`` has
+no such optional per-head input on its own schema to begin with. See each of
+those two families' own model builder/test section below, and each
+``Match*Producer`` function's own comment in ``structured_pruning_entry.cpp``,
+for the exact narrowing.
 """
 
 import ml_dtypes
@@ -6154,3 +6174,274 @@ def test_cpp_attention_head_wanda_pruning_leaves_matmul_nbits_qkv_chains_untouch
     )
     onnx.checker.check_model(pruned)
     assert pruned.SerializeToString() == model.SerializeToString()
+
+
+# --- Cross-family regression checks --------------------------------------
+#
+# The three per-head-input fixes above (GroupQueryAttention/plain
+# ai.onnx::Attention, MultiHeadAttention/PackedMultiHeadAttention,
+# DecoderMaskedMultiHeadAttention/PagedAttention) were each authored
+# independently against the SAME shared dispatch machinery
+# (``FindSeparateQkvChains``, ``ApplyOneGqaChain``, ``HeadBiasInputIsSafe``/
+# ``SliceOrGatherHeadBias``, ``PastKvConstantsAreSliceable``) and merged
+# together afterwards. The two tests below are not about any one family's
+# own new behavior (already covered above) -- they specifically probe the
+# merge-time risk of one family's own per-head-input index/handling
+# accidentally leaking onto a DIFFERENT family's node when both are matched
+# and pruned together in the same graph: a wrong hard-coded input index
+# reused across op types, a `keep_heads`/`keep_q_heads` index set computed
+# for one chain applied to another's own attention_bias/past_key/past_value,
+# or a `used_names` collision between two independently-inserted dynamic
+# Gather nodes.
+
+
+def test_cpp_attention_head_pruning_gqa_and_mha_attention_bias_do_not_cross_contaminate():
+    # One graph, two independent chains: a GroupQueryAttention node
+    # (num_heads=4, kv_num_heads=2) and a MultiHeadAttention node
+    # (num_heads=4), each with its OWN dynamic (graph-input) attention_bias.
+    # head_size=8 (onnxruntime's own GroupQueryAttention kernel requires a
+    # multiple of 8) with every column WITHIN a head sharing that head's own
+    # single value keeps each chain's own kept-head set fully deterministic
+    # and, by construction, DISJOINT from the other's -- so if the merged
+    # code ever applied one chain's own `keep_q_heads`/`keep_heads` index set
+    # (or wrong input index) to the other's node, the assertions below on the
+    # inserted Gathers' own indices content would catch it immediately.
+    seq = 3
+    batch = 1
+    d = 8
+
+    def _per_head(values):
+        return np.repeat(np.asarray(values, dtype=np.float32), d).reshape(1, -1)
+
+    # GQA branch: group 1 (query heads {2, 3}) is the more important KV
+    # group by construction (larger Wk/Wv magnitude), so sparsity=0.5 (1 of
+    # 2 KV groups dropped) keeps exactly heads {2, 3}.
+    wq_g = _per_head([1.0, 2.0, 3.0, 4.0])
+    wk_g = _per_head([10.0, 20.0])
+    wv_g = _per_head([100.0, 200.0])
+    wout_g = np.eye(4 * d, dtype=np.float32)
+
+    # MHA branch: heads are ranked in the OPPOSITE order (head 0 most
+    # important), so the same sparsity=0.5 keeps exactly heads {0, 1} --
+    # disjoint from the GQA branch's own kept {2, 3}.
+    wq_m = _per_head([40.0, 30.0, 20.0, 10.0])
+    wk_m = np.ones((1, 4 * d), dtype=np.float32)
+    wv_m = np.ones((1, 4 * d), dtype=np.float32)
+    wout_m = np.eye(4 * d, dtype=np.float32)
+
+    seqlensk = np.full((batch,), seq - 1, dtype=np.int32)
+    totalseq = np.array(seq, dtype=np.int32)
+
+    body = f"""
+        g (float[{batch},{seq},1] X,
+           float[1,4,{seq},{seq}] AttnBiasGqaIn,
+           float[1,4,{seq},{seq}] AttnBiasMhaIn)
+          => (float[{batch},{seq},{4 * d}] Yg, float[{batch},{seq},{4 * d}] Ym)
+        {{
+          qg = MatMul(X, WqG)
+          kg = MatMul(X, WkG)
+          vg = MatMul(X, WvG)
+          ctxg, pkg, pvg = com.microsoft.GroupQueryAttention <num_heads=4, kv_num_heads=2> (qg, kg, vg, , , SeqLensK, TotalSeq, , , , AttnBiasGqaIn)
+          Yg = MatMul(ctxg, WoutG)
+          qm = MatMul(X, WqM)
+          km = MatMul(X, WkM)
+          vm = MatMul(X, WvM)
+          ctxm = com.microsoft.MultiHeadAttention <num_heads=4> (qm, km, vm, , , AttnBiasMhaIn)
+          Ym = MatMul(ctxm, WoutM)
+        }}
+        """
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            _f32(wq_g, "WqG"),
+            _f32(wk_g, "WkG"),
+            _f32(wv_g, "WvG"),
+            _f32(wout_g, "WoutG"),
+            _f32(wq_m, "WqM"),
+            _f32(wk_m, "WkM"),
+            _f32(wv_m, "WvM"),
+            _f32(wout_m, "WoutM"),
+            onnx.numpy_helper.from_array(seqlensk, "SeqLensK"),
+            onnx.numpy_helper.from_array(totalseq, "TotalSeq"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    gqa_node = next(n for n in pruned.graph.node if n.op_type == "GroupQueryAttention")
+    mha_node = next(n for n in pruned.graph.node if n.op_type == "MultiHeadAttention")
+    assert next(a.i for a in gqa_node.attribute if a.name == "num_heads") == 2
+    assert next(a.i for a in gqa_node.attribute if a.name == "kv_num_heads") == 1
+    assert next(a.i for a in mha_node.attribute if a.name == "num_heads") == 2
+
+    # Each node's own attention_bias input now names a freshly-inserted
+    # Gather's own output -- distinct nodes reading from each's own original
+    # dynamic input, never each other's.
+    gqa_bias_name = gqa_node.input[10]
+    mha_bias_name = mha_node.input[5]
+    assert gqa_bias_name != mha_bias_name
+
+    gather_by_output = {
+        n.output[0]: n for n in pruned.graph.node if n.op_type == "Gather"
+    }
+    init_by_name = {t.name: t for t in pruned.graph.initializer}
+    gqa_gather = gather_by_output[gqa_bias_name]
+    mha_gather = gather_by_output[mha_bias_name]
+    assert gqa_gather.name != mha_gather.name
+    assert gqa_gather.input[0] == "AttnBiasGqaIn"
+    assert mha_gather.input[0] == "AttnBiasMhaIn"
+
+    gqa_indices = list(onnx.numpy_helper.to_array(init_by_name[gqa_gather.input[1]]))
+    mha_indices = list(onnx.numpy_helper.to_array(init_by_name[mha_gather.input[1]]))
+    assert gqa_indices == [2, 3]
+    assert mha_indices == [0, 1]
+
+    # No name collision between the two independently-inserted Gathers/
+    # indices initializers -- a shared, incorrectly-threaded `used_names`
+    # set across the two chains would otherwise silently produce two
+    # differently-behaving nodes with the same name.
+    node_names = [n.name for n in pruned.graph.node if n.name]
+    assert len(node_names) == len(set(node_names))
+    init_names = [t.name for t in pruned.graph.initializer]
+    assert len(init_names) == len(set(init_names))
+
+    # Functional smoke test: the rewritten graph is still valid, executable
+    # ONNX -- each branch's own Gather correctly feeds its own node.
+    rng = np.random.default_rng(0)
+    feeds = {
+        "X": rng.standard_normal((batch, seq, 1)).astype(np.float32),
+        "AttnBiasGqaIn": rng.standard_normal((1, 4, seq, seq)).astype(np.float32),
+        "AttnBiasMhaIn": rng.standard_normal((1, 4, seq, seq)).astype(np.float32),
+    }
+    outs = _run(pruned, feeds)
+    assert all(np.isfinite(o).all() for o in outs)
+
+
+def test_cpp_attention_head_pruning_dmmha_and_mha_constant_inputs_do_not_cross_contaminate():
+    # A DecoderMaskedMultiHeadAttention node (attention_bias at index 4,
+    # past_key/past_value at 5/6) and a MultiHeadAttention node
+    # (attention_bias at index 5, past_key/past_value at 6/7) side by side in
+    # one graph -- deliberately overlapping-but-different index conventions,
+    # the exact shape of bug a copy-paste merge error between the two
+    # families' own matchers/appliers would produce. Every per-head constant
+    # here is filled with the head index scaled by a distinct base, so a
+    # sliced tensor's own surviving values pin exactly which head indices
+    # each op's own inputs were sliced by.
+    K = 1
+    Hd, Hm = 3, 4
+    total_seq = 2
+    past_seq = 2
+
+    # DecoderMaskedMultiHeadAttention: head 0 most important, so
+    # sparsity=1/3 (round(3/3)=1 KV/query head dropped) keeps heads {0, 1}.
+    wq_d = np.array([[100.0, 10.0, 1.0]], dtype=np.float32)
+    wk_d = np.ones((1, Hd), dtype=np.float32)
+    wv_d = np.ones((1, Hd), dtype=np.float32)
+    wout_d = np.eye(Hd, dtype=np.float32)
+    attn_bias_d = np.array(
+        [[[[h * 10.0] * total_seq] for h in range(Hd)]], dtype=np.float32
+    )
+    past_key_d = np.array(
+        [[[[h * 1000.0] * 1] * past_seq for h in range(Hd)]], dtype=np.float32
+    )
+    past_value_d = np.array(
+        [[[[h * 1000.0 + 1] * 1] * past_seq for h in range(Hd)]], dtype=np.float32
+    )
+
+    # MultiHeadAttention: head 3 most important, so sparsity=1/3
+    # (round(4/3)=1 head dropped) keeps heads {1, 2, 3}.
+    wq_m = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32)
+    wk_m = np.ones((1, Hm), dtype=np.float32)
+    wv_m = np.ones((1, Hm), dtype=np.float32)
+    wout_m = np.eye(Hm, dtype=np.float32)
+    attn_bias_m = np.array(
+        [[[[h * 100.0] * total_seq] * total_seq for h in range(Hm)]], dtype=np.float32
+    )
+    past_key_m = np.array(
+        [[[[h * 10000.0] * 1] * past_seq for h in range(Hm)]], dtype=np.float32
+    )
+    past_value_m = np.array(
+        [[[[h * 10000.0 + 1] * 1] * past_seq for h in range(Hm)]], dtype=np.float32
+    )
+
+    body = f"""
+        g (float[1,1,{K}] X) => (float[1,1,{Hd}] Yd, float[1,1,{Hm}] Ym)
+        {{
+          qd = MatMul(X, WqD)
+          kd = MatMul(X, WkD)
+          vd = MatMul(X, WvD)
+          ctxd = com.microsoft.DecoderMaskedMultiHeadAttention <num_heads={Hd}> (qd, kd, vd, , AttnBiasD, PastKeyD, PastValueD)
+          Yd = MatMul(ctxd, WoutD)
+          qm = MatMul(X, WqM)
+          km = MatMul(X, WkM)
+          vm = MatMul(X, WvM)
+          ctxm = com.microsoft.MultiHeadAttention <num_heads={Hm}> (qm, km, vm, , , AttnBiasM, PastKeyM, PastValueM)
+          Ym = MatMul(ctxm, WoutM)
+        }}
+        """
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            _f32(wq_d, "WqD"),
+            _f32(wk_d, "WkD"),
+            _f32(wv_d, "WvD"),
+            _f32(wout_d, "WoutD"),
+            _f32(attn_bias_d, "AttnBiasD"),
+            _f32(past_key_d, "PastKeyD"),
+            _f32(past_value_d, "PastValueD"),
+            _f32(wq_m, "WqM"),
+            _f32(wk_m, "WkM"),
+            _f32(wv_m, "WvM"),
+            _f32(wout_m, "WoutM"),
+            _f32(attn_bias_m, "AttnBiasM"),
+            _f32(past_key_m, "PastKeyM"),
+            _f32(past_value_m, "PastValueM"),
+        ]
+    )
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=1 / 3)
+    onnx.checker.check_model(pruned)
+
+    dmmha_node = next(
+        n for n in pruned.graph.node if n.op_type == "DecoderMaskedMultiHeadAttention"
+    )
+    mha_node = next(n for n in pruned.graph.node if n.op_type == "MultiHeadAttention")
+    assert next(a.i for a in dmmha_node.attribute if a.name == "num_heads") == 2
+    assert next(a.i for a in mha_node.attribute if a.name == "num_heads") == 3
+
+    init_by_name = {t.name: t for t in pruned.graph.initializer}
+
+    # DecoderMaskedMultiHeadAttention's own attention_bias/past_key/past_value
+    # (indices 4/5/6) are sliced to its OWN kept heads {0, 1} -- never
+    # touched by MultiHeadAttention's own {1, 2, 3}.
+    pruned_bias_d = onnx.numpy_helper.to_array(init_by_name[dmmha_node.input[4]])
+    assert list(pruned_bias_d[0, :, 0, 0]) == [0.0, 10.0]
+    pruned_past_key_d = onnx.numpy_helper.to_array(init_by_name[dmmha_node.input[5]])
+    assert list(pruned_past_key_d[0, :, 0, 0]) == [0.0, 1000.0]
+
+    # MultiHeadAttention's own attention_bias/past_key/past_value (indices
+    # 5/6/7) are sliced to ITS OWN kept heads {1, 2, 3} -- never touched by
+    # DecoderMaskedMultiHeadAttention's own {0, 1}.
+    pruned_bias_m = onnx.numpy_helper.to_array(init_by_name[mha_node.input[5]])
+    assert list(pruned_bias_m[0, :, 0, 0]) == [100.0, 200.0, 300.0]
+    pruned_past_key_m = onnx.numpy_helper.to_array(init_by_name[mha_node.input[6]])
+    assert list(pruned_past_key_m[0, :, 0, 0]) == [10000.0, 20000.0, 30000.0]

--- a/tests/test_attention_head_wanda_pruning_cpp.py
+++ b/tests/test_attention_head_wanda_pruning_cpp.py
@@ -519,6 +519,155 @@ def test_cpp_gqa_wanda_pruning_empty_calibration_data_matches_plain():
     assert wanda_empty.SerializeToString() == plain.SerializeToString()
 
 
+# GroupQueryAttention's own optional attention_bias/past_key/past_value inputs
+# now reuse the exact same HeadBiasInputIsSafe/SliceOrGatherHeadBias/
+# PastKvConstantsAreSliceable/SliceKvCacheAxis1 machinery whether reached from
+# the plain (`apply_attention_head_pruning_cpp`, see
+# ``test_attention_head_pruning_cpp.py``'s own dedicated coverage) or this
+# Wanda-calibrated entry point -- both dispatch through the identical
+# ApplyOneGqaChain, just with a real calibrated `act_norm` map threaded
+# through here instead of `nullptr`. A small, local `_gqa_model_ext` (rather
+# than widening this file's own shared `_gqa_model`, used by many pre-existing
+# tests above with a fixed operand list) covers just the two new roles this
+# fix closes, to confirm the fix also holds up end to end through THIS entry
+# point's own separate graph/used_names/value_info_by_name plumbing
+# (ApplyAttentionHeadWandaPruning -> ApplyAttentionChains -> ApplyOneGqaChain).
+def _gqa_model_ext(
+    K=8,
+    H=8,
+    KVH=2,
+    D=8,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    attention_bias=None,
+    past_kv=None,
+):
+    rng = np.random.default_rng(seed)
+    Nq, Nkv = H * D, KVH * D
+    wq = rng.standard_normal((K, Nq)).astype(np.float32)
+    wk = rng.standard_normal((K, Nkv)).astype(np.float32)
+    wv = rng.standard_normal((K, Nkv)).astype(np.float32)
+    wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    initializer.append(
+        onnx.numpy_helper.from_array(
+            np.full((batch,), seq - 1, dtype=np.int32), "SeqLensK"
+        )
+    )
+    initializer.append(
+        onnx.numpy_helper.from_array(np.array(seq, dtype=np.int32), "TotalSeq")
+    )
+
+    operands = ["q", "k", "v"]
+    extra_graph_inputs = ""
+    if past_kv == "nonempty":
+        past_key = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        past_value = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
+        operands += ["PastKey", "PastValue"]
+    else:
+        operands += ["", ""]
+    operands += ["SeqLensK", "TotalSeq", "", "", ""]
+
+    if attention_bias == "per_head":
+        bias_t = rng.standard_normal((1, H, seq, seq)).astype(np.float32)
+        initializer.append(_f32(bias_t, "AttnBias"))
+        operands.append("AttnBias")
+    elif attention_bias == "dynamic_per_head":
+        operands.append("AttnBiasIn")
+        extra_graph_inputs += f", float[1,{H},{seq},{seq}] AttnBiasIn"
+    else:
+        operands.append("")
+
+    while operands and operands[-1] == "":
+        operands.pop()
+
+    body = f"""
+        g (float[{batch},{seq},{K}] X{extra_graph_inputs}) => (float[{batch},{seq},{Out}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          ctx, pk, pv = com.microsoft.GroupQueryAttention <num_heads={H}, kv_num_heads={KVH}> ({", ".join(operands)})
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(K=K, H=H, KVH=KVH, D=D, Out=Out, batch=batch, seq=seq)
+
+
+def test_cpp_gqa_wanda_pruning_per_head_attention_bias_matches_python_reference():
+    model, cfg = _gqa_model_ext(seed=120, attention_bias="per_head")
+    rng_cal = np.random.default_rng(121)
+    x_cal = rng_cal.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(
+        np.float32
+    )
+    calibration_data = [{"X": x_cal}]
+    pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+
+def test_cpp_gqa_wanda_pruning_dynamic_attention_bias_gather_matches_python_reference():
+    model, cfg = _gqa_model_ext(seed=122, attention_bias="dynamic_per_head")
+    rng_cal = np.random.default_rng(123)
+    x_cal = rng_cal.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(
+        np.float32
+    )
+    attn_bias_cal = rng_cal.standard_normal(
+        (1, cfg["H"], cfg["seq"], cfg["seq"])
+    ).astype(np.float32)
+    calibration_data = [{"X": x_cal, "AttnBiasIn": attn_bias_cal}]
+    pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    assert any(n.op_type == "Gather" for n in pruned_cpp.graph.node)
+
+
+def test_cpp_gqa_wanda_pruning_sliceable_past_kv_matches_python_reference():
+    model, cfg = _gqa_model_ext(seed=124, past_kv="nonempty")
+    rng_cal = np.random.default_rng(125)
+    x_cal = rng_cal.standard_normal((cfg["batch"], cfg["seq"], cfg["K"])).astype(
+        np.float32
+    )
+    calibration_data = [{"X": x_cal}]
+    pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    node = _gqa_node(pruned_cpp)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
+    }
+    assert inits["PastKey"].shape == (cfg["batch"], kv_num_heads, 1, cfg["D"])
+
+
 # --- Cross-check against the pure-Python reference --------------------------
 
 


### PR DESCRIPTION
## Context

This continues directly from commit `29f8d0f` ("Close FLOAT16/BFLOAT16, op-type, and MatMulNBitsQkv-scope gaps in C++ attention-head pruning"), already pushed to this same branch with no separate PR opened for it since it's bundled with this round's work, and from #1145's decomposed-GQA work.

Three background agents each extended the C++ attention-head-pruning port in `onnxsim/structured_pruning_entry.cpp`, all branched from `29f8d0f`, each closing the same category of gap for a different set of fused-attention ops: a producer matcher declining outright whenever an optional per-head input (mask/bias, past_key/past_value KV-cache, k_scale/v_scale, head_sink) was non-empty, instead of validating-and-slicing it the way the Python reference (`onnxsim/pruning.py`) does.

- `worktree-agent-a0fc5de6a07ac9d52` — `GroupQueryAttention` + plain `ai.onnx::Attention`.
- `worktree-agent-ac8b4e68f8c413a83` — `com.microsoft::MultiHeadAttention` + `PackedMultiHeadAttention`.
- `worktree-agent-af6423182b0a1d008` — `com.microsoft::DecoderMaskedMultiHeadAttention` + `PagedAttention`.

## What this PR does

Merges all three branches into one and reconciles the overlapping work each was independently asked to do (all three ported a `_past_kv_constants_are_sliceable`/`_slice_axis1` equivalent, since it didn't exist yet at their shared base commit):

- **Consolidated to one `PastKvConstantsAreSliceable`/`SliceKvCacheAxis1`** (three near-identical copies existed after a mechanical merge — one inline before `MatchGqaProducer`, one in the decomposed-GQA section, one inline before `MatchDecoderMaskedMultiHeadAttentionProducer`). All matchers/appliers now call the single global-scope definition, forward-declared once near the top of the file.
- **Unified `FindSeparateQkvChains`/`ApplyOneGqaChain` signatures** to the union of all three agents' needs: `value_info_by_name` threaded uniformly to every matcher (including a new `qk_norm_weight_indices` parameter for PagedAttention's own deferred q/k-norm shape check), `ApplyOneGqaChain`'s `graph`/`used_names` kept as required references (dropping one branch's alternate nullable-pointer design, which predated the other two merges making them required).
- **Removed a mid-file namespace close/reopen** one branch used to forward-declare shared helpers, in favor of this file's pre-existing top-of-file forward-declaration convention.
- Renamed two now-colliding local `mask_idx` variables in `ApplyOneGqaChain` to `gqa_mask_idx`/`mha_mask_idx`.
- Merged all three branches' test additions, fixed a stale doc comment left over from the merge (`NoNonEmptyConstantAt`'s own scope shrank as each family gained real handling), and rewrote `tests/test_attention_head_pruning_cpp.py`'s top-of-file docstring to describe the final, fully-merged scope.
- **Added two new cross-family regression tests** targeting the specific risk of merging three agents' edits to the same shared dispatch machinery: a `GroupQueryAttention` + `MultiHeadAttention` graph with independent dynamic `attention_bias` inputs (checks the inserted `Gather` nodes' own indices content and name uniqueness — a `used_names` collision risk), and a `DecoderMaskedMultiHeadAttention` + `MultiHeadAttention` graph with constant `attention_bias`/`past_key`/`past_value` at each op's own overlapping-but-different indices (checks sliced values pin the correct, non-swapped head set for each).

## Verification

- Rebuilt after each merge step (`pip install -e . -v`): zero compile errors, zero duplicate-symbol/redefinition warnings at every stage.
- `clang-format -i onnxsim/structured_pruning_entry.cpp`: minor reflow only (file was already conformant).
- `ruff format`/`ruff check` on touched test files: no changes needed, all checks pass.
- Full suite (`CI=1 pytest tests/ -q`, `tests/test_timm.py` deselected — `timm` isn't installed in this environment, unrelated to this change): **3030 passed, 131 skipped, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_