### PR TITLE
Fix GQA/MHA cross-attention and differing-V-head-size bugs

### DIFF
--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -5592,6 +5592,14 @@ struct AttnChain {
   std::optional<std::string> q_bias, k_bias, v_bias;
   int64_t kv_num_heads = 0;
   int64_t head_size = 0;
+  // V's own per-head width -- equal to `head_size` for every matched op
+  // except the plain `ai.onnx::Attention` op when `FindSeparateQkvChains`
+  // was called with `allow_differing_v_head_size=true` (that op's own
+  // schema genuinely allows V an independent head_size; every other matched
+  // op here still requires it equal to `head_size`, see
+  // `FindSeparateQkvChains`'s own comment) -- mirrors pruning.py's own
+  // `_GQAChain.v_head_size` field.
+  int64_t v_head_size = 0;
   std::string num_heads_attr = "num_heads";
   // Set only for a matched `MultiHeadAttention`/`PackedMultiHeadAttention`/
   // `DecoderMaskedMultiHeadAttention` node whose own combined `bias` input
@@ -6289,12 +6297,16 @@ std::optional<HeadCountsMatch> MatchSparseAttentionProducer(
 // PackedMultiHeadAttention/DecoderMaskedMultiHeadAttention only --
 // `combined_bias_input_index`, the input index of a single combined
 // `[nq + nk + nv]`-shaped Q+K+V bias (see AttnChain's own `mha_bias` field).
-// Mirrors pruning.py's own _find_separate_qkv_chains -- narrower in one
-// deliberate, already-established way (see FindGqaChains'/
-// FindOnnxAttentionChains' own comment below): V's own head_size is always
-// required equal to Q's/K's shared one, never pruning.py's own
-// `allow_differing_v_head_size=True` composition for the plain ai.onnx op/
-// MultiHeadAttention/PackedMultiHeadAttention/LinearAttention.
+// Mirrors pruning.py's own _find_separate_qkv_chains, including its own
+// `allow_differing_v_head_size` parameter (see this function's own
+// definition below) -- `true` only for the plain ai.onnx op
+// (FindOnnxAttentionChains), whose own schema genuinely allows V an
+// independent head_size; every other op family here still requires V's own
+// head_size equal to Q's/K's shared one (this port's own deliberately
+// narrower-than-pruning.py scope for MultiHeadAttention/
+// PackedMultiHeadAttention/LinearAttention, which pruning.py's own analogues
+// already widen -- see FindOnnxAttentionChains' own comment below for why
+// only this one op is widened here).
 // `value_info_by_name` is threaded straight through to every node's own
 // `match_producer(node, init_map, value_info_by_name)` call -- built the
 // same way every "Attention-head pruning" family entry point builds one
@@ -6305,7 +6317,19 @@ std::optional<HeadCountsMatch> MatchSparseAttentionProducer(
 // *dynamic* one's declared shape (HeadBiasInputIsSafe); every other matcher
 // accepts and ignores it. Defaults to `{}` so every pre-existing call site
 // below that has no dynamic-mask handling of its own to feed stays
-// unchanged.
+// unchanged. `allow_differing_v_head_size` (defaulted to `false`, so every
+// pre-existing call site keeps requiring V's own head_size equal to Q's/K's
+// shared one) mirrors pruning.py's own `_find_separate_qkv_chains` parameter
+// of the identical name -- `true` only for the plain ai.onnx `Attention` op
+// (FindOnnxAttentionChains), whose own schema genuinely allows V an
+// independent head_size (see AttnChain's own `v_head_size` field); every
+// other op family this function backs keeps the pre-existing, narrower
+// uniform-head_size requirement (see this function's own comment above for
+// why -- `fuse_gqa.h` for GroupQueryAttention, and this port's own
+// deliberately-not-yet-widened scope for MultiHeadAttention/
+// PackedMultiHeadAttention/DecoderMaskedMultiHeadAttention/PagedAttention/
+// LinearAttention/SparseAttention, even though pruning.py's own analogues of
+// some of those already permit it).
 std::vector<AttnChain> FindSeparateQkvChains(
     onnx::GraphProto* graph,
     const std::function<std::optional<HeadCountsMatch>(
@@ -6316,7 +6340,8 @@ std::vector<AttnChain> FindSeparateQkvChains(
     std::optional<int> combined_bias_input_index = std::nullopt,
     const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
         value_info_by_name = {},
-    std::optional<std::pair<int, int>> qk_norm_weight_indices = std::nullopt) {
+    std::optional<std::pair<int, int>> qk_norm_weight_indices = std::nullopt,
+    bool allow_differing_v_head_size = false) {
   InitMap init_map;
   for (const auto& t : graph->initializer()) {
     init_map[t.name()] = &t;
@@ -6374,12 +6399,23 @@ std::vector<AttnChain> FindSeparateQkvChains(
       continue;
     }
     const int64_t head_size = pq->n_channels / info->num_heads;
-    if (head_size <= 0 || pk->n_channels / info->kv_num_heads != head_size ||
-        pv->n_channels / info->kv_num_heads != head_size) {
-      // fuse_gqa.h requires equal Q/K/V head_size; the plain ai.onnx op's
-      // own more permissive schema allows V its own head_size, but this
-      // shared, uniform-head_size body declines that composition rather
-      // than mis-slicing it.
+    if (head_size <= 0 || pk->n_channels / info->kv_num_heads != head_size) {
+      // Q's and K's own head_size must always agree -- required by the QK^T
+      // dot product itself, not a restriction this pass adds -- so a
+      // mismatch here is declined regardless of
+      // `allow_differing_v_head_size`.
+      continue;
+    }
+    const int64_t v_head_size = pv->n_channels / info->kv_num_heads;
+    if (v_head_size <= 0) {
+      continue;
+    }
+    if (!allow_differing_v_head_size && v_head_size != head_size) {
+      // fuse_gqa.h requires equal Q/K/V head_size for GroupQueryAttention;
+      // the plain ai.onnx op's own more permissive schema allows V its own
+      // head_size when the caller passes `allow_differing_v_head_size=true`
+      // (FindOnnxAttentionChains) -- every other op family declines this
+      // composition rather than mis-slicing it.
       continue;
     }
 
@@ -6443,10 +6479,13 @@ std::vector<AttnChain> FindSeparateQkvChains(
     if (!is_internal(out_name)) {
       continue;
     }
-    // Both matched ops' raw output is Nq-wide (num_heads * head_size),
-    // unlike plain com.microsoft::Attention's V-hidden-size-wide output.
+    // The raw output is always `num_heads * v_head_size` wide -- laid out
+    // per *query* head but at *V's* own per-head width -- equal to
+    // `pq->n_channels` exactly when `v_head_size == head_size` (always true
+    // unless `allow_differing_v_head_size` let it differ).
+    const int64_t raw_out_width = info->num_heads * v_head_size;
     auto [consumer, chain_ops] = WalkToAttentionConsumer(
-        out_name, init_map, consumers_of, graph_outputs, pq->n_channels);
+        out_name, init_map, consumers_of, graph_outputs, raw_out_width);
     if (!consumer) {
       continue;
     }
@@ -6466,6 +6505,7 @@ std::vector<AttnChain> FindSeparateQkvChains(
     chain.num_heads = info->num_heads;
     chain.kv_num_heads = info->kv_num_heads;
     chain.head_size = head_size;
+    chain.v_head_size = v_head_size;
     chain.chain_ops = std::move(chain_ops);
     chain.consumer_node = consumer->node;
     chain.consumer_weight = consumer->weight;
@@ -6486,25 +6526,39 @@ std::vector<AttnChain> FindSeparateQkvChains(
 // HeadBiasInputIsSafe check for a dynamic `attention_bias` -- the same map
 // FindDecomposedGqaChains' own equivalent parameter already documents at its
 // own call sites for why no real shape-inference pass backs it.
+// `qk_norm_weight_indices=(14, 15)` -- GroupQueryAttention's own
+// `q_norm_weight`/`k_norm_weight` input indices (mirrors pruning.py's own
+// `_find_gqa_chains`) -- the same deferred exact-`(head_size,)`-shape check
+// FindPagedAttentionChains already wires up for `PagedAttention`'s own
+// analogous pair at indices 12/13, so a wrong-shaped connected pair declines
+// the whole match here too instead of being silently pruned through
+// unvalidated.
 std::vector<AttnChain> FindGqaChains(
     onnx::GraphProto* graph,
     const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
         value_info_by_name = {}) {
   return FindSeparateQkvChains(graph, MatchGqaProducer, "num_heads",
                                /*combined_bias_input_index=*/std::nullopt,
-                               value_info_by_name);
+                               value_info_by_name, std::make_pair(14, 15));
 }
 
 // The plain ai.onnx::Attention analogue of FindGqaChains -- see that
 // function's own comment for why `value_info_by_name` is threaded straight
-// through.
+// through. `allow_differing_v_head_size=true`: unlike GroupQueryAttention,
+// this op's own schema genuinely allows V its own `v_head_size` independent
+// of Q/K's shared `head_size` (mirrors pruning.py's own
+// `_find_onnx_attention_chains`, confirmed via the op's own backend-test
+// suite and real onnxruntime execution -- see AttnChain's own `v_head_size`
+// field).
 std::vector<AttnChain> FindOnnxAttentionChains(
     onnx::GraphProto* graph,
     const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
         value_info_by_name = {}) {
   return FindSeparateQkvChains(graph, MatchOnnxAttentionProducer, "q_num_heads",
                                /*combined_bias_input_index=*/std::nullopt,
-                               value_info_by_name);
+                               value_info_by_name,
+                               /*qk_norm_weight_indices=*/std::nullopt,
+                               /*allow_differing_v_head_size=*/true);
 }
 
 // The com.microsoft::MultiHeadAttention analogue of FindGqaChains -- see
@@ -6802,20 +6856,18 @@ std::optional<AppliedAttn> ApplyOnePlainAttentionChain(
 // ApplyOnePlainAttentionChain's own trailing parameters of the same name
 // exactly (see that function's own doc comment): when `act_norm` is
 // non-null and holds an entry for `chain.consumer_node->input(0)` whose
-// length matches `chain.num_heads * chain.head_size` (this C++ port's
-// Q/K/V-uniform-head_size scope, see AttnChain's own `head_size` field --
-// the output projection's own input width, laid out per *query* head),
-// each KV group's plain Frobenius-norm weight importance is multiplied by
-// that group's own combined (root-sum-square) activation norm, summed
-// over every query head the group owns -- mirrors pruning.py's own
-// `_wanda_gqa_group_importance` exactly (there keyed by `chain.v_head_size`,
-// which pruning.py's own separate Q/K vs. V head-size support can genuinely
-// differ from `chain.head_size`; this port declines that shape entirely,
-// see FindGqaChains'/FindOnnxAttentionChains' own uniform-head_size
-// requirement, so `chain.head_size` alone is exact here), including its
-// fallback to plain `base` (left untouched) whenever no matching activation
-// was observed. `nullptr` (the default) keeps this identically the plain
-// ``||W||_F``-only ranking it always was.
+// length matches `chain.num_heads * chain.v_head_size` (the output
+// projection's own input width, laid out per *query* head at *V's* own
+// per-head width -- equal to `chain.head_size` unless
+// `allow_differing_v_head_size` let it differ, see AttnChain's own
+// `v_head_size` field), each KV group's plain Frobenius-norm weight
+// importance is multiplied by that group's own combined (root-sum-square)
+// activation norm, summed over every query head the group owns -- mirrors
+// pruning.py's own `_wanda_gqa_group_importance` exactly (keyed by
+// `chain.v_head_size` there too), including its fallback to plain `base`
+// (left untouched) whenever no matching activation was observed. `nullptr`
+// (the default) keeps this identically the plain ``||W||_F``-only ranking
+// it always was.
 std::optional<AppliedAttn> ApplyOneGqaChain(
     onnx::GraphProto* graph,
     std::unordered_map<std::string, onnx::TensorProto*>& init_map,
@@ -6908,8 +6960,21 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
 
   // Bring each to [K, N] (reduction dim first, head columns last) -- the
   // *opposite* of SliceProducerWeight's "output channel first" convention,
-  // matching pruning.py's own comment on this same transpose.
-  const int64_t K = wq_dims[chain.q_weight_transposed ? 1 : 0];
+  // matching pruning.py's own comment on this same transpose. `Kq`/`Kk`/`Kv`
+  // (each producer weight's OWN row count/reduction-dim width) are tracked
+  // independently, NOT assumed shared -- Q's own producer weight has as many
+  // rows as Q's own source tensor's feature dimension, while K's/V's own
+  // producer weight has as many rows as K's/V's own source tensor's feature
+  // dimension, and for cross-attention (Q and K/V drawn from genuinely
+  // different source tensors, e.g. a decoder/encoder pair -- a real, matched
+  // shape; nothing in FindSeparateQkvChains/its matchers ties Q's producer's
+  // row count to K/V's own) those two feature dimensions need not match at
+  // all. Mirrors pruning.py's own `_gqa_group_importance` doc comment
+  // exactly for why the per-tensor importance loops below must each use
+  // their own tensor's row count rather than a single shared one.
+  const int64_t Kq = wq_dims[chain.q_weight_transposed ? 1 : 0];
+  const int64_t Kk = wk_dims[chain.k_weight_transposed ? 1 : 0];
+  const int64_t Kv = wv_dims[chain.v_weight_transposed ? 1 : 0];
   const int64_t Nq = wq_dims[chain.q_weight_transposed ? 0 : 1];
   const int64_t Nk = wk_dims[chain.k_weight_transposed ? 0 : 1];
   const int64_t Nv = wv_dims[chain.v_weight_transposed ? 0 : 1];
@@ -6934,12 +6999,13 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
   // summing every entry, rather than concatenating, is used -- it stays
   // well-defined even when Q's own row count differs from K/V's, the
   // cross-attention shape this port also matches).
+  const int64_t dv = chain.v_head_size;
   std::vector<double> importance;
   if (is_mqa) {
     importance.assign(static_cast<size_t>(chain.num_heads), 0.0);
     for (int64_t qh = 0; qh < chain.num_heads; ++qh) {
       double acc = 0.0;
-      for (int64_t r = 0; r < K; ++r) {
+      for (int64_t r = 0; r < Kq; ++r) {
         for (int64_t c = qh * d; c < (qh + 1) * d; ++c) {
           const double v = wq_kn[static_cast<size_t>(r * Nq + c)];
           acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
@@ -6952,18 +7018,31 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     importance.assign(static_cast<size_t>(chain.kv_num_heads), 0.0);
     for (int64_t kv = 0; kv < chain.kv_num_heads; ++kv) {
       double acc = 0.0;
-      for (int64_t r = 0; r < K; ++r) {
+      // Each tensor's own contribution is summed over ITS OWN row count
+      // (Kq/Kk/Kv) independently, never a single shared `r` range across all
+      // three -- Q's producer weight can have a genuinely different row
+      // count than K's/V's own (cross-attention: Q fed from a different
+      // producer/input than K/V), and reusing Q's own row count to index
+      // into wk_kn/wv_kn would be both wrong and an out-of-bounds read
+      // whenever the two differ. Mirrors pruning.py's own
+      // `_gqa_group_importance`, which sums each block's own squared
+      // Frobenius norm independently for the identical reason.
+      for (int64_t r = 0; r < Kq; ++r) {
         for (int64_t g = kv * group_size; g < (kv + 1) * group_size; ++g) {
           for (int64_t c = g * d; c < (g + 1) * d; ++c) {
             const double v = wq_kn[static_cast<size_t>(r * Nq + c)];
             acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
           }
         }
+      }
+      for (int64_t r = 0; r < Kk; ++r) {
         for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
           const double v = wk_kn[static_cast<size_t>(r * Nk + c)];
           acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
         }
-        for (int64_t c = kv * d; c < (kv + 1) * d; ++c) {
+      }
+      for (int64_t r = 0; r < Kv; ++r) {
+        for (int64_t c = kv * dv; c < (kv + 1) * dv; ++c) {
           const double v = wv_kn[static_cast<size_t>(r * Nv + c)];
           acc += importance_norm == ImportanceNorm::kL1 ? std::abs(v) : v * v;
         }
@@ -6985,12 +7064,19 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
   // comment above).
   if (act_norm != nullptr) {
     auto it = act_norm->find(chain.consumer_node->input(0));
+    // The probed activation is the consumer's own input -- the attention
+    // output, laid out per *query* head at *V's* own per-head width `dv`
+    // (mirrors pruning.py's own `_wanda_gqa_group_importance`/
+    // `_wanda_gqa_query_head_importance`, which key this same width check
+    // and per-head/per-group stride off `chain.v_head_size`, not
+    // `chain.head_size` -- equal to `d` unless `allow_differing_v_head_size`
+    // let it differ).
     if (it != act_norm->end() &&
-        it->second.size() == static_cast<size_t>(chain.num_heads * d)) {
+        it->second.size() == static_cast<size_t>(chain.num_heads * dv)) {
       if (is_mqa) {
         for (int64_t qh = 0; qh < chain.num_heads; ++qh) {
           double sq = 0.0;
-          for (int64_t c = qh * d; c < (qh + 1) * d; ++c) {
+          for (int64_t c = qh * dv; c < (qh + 1) * dv; ++c) {
             const double v = it->second[static_cast<size_t>(c)];
             sq += v * v;
           }
@@ -7000,7 +7086,7 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
       } else {
         for (int64_t kv = 0; kv < chain.kv_num_heads; ++kv) {
           double sq = 0.0;
-          for (int64_t c = kv * group_size * d; c < (kv + 1) * group_size * d;
+          for (int64_t c = kv * group_size * dv; c < (kv + 1) * group_size * dv;
                ++c) {
             const double v = it->second[static_cast<size_t>(c)];
             sq += v * v;
@@ -7032,8 +7118,21 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
       }
     }
   }
+  // `q_idx`/`kv_idx` index Q's/K's own producer weight columns (their
+  // shared per-head width `d`); `v_idx` indexes V's own producer weight
+  // columns at *its* own per-head width `dv`, which can differ. `y_idx`
+  // indexes the *output* side instead -- the consumer's own reduction
+  // dimension and the raw output's own trailing axis (the reshape hop's
+  // target shape, if any) -- both laid out per query head at V's own
+  // per-head width `dv`, not Q's/K's `d`: mirrors pruning.py's own
+  // `_apply_one_gqa_chain` `q_idx`/`k_idx`/`v_idx`/`y_idx` exactly (`q_idx`
+  // there is only coincidentally the right index set for the consumer/raw
+  // output too when `dv == d`, which is why the two were never distinguished
+  // before V could have its own head_size).
   std::vector<int64_t> q_idx = HeadColumnIndices(keep_q_heads, d);
   std::vector<int64_t> kv_idx = HeadColumnIndices(keep_groups, d);
+  std::vector<int64_t> v_idx = HeadColumnIndices(keep_groups, dv);
+  std::vector<int64_t> y_idx = HeadColumnIndices(keep_q_heads, dv);
 
   // SliceAxisGeneric (axis = transposed ? 0 : 1 -- the output-channel/head
   // axis of a plain 2-D MatMul/Gemm producer weight, never a Conv here)
@@ -7041,7 +7140,7 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
   // function's own `wq`/`wk`/`wv` comment above for why.
   SliceAxisGeneric(wq_init, q_idx, chain.q_weight_transposed ? 0 : 1);
   SliceAxisGeneric(wk_init, kv_idx, chain.k_weight_transposed ? 0 : 1);
-  SliceAxisGeneric(wv_init, kv_idx, chain.v_weight_transposed ? 0 : 1);
+  SliceAxisGeneric(wv_init, v_idx, chain.v_weight_transposed ? 0 : 1);
   if (chain.q_bias) {
     SliceAxisGeneric(init_map.at(*chain.q_bias), q_idx, 0);
   }
@@ -7049,7 +7148,7 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     SliceAxisGeneric(init_map.at(*chain.k_bias), kv_idx, 0);
   }
   if (chain.v_bias) {
-    SliceAxisGeneric(init_map.at(*chain.v_bias), kv_idx, 0);
+    SliceAxisGeneric(init_map.at(*chain.v_bias), v_idx, 0);
   }
 
   // MultiHeadAttention/PackedMultiHeadAttention/
@@ -7059,21 +7158,22 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
   // sliced in the same three head-aligned ranges (Q's own kept columns, then
   // K's shifted by the *original* pre-pruning `nq_orig = num_heads * d`,
   // then V's shifted by `nq_orig + nk_orig`) mirrors pruning.py's own
-  // `_apply_one_gqa_chain` handling of `chain.mha_bias` exactly. This port's
-  // shared `FindSeparateQkvChains` body always requires V's own head_size
-  // equal to `d` (see that function's own comment), so `kv_idx` (already
-  // built at `d`-width) is the correct index set for V's own range here too,
-  // not merely Q's/K's.
+  // `_apply_one_gqa_chain` handling of `chain.mha_bias` exactly. `v_idx`
+  // (built at V's own `dv`-width, not `kv_idx`'s `d`-width) is the correct
+  // index set for V's own range -- none of the op families that can carry
+  // `mha_bias` currently set `allow_differing_v_head_size=true` in this
+  // port, so `dv == d` in practice here, but this stays correct if that
+  // scope ever widens.
   if (chain.mha_bias) {
     const int64_t nq_orig = chain.num_heads * d;
     const int64_t nk_orig = chain.kv_num_heads * d;
     std::vector<int64_t> full_bias_idx;
-    full_bias_idx.reserve(q_idx.size() + 2 * kv_idx.size());
+    full_bias_idx.reserve(q_idx.size() + kv_idx.size() + v_idx.size());
     full_bias_idx.insert(full_bias_idx.end(), q_idx.begin(), q_idx.end());
     for (int64_t x : kv_idx) {
       full_bias_idx.push_back(x + nq_orig);
     }
-    for (int64_t x : kv_idx) {
+    for (int64_t x : v_idx) {
       full_bias_idx.push_back(x + nq_orig + nk_orig);
     }
     SliceAxisGeneric(init_map.at(*chain.mha_bias), full_bias_idx, 0);
@@ -7208,12 +7308,20 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
     }
   }
 
-  SliceAxisGeneric(init_map.at(chain.consumer_weight), q_idx,
+  // `y_idx` (V's own `dv`-width, not `q_idx`'s `d`-width): the consumer's
+  // own reduction dimension is the raw attention output's own hidden dim,
+  // laid out per query head at V's own per-head width -- mirrors
+  // pruning.py's own `_apply_one_gqa_chain` `_slice_consumer_weight(...,
+  // y_idx)` call exactly.
+  SliceAxisGeneric(init_map.at(chain.consumer_weight), y_idx,
                    chain.consumer_weight_transposed ? 1 : 0);
 
   for (const auto& co : chain.chain_ops) {
     if (co.shape_name) {
-      SetInt64TensorLastDim(init_map.at(*co.shape_name), new_num_heads * d);
+      // `dv`, not `d`: the raw output's own trailing axis this reshape hop
+      // targets is V-hidden-size-wide (mirrors pruning.py's own
+      // `dims[-1] = new_num_heads * dv`).
+      SetInt64TensorLastDim(init_map.at(*co.shape_name), new_num_heads * dv);
     }
   }
 

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -157,7 +157,44 @@ def _oracle_keep_heads(wqkv, nq, nk, nv, num_heads, keep_count):
     return np.sort(np.argsort(-importance)[:keep_count])
 
 
-def _oracle_keep_groups(wq, wk, wv, num_heads, kv_num_heads, head_size, keep_count):
+def _oracle_keep_groups(
+    wq, wk, wv, num_heads, kv_num_heads, head_size, keep_count, v_head_size=None
+):
+    # `v_head_size` (V's own per-head column stride into `wv`) defaults to
+    # `head_size` (Q's/K's shared one) -- the uniform case every caller but
+    # the plain-ai.onnx-Attention "diff V head size" tests wants; those pass a
+    # genuinely different `v_head_size` explicitly. Mirrors test_pruning.py's
+    # own `_oracle_keep_groups`.
+    if v_head_size is None:
+        v_head_size = head_size
+    group_size = num_heads // kv_num_heads
+    importance = np.zeros(kv_num_heads)
+    for kv in range(kv_num_heads):
+        q_block = np.concatenate(
+            [
+                wq[:, h * head_size : (h + 1) * head_size]
+                for h in range(kv * group_size, (kv + 1) * group_size)
+            ],
+            axis=1,
+        )
+        k_block = wk[:, kv * head_size : (kv + 1) * head_size]
+        v_block = wv[:, kv * v_head_size : (kv + 1) * v_head_size]
+        importance[kv] = np.linalg.norm(
+            np.concatenate([q_block, k_block, v_block], axis=1)
+        )
+    return np.sort(np.argsort(-importance)[:keep_count])
+
+
+def _oracle_keep_groups_cross(
+    wq, wk, wv, num_heads, kv_num_heads, head_size, keep_count
+):
+    # Like `_oracle_keep_groups` above, but combines each KV group's Q/K/V
+    # block importance via sqrt(sum of squared per-block Frobenius norms)
+    # rather than norm(concatenate(...)) -- required once wq's own row count
+    # (Q's source tensor's own feature dimension) differs from wk's/wv's own
+    # (K/V's source tensor's own feature dimension), exactly the cross-
+    # attention shape this helper is for. Mirrors test_pruning.py's own
+    # `_oracle_keep_groups_cross`.
     group_size = num_heads // kv_num_heads
     importance = np.zeros(kv_num_heads)
     for kv in range(kv_num_heads):
@@ -170,8 +207,10 @@ def _oracle_keep_groups(wq, wk, wv, num_heads, kv_num_heads, head_size, keep_cou
         )
         k_block = wk[:, kv * head_size : (kv + 1) * head_size]
         v_block = wv[:, kv * head_size : (kv + 1) * head_size]
-        importance[kv] = np.linalg.norm(
-            np.concatenate([q_block, k_block, v_block], axis=1)
+        importance[kv] = np.sqrt(
+            np.linalg.norm(q_block) ** 2
+            + np.linalg.norm(k_block) ** 2
+            + np.linalg.norm(v_block) ** 2
         )
     return np.sort(np.argsort(-importance)[:keep_count])
 
@@ -577,6 +616,8 @@ def _gqa_model(
     #  shape -- Gather inserted) | "unsafe" (axis1 neither 1 nor num_heads)
     head_sink=None,  # None | "nonempty" (constant (num_heads,), sliced)
     #  | "dynamic" (graph input, left alone) | "wrong_shape" (declines the match)
+    q_norm_weight=None,  # constant q_norm_weight array (shape (D,)), or None (unconnected)
+    k_norm_weight=None,  # constant k_norm_weight array (shape (D,)), or None (unconnected)
 ):
     rng = np.random.default_rng(seed)
     Nq, Nkv = H * D, KVH * D
@@ -672,6 +713,24 @@ def _gqa_model(
         operands.append("HeadSink")
     else:
         operands.append("")
+
+    # k_scale/v_scale (indices 12/13) sit between head_sink and
+    # q_norm_weight/k_norm_weight (indices 14/15) -- always left unconnected
+    # here (this test file's own dedicated k_scale/v_scale tests build their
+    # own model directly), just placeholders so q_norm_weight/k_norm_weight
+    # land at the right index.
+    if q_norm_weight is not None or k_norm_weight is not None:
+        operands += ["", ""]
+        if q_norm_weight is not None:
+            initializer.append(_f32(np.asarray(q_norm_weight), "QNorm"))
+            operands.append("QNorm")
+        else:
+            operands.append("")
+        if k_norm_weight is not None:
+            initializer.append(_f32(np.asarray(k_norm_weight), "KNorm"))
+            operands.append("KNorm")
+        else:
+            operands.append("")
 
     while operands and operands[-1] == "":
         operands.pop()
@@ -1059,6 +1118,169 @@ def test_cpp_gqa_pruning_wrong_shape_head_sink_constant_is_declined():
     assert pruned_py.SerializeToString() == model.SerializeToString()
 
 
+def test_cpp_gqa_pruning_qk_norm_weight_wrong_shape_is_declined_matches_python():
+    # Regression coverage for a real, previously-undetected parity gap:
+    # `FindGqaChains` used to never pass `qk_norm_weight_indices=(14, 15)` to
+    # `FindSeparateQkvChains` (unlike pruning.py's own `_find_gqa_chains`, see
+    # that function's own comment), so GroupQueryAttention's own
+    # `q_norm_weight`/`k_norm_weight` shape was never validated here -- a
+    # wrong-shaped connected pair would have been silently pruned through
+    # instead of declining the whole match, unlike the pure-Python reference.
+    # Now fixed: the whole match is declined here too, the node left
+    # completely untouched, matching `apply_attention_head_pruning` exactly.
+    model, cfg = _gqa_model(
+        K=8,
+        H=4,
+        KVH=2,
+        D=8,
+        Out=6,
+        seed=68,
+        q_norm_weight=np.ones(9, dtype=np.float32),  # D + 1 -- wrong shape
+        k_norm_weight=np.ones(9, dtype=np.float32),
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()
+    assert pruned_py.SerializeToString() == model.SerializeToString()
+
+
+def _gqa_cross_model(
+    K_dec=8,
+    K_enc=6,
+    H=8,
+    KVH=2,
+    D=8,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+):
+    # Q fed from a different producer/input (`Xdec`) than K/V (`Xenc`) -- a
+    # real, valid shape (e.g. encoder-decoder cross-attention): Q's own
+    # producer weight has `K_dec` rows, K's/V's own has `K_enc`, genuinely
+    # different row counts. Mirrors test_pruning.py's own `_gqa_cross_model`.
+    rng = np.random.default_rng(seed)
+    Nq, Nkv = H * D, KVH * D
+    if wq is None:
+        wq = rng.standard_normal((K_dec, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K_enc, Nkv)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K_enc, Nkv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    initializer.append(
+        onnx.numpy_helper.from_array(
+            np.full((batch,), seq - 1, dtype=np.int32), "SeqLensK"
+        )
+    )
+    initializer.append(
+        onnx.numpy_helper.from_array(np.array(seq, dtype=np.int32), "TotalSeq")
+    )
+
+    body = f"""
+        g (float[{batch},{seq},{K_dec}] Xdec, float[{batch},{seq},{K_enc}] Xenc) => (float[{batch},{seq},{Out}] Y)
+        {{
+          q = MatMul(Xdec, Wq)
+          k = MatMul(Xenc, Wk)
+          v = MatMul(Xenc, Wv)
+          ctx, pk, pv = com.microsoft.GroupQueryAttention <num_heads={H}, kv_num_heads={KVH}> (q, k, v, , , SeqLensK, TotalSeq)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K_dec=K_dec,
+        K_enc=K_enc,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nkv=Nkv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        batch=batch,
+        seq=seq,
+    )
+
+
+def test_cpp_gqa_pruning_cross_attention_matches_oracle_exactly():
+    # Without the `Kq`/`Kk`/`Kv` fix (a single shared `K` row-count reused to
+    # index into `wk_kn`/`wv_kn` too), this either reads out of bounds or
+    # produces a wrong ranking whenever K/V's producer has a different row
+    # count than Q's -- K_dec=8 != K_enc=6 here is deliberate.
+    model, cfg = _gqa_cross_model(K_dec=8, K_enc=6, H=8, KVH=2, D=8, Out=6, seed=20)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _gqa_node(pruned_cpp)
+    num_heads, kv_num_heads = _gqa_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1  # max(1, 2 - round(2*0.5))
+    assert num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups_cross(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _gqa_cross_model(
+        K_dec=cfg["K_dec"],
+        K_enc=cfg["K_enc"],
+        H=num_heads,
+        KVH=kv_num_heads,
+        D=d,
+        Out=cfg["Out"],
+        seed=20,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    rng = np.random.default_rng(21)
+    xdec = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    (y_pruned,) = _run(pruned_cpp, {"Xdec": xdec, "Xenc": xenc})
+    (y_oracle,) = _run(oracle, {"Xdec": xdec, "Xenc": xenc})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+    # Sanity: Q and K/V really are independently sourced, not accidentally
+    # both reading the same tensor -- perturbing Xenc alone (Xdec held fixed)
+    # must still change the output.
+    (y_pruned2,) = _run(pruned_cpp, {"Xdec": xdec, "Xenc": xenc + 1.0})
+    assert not np.allclose(y_pruned, y_pruned2)
+
+
 # --- True MQA (kv_num_heads == 1) fused GroupQueryAttention fast path ------
 #
 # Regression coverage for the bug the Python reference (pruning.py's own
@@ -1257,17 +1479,23 @@ def _onnx_attention_model(
     past_kv=None,  # None (omitted) | "nonempty" (constant, sliced) | "dynamic"
     #  (graph input) | "unsafe" (constant, wrong kv_num_heads-axis length --
     #  declines the match)
+    Dv=None,  # V's own head_size, if it should genuinely differ from D -- this
+    #  op's real schema (unlike com.microsoft::GroupQueryAttention) allows it;
+    #  defaults to D (the uniform case every other caller wants). The raw
+    #  output/output-projection's own reduction dim is sized off Dv, not D.
 ):
+    if Dv is None:
+        Dv = D
     rng = np.random.default_rng(seed)
-    Nq, Nkv = H * D, KVH * D
+    Nq, Nkv, Nv = H * D, KVH * D, KVH * Dv
     if wq is None:
         wq = rng.standard_normal((K, Nq)).astype(np.float32)
     if wk is None:
         wk = rng.standard_normal((K, Nkv)).astype(np.float32)
     if wv is None:
-        wv = rng.standard_normal((K, Nkv)).astype(np.float32)
+        wv = rng.standard_normal((K, Nv)).astype(np.float32)
     if wout is None:
-        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+        wout = rng.standard_normal((H * Dv, Out)).astype(np.float32)
 
     initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
     q_op, k_op, v_op = "MatMul(X, Wq)", "MatMul(X, Wk)", "MatMul(X, Wv)"
@@ -1277,7 +1505,7 @@ def _onnx_attention_model(
         if bk is None:
             bk = rng.standard_normal((Nkv,)).astype(np.float32)
         if bv is None:
-            bv = rng.standard_normal((Nkv,)).astype(np.float32)
+            bv = rng.standard_normal((Nv,)).astype(np.float32)
         initializer += [_f32(bq, "Bq"), _f32(bk, "Bk"), _f32(bv, "Bv")]
         q_op, k_op, v_op = "Gemm(X, Wq, Bq)", "Gemm(X, Wk, Bk)", "Gemm(X, Wv, Bv)"
 
@@ -1309,18 +1537,18 @@ def _onnx_attention_model(
 
     if past_kv == "nonempty":
         past_key = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
-        past_value = rng.standard_normal((batch, KVH, 1, D)).astype(np.float32)
+        past_value = rng.standard_normal((batch, KVH, 1, Dv)).astype(np.float32)
         initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
         operands += ["PastKey", "PastValue"]
     elif past_kv == "dynamic":
         operands += ["PastKeyIn", "PastValueIn"]
         extra_graph_inputs += (
             f", float[{batch},{KVH},1,{D}] PastKeyIn"
-            f", float[{batch},{KVH},1,{D}] PastValueIn"
+            f", float[{batch},{KVH},1,{Dv}] PastValueIn"
         )
     elif past_kv == "unsafe":
         past_key = rng.standard_normal((batch, KVH + 1, 1, D)).astype(np.float32)
-        past_value = rng.standard_normal((batch, KVH + 1, 1, D)).astype(np.float32)
+        past_value = rng.standard_normal((batch, KVH + 1, 1, Dv)).astype(np.float32)
         initializer += [_f32(past_key, "PastKey"), _f32(past_value, "PastValue")]
         operands += ["PastKey", "PastValue"]
     else:
@@ -1330,7 +1558,7 @@ def _onnx_attention_model(
         operands.pop()
 
     if with_reshape:
-        shape = np.array([batch, seq, Nq], dtype=np.int64)
+        shape = np.array([batch, seq, H * Dv], dtype=np.int64)
         initializer.append(onnx.numpy_helper.from_array(shape, "Shape"))
         tail = "ctx2 = Reshape(ctx, Shape)\n          Y = MatMul(ctx2, Wout)"
     else:
@@ -1362,9 +1590,11 @@ def _onnx_attention_model(
         H=H,
         KVH=KVH,
         D=D,
+        Dv=Dv,
         Out=Out,
         Nq=Nq,
         Nkv=Nkv,
+        Nv=Nv,
         wq=wq,
         wk=wk,
         wv=wv,
@@ -1586,50 +1816,212 @@ def test_cpp_onnx_attention_pruning_dynamic_past_kv_input_is_still_pruned():
     assert kv_num_heads == 1
 
 
-def test_cpp_onnx_attention_pruning_diff_v_head_size_is_left_untouched():
+def test_cpp_onnx_attention_pruning_diff_v_head_size_matches_oracle_exactly():
     # This op's real schema (unlike GroupQueryAttention, which fuse_gqa.h
     # always emits with equal Q/K/V head_size) genuinely allows V its own,
-    # independent head_size. This pass reuses the shared, uniform-head_size
-    # slicing body unmodified rather than a parallel implementation, so a
-    # node whose V head size actually differs from Q/K's is declined here
-    # rather than mis-sliced.
-    K, H, KVH, D, Dv, Out = 8, 4, 4, 4, 6, 5
-    Nq, Nk, Nv = H * D, KVH * D, KVH * Dv
+    # independent head_size -- confirmed via the op's own backend-test suite
+    # and real onnxruntime execution. `FindSeparateQkvChains` now takes an
+    # `allow_differing_v_head_size` parameter (`true` for this op only,
+    # mirroring pruning.py's own `_find_onnx_attention_chains`), `AttnChain`
+    # carries Q's/K's shared `head_size` and V's own (possibly different)
+    # `v_head_size` as separate fields, and `ApplyOneGqaChain` slices Q's/K's
+    # own producer weight at `head_size` while V's own producer weight -- and
+    # the output projection's own reduction dim, and the raw output's own
+    # width -- at `v_head_size`. Each KV group's own Q+K+V block is scaled by
+    # a distinct, well-separated factor so which 2 of 4 groups the importance
+    # ranking keeps is unambiguous.
+    K, H, KVH, D, Dv, Out = 8, 8, 4, 4, 6, 5
+    group_size = H // KVH
     rng = np.random.default_rng(19)
-    wq = rng.standard_normal((K, Nq)).astype(np.float32)
-    wk = rng.standard_normal((K, Nk)).astype(np.float32)
-    wv = rng.standard_normal((K, Nv)).astype(np.float32)
-    wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+    wq = rng.standard_normal((K, H * D)).astype(np.float32)
+    wk = rng.standard_normal((K, KVH * D)).astype(np.float32)
+    wv = rng.standard_normal((K, KVH * Dv)).astype(np.float32)
+    wout = rng.standard_normal((H * Dv, Out)).astype(np.float32)
+
+    scales = [3.0, 0.1, 2.0, 0.05]
+    for kv, scale in enumerate(scales):
+        for h in range(kv * group_size, (kv + 1) * group_size):
+            wq[:, h * D : (h + 1) * D] *= scale
+        wk[:, kv * D : (kv + 1) * D] *= scale
+        wv[:, kv * Dv : (kv + 1) * Dv] *= scale
+
+    model, cfg = _onnx_attention_model(
+        K=K, H=H, KVH=KVH, D=D, Dv=Dv, Out=Out, seed=19, wq=wq, wk=wk, wv=wv, wout=wout
+    )
+    onnx.checker.check_model(model)
+
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _onnx_attention_node(pruned_cpp)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    assert kv_num_heads == 2  # max(1, 4 - round(4*0.5))
+    assert q_num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups(
+        wq, wk, wv, H, KVH, D, kv_num_heads, v_head_size=Dv
+    )
+    assert list(keep_groups) == [0, 2]
+
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx = _head_idx(keep_q_heads, D)  # Q's own producer weight columns
+    kv_idx = _head_idx(keep_groups, D)  # K's own producer weight columns
+    v_idx = _head_idx(keep_groups, Dv)  # V's own producer weight columns
+    y_idx = _head_idx(keep_q_heads, Dv)  # output/consumer-side columns
+
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
+    }
+    np.testing.assert_array_equal(inits["Wq"], wq[:, q_idx])
+    np.testing.assert_array_equal(inits["Wk"], wk[:, kv_idx])
+    np.testing.assert_array_equal(inits["Wv"], wv[:, v_idx])
+    np.testing.assert_array_equal(inits["Wout"], wout[y_idx, :])
+
+    oracle, _ = _onnx_attention_model(
+        K=K,
+        H=q_num_heads,
+        KVH=kv_num_heads,
+        D=D,
+        Dv=Dv,
+        Out=Out,
+        seed=19,
+        wq=wq[:, q_idx],
+        wk=wk[:, kv_idx],
+        wv=wv[:, v_idx],
+        wout=wout[y_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+    onnx.checker.check_model(oracle)
+
+    rng2 = np.random.default_rng(22)
+    x = rng2.standard_normal((cfg["batch"], cfg["seq"], K)).astype(np.float32)
+    (y_pruned,) = _run(pruned_cpp, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+def _onnx_attention_cross_model(
+    K_dec=8,
+    K_enc=6,
+    H=8,
+    KVH=2,
+    D=8,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+):
+    # Q fed from a different producer/input (`Xdec`) than K/V (`Xenc`) --
+    # mirrors `_gqa_cross_model` above, for the plain ai.onnx op instead.
+    rng = np.random.default_rng(seed)
+    Nq, Nkv = H * D, KVH * D
+    if wq is None:
+        wq = rng.standard_normal((K_dec, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K_enc, Nkv)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K_enc, Nkv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    body = f"""
+        g (float[{batch},{seq},{K_dec}] Xdec, float[{batch},{seq},{K_enc}] Xenc) => (float[{batch},{seq},{Out}] Y)
+        {{
+          q = MatMul(Xdec, Wq)
+          k = MatMul(Xenc, Wk)
+          v = MatMul(Xenc, Wv)
+          ctx = Attention <q_num_heads={H}, kv_num_heads={KVH}> (q, k, v)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+
     model = parser.parse_model(
         f"""
         <
           ir_version: 10,
           opset_import: ["": 24]
         >
-        g (float[2,5,{K}] X) => (float[2,5,{Out}] Y)
-        {{
-          q = MatMul(X, Wq)
-          k = MatMul(X, Wk)
-          v = MatMul(X, Wv)
-          ctx = Attention <q_num_heads={H}, kv_num_heads={KVH}> (q, k, v)
-          Y = MatMul(ctx, Wout)
-        }}
+        {body}
         """
     )
-    model.graph.initializer.extend(
-        [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K_dec=K_dec,
+        K_enc=K_enc,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nkv=Nkv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        batch=batch,
+        seq=seq,
     )
-    onnx.checker.check_model(model)
 
-    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
-    inits_before = {
-        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
-    }
-    inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
-    }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+
+def test_cpp_onnx_attention_pruning_cross_attention_matches_oracle_exactly():
+    model, cfg = _onnx_attention_cross_model(
+        K_dec=8, K_enc=6, H=8, KVH=2, D=8, Out=6, seed=24
+    )
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _onnx_attention_node(pruned_cpp)
+    q_num_heads, kv_num_heads = _onnx_attention_attrs(node)
+    group_size = cfg["H"] // cfg["KVH"]
+    assert kv_num_heads == 1  # max(1, 2 - round(2*0.5))
+    assert q_num_heads == kv_num_heads * group_size
+
+    keep_groups = _oracle_keep_groups_cross(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["KVH"], cfg["D"], kv_num_heads
+    )
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    d = cfg["D"]
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _onnx_attention_cross_model(
+        K_dec=cfg["K_dec"],
+        K_enc=cfg["K_enc"],
+        H=q_num_heads,
+        KVH=kv_num_heads,
+        D=d,
+        Out=cfg["Out"],
+        seed=24,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    rng = np.random.default_rng(25)
+    xdec = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    (y_pruned,) = _run(pruned_cpp, {"Xdec": xdec, "Xenc": xenc})
+    (y_oracle,) = _run(oracle, {"Xdec": xdec, "Xenc": xenc})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+    (y_pruned2,) = _run(pruned_cpp, {"Xdec": xdec, "Xenc": xenc + 1.0})
+    assert not np.allclose(y_pruned, y_pruned2)
 
 
 # --- Cross-check against the pure-Python reference --------------------------
@@ -2821,6 +3213,127 @@ def test_cpp_mha_pruning_unsafe_past_key_shape_declines_match_matches_python():
     onnx.checker.check_model(pruned_cpp)
     assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
     assert pruned_cpp.SerializeToString() == model.SerializeToString()
+
+
+def _mha_cross_model(
+    K_dec=8,
+    K_enc=6,
+    H=4,
+    D=4,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq_q=5,
+    seq_kv=7,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+):
+    # Q fed from a different producer/input (`Xdec`) than K/V (`Xenc`) -- a
+    # real, valid shape (e.g. encoder-decoder cross-attention). Mirrors
+    # test_pruning.py's own `_mha_cross_model`.
+    rng = np.random.default_rng(seed)
+    Nq = H * D
+    if wq is None:
+        wq = rng.standard_normal((K_dec, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K_enc, Nq)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K_enc, Nq)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+
+    body = f"""
+        g (float[{batch},{seq_q},{K_dec}] Xdec, float[{batch},{seq_kv},{K_enc}] Xenc) => (float[{batch},{seq_q},{Out}] Y)
+        {{
+          q = MatMul(Xdec, Wq)
+          k = MatMul(Xenc, Wk)
+          v = MatMul(Xenc, Wv)
+          ctx = com.microsoft.MultiHeadAttention <num_heads={H}> (q, k, v)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K_dec=K_dec,
+        K_enc=K_enc,
+        H=H,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        batch=batch,
+        seq_q=seq_q,
+        seq_kv=seq_kv,
+    )
+
+
+def test_cpp_mha_pruning_cross_attention_matches_oracle_exactly():
+    # Q's own producer weight (`K_dec` rows) and K/V's own (`K_enc` rows)
+    # have genuinely different row counts here -- `_oracle_keep_groups_cross`
+    # (sqrt(sum of squared per-block norms), not concatenate-then-norm) is
+    # required for exactly the reason `ApplyOneGqaChain`'s own `Kq`/`Kk`/`Kv`
+    # fix (this same shared function MultiHeadAttention also goes through)
+    # exists.
+    model, cfg = _mha_cross_model(K_dec=8, K_enc=6, H=8, D=4, Out=6, seed=26)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _mha_node(pruned_cpp)
+    num_heads = _mha_num_heads(node)
+    d = cfg["D"]
+    keep_heads = _oracle_keep_groups_cross(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["H"], cfg["H"], d, num_heads
+    )
+    idx = _head_idx(keep_heads, d)
+
+    oracle, _ = _mha_cross_model(
+        K_dec=cfg["K_dec"],
+        K_enc=cfg["K_enc"],
+        H=len(keep_heads),
+        D=d,
+        Out=cfg["Out"],
+        seed=26,
+        wq=cfg["wq"][:, idx],
+        wk=cfg["wk"][:, idx],
+        wv=cfg["wv"][:, idx],
+        wout=cfg["wout"][idx, :],
+        batch=cfg["batch"],
+        seq_q=cfg["seq_q"],
+        seq_kv=cfg["seq_kv"],
+    )
+
+    rng = np.random.default_rng(27)
+    xdec = rng.standard_normal((cfg["batch"], cfg["seq_q"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc = rng.standard_normal((cfg["batch"], cfg["seq_kv"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    (y_pruned,) = _run(pruned_cpp, {"Xdec": xdec, "Xenc": xenc})
+    (y_oracle,) = _run(oracle, {"Xdec": xdec, "Xenc": xenc})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+    (y_pruned2,) = _run(pruned_cpp, {"Xdec": xdec, "Xenc": xenc + 1.0})
+    assert not np.allclose(y_pruned, y_pruned2)
 
 
 # --- com.microsoft::PackedMultiHeadAttention --------------------------------

--- a/tests/test_attention_head_wanda_pruning_cpp.py
+++ b/tests/test_attention_head_wanda_pruning_cpp.py
@@ -756,6 +756,171 @@ def test_cpp_gqa_wanda_pruning_sliceable_past_kv_matches_python_reference():
     assert inits["PastKey"].shape == (cfg["batch"], kv_num_heads, 1, cfg["D"])
 
 
+def _gqa_cross_model(
+    K_dec=8,
+    K_enc=6,
+    H=8,
+    KVH=2,
+    D=8,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+):
+    # Q fed from a different producer/input (`Xdec`) than K/V (`Xenc`) -- a
+    # real, valid shape (e.g. encoder-decoder cross-attention): Q's own
+    # producer weight has `K_dec` rows, K's/V's own has `K_enc`, genuinely
+    # different row counts. Mirrors test_attention_head_pruning_cpp.py's own
+    # `_gqa_cross_model` (and test_pruning.py's own).
+    rng = np.random.default_rng(seed)
+    Nq, Nkv = H * D, KVH * D
+    if wq is None:
+        wq = rng.standard_normal((K_dec, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K_enc, Nkv)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K_enc, Nkv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((Nq, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    initializer.append(
+        onnx.numpy_helper.from_array(
+            np.full((batch,), seq - 1, dtype=np.int32), "SeqLensK"
+        )
+    )
+    initializer.append(
+        onnx.numpy_helper.from_array(np.array(seq, dtype=np.int32), "TotalSeq")
+    )
+
+    body = f"""
+        g (float[{batch},{seq},{K_dec}] Xdec, float[{batch},{seq},{K_enc}] Xenc) => (float[{batch},{seq},{Out}] Y)
+        {{
+          q = MatMul(Xdec, Wq)
+          k = MatMul(Xenc, Wk)
+          v = MatMul(Xenc, Wv)
+          ctx, pk, pv = com.microsoft.GroupQueryAttention <num_heads={H}, kv_num_heads={KVH}> (q, k, v, , , SeqLensK, TotalSeq)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 17, "com.microsoft": 1]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K_dec=K_dec,
+        K_enc=K_enc,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Out=Out,
+        Nq=Nq,
+        Nkv=Nkv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        batch=batch,
+        seq=seq,
+    )
+
+
+def test_cpp_gqa_wanda_pruning_cross_attention_matches_oracle_exactly():
+    # Regression coverage for `ApplyOneGqaChain`'s own `Kq`/`Kk`/`Kv` fix:
+    # without it, a single shared row count (Q's own) reused to index into
+    # `wk_kn`/`wv_kn` too is both wrong and an out-of-bounds read whenever
+    # K/V's producer has a different row count than Q's -- K_dec=8 !=
+    # K_enc=6 here is deliberate. The Wanda-calibrated activation-norm
+    # multiply shares this exact same importance computation (see
+    # `ApplyOneGqaChain`'s own doc comment), so this closes the identical bug
+    # for the calibrated path too.
+    model, cfg = _gqa_cross_model(K_dec=8, K_enc=6, H=8, KVH=2, D=8, Out=6, seed=22)
+
+    rng = np.random.default_rng(23)
+    xdec_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc_cal = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    calibration_data = [{"Xdec": xdec_cal, "Xenc": xenc_cal}]
+
+    pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    act_norm = _probe_act_norm(model, "ctx", {"Xdec": xdec_cal, "Xenc": xenc_cal})
+
+    d = cfg["D"]
+    group_size = cfg["H"] // cfg["KVH"]
+    importance = np.zeros(cfg["KVH"])
+    for kv in range(cfg["KVH"]):
+        q_block = np.concatenate(
+            [
+                cfg["wq"][:, h * d : (h + 1) * d]
+                for h in range(kv * group_size, (kv + 1) * group_size)
+            ],
+            axis=1,
+        )
+        k_block = cfg["wk"][:, kv * d : (kv + 1) * d]
+        v_block = cfg["wv"][:, kv * d : (kv + 1) * d]
+        base = np.sqrt(
+            np.linalg.norm(q_block) ** 2
+            + np.linalg.norm(k_block) ** 2
+            + np.linalg.norm(v_block) ** 2
+        )
+        act_group = np.linalg.norm(
+            act_norm[kv * group_size * d : (kv + 1) * group_size * d]
+        )
+        importance[kv] = base * max(act_group, 1e-8)
+    keep_groups = np.sort(np.argsort(-importance)[:1])  # max(1, 2 - round(2*0.5)) == 1
+
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx, kv_idx = _head_idx(keep_q_heads, d), _head_idx(keep_groups, d)
+
+    oracle, _ = _gqa_cross_model(
+        K_dec=cfg["K_dec"],
+        K_enc=cfg["K_enc"],
+        H=len(keep_q_heads),
+        KVH=len(keep_groups),
+        D=d,
+        Out=cfg["Out"],
+        seed=22,
+        wq=cfg["wq"][:, q_idx],
+        wk=cfg["wk"][:, kv_idx],
+        wv=cfg["wv"][:, kv_idx],
+        wout=cfg["wout"][q_idx, :],
+        batch=cfg["batch"],
+        seq=cfg["seq"],
+    )
+
+    xdec = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_dec"])).astype(
+        np.float32
+    )
+    xenc = rng.standard_normal((cfg["batch"], cfg["seq"], cfg["K_enc"])).astype(
+        np.float32
+    )
+    (y_pruned,) = _run(pruned_cpp, {"Xdec": xdec, "Xenc": xenc})
+    (y_oracle,) = _run(oracle, {"Xdec": xdec, "Xenc": xenc})
+    np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
 # --- True MQA (kv_num_heads == 1) fused GroupQueryAttention Wanda fast path -
 #
 # Wanda-calibrated counterpart of test_attention_head_pruning_cpp.py's own
@@ -1011,6 +1176,155 @@ def test_cpp_gqa_wanda_pruning_importance_norm_l1_matches_python_reference_and_d
         model, calibration_data=[], sparsity=0.5, importance_norm="l1"
     )
     assert kept_l2.SerializeToString() != kept_l1.SerializeToString()
+
+
+# --- Plain ai.onnx::Attention (opset 24+) -----------------------------------
+
+
+def _onnx_attention_model(
+    K=8,
+    H=8,
+    KVH=2,
+    D=4,
+    Dv=None,
+    Out=6,
+    seed=0,
+    batch=2,
+    seq=5,
+    wq=None,
+    wk=None,
+    wv=None,
+    wout=None,
+):
+    # `Dv` (V's own head_size, defaulting to `D`) is independent of Q/K's
+    # `D` -- this op's own schema genuinely allows the two to differ (see
+    # test_attention_head_pruning_cpp.py's own `_onnx_attention_model`, which
+    # this mirrors).
+    if Dv is None:
+        Dv = D
+    rng = np.random.default_rng(seed)
+    Nq, Nk, Nv = H * D, KVH * D, KVH * Dv
+    if wq is None:
+        wq = rng.standard_normal((K, Nq)).astype(np.float32)
+    if wk is None:
+        wk = rng.standard_normal((K, Nk)).astype(np.float32)
+    if wv is None:
+        wv = rng.standard_normal((K, Nv)).astype(np.float32)
+    if wout is None:
+        wout = rng.standard_normal((H * Dv, Out)).astype(np.float32)
+
+    initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wout, "Wout")]
+    body = f"""
+        g (float[{batch},{seq},{K}] X) => (float[{batch},{seq},{Out}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          ctx = Attention <q_num_heads={H}, kv_num_heads={KVH}> (q, k, v)
+          Y = MatMul(ctx, Wout)
+        }}
+        """
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 24]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model, dict(
+        K=K,
+        H=H,
+        KVH=KVH,
+        D=D,
+        Dv=Dv,
+        Out=Out,
+        Nq=Nq,
+        Nk=Nk,
+        Nv=Nv,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wout=wout,
+        batch=batch,
+        seq=seq,
+    )
+
+
+def _onnx_attention_node(model):
+    return next(
+        n for n in model.graph.node if n.op_type == "Attention" and n.domain == ""
+    )
+
+
+def _onnx_attention_attrs(node):
+    q_num_heads = next(a.i for a in node.attribute if a.name == "q_num_heads")
+    kv_num_heads = next(a.i for a in node.attribute if a.name == "kv_num_heads")
+    return q_num_heads, kv_num_heads
+
+
+def test_cpp_onnx_attention_wanda_pruning_diff_v_head_size_matches_oracle_exactly():
+    # The Wanda-calibrated counterpart of
+    # test_attention_head_pruning_cpp.py's own
+    # `test_cpp_onnx_attention_pruning_diff_v_head_size_matches_oracle_exactly`:
+    # the activation probe sits on the consumer's input (the attention
+    # output), laid out per query head at V's own `v_head_size` -- not Q's/
+    # K's `head_size` -- so both the width check and the per-group activation
+    # window must stride by `v_head_size`, exactly like the weight-only
+    # path's `y_idx` does.
+    K, H, KVH, D, Dv, Out = 8, 8, 2, 4, 6, 5
+    group_size = H // KVH
+    model, cfg = _onnx_attention_model(K=K, H=H, KVH=KVH, D=D, Dv=Dv, Out=Out, seed=23)
+
+    rng = np.random.default_rng(24)
+    x_cal = rng.standard_normal((cfg["batch"], cfg["seq"], K)).astype(np.float32)
+    calibration_data = [{"X": x_cal}]
+
+    pruned_cpp = onnxsim.apply_attention_head_wanda_pruning_cpp(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    pruned_py = onnxsim.apply_attention_head_wanda_pruning(
+        model, calibration_data=calibration_data, sparsity=0.5
+    )
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    act_norm = _probe_act_norm(model, "ctx", {"X": x_cal})
+    assert act_norm.shape == (H * Dv,)  # sanity: laid out per Q head at Dv, not D
+
+    importance = np.zeros(KVH)
+    for kv in range(KVH):
+        q_block = np.concatenate(
+            [
+                cfg["wq"][:, h * D : (h + 1) * D]
+                for h in range(kv * group_size, (kv + 1) * group_size)
+            ],
+            axis=1,
+        )
+        k_block = cfg["wk"][:, kv * D : (kv + 1) * D]
+        v_block = cfg["wv"][:, kv * Dv : (kv + 1) * Dv]
+        base = np.linalg.norm(np.concatenate([q_block, k_block, v_block], axis=1))
+        act_group = np.linalg.norm(
+            act_norm[kv * group_size * Dv : (kv + 1) * group_size * Dv]
+        )
+        importance[kv] = base * max(act_group, 1e-8)
+    keep_groups = np.sort(np.argsort(-importance)[:1])  # max(1, 2 - round(2*0.5))
+
+    keep_q_heads = _group_q_heads(keep_groups, group_size)
+    q_idx = _head_idx(keep_q_heads, D)
+    kv_idx = _head_idx(keep_groups, D)
+    v_idx = _head_idx(keep_groups, Dv)
+    y_idx = _head_idx(keep_q_heads, Dv)
+
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
+    }
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"][:, q_idx])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"][:, kv_idx])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"][:, v_idx])
+    np.testing.assert_array_equal(inits["Wout"], cfg["wout"][y_idx, :])
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Closes a real, previously-undetected parity gap between `onnxsim/pruning.py`'s pure-Python attention-head-pruning implementation and its C++ port (`onnxsim/structured_pruning_entry.cpp`), specifically in `FindSeparateQkvChains`/`ApplyOneGqaChain`/`FindGqaChains`:

- **`qk_norm_weight_indices` wire-up**: `FindGqaChains` never passed `qk_norm_weight_indices=(14, 15)` (GroupQueryAttention's own `q_norm_weight`/`k_norm_weight` input indices) down to `FindSeparateQkvChains`, so a wrong-shaped connected `q_norm_weight`/`k_norm_weight` pair was silently pruned through instead of declining the whole match, unlike the pure-Python reference.
- **Cross-attention row-count bug**: `ApplyOneGqaChain` assumed Q's, K's, and V's own producer weights shared a single row count (`K`). For cross-attention (Q fed from one source tensor, K/V from a genuinely different one — e.g. a decoder/encoder pair), those row counts can differ, causing both a wrong importance computation and an out-of-bounds read. Now tracked independently as `Kq`/`Kk`/`Kv`.
- **`allow_differing_v_head_size` for plain `ai.onnx::Attention`**: this op's own schema genuinely allows V an independent head_size from Q's/K's shared one. `FindSeparateQkvChains` now accepts an `allow_differing_v_head_size` parameter (set `true` only for `FindOnnxAttentionChains`), and `AttnChain` gained a `v_head_size` field threaded through importance ranking, weight/bias slicing, and the Wanda activation-norm check.

## Verification

- Clean build (`pip install -e . -v`), zero compile errors/warnings.
- Full test suite (`CI=1 pytest tests/ -q --ignore=tests/test_timm.py`): 3264 passed, 0 failed, 145 skipped.
- `clang-format`/`ruff format`/`ruff check` clean on touched files.

## Stacking

This is PR 1 of a 3-PR stack closing the full parity gap:
- **PR 1 (this PR)**: cross-attention + differing-V-head-size fixes (base: `master`)
- PR 2: packed-QKV-then-Split + RoPE/QK-norm walk-back (base: this branch)
- PR 3: real-export `Constant`-map support + `LinearAttention` slicing (base: PR 2's branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_