### PR TITLE
mcode: the 50 01 step set dispatches the op; bit24 is inert model-wide

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2300,6 +2300,49 @@ with each op's Wbt-offset write being followed by one weight DMA on the
 system DMA engine. (`conv0`/`conv1` have 522 events each; `teng2` 46;
 `cv3` 162.)
 
+### The four `50 01` steps on the device: three required, one optional, and a correction about what the validator checks
+
+`50 01` is written four times per op in a fixed order (`bit8, bit0,
+bit20, bit24`). Editing those four writes for one real `resnet18d` op
+on the device, one variant per run, then repeating on a second op:
+
+```
+                                      op @ word 8174   op @ word 12074
+skip bit8   (write 0 instead)         FAULT            FAULT
+skip bit0                             FAULT            (not repeated)
+skip bit20                            FAULT            (not repeated)
+skip bit24                            identical        identical
+swap bit8 <-> bit0                    identical        identical
+swap bit20 <-> bit24                  FAULT            (not repeated)
+all four -> 0                         runs, D (815)    runs, D (832)
+```
+
+- **`bit8`, `bit0`, `bit20` are each required**: removing any one of
+  them faults with the usual `0x8030070C`.
+- **`bit24` is optional**: removing it leaves the output bit-identical
+  on both ops -- whatever the fourth step does, correctness does not
+  depend on it (a timing or profiling pulse is the natural guess).
+- **`bit8` and `bit0` are order-free** (swapped, identical output);
+  **`bit20` must precede `bit24`** (swapped, fault; one op).
+- **Removing all four does *not* fault** -- the op runs, with a
+  different result, on both ops. So the check is not "a step is
+  missing" but "the steps present are inconsistent": a partial
+  sequence is rejected, an absent one falls back to some default mode.
+
+**Correction, stated in place.** The `40 02` operand section above
+concluded that "every fault in this whole investigation came from a
+header/format byte, never from an operand value, however absurd." That
+held for every *address* value tried, and it is wrong as a general
+statement: the `50 01` step values above are operand values, and
+zeroing one of them faults. The consistent reading of all of it is that
+`0x8030070C` is a **runtime sequencing rejection** rather than a static
+format check -- it fires when the command stream is inconsistent as a
+*sequence* (a corrupted selector word, a partial step set, a
+misordered step), and stays silent for values that do not break
+sequencing (an out-of-range address is still a well-formed step). That
+also explains why it never fired on any `40 02` value and why a wholly
+absent step set runs.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2343,6 +2343,35 @@ sequencing (an out-of-range address is still a well-formed step). That
 also explains why it never fired on any `40 02` value and why a wholly
 absent step set runs.
 
+### The `50 01` step set is the op's dispatch, and its fourth step is inert model-wide
+
+Two device probes that each settle one question with a single decisive
+comparison.
+
+**An op with no step set does not execute.** Zeroing all four `50 01`
+writes of one real `resnet18d` op makes the model run with a changed
+result (argmax 305 -> 815). Doing the same *and* also pointing that
+op's `40 02` Wbt offset at a different instance's weights gives the
+**byte-identical** changed result. If the op still executed in some
+"default mode," its weights would matter and the two outputs would
+differ; they do not. So the four `50 01` writes are what dispatch the
+op -- remove them and the op is simply skipped, its weight offset never
+read, and the model's output is whatever the downstream layers make of
+a missing contribution. This also reinterprets the "removing all four
+does not fault" observation: there is no partial sequence left for the
+sequencer to reject, because there is no op.
+
+**`bit24` is inert for correctness across the entire model.** The
+per-op probe found that zeroing the fourth step (`bit24`) leaves one
+op's output bit-identical. Zeroing it in **all 181 ops at once**, in one
+patched model, leaves the whole network's output **bit-identical to the
+unpatched baseline**. Whatever the fourth write does -- a completion or
+profiling pulse is the natural guess -- no part of `resnet18d`'s
+computed result depends on it. Combined with the previous section: each
+op is dispatched by three required steps (`bit8`, `bit0` in either
+order, then `bit20`), followed by one step that can be dropped
+model-wide without changing a single output bit.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2273,6 +2273,33 @@ the ~3.1 MB span is the on-chip memory's actual size is not confirmed
 against any spec here, and the tile-to-tensor mapping is not
 decoded; the field's *kind* -- aligned tile address -- is.
 
+### `50 01` is a per-op four-step sequence, written in a fixed order -- not an engine selector
+
+The most-written field, `50 01`, takes exactly four one-hot values
+(`0x1, 0x100, 0x100000, 0x1000000` -- bits 0, 8, 20, 24) in both
+models. Four values and four profiled engines (`conv0`, `conv1`,
+`teng2`, `sdma4`) invite the guess "it selects an engine." Testing that
+guess, locally, refutes it:
+
+- **Every op writes all four, in the same fixed order.** Splitting
+  `resnet18d`'s header stream at each `40 02` (Wbt-offset) write, the
+  `50 01` values between consecutive ops are `bit8, bit0, bit20, bit24`
+  in **180 of 180** segments, and the tiny two-Conv model's single op
+  writes exactly the same four in the same order. Each value occurs
+  exactly 181 times -- once per op -- so 724 = 4 x 181 is not "four
+  choices" but "four steps."
+- So `50 01` is a **per-op sequence register**: every op pulses it
+  four times in a fixed order. Which four steps -- four stage triggers,
+  four engine-enable pulses issued in sequence, a four-phase handshake
+  -- is not identified; what is settled is that it is not a per-op
+  choice of one engine.
+
+A count that lines up on the way: `sdma4` has exactly **181** events in
+`resnet18d`'s trace -- one per op, one per `40 02` write -- consistent
+with each op's Wbt-offset write being followed by one weight DMA on the
+system DMA engine. (`conv0`/`conv1` have 522 events each; `teng2` 46;
+`cv3` 162.)
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1940,3 +1940,74 @@ def test_resnet18d_50_01_steps_three_required_one_optional_on_device(tmp_path):
     assert out is not None and not np.array_equal(out, out_base), (
         "expected an absent step set to run with a changed result, not fault"
     )
+
+
+def test_resnet18d_50_01_step_set_dispatches_the_op_and_bit24_is_inert_model_wide(
+    tmp_path,
+):
+    """Confirmed real on the device (see the README's "The `50 01` step set
+    is the op's dispatch" section): with all four `50 01` steps of one op
+    zeroed, the model runs with a changed result, and additionally
+    pointing that op's Wbt offset at another instance's weights gives the
+    byte-identical changed result -- the op no longer executes at all.
+    And zeroing `bit24` in all 181 ops at once leaves the whole output
+    bit-identical to the unpatched baseline.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    hdrs = [
+        (i, w[2], w[3], int.from_bytes(words[i + 1], "little"))
+        for i, w in enumerate(words)
+        if w[:2] == b"\xa1\x00" and i + 1 < len(words)
+    ]
+    cuts = [i for i, xx, yy, _ in hdrs if (xx, yy) == (0x40, 0x02)]
+    op_start = 8174
+    assert op_start in cuts
+    op_end = min(i for i in cuts if i > op_start)
+    steps = [
+        i for i, xx, yy, _ in hdrs if (xx, yy) == (0x50, 0x01) and op_start < i < op_end
+    ]
+    assert len(steps) == 4
+    other_offset = int.from_bytes(
+        mcode[48300:48304], "little"
+    )  # a different op's 40 02 value
+    bit24_writes = [
+        i for i, xx, yy, v in hdrs if (xx, yy) == (0x50, 0x01) and v == 0x1000000
+    ]
+    assert len(bit24_writes) == 181
+
+    x = np.random.RandomState(42).randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = _run_retry_once(path, x)
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+
+    def run_variant(edits, tag):
+        patched = bytearray(mcode)
+        for word_index, value in edits:
+            patched[(word_index + 1) * 4 : (word_index + 2) * 4] = struct.pack(
+                "<I", value
+            )
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"dispatch_{tag}.axmodel")
+        onnx.save(c, p)
+        dev = _run_retry_once(p, x)
+        assert not dev.error, (tag, dev.error)
+        return np.frombuffer(dev.outputs[0], dtype=np.float32)
+
+    no_steps = run_variant([(w, 0) for w in steps], "no_steps")
+    assert not np.array_equal(no_steps, out_base)
+    no_steps_other_weights = run_variant(
+        [(w, 0) for w in steps] + [(op_start, other_offset)], "no_steps_other_weights"
+    )
+    assert np.array_equal(no_steps, no_steps_other_weights), (
+        "expected an op with no step set to be skipped, so its weight offset is never read"
+    )
+
+    all_bit24_zero = run_variant([(w, 0) for w in bit24_writes], "all_bit24_zero")
+    assert np.array_equal(all_bit24_zero, out_base), (
+        "expected bit24 to be inert for correctness across every op"
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1827,3 +1827,47 @@ def test_resnet18d_50_03_operands_are_a_64_byte_aligned_tile_arena(tmp_path):
     deltas = [b - a for a, b in zip(ops, ops[1:])]
     assert max(deltas) < 802_816, "expected tile-sized deltas, not tensor-sized ones"
     assert min(o for o in ops if o) == 37_120
+
+
+def _flag_sequence_per_op(mcode):
+    """For each pair of consecutive `40 02` (Wbt-offset) writes, the
+    ordered tuple of `50 01` values written between them -- see the
+    README's "`50 01` is a per-op four-step sequence" section."""
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    hdrs = [
+        (i, w[2], w[3], int.from_bytes(words[i + 1], "little"))
+        for i, w in enumerate(words)
+        if w[:2] == b"\xa1\x00" and i + 1 < len(words)
+    ]
+    cuts = [i for i, xx, yy, _ in hdrs if (xx, yy) == (0x40, 0x02)]
+    flags = [(i, v) for i, xx, yy, v in hdrs if (xx, yy) == (0x50, 0x01)]
+    return [tuple(v for i, v in flags if a < i < b) for a, b in zip(cuts, cuts[1:])]
+
+
+def test_50_01_is_a_fixed_four_step_sequence_per_op_in_both_models(tmp_path):
+    """Confirmed real (see the README's "`50 01` is a per-op four-step
+    sequence" section), all local: every op writes `50 01` exactly four
+    times in the fixed order bit8, bit0, bit20, bit24 -- 180 of 180
+    inter-op segments in resnet18d, and the tiny two-Conv model's single
+    op writes the same four in the same order. Not an engine selector.
+    Needs Docker for the builds but no device.
+    """
+    order = (0x100, 0x1, 0x100000, 0x1000000)
+
+    tiny = _mcode_from_axmodel(
+        _build_axmodel(
+            os.path.join(str(tmp_path), "tiny"),
+            _two_conv_model(vary_first=True, dilation=2, pad=2),
+            (1, 4, 16, 16),
+        )
+    )
+    tiny_flags = [v for xx, yy, v in _header_fields(tiny) if (xx, yy) == (0x50, 0x01)]
+    assert tuple(tiny_flags) == order, tiny_flags
+
+    _, _, r18 = _build_real_resnet18d(str(tmp_path))
+    segments = _flag_sequence_per_op(r18)
+    assert len(segments) == 180, len(segments)
+    assert all(seg == order for seg in segments), (
+        sum(1 for seg in segments if seg != order),
+        "expected every op to write the same four-step sequence",
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1871,3 +1871,72 @@ def test_50_01_is_a_fixed_four_step_sequence_per_op_in_both_models(tmp_path):
         sum(1 for seg in segments if seg != order),
         "expected every op to write the same four-step sequence",
     )
+
+
+def test_resnet18d_50_01_steps_three_required_one_optional_on_device(tmp_path):
+    """Confirmed real on the device (see the README's "The four `50 01`
+    steps on the device" section), on two independent ops: zeroing the
+    `bit8` step faults (`0x8030070C`), zeroing the `bit24` step leaves
+    the output bit-identical, swapping `bit8` and `bit0` leaves it
+    bit-identical, and zeroing all four runs with a changed output. Also
+    the concrete counter-example to "the validator never faults on an
+    operand value": these are operand values, and one of them faults.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    hdrs = [
+        (i, w[2], w[3], int.from_bytes(words[i + 1], "little"))
+        for i, w in enumerate(words)
+        if w[:2] == b"\xa1\x00" and i + 1 < len(words)
+    ]
+    cuts = [i for i, xx, yy, _ in hdrs if (xx, yy) == (0x40, 0x02)]
+    op_start = 8174  # the op whose 40 02 write sits at byte 32696
+    assert op_start in cuts
+    op_end = min(i for i in cuts if i > op_start)
+    steps = [
+        (i, v)
+        for i, xx, yy, v in hdrs
+        if (xx, yy) == (0x50, 0x01) and op_start < i < op_end
+    ]
+    assert [v for _, v in steps] == [0x100, 0x1, 0x100000, 0x1000000], steps
+
+    x = np.random.RandomState(42).randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = _run_retry_once(path, x)
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+
+    def run_variant(edits, tag):
+        patched = bytearray(mcode)
+        for word_index, value in edits:
+            patched[(word_index + 1) * 4 : (word_index + 2) * 4] = struct.pack(
+                "<I", value
+            )
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"steps_{tag}.axmodel")
+        onnx.save(c, p)
+        dev = _run_retry_once(p, x)
+        if dev.error:
+            assert "0x8030070C" in dev.error, (tag, dev.error)
+            return None
+        return np.frombuffer(dev.outputs[0], dtype=np.float32)
+
+    (w8, v8), (w0, v0), _, (w24, _) = steps
+    assert run_variant([(w8, 0)], "skip_bit8") is None, (
+        "expected skipping bit8 to fault"
+    )
+    out = run_variant([(w24, 0)], "skip_bit24")
+    assert out is not None and np.array_equal(out, out_base), (
+        "expected bit24 to be optional"
+    )
+    out = run_variant([(w8, v0), (w0, v8)], "swap_bit8_bit0")
+    assert out is not None and np.array_equal(out, out_base), (
+        "expected bit8/bit0 order-free"
+    )
+    out = run_variant([(w, 0) for w, _ in steps], "all_zero")
+    assert out is not None and not np.array_equal(out, out_base), (
+        "expected an absent step set to run with a changed result, not fault"
+    )


### PR DESCRIPTION
## Summary
Fourth new PR after #1173 merged; based on `master` (independent of #1178, #1179, #1180). Two real-device probes, each settled by one decisive comparison.

- **An op with no `50 01` step set does not execute.** Zeroing all four `50 01` writes of one real resnet18d op changes the result (argmax 305 -> 815); zeroing them *and* pointing that op's `40 02` Wbt offset at another instance's weights gives the **byte-identical** changed result. If the op still ran in some default mode its weights would matter; they don't -- the step set is the op's *dispatch*. This also explains why an absent step set does not fault: there is no partial sequence left to reject, because there is no op.
- **`bit24` is inert for correctness model-wide.** Zeroing it in **all 181 ops at once**, in one patched model, leaves the whole network's output **bit-identical** to the unpatched baseline. Each op is dispatched by three required steps (`bit8`, `bit0` in either order, then `bit20`), followed by one that can be dropped everywhere without changing a single output bit.

Device regression test locks in both (retry-once on the known transient, as elsewhere).

## Test plan
- [x] New test passes locally on real Docker + AX650N; device healthy afterward
- [x] `ruff format --check` / `ruff check` clean
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2usgepQwRi2s6ASVaHfk