### PR TITLE
mcode: type the field map -- three per-op fields are 91%; 50 03 is a 64-byte tile arena

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2217,6 +2217,62 @@ now gone from "49 KB of opaque bytes" to "a register map with ~50 named
 fields in a dozen banks, each written with a 32-bit value" -- a
 concrete, enumerable target.
 
+### Typing the field map: three per-op fields are 91% of a real model's mcode; the rest is one-time setup
+
+Counting, per field, how many times `resnet18d` writes it and how many
+distinct values it uses (local, zero device runs) turns the enumerable
+map into a typed one:
+
+```
+field         writes  distinct   value range               what it looks like
+a1 00 50 01     724       4      {bit 0, 8, 20, 24}         one-hot flag, per op
+a1 00 40 02     181     181      0x0 .. 0xb45ba0 (= Wbt)    Wbt offset, per op
+a1 00 50 03     181     176      0x0 .. 0x2f7040 (~3.1 MB)  address into a smaller region, per op
+a1 00 30 03      16      10      0x1 .. 0x30009683          packed config, occasional
+a1 00 20 02      15       9      0x1 .. 0x93ff              small counts/sizes, occasional
+(6 more fields written 3-4 times, all high-entropy packed words, e.g. 0x888c97ff, 0xc0031883)
+(57 fields written once or twice)
+```
+
+**68 distinct fields in total; 57 of them are written fewer than three
+times.** Only three fields are written at per-op scale, and those three
+account for **1,086 of the 1,197 writes (91%)**. In other words, a
+real model's mcode is overwhelmingly a per-op loop of "set the flag,
+set the weight offset, set the other address" against a fixed
+configuration laid down once. That also says where the remaining
+decoding effort is worth spending: the semantics of exactly three
+fields would cover 91% of what the hardware is told, and two of them
+are already pinned quantitatively (`40 02`) or by value set (`50 01`).
+The obvious next target is `50 03`'s ~3.1 MB region -- the same
+size-matching argument that decoded `40 02` against the Wbt can be run
+against the model's activation tensors.
+
+### `50 03` is not whole activation tensors; it is a 64-byte-aligned tile arena
+
+Running that size-matching argument (local; shape inference on the
+cached `resnet18d` ONNX vs. the 176 distinct `50 03` operands):
+
+- **The whole-tensor hypothesis fails, and is reported as such.** The
+  operands' consecutive differences -- 4,096; 37,120; 14,080; 23,040;
+  7,936; ... -- are not activation-tensor sizes (`resnet18d` has 10
+  distinct INT8 activation sizes, from 512 to 802,816 bytes); only 2 of
+  the top 10 deltas coincide with a tensor size (25,088 and 512),
+  consistent with chance. Neither the largest tensor (802,816 B) nor the
+  sum of all intermediates (7.59 MB) equals the 3.1 MB span.
+- **What does hold is alignment and scale.** 175 of the 176 operands
+  are exact multiples of 64; the smallest non-zero one is 37,120
+  (`0x9100`, also the most frequent delta); the deltas are
+  tile-sized (a few KB to a few tens of KB), not tensor-sized.
+
+So `50 03` addresses a 64-byte-aligned arena of *tiles*, into which
+the compiler places activation chunks -- which fits both the earliest
+"32-byte unit / channel tiling" findings and the `_ocm_base` string
+this README decoded from the mcode header table long ago (on-chip
+memory has exactly this shape: small, aligned, tile-addressed). Whether
+the ~3.1 MB span is the on-chip memory's actual size is not confirmed
+against any spec here, and the tile-to-tensor mapping is not
+decoded; the field's *kind* -- aligned tile address -- is.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1785,3 +1785,45 @@ def test_mcode_headers_are_field_writes_with_a_shared_map_across_models(tmp_path
     assert (
         sum(1 for xx, yy, _ in _header_fields(r18) if (xx, yy) == (0x40, 0x02)) == 181
     )
+
+
+def test_resnet18d_three_per_op_fields_are_91_percent_of_all_field_writes(tmp_path):
+    """Confirmed real (see the README's "Typing the field map" section),
+    all local: resnet18d writes 68 distinct fields, but 57 of them fewer
+    than three times (one-time setup), and just three per-op fields --
+    `50 01` (flag), `40 02` (Wbt offset), `50 03` (the ~3.1 MB address
+    region) -- account for 1,086 of the 1,197 writes, 91%. Needs Docker
+    for the build but no device.
+    """
+    from collections import Counter
+
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    fields = _header_fields(mcode)
+    writes = Counter((xx, yy) for xx, yy, _ in fields)
+    assert len(writes) >= 60, len(writes)
+    assert sum(1 for n in writes.values() if n < 3) >= 50, writes.most_common(12)
+
+    hot = writes[(0x50, 0x01)] + writes[(0x40, 0x02)] + writes[(0x50, 0x03)]
+    assert hot >= 0.9 * len(fields), (hot, len(fields))
+    assert len({v for xx, yy, v in fields if (xx, yy) == (0x50, 0x03)}) >= 170
+
+
+def test_resnet18d_50_03_operands_are_a_64_byte_aligned_tile_arena(tmp_path):
+    """Confirmed real (see the README's "`50 03` is not whole activation
+    tensors" section), all local: the 176 distinct `50 03` operands are
+    64-byte aligned (175 of 176 exact multiples of 64), span ~3.1 MB, and
+    their consecutive deltas are tile-sized, not activation-tensor-sized
+    -- the largest resnet18d activation is 802,816 bytes and the span is
+    neither that nor the sum of all intermediates. Needs Docker for the
+    build but no device.
+    """
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    ops = sorted({v for xx, yy, v in _header_fields(mcode) if (xx, yy) == (0x50, 0x03)})
+    assert len(ops) >= 170, len(ops)
+    assert sum(1 for o in ops if o % 64 == 0) >= len(ops) - 1, (
+        "expected 64-byte alignment"
+    )
+    assert 3_000_000 < max(ops) < 3_300_000, max(ops)
+    deltas = [b - a for a, b in zip(ops, ops[1:])]
+    assert max(deltas) < 802_816, "expected tile-sized deltas, not tensor-sized ones"
+    assert min(o for o in ops if o) == 37_120


### PR DESCRIPTION
## Summary
First new PR after #1173 merged. All local byte analysis on the merged field-write reading of mcode (`a1 00 xx yy <value>`), zero device runs.

- **Typed field map.** resnet18d writes 68 distinct fields, 57 of them fewer than three times (one-time setup). Three per-op fields -- `50 01` (one-hot flag), `40 02` (Wbt offset), `50 03` -- account for **1,086 of 1,197 writes (91%)**. A real model's mcode is overwhelmingly a per-op loop of three writes against a fixed configuration.
- **`50 03` is a 64-byte-aligned tile arena, not whole activation tensors.** Tested against the model's activation tensors the way `40 02` was tested against the Wbt: the whole-tensor hypothesis fails (operand deltas are not tensor sizes; neither the largest tensor nor the sum of intermediates equals the 3.1 MB span) and is reported as such. What holds: 175/176 operands are exact multiples of 64, deltas are tile-sized -- matching the earliest tiling findings and the `_ocm_base` header string. Arena size vs. spec and tile-to-tensor mapping remain unconfirmed; the field's *kind* is pinned.

Two device-free regression tests (Docker only) lock in both.

## Test plan
- [x] Both new tests pass locally (Docker build, no device)
- [x] `ruff format --check` / `ruff check` clean
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2usgepQwRi2s6ASVaHfk