### PR TITLE
mcode: 50 01 is a per-op four-step sequence in a fixed order, not an engine selector

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2273,6 +2273,33 @@ the ~3.1 MB span is the on-chip memory's actual size is not confirmed
 against any spec here, and the tile-to-tensor mapping is not
 decoded; the field's *kind* -- aligned tile address -- is.
 
+### `50 01` is a per-op four-step sequence, written in a fixed order -- not an engine selector
+
+The most-written field, `50 01`, takes exactly four one-hot values
+(`0x1, 0x100, 0x100000, 0x1000000` -- bits 0, 8, 20, 24) in both
+models. Four values and four profiled engines (`conv0`, `conv1`,
+`teng2`, `sdma4`) invite the guess "it selects an engine." Testing that
+guess, locally, refutes it:
+
+- **Every op writes all four, in the same fixed order.** Splitting
+  `resnet18d`'s header stream at each `40 02` (Wbt-offset) write, the
+  `50 01` values between consecutive ops are `bit8, bit0, bit20, bit24`
+  in **180 of 180** segments, and the tiny two-Conv model's single op
+  writes exactly the same four in the same order. Each value occurs
+  exactly 181 times -- once per op -- so 724 = 4 x 181 is not "four
+  choices" but "four steps."
+- So `50 01` is a **per-op sequence register**: every op pulses it
+  four times in a fixed order. Which four steps -- four stage triggers,
+  four engine-enable pulses issued in sequence, a four-phase handshake
+  -- is not identified; what is settled is that it is not a per-op
+  choice of one engine.
+
+A count that lines up on the way: `sdma4` has exactly **181** events in
+`resnet18d`'s trace -- one per op, one per `40 02` write -- consistent
+with each op's Wbt-offset write being followed by one weight DMA on the
+system DMA engine. (`conv0`/`conv1` have 522 events each; `teng2` 46;
+`cv3` 162.)
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1827,3 +1827,47 @@ def test_resnet18d_50_03_operands_are_a_64_byte_aligned_tile_arena(tmp_path):
     deltas = [b - a for a, b in zip(ops, ops[1:])]
     assert max(deltas) < 802_816, "expected tile-sized deltas, not tensor-sized ones"
     assert min(o for o in ops if o) == 37_120
+
+
+def _flag_sequence_per_op(mcode):
+    """For each pair of consecutive `40 02` (Wbt-offset) writes, the
+    ordered tuple of `50 01` values written between them -- see the
+    README's "`50 01` is a per-op four-step sequence" section."""
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    hdrs = [
+        (i, w[2], w[3], int.from_bytes(words[i + 1], "little"))
+        for i, w in enumerate(words)
+        if w[:2] == b"\xa1\x00" and i + 1 < len(words)
+    ]
+    cuts = [i for i, xx, yy, _ in hdrs if (xx, yy) == (0x40, 0x02)]
+    flags = [(i, v) for i, xx, yy, v in hdrs if (xx, yy) == (0x50, 0x01)]
+    return [tuple(v for i, v in flags if a < i < b) for a, b in zip(cuts, cuts[1:])]
+
+
+def test_50_01_is_a_fixed_four_step_sequence_per_op_in_both_models(tmp_path):
+    """Confirmed real (see the README's "`50 01` is a per-op four-step
+    sequence" section), all local: every op writes `50 01` exactly four
+    times in the fixed order bit8, bit0, bit20, bit24 -- 180 of 180
+    inter-op segments in resnet18d, and the tiny two-Conv model's single
+    op writes the same four in the same order. Not an engine selector.
+    Needs Docker for the builds but no device.
+    """
+    order = (0x100, 0x1, 0x100000, 0x1000000)
+
+    tiny = _mcode_from_axmodel(
+        _build_axmodel(
+            os.path.join(str(tmp_path), "tiny"),
+            _two_conv_model(vary_first=True, dilation=2, pad=2),
+            (1, 4, 16, 16),
+        )
+    )
+    tiny_flags = [v for xx, yy, v in _header_fields(tiny) if (xx, yy) == (0x50, 0x01)]
+    assert tuple(tiny_flags) == order, tiny_flags
+
+    _, _, r18 = _build_real_resnet18d(str(tmp_path))
+    segments = _flag_sequence_per_op(r18)
+    assert len(segments) == 180, len(segments)
+    assert all(seg == order for seg in segments), (
+        sum(1 for seg in segments if seg != order),
+        "expected every op to write the same four-step sequence",
+    )


### PR DESCRIPTION
## Summary
Second new PR after #1173 merged; based on `master` (independent of #1178). All local byte analysis, zero device runs.

- The most-written mcode field, `50 01`, takes exactly four one-hot values (bits 0, 8, 20, 24) in both models, and four profiled engines invite the guess that it selects one. **Refuted:** every op writes all four, in the same fixed order `bit8, bit0, bit20, bit24` -- 180 of 180 inter-op segments in resnet18d (split at each `40 02` Wbt-offset write), and the tiny two-Conv model's single op writes the same four in the same order. Each value occurs exactly 181 times, once per op: 724 = four *steps*, not four choices. Which four steps is not identified.
- A count that lines up: `sdma4` has exactly 181 trace events -- one per op, one per `40 02` write -- consistent with one weight DMA following each op's Wbt-offset write.

Device-free regression test (Docker only) locks in the fixed sequence in both models.

## Test plan
- [x] New test passes locally (Docker builds, no device)
- [x] `ruff format --check` / `ruff check` clean
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2usgepQwRi2s6ASVaHfk