### PR TITLE
mcode: hand-patch the decoded Wbt requant scale; bit-flip probe on real resnet18d

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2160,6 +2160,63 @@ One suggestive detail, single data point: pointing the op at the last
 in-range word produced the *smallest* change of all six (0.83, vs
 2.4-7.5), as reading a near-empty tail of the weight table would.
 
+### `a1 00 xx yy` is a field write: `xx` is a 16-byte-granular field offset, `yy` a bank, and the map is shared across models
+
+Re-running the header statistics on the tiny two-Conv blob, side by
+side with `resnet18d`, corrects the "instruction kinds" framing above
+into something more specific and better supported -- all local, zero
+device runs.
+
+**Three checked regularities, both models:**
+
+- **`xx` is a multiple of `0x10` in every header: 58/58 and
+  1,197/1,197.** Not a single exception in 1,255 headers -- a 16-byte
+  granular offset, not an opcode.
+- **The `xx` values form ladders within each `yy`, and the ladders are
+  the same in both models.** Bank `0x02`: `0x10,0x20,0x40,...,0xd0` in
+  the tiny model, `0x10..0xd0` in `resnet18d`; bank `0x03`:
+  `0x30,0x50..0xe0` vs `0x30,0x50..0xf0`; bank `0x04`: `0x30..0xe0` vs
+  `0x40..0xf0`; bank `0x01`: `{0x50,0x60}` in both. A shared map of
+  fields, not a per-model vocabulary.
+- **`50 01` takes the identical operand set in both models:**
+  `{0x1, 0x100, 0x100000, 0x1000000}` -- single bits 0, 8, 20, 24. A
+  one-hot enable/mode register, written 724 times in `resnet18d` and 4
+  times in the tiny model, with the same four values.
+
+**So the reading is: `a1 00 xx yy <value>` writes a 32-bit value to
+field `xx` of bank `yy`** -- a descriptor or register-file write. That
+one reading explains everything found so far at once: a write is
+`[selector][value]`, so no selector is ever immediately followed by
+another (0/1,255); writes are two words, so the 2-word granularity and
+the 32-byte (four-write) unit; the "gate" is the selector word (corrupt
+it and the value goes to the wrong field, or nowhere -- one fixed
+fallback state); the validator faults on malformed *selectors*, never on
+*values*; `40 02` is the Wbt-offset field (181 distinct values spanning
+the Wbt in `resnet18d`; the single write in the tiny model is `0`, the
+first op's offset -- and `resnet18d`'s values include
+`0x14f80, 0x14f82, 0x14f84`, byte-granular steps, as INT8 weight
+offsets would be); and the input-independent vs input-dependent split is
+just which field got a bad value.
+
+**Corrections, stated in place.** (1) "The instruction mix is
+model-dependent; the format is not" -- better: the *field map* is
+shared; a large model re-writes a few fields (Wbt offset, an address in
+bank 3, the `50 01` flags) once per op, while a small model touches many
+fields once each as setup. (2) The tiny-model "structure holds" table
+earlier rested on 58 headers with many one-offs, which was thin; the
+ladders and the identical `50 01` set are the real, strong tiny-model
+evidence. (3) "Operands are address-like" holds for address *fields*
+(`40 02`, `50 03`); many bank-2/3/4 fields in the tiny model carry
+high-entropy packed values (`0xa1020c81`, `0x8130180f`, ...) -- packed
+configuration words, not addresses.
+
+What this still does not settle: the meaning of any field other than
+`40 02` (Wbt offset, quantitatively) and `50 01` (a one-hot flag, values
+known, meaning not), and what the banks are. But "decode mcode" has
+now gone from "49 KB of opaque bytes" to "a register map with ~50 named
+fields in a dozen banks, each written with a 32-bit value" -- a
+concrete, enumerable target.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2123,6 +2123,43 @@ The most common instruction, `50 01`, takes only four distinct operand
 values across 724 uses -- a small enumerated control/flag word, not a
 pointer; which flags is not identified.
 
+### Patching a `40 02` operand on the device: in-range predictions hold, the bounds-check prediction fails
+
+The section above named one targeted test; here it is, on the real
+device. Overwrite instance 32700's whole 4-byte operand (`0x00064c8c`)
+and run, one variant per fresh copy, same fixed input:
+
+```
+A <- B's operand 0x00b349a0 (valid, in range)   runs, D  argmax 905
+B <- A's operand 0x00064c8c (valid, in range)   runs, D  argmax 832
+A <- 0                                          runs, D  argmax 925
+A <- last in-range word (Wbt end - 4)           runs, D  argmax 18  (smallest change, 0.83)
+A <- 1 MB past the Wbt's end                    runs, D  argmax 530
+A <- 0x7fffff00 (~2 GB, far past)               runs, D  argmax 794
+```
+
+**Confirmed:** the operand is live and causal for any value -- every
+variant ran and changed the output, deterministically (the two past-end
+variants and the swap each reproduce the identical output across three
+reruns). Swapping two instances' offsets works in both directions.
+
+**Refuted, and worth stating plainly:** the prediction that an
+out-of-range offset would fault. It does not. The runtime accepts 1 MB
+past the Wbt's end, and `0x7fffff00`, without any error -- there is **no
+bounds check on this operand**. So the "weight-table offset" reading
+rests on the static evidence (181 distinct values whose maximum matches
+the Wbt's size to 0.3%), not on any runtime enforcement; mechanically
+this behaves like a raw base-plus-offset read, and a past-end value
+simply reads whatever stable, mapped memory sits there (deterministic
+across reruns, so not uninitialized garbage). It also sharpens what the
+`0x8030070C` validator is: every fault in this whole investigation came
+from a *header/format* byte, never from an operand value, however
+absurd -- the validator checks instruction structure, not operands.
+
+One suggestive detail, single data point: pointing the op at the last
+in-range word produced the *smallest* change of all six (0.83, vs
+2.4-7.5), as reading a near-empty tail of the weight table would.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1741,6 +1741,54 @@ recurring lesson: a correlation-only finding (an array that "shrinks as
 bias grows") can misdescribe the actual mechanism even when the general
 hypothesis is right, and only a direct intervention exposes that.
 
+### The bit-flip probe on the real `resnet18d` mcode: a third outcome appears, and the blob is ~83% live
+
+The single-byte-flip probe above only ever saw two outcomes on a tiny
+two-Conv model (inert, or a `0x8030070C` fault), across just 8 offsets.
+Running the same probe across the **real, unmodified `resnet18d_Opset18`
+mcode** (49,080 bytes; 41 offsets evenly spaced every 1,200 bytes through
+the interior, one flipped byte per run, each on a fresh copy of the same
+base file, all fed the identical fixed `uint8 [1,224,224,3]` input) gives
+a quantified, real-model-scale picture, and finds something the tiny
+model never showed:
+
+```
+25 / 41  (61%)  FAULT      -- runtime rejects it: 0x8030070C, same code every time
+ 9 / 41  (22%)  DIFFERENT  -- runs, but the 1000-class logits change
+ 7 / 41  (17%)  identical  -- runs, bit-identical output
+```
+
+**The `DIFFERENT` class is new, and it is real computation.** Every one of
+those 9 flips ran to completion with no error, yet produced different
+logits -- and in **7 of the 9 the predicted class itself changed** (e.g.
+argmax 305 -> 567, 908, 834, 143, 111, 533, 318), with max-abs logit
+deltas from 0.18 up to 7.29. The other 2 shifted the logits only mildly
+(0.18, 0.29) and kept the argmax. These are the first bytes this project
+has ever identified whose effect on the *actual computation* is directly
+observable -- a genuine instruction/parameter class, distinct from the
+checksum/opcode-validation class that faults, and from the inert class.
+All three outcomes were verified to be deterministic and not device noise:
+the unpatched baseline is bit-identical across 3 repeated runs; three of
+the `DIFFERENT` flips (9900, 32700, 48300) reproduce the *same* changed
+output on rerun; and two `identical` flips (12300, 26700) stay
+bit-identical against a second, different random input. The device stayed
+healthy throughout 25 consecutive faults (`axcl-smi` fine afterward) --
+the fault is graceful every time, never a lockup.
+
+**Bottom line for "how live is a real model's mcode":** by this sampling,
+**~83% of `resnet18d`'s mcode bytes are load-bearing** (61% checked
+structurally, 22% affecting real output), and only ~17% are inert -- far
+more live than the tiny model's 50/50 split suggested, and a direct,
+quantified counterpart to the earlier "43.4% of bytes are exact
+duplicates" finding: a byte being a *copy* of another span does not make
+it dead, since the hardware evidently reads those copies. The 9
+output-changing offsets are the most concrete decoding targets this
+README has produced so far -- each is a real, known-live byte whose
+effect on a real classifier is already measurable, so the next step
+(bisecting each one's *neighbors* to map the extent of its field, and
+correlating the resulting logit change with which layer's Conv it sits
+in) needs no new technique at all.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1837,6 +1837,75 @@ is: a fully-live, non-bit-weighted numeric-ish field whose encoding is
 still not identified -- the exact-equality pairs are the lead, not a
 decoding.
 
+### Inside one repeated template: a gate, three address-like bytes, and a checked sign bit
+
+Two follow-up probes on the `FF==D=FDDDDDF=FF=` template, again no
+rebuild needed, sharpen what its live bytes actually are.
+
+**The interchangeable `X-4`/`X-1` pair is a gate, not a value.** Flipping
+`X-4` alone, `X-1` alone, or **both at once** lands in the byte-identical
+output at both template instances (32700: 3.986/argmax 111; 48300:
+1.293/argmax 305), and never back at baseline. A double flip that neither
+cancels (as two XOR-combined copies would) nor compounds (as two
+independent numeric contributions would) means the two bytes don't carry
+a *value* -- they gate a condition that either holds or doesn't, and any
+disturbance drops the computation into one fixed fallback state.
+
+**Per-bit across the 5-byte live run (`X-1..X+3`) at 32700:**
+
+```
+byte    bit0   bit1   bit2   bit3   bit4   bit5   bit6   bit7
+32699  3.986  3.986  3.986  3.986    =      =      =      =     <- X-1
+32700  5.135  3.016  5.063  6.176  6.068  6.751  5.530  5.099   <- X
+32701  5.386  6.284  3.447  6.894  6.858  2.370  7.469  3.052
+32702  3.591  5.745  5.997  3.375  4.776  4.453  4.596  6.104
+32703  5.925  4.740  5.889  3.627  5.853  4.309  5.673    F     <- X+3
+```
+
+- **`X-1` is half dead, half gate.** Its low nibble (bits 0-3) each
+  trips the *same* 3.986/argmax-111 state as `X-4` does; its high nibble
+  (bits 4-7) is completely inert. So `X-4` and the low nibble of `X-1`
+  are one gate -- the same fallback state now replicated across seven
+  independent single-flip measurements plus the double flip.
+- **`X..X+2` are three fully-live bytes with large, non-bit-weighted
+  effects** (every bit changes the output, deltas 2.4-7.5, no monotone
+  trend with bit index; e.g. at 32701 bit 6 gives 7.47 but bit 7 gives
+  3.05). A magnitude field would scale with bit significance; a field
+  where *any* corrupted bit makes the hardware read the wrong data --
+  an address, offset, or index -- would look exactly like this. Reported
+  as "address-like," not as a decoded address.
+- **`X+3`'s MSB is checked, its other 7 bits are live.** Bit 7 of the
+  run's last byte is the one single-bit flip in the whole 40-flip matrix
+  that faults (`0x8030070C`); bits 0-6 all run and change the output. A
+  sign/valid/reserved bit sitting at the top of a 4-byte little-endian
+  field, checked by the same validator the `F` positions hit, is the
+  simplest reading.
+
+Net: this template's live region reads as `[gate byte] [gate nibble |
+dead nibble] [3 address-like bytes] [7 live bits | 1 checked bit]` --
+the most detailed internal map of any mcode command this README has
+produced, obtained entirely from single-bit interventions on the real
+`resnet18d` blob.
+
+**A caveat on the fault class, found the hard way: `0x8030070C` can hit
+a valid model, rarely.** While locking the template findings into a
+regression test, the *unpatched* baseline of a freshly-built `resnet18d`
+faulted with the same `0x8030070C` -- once, immediately after a dense
+burst of roughly 65 deliberately-faulting runs plus a Docker build. The
+same file ran fine seconds later, and so did the known-good build, so it
+was neither a bad build nor a wedged device (no kernel/PCIe events;
+telemetry normal). Trying to reproduce it on purpose failed: 10 trials of
+a deterministic-fault run immediately followed by a valid run gave **0/10
+transient faults** (and 10/10 deliberate faults, reconfirming that class
+is deterministic). So this is a rare event -- one in well over 200 valid
+runs this session -- not something a single preceding fault triggers,
+and its trigger is not identified. The tests now retry a `0x8030070C`
+exactly once (`_run_retry_once`): safe, because a genuinely faulting
+byte faults on every attempt, so a second fault is a real one, while a
+transient recovers -- and it never masks anything, since no other error
+is retried. Worth knowing for anyone running large fault-injection
+sweeps on this hardware.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2071,6 +2071,58 @@ to an output buffer" vs "an address to weights" would produce, which is
 now the leading hypothesis and one a single targeted test (patch an
 operand to another instance's value) could check.
 
+### `40 02` operands are weight-table offsets; `40 02`/`50 03` come in pairs one 32-byte unit apart; `50 01` is a 4-valued flag
+
+Still zero device runs -- pairing and operand statistics over all 1,197
+headers, then one size cross-check.
+
+**`40 02` and `50 03` are paired one-to-one.** Every one of the 181
+`50 03` headers has a `40 02` before it at a word distance of 8 (166
+cases), 10 (14), or 44 (1), and the reverse histogram -- each `40 02` to
+its next `50 03` -- is identical. Eight words is 32 bytes: the pair sits
+exactly one "32-byte mcode unit" apart, the unit this whole
+investigation began with, with three other two-word instructions in
+between.
+
+**Operand statistics separate the kinds cleanly:**
+
+```
+kind        n    distinct   operand range          reading
+a1 00 40 02  181    181     0x000000..0xb45ba0     address-like, one per op
+a1 00 50 03  181    176     0x000000..0x2f7040     address-like, smaller region
+a1 00 50 01  724      4     {0x1 .. 0x01000000}    enumerated flag, not an address
+```
+
+**And the size cross-check decodes `40 02`.** `resnet18d`'s Wbt
+(`npu_params`) is 11,855,108 bytes = `0x00b4e504`; the largest `40 02`
+operand is `0x00b45ba0` -- within 0.3% of the Wbt's end -- and the 181
+values are all distinct. So **`a1 00 40 02 <operand>` sets this op's
+offset into the weight table**: a real, quantitative, independently
+checkable semantic for one instruction kind, obtained without any
+device. `50 03`'s operands stop at ~3.1 MB, about a quarter of the Wbt,
+so they address a different, smaller region -- the size is consistent
+with an activation/intermediate-buffer arena, but that is inferred from
+size alone and is not confirmed.
+
+**Correction, stated in place.** The previous section guessed the
+opposite assignment -- `40 02` as an output-buffer address and `50 03`
+as a weight address -- from the input-dependence split alone. The Wbt
+span settles it the other way. The two observations still fit together:
+corrupting a Wbt offset can land the op on per-channel scale/bias data
+that saturates its output to a fixed value regardless of input
+(input-independent, as 32700/48300 showed), while corrupting a pointer
+into an activation region reads data that still varies with the input
+(input-dependent, as 43500 showed). A related caveat on that
+input-dependence experiment: its three "different inputs" were all
+independent uniform-noise images, which are statistically alike -- a
+weaker test than three genuinely different photographs. It still had
+discriminating power (43500 did vary), but the 8-of-9 count should be
+read with that in mind.
+
+The most common instruction, `50 01`, takes only four distinct operand
+values across 724 uses -- a small enumerated control/flag word, not a
+pointer; which flags is not identified.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1789,6 +1789,54 @@ effect on a real classifier is already measurable, so the next step
 correlating the resulting logit change with which layer's Conv it sits
 in) needs no new technique at all.
 
+### Bisecting the live bytes' neighbors: an identical field template 15,600 bytes apart, and every bit of one byte is live
+
+Following the step named above: flip each byte in a 17-byte window
+(`X-8..X+8`) around three of the output-changing offsets, one flip per
+run, and classify each as fault (`F`), identical (`=`), or different
+(`D`). Then flip each of the 8 bits of one such byte individually.
+
+```
+X=9900:   [FFFF=FFFDDFFFFDFF]
+X=32700:  [FF==D=FDDDDDF=FF=]
+X=48300:  [FF==D=FDDDDDF=FF=]     <- byte-for-byte the same signature as 32700
+```
+
+**Two offsets 15,600 bytes apart have the identical 17-position live-byte
+signature.** Not merely similar bytes: the same layout of which
+positions fault, which are inert, and which change the output --
+including the same contiguous 5-byte live run at `X-1..X+3` and the same
+isolated live byte at `X-4`. This is the earlier "43.4% of bytes are
+exact duplicates / repeated command templates" finding seen from the
+*hardware's* side: the same command template recurs, and its internal
+field structure recurs with it. `9900` has a different, narrower layout
+(a 2-byte live pair at `X..X+1`, one isolated live byte at `X+6`, faults
+everywhere else), i.e. a different template.
+
+**Two different bytes that are functionally interchangeable.** Within
+both templates, flipping `X-4` and flipping `X-1` (e.g. 32696 vs 32699,
+48296 vs 48299) produce the **bit-identical full 1000-logit output** --
+confirmed on rerun. Two distinct bytes, 3 apart, whose corruption drives
+the computation to exactly the same state: consistent with two copies of
+one value being combined (or a field where those two bytes play the same
+role), and a concrete, reproducible handle on this template's internal
+redundancy.
+
+**Every bit of byte 9900 is live, and the effect is not bit-weighted.**
+All 8 single-bit flips run without fault and all change the output --
+no bit is padding. But the max-abs logit delta does *not* grow with bit
+significance (bit0 3.41, bit1 1.54, bit2 2.15, bit3 1.97, bit4 1.08, bit5
+1.08, bit6 2.15, bit7 2.98), as a plain little-endian integer or a
+float32 byte would predict. Instead the deltas fall on a grid: bit4 and
+bit5 give exactly 1.077231, bit2 and bit6 exactly 2.154462 = 2 x 1.077231
+(equal max-abs, but *different* full outputs -- so it's the magnitude
+that quantizes, not the result). That grid is the output tensor's own
+int8 dequantization step showing through, which is why it cannot be used
+to read the byte's encoding off the logits directly. Reported as what it
+is: a fully-live, non-bit-weighted numeric-ish field whose encoding is
+still not identified -- the exact-equality pairs are the lead, not a
+decoding.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1993,6 +1993,84 @@ by half the range -- so this is exactly the ordering a small signed byte
 would show. Consistent with a signed quantized parameter, not a
 decoding of one.
 
+### The opaque region is a 32-bit-word instruction stream: `a1 00 xx yy` headers, never adjacent, each followed by an operand
+
+The hardware probes above pointed at *which* bytes matter; comparing the
+raw bytes of the probed windows -- zero device runs -- shows *why*, and
+it is the most concrete structural decoding of mcode this project has
+produced.
+
+**The two control-template instances differ at exactly the three
+"address-like" bytes and nowhere else.** The 17-byte windows around
+32700 and 48300 are identical at all 14 positions the probes classified
+as fault, inert, or gate, and differ only at `X..X+2` -- precisely the
+bytes whose flips gave large, unordered, input-independent effects:
+
+```
+32700:  05 00 00 00 | a1 00 40 02 | 8c 4c 06 00 | a1 00 50 01 | 00
+48300:  05 00 00 00 | a1 00 40 02 | a0 49 b3 00 | a1 00 50 01 | 00
+43500:  00 00 00 00 | a1 00 50 03 | 80 64 1e 00 | a1 00 50 01 | 00
+```
+
+Segmented into 4-byte words (all three windows start on a 4-byte
+boundary), the layout is the same everywhere: a **header word
+`a1 00 xx yy`**, then a **32-bit little-endian operand** (`0x00064c8c`,
+`0x00b349a0`, `0x001e6480`), then the next header. Every probe result now
+has a place: the gate at `X-4` is the header's first byte `a1`; the
+"gate nibble" at `X-1` is the low nibble of the header's last byte
+(`02`/`03`); the three address-like bytes are the operand's low three
+bytes; the checked MSB at `X+3` is bit 7 of the operand's top byte
+(`00`); and the data-like instance simply has a different header
+(`50 03` vs `40 02`), i.e. a different instruction kind whose operand
+the hardware treats differently.
+
+**This is the format of the whole blob, in two different models, not a
+local coincidence** (all of it local byte analysis, deterministic,
+re-checkable in seconds):
+
+```
+                             resnet18d (49,080 B)     tiny two-Conv (3,920 B)
+length % 4                   0                        0
+`a1 00` words, 4-byte aligned  1,197                  58
+`a1 00` byte pairs, unaligned  167 (~56 per phase)    49 (~16 per phase)
+header followed by a header  0 / 1,197                0 / 58
+even gaps between headers    98% (1,174 / 1,196)      86% (49 / 57)
+```
+
+Aligned headers are ~21x (resnet18d) and ~3.6x (tiny) more frequent than
+the same byte pair at any other phase, so the alignment is real, not
+chance. **No header is ever immediately followed by another** (random
+placement would give ~117 such pairs in resnet18d), which is the
+`[header][>=1 operand]` structure exactly. Gaps between headers are
+dominantly 2 words -- one operand -- with 4, 8, 10, 12 next; a first
+version of this section said "strictly even," which was an overstatement
+from reading only the top gap sizes: it is 98% and 86%, i.e. 2-word
+granularity with exceptions, and 32 bytes is four such 2-word
+instructions, reconciling the very first "32-byte mcode unit" finding.
+
+**The instruction mix is model-dependent; the format is not.** In
+`resnet18d` three header kinds dominate -- `50 01` (724), and `40 02`
+and `50 03` at *exactly* 181 each (the two probed control bytes were
+`40 02`, the data-like one `50 03`, so a `40 02`/`50 03` pair per op is
+the natural reading, e.g. an address-set and a data-set). The tiny model
+has a different top set (`80 02`, `b0 03`, `b0 0b`, `30 04`), as a
+different op/shape mix should. One more tie-in: the tiny model's four
+known non-deterministic noise bytes (858/864/870/876) fall in `23 00 xx
+82`-style words, never in an `a1 00` header, carrying exactly the known
+`{0x10,0x20,0x30,0x40}` label values -- the label noise is a field of a
+different word family.
+
+**What this does and does not settle.** It settles that the "99% opaque"
+region is a parseable stream of 4-byte words with a recognizable header
+kind, so "decoding mcode" now means "decoding operand semantics per
+header kind," a far smaller and better-posed problem. It does *not*
+identify what `a1` means, what `xx yy` encode beyond "kind," or confirm
+that operands are addresses -- though the input-dependence split
+(control-like `40 02` vs data-like `50 03`) is exactly what "an address
+to an output buffer" vs "an address to weights" would produce, which is
+now the leading hypothesis and one a single targeted test (patch an
+operand to another instance's value) could check.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1696,6 +1696,51 @@ to instrument or bisect further -- and a hard existence proof that some
 of that 99%-opaque region cannot be padding: a mechanism this precise and
 reproducible almost certainly means it's live, checked, structural data.
 
+### Hand-patching the *decoded* Wbt requantization scale: confirms the field, corrects the mental model of how it acts
+
+Everything above hand-patches still-*undecoded* mcode bytes. This applies
+the same causal-intervention technique to a field this README already
+claims to have decoded -- `Conv`'s per-channel requantization multiplier
+`M_channel` in Wbt (`input_scale * weight_scale_channel / output_scale`,
+identified earlier purely by correlation: it shrinks monotonically as
+bias grows). A `Conv(cin=cout=4)` with a distinctly non-uniform bias
+(`[0, 5, 10, 15]`, so each channel's own float32 value is individually
+identifiable instead of accidentally coinciding across channels) locates
+each channel's `M_channel` value at a precise Wbt offset, present in 4
+identical repeated copies (64 bytes apart) -- consistent with this
+README's earlier "Wbt reveals real channel-tiling structure" finding.
+
+**Multiplying channel 0's value by 0.5 at all 4 repeated copies, confirmed
+stable across two independent rebuilds**, cleanly isolates to exactly that
+channel: channels 1-3's real device output are **bit-identical** to the
+unpatched baseline, direct proof the offset identification and per-channel
+indexing are both correct. But channel 0's actual change **refutes the
+simple mental model** ("this scales the final float output by the same
+factor") the earlier correlation-only description implied:
+
+```
+channel 0, baseline:  min=-1.73 max=1.73 mean=0.034 std=0.649 (42 unique values)
+channel 0, M x 0.5:   min=-2.41 max=-1.13 mean=-1.976 std=0.299 (17 unique values)
+```
+
+Halving `M_channel` did **not** halve the float output (that would predict
+a new mean near 0.017, still centered on zero) -- it collapsed the channel
+to a much narrower, shifted band with far fewer distinct values. That
+signature -- reduced spread, fewer unique output codes, a shifted center
+-- is exactly what happens when a scale factor used *inside* int8
+requantization (`int8_code = round(int32_accumulator * M) + zero_point`)
+gets halved: the accumulator's full dynamic range collapses toward
+`zero_point` in int8-code space *before* a separate, untouched
+output-dequantization step converts back to float32, rather than `M`
+being applied as an external multiplier on the already-dequantized float
+result. This is consistent with -- and actually a more precise,
+causally-verified version of -- the standard quantized-conv formula this
+README already named, it just corrects exactly where the multiplication
+happens in the pipeline. A real, verified example of this project's
+recurring lesson: a correlation-only finding (an array that "shrinks as
+bias grows") can misdescribe the actual mechanism even when the general
+hypothesis is right, and only a direct intervention exposes that.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -1906,6 +1906,93 @@ transient recovers -- and it never masks anything, since no other error
 is retried. Worth knowing for anyone running large fault-injection
 sweeps on this hardware.
 
+### What the output-changing bytes *are*: 8 of 9 are control-like, 1 is data-like
+
+The 22% "runs, but changes the output" class above says a byte is live
+and computational, but not what *kind* of byte it is. A cheap
+discriminator: run the same flipped model against **different inputs**.
+A corrupted *weight or data* value interacts with the input, so its
+effect should vary with the input; a corrupted *control* value (an
+address, offset, index, or fixed constant) redirects the computation the
+same way regardless of what flows through it. Each of the 9
+output-changing flips against three independent random `uint8` inputs
+(seeds 42, 7, 123; all three baselines classify as 305):
+
+```
+offset   seed42          seed7           seed123         shifted class
+ 6300    305  0.18       305  0.18       305  0.14       same
+ 9900    567  3.81       567  3.81       567  3.81       same
+20700    143  0.50       143  0.50       143  0.50       same
+24300    111  0.97       111  1.04       111  1.01       same
+32700    908  4.45       908  4.42       908  4.42       same
+36300    533  5.75       533  5.85       533  5.82       same
+43500    305  0.29        65  0.32        60  0.29       DIFFERS
+44700    318  1.47       318  1.47       318  1.51       same
+48300    834  7.29       834  7.29       834  7.33       same
+         (argmax, max-abs logit delta vs. that input's own baseline)
+```
+
+**Eight of the nine are input-independent**: the same flip lands the
+classifier on the same wrong class with a near-identical delta on every
+input -- 9900 goes to 567 at 3.81 all three times, 48300 to 834 at
+7.29/7.29/7.33. That is control-like behavior, and it lines up with the
+template map above: 32700 and 48300 are the template whose live run
+reads as address-like bytes, and a wrong address fetches the same wrong
+data no matter the input. **Exactly one, 43500, is input-dependent** --
+the shifted class moves with the input (305, 65, 60) and the delta stays
+small (~0.3): the signature of a corrupted weight/data value whose effect
+is modulated by what it multiplies. So the "changes the output" class is
+itself ~8:1 control-like to data-like at this sampling, which is also a
+useful hint about mcode's overall composition: it is dominated by
+control/addressing, with real numeric data mostly living elsewhere (Wbt)
+-- exactly what the `AxQuantizedConv` weight-in-Wbt / commands-in-mcode
+split found much earlier would predict.
+
+### The one data-like byte, probed: the gate recurs in a third template, and the prediction is only half right
+
+The control-vs-data reading above makes a falsifiable prediction: a
+data-like byte should be *bit-weighted* (its high bits should matter
+more than its low bits), unlike the control bytes at 9900/32700 whose
+every bit produced a large, unordered effect. Probing 43500 the same
+two ways:
+
+```
+window:  F===D=FDDDFFF=FF=      (43492..43508; control template was FF==D=FDDDDDF=FF=)
+  43496 (X-4): D 2.442 / argmax 116
+  43499 (X-1): D 2.442 / argmax 116      <- bit-identical output to X-4
+  43500 (X):   D 0.287 / argmax 305
+  43501 (X+1): D 1.149 / argmax 106
+
+per-bit at 43500:
+  bit0 0.323  bit1 0.395  bit2 0.287  bit3 0.359     (argmax stays 305)
+  bit4 0.682  bit5 1.149  bit7 1.508                 (argmax -> 741, 741, 106)
+  bit6 0.323                                         (argmax 305; == bit0 exactly)
+```
+
+**The gate is now seen in a third template.** The window shares the
+control template's skeleton -- an isolated live byte at `X-4`, the run
+starting at `X-1` -- and `X-4` and `X-1` again yield the bit-identical
+output. That makes the "any disturbance trips one fixed state"
+`X-4`/`X-1` structure a recurring feature of these command templates
+(three templates, ~10 independent measurements), not a quirk of one.
+The live run here is 3 bytes (`X-1..X+1`) rather than 5, so this is a
+related variant, not the same template.
+
+**The bit-weighting prediction is half right, and reported as such.**
+High bits dominate: bits 4, 5, and 7 produce the largest deltas and are
+the only ones that move the predicted class, while bits 0-3 perturb the
+logits without changing the class. That is more ordered than the control
+bytes ever were. But it is not a clean weighting: bit 6 is small (0.323,
+exactly equal to bit 0 -- the output's int8 grid again), so a strict
+"delta grows with bit index" test fails. One further observation does
+fit a *signed* numeric value specifically: flipping all 8 bits at once
+changes the output *less* (0.287) than flipping bit 7 alone (1.508).
+XOR-ing every bit of a small two's-complement value is approximately a
+negation and lands near zero, whereas flipping only the top bit moves it
+by half the range -- so this is exactly the ordering a small signed byte
+would show. Consistent with a signed quantized parameter, not a
+decoding of one.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1482,3 +1482,100 @@ def test_resnet18d_template_has_a_gate_a_dead_nibble_and_a_checked_msb(tmp_path)
     # The MSB of X+3 is the one single-bit flip that faults.
     assert run([(32703, 0x80)], "32703_b7") is None
     assert run([(32703, 0x01)], "32703_b0") is not None
+
+
+def test_resnet18d_output_changing_bytes_are_mostly_input_independent(tmp_path):
+    """Confirmed real (see the README's "What the output-changing bytes
+    are" section): running the same flipped real-resnet18d model against
+    different inputs discriminates control-like bytes from data-like
+    ones. Offsets 9900 and 48300 are control-like: the flip lands the
+    classifier on the same wrong class (567 and 834) with a near-identical
+    delta regardless of input. Offset 43500 is data-like: the shifted
+    class moves with the input and the delta stays small. 8 of the 9
+    output-changing offsets behaved like the former.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+    inputs = {
+        seed: np.random.RandomState(seed).randint(
+            0, 256, size=(1, 224, 224, 3), dtype=np.uint8
+        )
+        for seed in (42, 7)
+    }
+    base = {}
+    for seed, x in inputs.items():
+        dev = _run_retry_once(path, x)
+        assert not dev.error, (seed, dev.error)
+        base[seed] = np.frombuffer(dev.outputs[0], dtype=np.float32)
+
+    def flipped_argmax(offset, seed):
+        patched = bytearray(mcode)
+        patched[offset] ^= 0xFF
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"flip_{offset}.axmodel")
+        onnx.save(c, p)
+        dev = _run_retry_once(p, inputs[seed])
+        assert not dev.error, (offset, seed, dev.error)
+        out = np.frombuffer(dev.outputs[0], dtype=np.float32)
+        assert not np.array_equal(out, base[seed]), (offset, seed)
+        return int(out.argmax())
+
+    for offset, wrong_class in ((9900, 567), (48300, 834)):
+        assert flipped_argmax(offset, 42) == flipped_argmax(offset, 7) == wrong_class, (
+            offset,
+            "expected a control-like byte to shift to the same class on every input",
+        )
+
+    assert flipped_argmax(43500, 42) != flipped_argmax(43500, 7), (
+        "expected the data-like byte's shifted class to move with the input"
+    )
+
+
+def test_resnet18d_data_like_byte_sits_in_a_gated_template_and_is_sign_like(tmp_path):
+    """Confirmed real (see the README's "The one data-like byte, probed"
+    section): the data-like byte 43500 sits in a third template that
+    shares the recurring gate structure -- flipping X-4 (43496) and X-1
+    (43499) yields the bit-identical output. Its own per-bit behavior is
+    only partly bit-weighted (bit 7 moves the class, bits 0-3 do not),
+    and it shows the signature of a small *signed* value: flipping all 8
+    bits changes the output less than flipping bit 7 alone. Every bit is
+    live.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+    x = np.random.RandomState(42).randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = _run_retry_once(path, x)
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+
+    def flip(offset, mask):
+        patched = bytearray(mcode)
+        patched[offset] ^= mask
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"flip_{offset}_{mask:02x}.axmodel")
+        onnx.save(c, p)
+        dev = _run_retry_once(p, x)
+        assert not dev.error, (offset, mask, dev.error)
+        return np.frombuffer(dev.outputs[0], dtype=np.float32)
+
+    # The gate: X-4 and X-1 are interchangeable, and neither is the baseline.
+    gate_a, gate_b = flip(43496, 0xFF), flip(43499, 0xFF)
+    assert not np.array_equal(gate_a, out_base)
+    assert np.array_equal(gate_a, gate_b), "expected X-4 and X-1 to trip one state"
+
+    # Every bit of 43500 is live; bit 7 moves the class, bit 0 does not.
+    outs = {bit: flip(43500, 1 << bit) for bit in range(8)}
+    for bit, out in outs.items():
+        assert not np.array_equal(out, out_base), (bit, "expected every bit to be live")
+    assert outs[7].argmax() != out_base.argmax()
+    assert outs[0].argmax() == out_base.argmax()
+
+    # Sign-like: flipping all 8 bits perturbs less than flipping bit 7 alone.
+    all_bits = flip(43500, 0xFF)
+    assert np.max(np.abs(all_bits - out_base)) < np.max(np.abs(outs[7] - out_base))

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -711,6 +711,22 @@ def _build_real_resnet18d(work_dir):
     return result.axmodel_path, key, mcode
 
 
+def _run_retry_once(axmodel_path, x):
+    """`run_on_device_with_inputs`, retried once on a `0x8030070C` fault.
+
+    Confirmed real (see the README's "the fault is transient after a
+    burst" note): immediately after a run of deliberately-faulting
+    models, the runtime can transiently reject a *valid* model with the
+    same `0x8030070C` -- it self-clears on the next attempt. A retry
+    cleanly separates the two: a genuinely faulting byte faults on every
+    attempt (verified many times), so a second fault is a real one, while
+    a transient recovers. Never retries any other error."""
+    dev = pulsar2_docker.run_on_device_with_inputs(axmodel_path, {"x": x.tobytes()})
+    if dev.error and "0x8030070C" in dev.error:
+        dev = pulsar2_docker.run_on_device_with_inputs(axmodel_path, {"x": x.tobytes()})
+    return dev
+
+
 def _gemm_model(transb, m=1, k=16, n=8):
     """One `Gemm(x, w, b)` -- `transb` selects whether `w` is stored as
     `[k,n]` (transB=0) or `[n,k]` (transB=1), same logical matrix either
@@ -1189,11 +1205,11 @@ def test_bit_flip_in_opaque_mcode_region_is_sometimes_inert_sometimes_faults(tmp
         {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
         p = os.path.join(str(tmp_path), f"flip_{offset}.axmodel")
         onnx.save(c, p)
-        return pulsar2_docker.run_on_device_with_inputs(p, {"x": x.tobytes()})
+        return _run_retry_once(p, x)
 
     rng = np.random.RandomState(42)
     x = rng.randn(1, 4, 16, 16).astype(np.float32)
-    dev_base = pulsar2_docker.run_on_device_with_inputs(path, {"x": x.tobytes()})
+    dev_base = _run_retry_once(path, x)
     assert not dev_base.error, dev_base.error
     out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
 
@@ -1250,7 +1266,7 @@ def test_patching_decoded_requant_scale_isolates_to_one_channel(tmp_path):
 
     rng = np.random.RandomState(42)
     x = rng.randn(1, 4, 16, 16).astype(np.float32)
-    dev_base = pulsar2_docker.run_on_device_with_inputs(path, {"x": x.tobytes()})
+    dev_base = _run_retry_once(path, x)
     dev_patch = pulsar2_docker.run_on_device_with_inputs(
         patched_path, {"x": x.tobytes()}
     )
@@ -1305,7 +1321,7 @@ def test_bit_flip_probe_on_real_resnet18d_has_three_outcome_classes(tmp_path):
 
     rng = np.random.RandomState(42)
     x = rng.randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
-    dev_base = pulsar2_docker.run_on_device_with_inputs(path, {"x": x.tobytes()})
+    dev_base = _run_retry_once(path, x)
     assert not dev_base.error, dev_base.error
     out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
     assert out_base.shape == (1000,)
@@ -1317,7 +1333,7 @@ def test_bit_flip_probe_on_real_resnet18d_has_three_outcome_classes(tmp_path):
         {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
         p = os.path.join(work_dir, f"flip_{offset}.axmodel")
         onnx.save(c, p)
-        return pulsar2_docker.run_on_device_with_inputs(p, {"x": x.tobytes()})
+        return _run_retry_once(p, x)
 
     for off in (300, 1500):
         dev = flip_and_run(off)
@@ -1360,7 +1376,7 @@ def test_resnet18d_live_byte_neighborhoods_share_a_template_signature(tmp_path):
 
     rng = np.random.RandomState(42)
     x = rng.randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
-    dev_base = pulsar2_docker.run_on_device_with_inputs(path, {"x": x.tobytes()})
+    dev_base = _run_retry_once(path, x)
     assert not dev_base.error, dev_base.error
     out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
 
@@ -1371,7 +1387,7 @@ def test_resnet18d_live_byte_neighborhoods_share_a_template_signature(tmp_path):
         {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
         p = os.path.join(str(tmp_path), f"flip_{offset}_{mask:02x}.axmodel")
         onnx.save(c, p)
-        dev = pulsar2_docker.run_on_device_with_inputs(p, {"x": x.tobytes()})
+        dev = _run_retry_once(p, x)
         if dev.error:
             assert "0x8030070C" in dev.error, (offset, mask, dev.error)
             return "F", None
@@ -1402,3 +1418,67 @@ def test_resnet18d_live_byte_neighborhoods_share_a_template_signature(tmp_path):
     for bit in range(8):
         cls, _ = flip_and_run(9900, 1 << bit)
         assert cls == "D", (bit, cls, "expected every bit of byte 9900 to be live")
+
+
+def test_resnet18d_template_has_a_gate_a_dead_nibble_and_a_checked_msb(tmp_path):
+    """Confirmed real (see the README's "Inside one repeated template"
+    section): in the `FF==D=FDDDDDF=FF=` template of the real resnet18d
+    mcode, bytes X-4 and X-1 are a *gate*, not a value -- flipping X-4,
+    X-1, or both at once lands in the byte-identical output (a double
+    flip neither cancels nor compounds). Byte X-1 is half dead, half
+    gate: each low-nibble bit trips that same state, every high-nibble
+    bit is inert. And bit 7 of X+3 is the one single-bit flip that
+    faults the runtime's validator, while its other bits are live.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+
+    rng = np.random.RandomState(42)
+    x = rng.randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = _run_retry_once(path, x)
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+
+    def run(edits, tag):
+        patched = bytearray(mcode)
+        for off, mask in edits:
+            patched[off] ^= mask
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"edit_{tag}.axmodel")
+        onnx.save(c, p)
+        dev = _run_retry_once(p, x)
+        if dev.error:
+            assert "0x8030070C" in dev.error, (tag, dev.error)
+            return None
+        return np.frombuffer(dev.outputs[0], dtype=np.float32)
+
+    gate_state = {}
+    for X in (32700, 48300):
+        a = run([(X - 4, 0xFF)], f"{X}_a")
+        b = run([(X - 1, 0xFF)], f"{X}_b")
+        ab = run([(X - 4, 0xFF), (X - 1, 0xFF)], f"{X}_ab")
+        assert a is not None and b is not None and ab is not None
+        assert not np.array_equal(a, out_base), X
+        assert np.array_equal(a, b) and np.array_equal(a, ab), (
+            X,
+            "expected X-4, X-1, and both together to land in one gate state",
+        )
+        gate_state[X] = a
+
+    # X-1 at 32700: low nibble is the gate, high nibble is dead.
+    for bit in range(4):
+        out = run([(32699, 1 << bit)], f"32699_b{bit}")
+        assert out is not None and np.array_equal(out, gate_state[32700]), bit
+    for bit in range(4, 8):
+        out = run([(32699, 1 << bit)], f"32699_b{bit}")
+        assert out is not None and np.array_equal(out, out_base), (
+            bit,
+            "expected the high nibble of X-1 to be inert",
+        )
+
+    # The MSB of X+3 is the one single-bit flip that faults.
+    assert run([(32703, 0x80)], "32703_b7") is None
+    assert run([(32703, 0x01)], "32703_b0") is not None

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -676,6 +676,41 @@ def _conv_with_bias_model(bias_vals, cin=4, cout=4, k=3, insz=16):
     return model
 
 
+def _build_real_resnet18d(work_dir):
+    """Fetch and really build `resnet18d_Opset18` the same way
+    `convert_onnxmodelzoo.py` does (single-image-classifier config,
+    synthetic calibration tar). Returns `(axmodel_path, mcode_key,
+    mcode_bytes)`; shared by the real-resnet18d hand-patching tests."""
+    import convert_onnxmodelzoo  # also puts model_zoo on sys.path
+    import model_zoo
+
+    model = onnx.load(model_zoo.fetch_model("resnet18d_Opset18"))
+    tensor_name = convert_onnxmodelzoo._single_image_input(model)
+    assert tensor_name is not None
+
+    os.makedirs(os.path.join(work_dir, "model"), exist_ok=True)
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    pulsar2_docker.make_synthetic_calibration_tar(
+        os.path.join(work_dir, "dataset", "calib.tar")
+    )
+    onnx.save(model, os.path.join(work_dir, "model", "resnet18d.onnx"))
+    result = pulsar2_docker.build(
+        work_dir,
+        "model/resnet18d.onnx",
+        "output/resnet18d",
+        tensor_name=tensor_name,
+        mean=convert_onnxmodelzoo._DEFAULT_MEAN,
+        std=convert_onnxmodelzoo._DEFAULT_STD,
+        calibration_dataset_rel_path="dataset/calib.tar",
+    )
+    assert result.success, result.error
+    compiled = onnx.load(result.axmodel_path)
+    key = _mcode_key(compiled)
+    mcode = bytes({i.name: i for i in compiled.graph.initializer}[key].raw_data)
+    assert len(mcode) == 49080, len(mcode)
+    return result.axmodel_path, key, mcode
+
+
 def _gemm_model(transb, m=1, k=16, n=8):
     """One `Gemm(x, w, b)` -- `transb` selects whether `w` is stored as
     `[k,n]` (transB=0) or `[n,k]` (transB=1), same logical matrix either
@@ -1265,36 +1300,8 @@ def test_bit_flip_probe_on_real_resnet18d_has_three_outcome_classes(tmp_path):
     if not pulsar2_docker.axcl_available():
         pytest.skip("no AXCL device connected")
 
-    import convert_onnxmodelzoo  # noqa: E402  -- also puts model_zoo on sys.path
-    import model_zoo  # noqa: E402
-
-    model = onnx.load(model_zoo.fetch_model("resnet18d_Opset18"))
-    tensor_name = convert_onnxmodelzoo._single_image_input(model)
-    assert tensor_name is not None
-
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
     work_dir = str(tmp_path)
-    os.makedirs(os.path.join(work_dir, "model"), exist_ok=True)
-    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
-    pulsar2_docker.make_synthetic_calibration_tar(
-        os.path.join(work_dir, "dataset", "calib.tar")
-    )
-    onnx.save(model, os.path.join(work_dir, "model", "resnet18d.onnx"))
-    result = pulsar2_docker.build(
-        work_dir,
-        "model/resnet18d.onnx",
-        "output/resnet18d",
-        tensor_name=tensor_name,
-        mean=convert_onnxmodelzoo._DEFAULT_MEAN,
-        std=convert_onnxmodelzoo._DEFAULT_STD,
-        calibration_dataset_rel_path="dataset/calib.tar",
-    )
-    assert result.success, result.error
-    path = result.axmodel_path
-
-    compiled = onnx.load(path)
-    key = _mcode_key(compiled)
-    mcode = bytes({i.name: i for i in compiled.graph.initializer}[key].raw_data)
-    assert len(mcode) == 49080, len(mcode)
 
     rng = np.random.RandomState(42)
     x = rng.randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
@@ -1332,3 +1339,66 @@ def test_bit_flip_probe_on_real_resnet18d_has_three_outcome_classes(tmp_path):
             off,
             "expected the predicted class to change",
         )
+
+
+def test_resnet18d_live_byte_neighborhoods_share_a_template_signature(tmp_path):
+    """Confirmed real (see the README's "Bisecting the live bytes'
+    neighbors" section): flipping each byte in a 17-byte window around
+    two of the real resnet18d mcode's output-changing offsets, 15,600
+    bytes apart, gives the byte-for-byte identical fault/inert/different
+    signature `FF==D=FDDDDDF=FF=` -- the repeated-command-template
+    structure seen from the hardware's side, with the same internal field
+    layout. Within it, two distinct bytes (X-4 and X-1) are functionally
+    interchangeable: corrupting either yields the bit-identical full
+    1000-logit output. And every one of the 8 bits of byte 9900 is live
+    (all run, all change the output).
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+
+    rng = np.random.RandomState(42)
+    x = rng.randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = pulsar2_docker.run_on_device_with_inputs(path, {"x": x.tobytes()})
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+
+    def flip_and_run(offset, mask):
+        patched = bytearray(mcode)
+        patched[offset] ^= mask
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"flip_{offset}_{mask:02x}.axmodel")
+        onnx.save(c, p)
+        dev = pulsar2_docker.run_on_device_with_inputs(p, {"x": x.tobytes()})
+        if dev.error:
+            assert "0x8030070C" in dev.error, (offset, mask, dev.error)
+            return "F", None
+        out = np.frombuffer(dev.outputs[0], dtype=np.float32)
+        return ("=" if np.array_equal(out, out_base) else "D"), out
+
+    outputs = {}
+    signatures = {}
+    for center in (32700, 48300):
+        sig = ""
+        for off in range(center - 8, center + 9):
+            cls, out = flip_and_run(off, 0xFF)
+            sig += cls
+            outputs[off] = out
+        signatures[center] = sig
+
+    assert signatures[32700] == signatures[48300] == "FF==D=FDDDDDF=FF=", signatures
+
+    for center in (32700, 48300):
+        a, b = outputs[center - 4], outputs[center - 1]
+        assert a is not None and b is not None
+        assert not np.array_equal(a, out_base)
+        assert np.array_equal(a, b), (
+            center,
+            "expected X-4 and X-1 to be interchangeable",
+        )
+
+    for bit in range(8):
+        cls, _ = flip_and_run(9900, 1 << bit)
+        assert cls == "D", (bit, cls, "expected every bit of byte 9900 to be live")

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1235,3 +1235,93 @@ def test_patching_decoded_requant_scale_isolates_to_one_channel(tmp_path):
         "expected halving the requant scale to narrow channel 0's output spread",
     )
     assert len(np.unique(patch0)) < len(np.unique(base0))
+
+
+def test_bit_flip_probe_on_real_resnet18d_has_three_outcome_classes(tmp_path):
+    """Confirmed real (see the README's "The bit-flip probe on the real
+    resnet18d mcode" section): on the real, unmodified resnet18d_Opset18
+    mcode (49,080 bytes), flipping a single byte lands in one of THREE
+    deterministic classes -- not the two the tiny two-Conv model showed:
+
+    - FAULT: the runtime rejects it with 0x8030070C (structural check).
+    - DIFFERENT: it runs, but the real 1000-class logits change -- the
+      first bytes this project found whose effect on actual computation
+      is directly observable, most of them changing the predicted class.
+    - identical: it runs, bit-identical output (inert).
+
+    A 41-offset sweep measured 61% / 22% / 17%. This locks in two
+    representative offsets per class. Heavier than this file's other
+    tests (fetches the real model, one real Docker build) -- the same
+    class of work as the dormant self-hosted `pulsar2-docker-convert` CI
+    job, which is where it is meant to run.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    import convert_onnxmodelzoo  # noqa: E402  -- also puts model_zoo on sys.path
+    import model_zoo  # noqa: E402
+
+    model = onnx.load(model_zoo.fetch_model("resnet18d_Opset18"))
+    tensor_name = convert_onnxmodelzoo._single_image_input(model)
+    assert tensor_name is not None
+
+    work_dir = str(tmp_path)
+    os.makedirs(os.path.join(work_dir, "model"), exist_ok=True)
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    pulsar2_docker.make_synthetic_calibration_tar(
+        os.path.join(work_dir, "dataset", "calib.tar")
+    )
+    onnx.save(model, os.path.join(work_dir, "model", "resnet18d.onnx"))
+    result = pulsar2_docker.build(
+        work_dir,
+        "model/resnet18d.onnx",
+        "output/resnet18d",
+        tensor_name=tensor_name,
+        mean=convert_onnxmodelzoo._DEFAULT_MEAN,
+        std=convert_onnxmodelzoo._DEFAULT_STD,
+        calibration_dataset_rel_path="dataset/calib.tar",
+    )
+    assert result.success, result.error
+    path = result.axmodel_path
+
+    compiled = onnx.load(path)
+    key = _mcode_key(compiled)
+    mcode = bytes({i.name: i for i in compiled.graph.initializer}[key].raw_data)
+    assert len(mcode) == 49080, len(mcode)
+
+    rng = np.random.RandomState(42)
+    x = rng.randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = pulsar2_docker.run_on_device_with_inputs(path, {"x": x.tobytes()})
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+    assert out_base.shape == (1000,)
+
+    def flip_and_run(offset):
+        patched = bytearray(mcode)
+        patched[offset] ^= 0xFF
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(work_dir, f"flip_{offset}.axmodel")
+        onnx.save(c, p)
+        return pulsar2_docker.run_on_device_with_inputs(p, {"x": x.tobytes()})
+
+    for off in (300, 1500):
+        dev = flip_and_run(off)
+        assert dev.error and "0x8030070C" in dev.error, (off, dev.error)
+
+    for off in (12300, 26700):
+        dev = flip_and_run(off)
+        assert not dev.error, (off, dev.error)
+        assert np.array_equal(
+            np.frombuffer(dev.outputs[0], dtype=np.float32), out_base
+        ), off
+
+    for off in (9900, 32700):
+        dev = flip_and_run(off)
+        assert not dev.error, (off, dev.error)
+        out = np.frombuffer(dev.outputs[0], dtype=np.float32)
+        assert not np.array_equal(out, out_base), off
+        assert out.argmax() != out_base.argmax(), (
+            off,
+            "expected the predicted class to change",
+        )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1741,3 +1741,47 @@ def test_resnet18d_40_02_operand_is_live_for_any_value_with_no_bounds_check(tmp_
     assert np.array_equal(first, second), (
         "expected the past-end read to be deterministic"
     )
+
+
+def _header_fields(mcode):
+    """Every `a1 00 xx yy` header in an mcode blob read as 4-byte words,
+    as `(xx, yy, following 32-bit LE value)` -- see the README's
+    "`a1 00 xx yy` is a field write" section."""
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    return [
+        (w[2], w[3], int.from_bytes(words[i + 1], "little"))
+        for i, w in enumerate(words)
+        if w[:2] == b"\xa1\x00" and i + 1 < len(words)
+    ]
+
+
+def test_mcode_headers_are_field_writes_with_a_shared_map_across_models(tmp_path):
+    """Confirmed real (see the README's "`a1 00 xx yy` is a field write"
+    section), on both the tiny two-Conv blob and the real resnet18d
+    blob: `xx` is a multiple of 0x10 in every single header (a 16-byte
+    granular field offset, not an opcode); bank 0x02's `xx` ladder is
+    shared by both models; and the `50 01` field takes the identical
+    one-hot operand set {bit 0, 8, 20, 24} in both. Needs Docker for the
+    builds but no device.
+    """
+    tiny = _mcode_from_axmodel(
+        _build_axmodel(
+            os.path.join(str(tmp_path), "tiny"),
+            _two_conv_model(vary_first=True, dilation=2, pad=2),
+            (1, 4, 16, 16),
+        )
+    )
+    _, _, r18 = _build_real_resnet18d(str(tmp_path))
+    one_hot = {0x1, 0x100, 0x100000, 0x1000000}
+    shared_bank2_ladder = {0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xA0, 0xB0, 0xC0}
+
+    for name, mcode in (("tiny", tiny), ("resnet18d", r18)):
+        fields = _header_fields(mcode)
+        assert len(fields) >= 40, (name, len(fields))
+        assert all(xx % 0x10 == 0 for xx, _, _ in fields), name
+        assert {v for xx, yy, v in fields if (xx, yy) == (0x50, 0x01)} == one_hot, name
+        assert shared_bank2_ladder <= {xx for xx, yy, _ in fields if yy == 0x02}, name
+
+    assert (
+        sum(1 for xx, yy, _ in _header_fields(r18) if (xx, yy) == (0x40, 0x02)) == 181
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1689,3 +1689,55 @@ def test_resnet18d_40_02_operands_are_wbt_offsets_paired_with_50_03(tmp_path):
     assert max(ops5003) < 0.35 * wbt_size, (max(ops5003), wbt_size)
 
     assert len({operand(i) for i in by_kind["50 01"]}) <= 4
+
+
+def test_resnet18d_40_02_operand_is_live_for_any_value_with_no_bounds_check(tmp_path):
+    """Confirmed real (see the README's "Patching a `40 02` operand on the
+    device" section): overwriting instance 32700's whole 4-byte operand
+    with another instance's valid offset, with 0, or with a value 1 MB
+    past the Wbt's end all run without fault and all change the output
+    -- the operand is live and causal for any value, and the runtime
+    does not bounds-check it (the 0x8030070C validator guards header
+    words, never operand values). The past-end read is deterministic.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+    compiled = onnx.load(path)
+    wbt_size = len(
+        bytes(
+            {i.name: i for i in compiled.graph.initializer}[
+                _params_key(compiled)
+            ].raw_data
+        )
+    )
+    x = np.random.RandomState(42).randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = _run_retry_once(path, x)
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+
+    a, b = 32700, 48300  # the two probed `40 02` instances' operand words
+    op_b = int.from_bytes(mcode[b : b + 4], "little")
+    assert op_b <= wbt_size
+
+    def run_with_operand(value, tag):
+        patched = bytearray(mcode)
+        patched[a : a + 4] = struct.pack("<I", value)
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"op_{tag}.axmodel")
+        onnx.save(c, p)
+        dev = _run_retry_once(p, x)
+        assert not dev.error, (tag, value, dev.error)
+        out = np.frombuffer(dev.outputs[0], dtype=np.float32)
+        assert not np.array_equal(out, out_base), (tag, value)
+        return out
+
+    run_with_operand(op_b, "foreign")
+    run_with_operand(0, "zero")
+    past = wbt_size + 0x100000
+    first, second = run_with_operand(past, "past1"), run_with_operand(past, "past2")
+    assert np.array_equal(first, second), (
+        "expected the past-end read to be deterministic"
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -559,24 +559,31 @@ def test_mcode_nondeterminism_is_a_label_permutation_not_metadata(tmp_path):
     exact same value set across independent builds run at different
     times, only a fixed label set being reshuffled could.
     """
+    # 4 rebuilds, not 2: with only 2, the non-deterministic label
+    # assignment occasionally lands identically by chance, giving zero
+    # differing positions and nothing to test (a real flake hit in CI --
+    # the same 2-build sample-size pitfall the frankenstein-splice test
+    # below fixed). Noisy positions are taken as the union against build 0.
     model = _two_conv_model(vary_first=True, dilation=2, pad=2)
-    _, mcode_a = _build_and_get_wbt_and_mcode_bytes(
-        os.path.join(str(tmp_path), "run1"), model, (1, 4, 16, 16)
-    )
-    _, mcode_b = _build_and_get_wbt_and_mcode_bytes(
-        os.path.join(str(tmp_path), "run2"), model, (1, 4, 16, 16)
-    )
-    assert len(mcode_a) == len(mcode_b)
+    mcodes = [
+        _build_and_get_wbt_and_mcode_bytes(
+            os.path.join(str(tmp_path), f"run{i}"), model, (1, 4, 16, 16)
+        )[1]
+        for i in range(4)
+    ]
+    assert len({len(m) for m in mcodes}) == 1
 
-    noisy = [i for i in range(len(mcode_a)) if mcode_a[i] != mcode_b[i]]
+    noisy = [i for i in range(len(mcodes[0])) if len({m[i] for m in mcodes}) > 1]
     assert noisy, "expected the known small amount of run-to-run mcode noise"
 
-    multiset_a = sorted(mcode_a[i] for i in noisy)
-    multiset_b = sorted(mcode_b[i] for i in noisy)
-    assert multiset_a == multiset_b, (
-        (multiset_a, multiset_b),
-        "expected the same multiset of values at the noisy positions, just reordered",
-    )
+    multiset_0 = sorted(mcodes[0][i] for i in noisy)
+    for n, other in enumerate(mcodes[1:], start=1):
+        multiset_n = sorted(other[i] for i in noisy)
+        assert multiset_0 == multiset_n, (
+            (n, multiset_0, multiset_n),
+            "expected the same multiset of values at the noisy positions, "
+            "just reordered",
+        )
 
 
 def _build_axmodel(work_dir, model, input_shape, profile=False):

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1642,3 +1642,50 @@ def test_resnet18d_mcode_word_stream_counts(tmp_path):
         suffixes["50 03"],
     )
     assert suffixes.most_common(1)[0] == ("50 01", 724), suffixes.most_common(3)
+
+
+def test_resnet18d_40_02_operands_are_wbt_offsets_paired_with_50_03(tmp_path):
+    """Confirmed real (see the README's "`40 02` operands are weight-table
+    offsets" section), all local byte analysis: `40 02` and `50 03`
+    headers are paired one-to-one, canonically 8 words (one 32-byte unit)
+    apart; the 181 `40 02` operands are all distinct and span exactly the
+    Wbt (the largest lands within 0.3% of `npu_params`'s size); `50 03`
+    operands stop at about a quarter of that; and the most common kind,
+    `50 01`, takes only four distinct operand values across 724 uses.
+    Needs Docker for the build but no device.
+    """
+    from collections import Counter
+
+    path, _, mcode = _build_real_resnet18d(str(tmp_path))
+    compiled = onnx.load(path)
+    wbt_size = len(
+        bytes(
+            {i.name: i for i in compiled.graph.initializer}[
+                _params_key(compiled)
+            ].raw_data
+        )
+    )
+
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    kind = {i: w[2:].hex(" ") for i, w in enumerate(words) if w[:2] == b"\xa1\x00"}
+    by_kind = {}
+    for i, k in kind.items():
+        by_kind.setdefault(k, []).append(i)
+    operand = lambda i: int.from_bytes(words[i + 1], "little")  # noqa: E731
+
+    i4002, i5003 = by_kind["40 02"], by_kind["50 03"]
+    assert len(i4002) == len(i5003) == 181
+    dist = Counter(
+        j - max(i for i in i4002 if i < j) for j in i5003 if any(i < j for i in i4002)
+    )
+    assert dist.most_common(1)[0][0] == 8 and dist[8] >= 160, dist.most_common(3)
+
+    ops4002 = [operand(i) for i in i4002]
+    assert len(set(ops4002)) == 181
+    assert max(ops4002) <= wbt_size
+    assert max(ops4002) >= 0.99 * wbt_size, (max(ops4002), wbt_size)
+
+    ops5003 = [operand(i) for i in i5003]
+    assert max(ops5003) < 0.35 * wbt_size, (max(ops5003), wbt_size)
+
+    assert len({operand(i) for i in by_kind["50 01"]}) <= 4

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1579,3 +1579,66 @@ def test_resnet18d_data_like_byte_sits_in_a_gated_template_and_is_sign_like(tmp_
     # Sign-like: flipping all 8 bits perturbs less than flipping bit 7 alone.
     all_bits = flip(43500, 0xFF)
     assert np.max(np.abs(all_bits - out_base)) < np.max(np.abs(outs[7] - out_base))
+
+
+def _word_stream_stats(mcode):
+    """Local, deterministic structure stats for an mcode blob read as a
+    stream of 4-byte words (see the README's "32-bit-word instruction
+    stream" section): the word indices holding an `a1 00 xx yy` header,
+    how many headers are immediately followed by another header, the
+    fraction of even gaps between consecutive headers, and a Counter of
+    the `xx yy` header suffixes. No Docker or device needed beyond
+    producing the blob."""
+    from collections import Counter
+
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    headers = [i for i, w in enumerate(words) if w[0] == 0xA1 and w[1] == 0x00]
+    adjacent = sum(
+        1
+        for i in headers
+        if i + 1 < len(words) and words[i + 1][0] == 0xA1 and words[i + 1][1] == 0x00
+    )
+    gaps = [b - a for a, b in zip(headers, headers[1:])]
+    even_frac = sum(1 for g in gaps if g % 2 == 0) / len(gaps) if gaps else 0.0
+    suffixes = Counter(words[i][2:].hex(" ") for i in headers)
+    return headers, adjacent, even_frac, suffixes
+
+
+def test_mcode_is_a_word_stream_with_never_adjacent_headers_tiny_model(tmp_path):
+    """Confirmed real (see the README's "32-bit-word instruction stream"
+    section), on the tiny two-Conv model: the mcode blob is 4-byte
+    aligned, holds `a1 00 xx yy` header words at word alignment, no
+    header is ever immediately followed by another (the [header][operand]
+    structure), and the gaps between headers are dominantly even. Needs
+    Docker for the build but no device.
+    """
+    model = _two_conv_model(vary_first=True, dilation=2, pad=2)
+    mcode = _mcode_from_axmodel(
+        _build_axmodel(os.path.join(str(tmp_path), "tiny"), model, (1, 4, 16, 16))
+    )
+    assert len(mcode) % 4 == 0
+    headers, adjacent, even_frac, _ = _word_stream_stats(mcode)
+    assert len(headers) >= 40, len(headers)
+    assert adjacent == 0, adjacent
+    assert even_frac >= 0.8, even_frac
+
+
+def test_resnet18d_mcode_word_stream_counts(tmp_path):
+    """Confirmed real (see the README's "32-bit-word instruction stream"
+    section), on the real resnet18d blob: exactly 1,197 word-aligned
+    `a1 00` headers, none adjacent to another, 98% even gaps, and the two
+    probed instruction kinds `40 02` (control-like) and `50 03`
+    (data-like) occurring exactly as often as each other. Needs Docker
+    for the build but no device.
+    """
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    assert len(mcode) % 4 == 0
+    headers, adjacent, even_frac, suffixes = _word_stream_stats(mcode)
+    assert len(headers) == 1197, len(headers)
+    assert adjacent == 0, adjacent
+    assert even_frac >= 0.95, even_frac
+    assert suffixes["40 02"] == suffixes["50 03"] == 181, (
+        suffixes["40 02"],
+        suffixes["50 03"],
+    )
+    assert suffixes.most_common(1)[0] == ("50 01", 724), suffixes.most_common(3)

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -14,6 +14,7 @@ tests/test_pulsar2_hf_to_axmodel.py.
 import json
 import os
 import re
+import struct
 import sys
 
 import numpy as np
@@ -638,6 +639,36 @@ def _mcode_key(compiled):
     return info["dotneus"][0]["neu_key"]
 
 
+def _params_key(compiled):
+    """The `npu_params` initializer name holding a compiled model's Wbt --
+    the hand-patching counterpart to `_mcode_key`."""
+    neu_node = next(nd for nd in compiled.graph.node if nd.op_type == "neu mode")
+    for attr in neu_node.attribute:
+        if attr.name == "npu_graph_info":
+            info = json.loads(attr.s.decode())
+    return info["dotneus"][0]["extra_inputs"][0]["const_data_key"]
+
+
+def _conv_with_bias_model(bias_vals, cin=4, cout=4, k=3, insz=16):
+    """One `Conv(x, w, b)` with an explicit, distinctly non-uniform bias --
+    used for hand-patching Wbt's per-channel requantization scale, where a
+    uniform bias would make every channel's own decoded value coincide and
+    hide per-channel indexing bugs."""
+    pad = k // 2
+    model = parser.parse_model(
+        f'<ir_version: 10, opset_import: ["": 17]> '
+        f"agraph (float[1,{cin},{insz},{insz}] x) => (float[1,{cout},{insz},{insz}] y) "
+        f"{{ y = Conv<pads=[{pad},{pad},{pad},{pad}]>(x, w, b) }}"
+    )
+    rng = np.random.RandomState(0)
+    w = (rng.randn(cout, cin, k, k) * 0.1).astype(np.float32)
+    b = np.array(bias_vals, dtype=np.float32)
+    model.graph.initializer.append(numpy_helper.from_array(w, name="w"))
+    model.graph.initializer.append(numpy_helper.from_array(b, name="b"))
+    onnx.checker.check_model(model)
+    return model
+
+
 def _gemm_model(transb, m=1, k=16, n=8):
     """One `Gemm(x, w, b)` -- `transb` selects whether `w` is stored as
     `[k,n]` (transB=0) or `[n,k]` (transB=1), same logical matrix either
@@ -1131,3 +1162,76 @@ def test_bit_flip_in_opaque_mcode_region_is_sometimes_inert_sometimes_faults(tmp
 
     dev_fault = flip_and_run(700, x)
     assert dev_fault.error and "0x8030070C" in dev_fault.error, dev_fault.error
+
+
+def test_patching_decoded_requant_scale_isolates_to_one_channel(tmp_path):
+    """Confirmed real (see the README's "Hand-patching the decoded Wbt
+    requantization scale" section): halving `Conv`'s per-channel
+    requantization scale `M_channel` (Wbt's small ~1e-3-magnitude
+    per-channel float32 array, present in 4 identical repeated copies) at
+    only channel 0's 4 copies produces bit-identical device output for
+    channels 1-3, but visibly reshapes channel 0's own output (narrower
+    spread, fewer unique values -- the signature of compressing the int8
+    requantization range around a fixed zero-point, not simply halving
+    the final float result). Confirmed stable across independent
+    rebuilds. This test locks in the causal isolation (other channels
+    untouched) and the qualitative reshaping (not a naive linear scale),
+    without depending on brittle exact-offset assumptions beyond this
+    specific, confirmed model configuration.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    model = _conv_with_bias_model([0, 5, 10, 15])
+    path = _build_axmodel(os.path.join(str(tmp_path), "base"), model, (1, 4, 16, 16))
+    compiled = onnx.load(path)
+    key = _params_key(compiled)
+    wbt = bytes({i.name: i for i in compiled.graph.initializer}[key].raw_data)
+
+    # channel 0's requant-scale value, confirmed present at these 4
+    # identical repeated offsets for this exact model configuration.
+    repeat_offsets = [1216, 1232, 1248, 1264]
+    values = [struct.unpack("<f", wbt[o : o + 4])[0] for o in repeat_offsets]
+    assert len(set(values)) == 1, "expected the 4 repeated copies to agree"
+    assert 1e-4 < values[0] < 1e-2, (values, "expected a small requant-scale value")
+
+    patched = bytearray(wbt)
+    for off in repeat_offsets:
+        v = struct.unpack("<f", patched[off : off + 4])[0]
+        patched[off : off + 4] = struct.pack("<f", v * 0.5)
+    compiled_patched = onnx.load(path)
+    {i.name: i for i in compiled_patched.graph.initializer}[key].raw_data = bytes(
+        patched
+    )
+    patched_path = os.path.join(str(tmp_path), "patched.axmodel")
+    onnx.save(compiled_patched, patched_path)
+
+    rng = np.random.RandomState(42)
+    x = rng.randn(1, 4, 16, 16).astype(np.float32)
+    dev_base = pulsar2_docker.run_on_device_with_inputs(path, {"x": x.tobytes()})
+    dev_patch = pulsar2_docker.run_on_device_with_inputs(
+        patched_path, {"x": x.tobytes()}
+    )
+    assert not dev_base.error, dev_base.error
+    assert not dev_patch.error, dev_patch.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32).reshape(
+        1, 4, 16, 16
+    )
+    out_patch = np.frombuffer(dev_patch.outputs[0], dtype=np.float32).reshape(
+        1, 4, 16, 16
+    )
+
+    for c in (1, 2, 3):
+        assert np.array_equal(out_base[0, c], out_patch[0, c]), (
+            c,
+            "expected untouched channels to be bit-identical",
+        )
+
+    base0, patch0 = out_base[0, 0], out_patch[0, 0]
+    assert not np.array_equal(base0, patch0)
+    assert patch0.std() < base0.std(), (
+        base0.std(),
+        patch0.std(),
+        "expected halving the requant scale to narrow channel 0's output spread",
+    )
+    assert len(np.unique(patch0)) < len(np.unique(base0))


### PR DESCRIPTION
## Summary
Follow-up to #1158 (merged at `3f39472`): three commits that landed on the same branch after the merge, so they never got a CI run.

- **Hand-patch the *decoded* Wbt requantization scale** (`2496eb2`): halving `Conv`'s per-channel `M_channel` at its 4 repeated Wbt copies leaves channels 1-3 bit-identical on real device output (proving the offset/per-channel indexing), but channel 0 collapses to a narrower, shifted distribution rather than simply halving -- the field acts inside int8 requantization around a fixed zero-point, not on the dequantized float result. Corrects the earlier correlation-only mental model.
- **Bit-flip probe on the real resnet18d mcode** (`647f569`): 41 offsets across the real 49,080-byte blob. A third outcome class appears that the tiny model never showed -- 9/41 flips run but change the real 1000-class logits (7 change the predicted class). The first bytes found whose effect on actual computation is directly observable. Net: ~83% live (61% fault with `0x8030070C`, 22% change output), ~17% inert. All verified deterministic; device healthy after 25 consecutive faults.
- **Fix flaky label-permutation test** (`ca01e35`): 4 rebuilds instead of 2 -- with 2, the label assignment occasionally lands identically by chance, leaving nothing to test.

## Test plan
- [x] All 3 new/changed tests pass in isolation on real Docker + AX650N
- [x] Full `tests/test_axera_mcode_structure.py` suite: 19/20, the 1 failure being the flake fixed by `ca01e35` (verified in isolation after the fix)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2usgepQwRi2s6ASVaHfk