### PR TITLE
Add Constant-map support for real-export decomposed attention + LinearAttention slicing

### DIFF
--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -6226,23 +6226,33 @@ std::optional<HeadCountsMatch> MatchPagedAttentionProducer(
 // already-projected activations, `q_num_heads`/`kv_num_heads` both required
 // attributes with `q_num_heads` a positive multiple of `kv_num_heads`.
 //
-// Deliberately narrower than pruning.py's own matcher: `past_state`/`decay`/
-// `beta` (3/4/5) must all be absent here. This port only ever prunes the
-// stateless "linear" `update_rule` shape that needs none of the three --
-// pruning.py's own comment for this op already narrows its *real-world*
-// scope to almost exactly this (a genuinely dynamic `decay`/`beta` declines
-// the whole match there too; a *constant* one is called out as "a
-// degenerate shape no real dynamic-decode export produces" -- see this
-// file's own "Attention-head pruning" section comment, the `LinearAttention`
-// bullet), so requiring all three absent here -- rather than porting the
-// deferred decay/beta shape-classification logic pruning.py's own
-// matcher/finder pair uses -- gives up essentially nothing over the
-// realistic export shape while avoiding new, unverified slicing machinery.
+// `past_state`/`decay`/`beta` (3/4/5) are now validated-and-allowed, not a
+// blanket decline, mirroring pruning.py's own `_match_linear_attention_
+// producer` for the *constant* case exactly: a connected `past_state` is
+// checked here only when constant (a dynamic one is the caller's own
+// runtime data, left alone entirely, same as GroupQueryAttention's own
+// `past_key`/`past_value`) against this op's own documented `(*,
+// kv_num_heads, *, *)` shape; a connected `beta` is checked here, constant
+// or not needed (its own two documented shapes -- `(*, *, kv_num_heads)` or
+// a size-1 broadcast -- don't need `head_size` to tell apart, unlike
+// `decay`'s own).
+//
+// Still deliberately narrower than pruning.py's own matcher in one respect:
+// a *dynamic* `decay`/`beta` still declines the whole match here outright,
+// rather than being deferred to a `com.microsoft::LinearAttentionGate`
+// pass-through check the way pruning.py's own `_find_linear_attention_
+// chains` (via `_match_linear_attention_gate`) does -- that dynamic
+// producer-recognition machinery is not ported here (see this file's own
+// "Attention-head pruning" section comment, the `LinearAttention` bullet,
+// for the documented scope boundary this narrowing keeps). `decay`'s own
+// exact-shape check (which needs `head_size`, not known yet here) is
+// deferred to `FindLinearAttentionChains`, mirroring pruning.py's own
+// identical deferral to `_find_linear_attention_chains`.
 // `value_info_by_name` accepted (see MatchPagedAttentionProducer's own
 // comment) but ignored: this op has no attention_bias/attn_mask-equivalent
 // input on its own schema either.
 std::optional<HeadCountsMatch> MatchLinearAttentionProducer(
-    const onnx::NodeProto& node, const InitMap& /*init_map*/,
+    const onnx::NodeProto& node, const InitMap& init_map,
     const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
     /*value_info_by_name*/
     = {}) {
@@ -6270,11 +6280,49 @@ std::optional<HeadCountsMatch> MatchLinearAttentionProducer(
   if (q_num_heads % kv_num_heads != 0) {
     return std::nullopt;
   }
-  for (int idx : {3, 4, 5}) {  // past_state, decay, beta
-    if (node.input_size() > idx && !node.input(idx).empty()) {
+
+  if (node.input_size() > 3 && !node.input(3).empty()) {
+    auto ps_it = init_map.find(node.input(3));
+    if (ps_it != init_map.end()) {
+      const onnx::TensorProto* ps_init = ps_it->second;
+      if (!IsSupportedFloatDtype(ps_init->data_type()) ||
+          ps_init->dims_size() != 4 || ps_init->dims(1) != kv_num_heads) {
+        return std::nullopt;  // not this schema's own (B, kv_num_heads,
+                              // d_k, d_v) shape
+      }
+    }
+    // else: dynamic past_state -- the caller's own runtime data, left
+    // alone entirely, nothing to check here.
+  }
+
+  for (int idx : {4, 5}) {  // decay, beta
+    if (node.input_size() <= idx || node.input(idx).empty()) {
+      continue;
+    }
+    auto it = init_map.find(node.input(idx));
+    if (it == init_map.end()) {
+      // Dynamic decay/beta -- unlike pruning.py's own deferred
+      // LinearAttentionGate-pass-through check (not ported here, see this
+      // function's own comment above), declined outright.
+      return std::nullopt;
+    }
+    if (!IsSupportedFloatDtype(it->second->data_type()) ||
+        it->second->dims_size() != 3) {
       return std::nullopt;
     }
   }
+
+  if (node.input_size() > 5 && !node.input(5).empty()) {
+    auto beta_it = init_map.find(node.input(5));
+    if (beta_it != init_map.end()) {
+      const int64_t last =
+          beta_it->second->dims(beta_it->second->dims_size() - 1);
+      if (last != kv_num_heads && last != 1) {
+        return std::nullopt;  // neither of beta's own two documented shapes
+      }
+    }
+  }
+
   return HeadCountsMatch{q_num_heads, kv_num_heads};
 }
 
@@ -6659,9 +6707,38 @@ std::vector<AttnChain> FindPagedAttentionChains(onnx::GraphProto* graph) {
 // MatchLinearAttentionProducer's own comment. Its own query head-count
 // attribute is named `q_num_heads` (same as the plain ai.onnx `Attention`
 // op's own), no combined bias input.
+//
+// Performs the one deferred check MatchLinearAttentionProducer itself
+// cannot: a connected constant `decay` (index 4) must be exactly one of its
+// own two documented shapes -- `(*, *, kv_num_heads)` (DeltaNet/RetNet,
+// per-head scalar decay) or `(*, *, kv_num_heads * head_size)` (GLA/RWKV-6,
+// per-key-dimension decay) -- anything else declines the whole chain here,
+// mirroring pruning.py's own `_find_linear_attention_chains` exactly
+// (`head_size`, Q's/K's own shared per-head width, is resolved only here,
+// by FindSeparateQkvChains itself, not yet known at match time).
 std::vector<AttnChain> FindLinearAttentionChains(onnx::GraphProto* graph) {
-  return FindSeparateQkvChains(graph, MatchLinearAttentionProducer,
-                               "q_num_heads");
+  std::vector<AttnChain> chains =
+      FindSeparateQkvChains(graph, MatchLinearAttentionProducer, "q_num_heads");
+  InitMap init_map;
+  for (const auto& t : graph->initializer()) {
+    init_map[t.name()] = &t;
+  }
+  std::vector<AttnChain> out;
+  out.reserve(chains.size());
+  for (auto& chain : chains) {
+    if (chain.node->input_size() > 4 && !chain.node->input(4).empty()) {
+      auto it = init_map.find(chain.node->input(4));
+      if (it != init_map.end() && it->second->dims_size() > 0) {
+        const int64_t last = it->second->dims(it->second->dims_size() - 1);
+        if (last != chain.kv_num_heads &&
+            last != chain.kv_num_heads * chain.head_size) {
+          continue;  // neither of decay's own two documented shapes
+        }
+      }
+    }
+    out.push_back(std::move(chain));
+  }
+  return out;
 }
 
 // The com.microsoft::SparseAttention analogue of FindGqaChains -- see
@@ -7271,6 +7348,59 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
         SliceAxisGeneric(scale_it->second, keep_groups, 0);
       }
       // else: PER_TENSOR broadcast scalar -- no per-head axis to slice
+    }
+  }
+
+  // LinearAttention-only: its own `past_state`/`decay`/`beta` (indices
+  // 3/4/5), each already confirmed sliceable at match time
+  // (MatchLinearAttentionProducer/FindLinearAttentionChains -- see either's
+  // own comment for the full shape reasoning), sliced here exactly mirroring
+  // pruning.py's own `_apply_one_gqa_chain` `is_linear_attention` branch:
+  // `past_state` (rank-4 `(B, kv_num_heads, d_k, d_v)`) along its own axis 1
+  // by `keep_groups`; `decay` (rank-3) along its own last axis -- directly
+  // by `keep_groups` when `kv_num_heads`-wide (DeltaNet/RetNet, per-head
+  // scalar), or by the same per-head *column* expansion K's own producer
+  // weight gets (HeadColumnIndices) when `kv_num_heads * head_size`-wide
+  // (GLA/RWKV-6, per-key-dimension); and `beta` (rank-3) along its own last
+  // axis by `keep_groups`, only when genuinely `kv_num_heads`-wide (a size-1
+  // broadcast needs no slicing at all, the same "PER_TENSOR broadcast, left
+  // alone" reasoning as k_scale/v_scale above). A
+  // `com.microsoft::LinearAttentionGate`-fed dynamic `decay`/`beta`
+  // pass-through (pruning.py's own further upgrade, ranked/sliced through
+  // `chain.linear_attention_gate` there) is NOT ported here --
+  // MatchLinearAttentionProducer already declines that shape outright (see
+  // that function's own comment for the documented scope boundary), so it
+  // never reaches this branch.
+  const bool is_linear_attention = chain.node->domain().empty() &&
+                                   chain.node->op_type() == "LinearAttention";
+  if (is_linear_attention) {
+    if (chain.node->input_size() > 3 && !chain.node->input(3).empty()) {
+      auto it = init_map.find(chain.node->input(3));
+      if (it != init_map.end()) {
+        SliceAxisGeneric(it->second, keep_groups, 1);
+      }
+    }
+    if (chain.node->input_size() > 4 && !chain.node->input(4).empty()) {
+      auto it = init_map.find(chain.node->input(4));
+      if (it != init_map.end()) {
+        const int64_t last_axis = it->second->dims_size() - 1;
+        const int64_t last = it->second->dims(last_axis);
+        if (last == h) {
+          SliceAxisGeneric(it->second, keep_groups, last_axis);
+        } else if (last == h * d) {
+          SliceAxisGeneric(it->second, HeadColumnIndices(keep_groups, d),
+                           last_axis);
+        }
+      }
+    }
+    if (chain.node->input_size() > 5 && !chain.node->input(5).empty()) {
+      auto it = init_map.find(chain.node->input(5));
+      if (it != init_map.end()) {
+        const int64_t last_axis = it->second->dims_size() - 1;
+        if (it->second->dims(last_axis) == h) {
+          SliceAxisGeneric(it->second, keep_groups, last_axis);
+        }
+      }
     }
   }
 

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -487,6 +487,89 @@ using InitMap = std::unordered_map<std::string, const onnx::TensorProto*>;
 using ConsumerMap =
     std::unordered_map<std::string, std::vector<onnx::NodeProto*>>;
 
+// Builds an `InitMap`-equivalent lookup from BOTH `graph.initializer()` AND
+// every plain (default-domain) `Constant` node's own embedded `value`
+// attribute tensor, keyed by that node's single output name -- the C++
+// mirror of pruning.py's own `_constant_map` (see that function's docstring
+// for the full rationale/semantics this reproduces exactly). Real
+// `torch.onnx.export` output routinely lowers an inline literal
+// shape/scalar operand (a `Reshape`'s target shape, a `Pow`'s exponent, ...)
+// to a `Constant` node rather than a genuine `graph.initializer` entry --
+// and onnxsim's own `simplify()` deliberately leaves it that way (its own
+// optimizer list always drops onnx-optimizer's
+// `extract_constant_to_initializer` pass) -- so a plain
+// `{t.name(): &t for t in graph.initializer()}`-style map alone misses
+// exactly this common, real shape.
+//
+// Only a `Constant` node's own `value` *tensor* attribute is recognized here
+// (`sparse_value`/`value_int`/`value_float`/`value_string`-family attributes
+// and their list forms are a different representation, never emitted by a
+// real exporter for a full tensor payload) -- mirrors `_constant_map`'s own
+// identical, deliberate narrowing.
+//
+// An actual `graph.initializer` entry always wins on a genuine name
+// collision with a `Constant` node's output (vanishingly unlikely in
+// practice): this uses `emplace`, which is a no-op when the key -- already
+// inserted from `graph.initializer()` in the loop above -- is present,
+// exactly mirroring `_constant_map`'s own `dict.setdefault` call.
+InitMap BuildConstantMap(const onnx::GraphProto& graph) {
+  InitMap constants;
+  for (const auto& t : graph.initializer()) {
+    constants[t.name()] = &t;
+  }
+  for (const auto& node : graph.node()) {
+    if ((node.domain() != "" && node.domain() != "ai.onnx") ||
+        node.op_type() != "Constant" || node.output_size() != 1 ||
+        node.output(0).empty()) {
+      continue;
+    }
+    for (const auto& attr : node.attribute()) {
+      if (attr.name() == "value" &&
+          attr.type() == onnx::AttributeProto::TENSOR) {
+        constants.emplace(node.output(0), &attr.t());
+        break;
+      }
+    }
+  }
+  return constants;
+}
+
+// Mutable analogue of `BuildConstantMap` above, for a caller (e.g.
+// `ApplyOneDecomposedGqaChain`'s own `_rewrite_shape_dim`-equivalent local
+// helper) that goes on to slice/edit a resolved value in place: a
+// `Constant` node's own `value` attribute tensor is returned via
+// `mutable_t()`, a live pointer into that node's own embedded `TensorProto`
+// -- editing through it (e.g. `SliceAxisGeneric`) mutates the node's own
+// serialized form directly, exactly as if it had been a real initializer
+// entry all along. Mirrors `_constant_map`'s own docstring paragraph on why
+// this is safe: protobuf's `attr.t`/`mutable_t()` is a live reference, never
+// a copy, in both languages.
+std::unordered_map<std::string, onnx::TensorProto*> BuildMutableConstantMap(
+    onnx::GraphProto* graph) {
+  std::unordered_map<std::string, onnx::TensorProto*> constants;
+  for (int i = 0; i < graph->initializer_size(); ++i) {
+    onnx::TensorProto* t = graph->mutable_initializer(i);
+    constants[t->name()] = t;
+  }
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    if ((node->domain() != "" && node->domain() != "ai.onnx") ||
+        node->op_type() != "Constant" || node->output_size() != 1 ||
+        node->output(0).empty()) {
+      continue;
+    }
+    for (int j = 0; j < node->attribute_size(); ++j) {
+      onnx::AttributeProto* attr = node->mutable_attribute(j);
+      if (attr->name() == "value" &&
+          attr->type() == onnx::AttributeProto::TENSOR) {
+        constants.emplace(node->output(0), attr->mutable_t());
+        break;
+      }
+    }
+  }
+  return constants;
+}
+
 // Forward declarations for this file's own generic (FLOAT/FLOAT16/BFLOAT16)
 // dtype infrastructure -- defined much later in the file, inside this same
 // anonymous namespace (the "MoE/QMoE whole-expert pruning" section's own
@@ -25002,10 +25085,14 @@ std::vector<DecomposedGqaChain> FindDecomposedGqaChains(
     onnx::GraphProto* graph,
     const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
         value_info_by_name = {}) {
-  InitMap init_map;
-  for (const auto& t : graph->initializer()) {
-    init_map[t.name()] = &t;
-  }
+  // BuildConstantMap (not a plain `graph.initializer()` loop) -- see that
+  // function's own comment: a real `torch.onnx.export` + `simplify()`
+  // pipeline's `Reshape`/`Unsqueeze`/`Expand` shape operands below are
+  // routinely `Constant`-node-fed rather than genuine `graph.initializer`
+  // entries, and every lookup in this function needs to see those too.
+  // Mirrors pruning.py's own `_find_decomposed_gqa_chains`'s identical
+  // `initializer_map = _constant_map(graph)`.
+  InitMap init_map = BuildConstantMap(*graph);
   ConsumerMap consumers_of = ConsumersOf(graph);
   std::unordered_set<std::string> graph_outputs;
   for (const auto& o : graph->output()) {
@@ -26071,11 +26158,17 @@ void ApplyDecomposedGqaChains(
     double epsilon = 1e-8, ImportanceNorm importance_norm = ImportanceNorm::kL2,
     const std::unordered_map<std::string, const onnx::ValueInfoProto*>&
         value_info_by_name = {}) {
-  std::unordered_map<std::string, onnx::TensorProto*> init_map;
-  for (int i = 0; i < graph->initializer_size(); ++i) {
-    onnx::TensorProto* t = graph->mutable_initializer(i);
-    init_map[t->name()] = t;
-  }
+  // BuildMutableConstantMap (not a plain `graph->initializer()` loop) -- see
+  // that function's own comment, and `FindDecomposedGqaChains`'s own
+  // identical `BuildConstantMap` call above: `ApplyOneDecomposedGqaChain`'s
+  // own `rewrite_shape_dim` local helper below resolves/edits exactly the
+  // same `Reshape`/`Expand` shape operands `FindDecomposedGqaChains` already
+  // matched, which on a real `torch.onnx.export` + `simplify()` pipeline are
+  // routinely `Constant`-node-fed rather than genuine `graph->initializer()`
+  // entries. Mirrors pruning.py's own shared apply-dispatch's identical
+  // `initializer_map = _constant_map(graph)`.
+  std::unordered_map<std::string, onnx::TensorProto*> init_map =
+      BuildMutableConstantMap(graph);
   std::unordered_set<std::string> used_names = ExistingGraphNames(*graph);
   std::unordered_set<std::string> producer_touched, consumer_touched,
       stale_value_info;

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -104,6 +104,8 @@ fused-op family, has no optional per-head bias/mask/past-KV input on its own
 schema at all, so none of this machinery applies to it.
 """
 
+import io
+
 import ml_dtypes
 import numpy as np
 import onnx
@@ -6032,6 +6034,462 @@ def test_cpp_decomposed_gqa_qk_norm_pruning_matches_oracle_and_python_reference_
     (y_pruned,) = _run(pruned_cpp, {"X": x})
     (y_oracle,) = _run(oracle, {"X": x})
     np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
+
+
+# --- Decomposed-GQA, real `torch.onnx.export` pipeline: `Constant`-node-fed
+# --- shape operands (BuildConstantMap/BuildMutableConstantMap) --------------
+#
+# Every ``_decomposed_gqa_model`` fixture above spells its own `Reshape`/
+# `Expand` shape operands as genuine `graph.initializer` entries -- adequate
+# for exercising `FindDecomposedGqaChains`'/`ApplyOneDecomposedGqaChain`'s own
+# matching/slicing logic, but NOT for exercising `BuildConstantMap`'s own
+# reason to exist: a real `torch.onnx.export` -> `onnxsim.simplify()`
+# pipeline leaves exactly these operands as plain (default-domain) `Constant`
+# nodes instead (onnxsim's own `simplify()` deliberately never promotes one to
+# an initializer -- see `BuildConstantMap`'s own comment in
+# structured_pruning_entry.cpp, and pruning.py's own `_constant_map`
+# docstring, for the full empirical justification). Before `BuildConstantMap`/
+# `BuildMutableConstantMap` were wired into `FindDecomposedGqaChains`/
+# `ApplyDecomposedGqaChains`, every one of the five real-export shapes below
+# silently declined to match at all (its own `init_map` -- built from
+# `graph->initializer()` alone -- had no entry for a `Constant`-node-fed shape
+# name), even though the *same* chain, hand-built with those same values
+# sitting in `graph.initializer` (`_decomposed_gqa_model`'s own convention
+# above), matched and pruned correctly.
+#
+# Each test below builds the identical hand-written eager-attention
+# `nn.Module` one of `test_pruning.py`'s own
+# ``test_decomposed_attention_*_real_torch_export_pipeline`` tests uses,
+# exports it, and runs it through `onnxsim.simplify()` -- exactly the same
+# fixture-construction pattern (kept deliberately in sync; a real
+# `torch.onnx.export` graph cannot be reasonably hand-spelled via
+# `onnx.parser.parse_model`, per this repo's own CLAUDE.md note on this
+# convention's own limits). Rather than re-deriving each one's own numpy
+# oracle (already done exhaustively in `test_pruning.py`), each test here
+# instead directly confirms this C++ port's own parity bar: comparing
+# ``apply_attention_head_pruning_cpp`` against the live pure-Python
+# ``apply_attention_head_pruning`` reference on the exact same simplified
+# model, byte-for-byte -- this file's own established convention (see e.g.
+# ``test_cpp_attention_head_pruning_per_head_attention_bias_is_sliced_matches_python``
+# above) -- while also confirming the model genuinely contains `Constant`-fed
+# shape operands (not vacuously all-initializer) and that pruning actually
+# fired (not a silent no-op decline).
+def _export_and_simplify_decomposed(m, inputs, input_names):
+    """Shared plumbing every test below reuses: export `m`, load it back, and
+    run it through `onnxsim.simplify()`. Mirrors each
+    ``test_decomposed_attention_*_real_torch_export_pipeline`` test's own
+    identical opening in ``test_pruning.py``.
+    """
+    import torch
+
+    m.eval()
+    buf = io.BytesIO()
+    torch.onnx.export(
+        m,
+        inputs,
+        buf,
+        input_names=input_names,
+        output_names=["output"],
+        opset_version=17,
+        dynamo=False,
+    )
+    raw = onnx.load_from_string(buf.getvalue())
+    simplified, ok = onnxsim.onnx_simplifier.simplify(raw)
+    assert ok
+    return simplified
+
+
+def _assert_cpp_matches_python_and_fires(simplified, sparsity=0.5):
+    """Shared parity assertion every test below reuses: `Constant`-node-fed
+    shape operands are genuinely present (else the whole test would be
+    vacuous -- a real export with everything already an initializer would
+    never have exposed this gap), pruning actually fires (rather than
+    silently declining the whole chain, this gap's own failure mode before
+    the fix), and the C++ port's own output is byte-identical to the live
+    pure-Python reference on the exact same input.
+    """
+    assert any(
+        n.op_type == "Constant" and n.domain == "" for n in simplified.graph.node
+    ), "fixture is vacuous: no Constant-node-fed operand in the simplified graph"
+
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(simplified)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=sparsity)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(simplified, sparsity=sparsity)
+    onnx.checker.check_model(pruned_py)
+    onnx.checker.check_model(pruned_cpp)
+
+    assert pruned_cpp.SerializeToString() != simplified.SerializeToString(), (
+        "pruning did not fire at all -- BuildConstantMap wiring is not "
+        "actually closing the gap"
+    )
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+    return pruned_cpp
+
+
+def test_cpp_decomposed_attention_real_torch_export_pipeline_matches_python():
+    # Mirrors test_pruning.py's own
+    # test_decomposed_attention_real_torch_export_pipeline: plain GQA +
+    # causal mask, MatMul-based QK^T/AV products.
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn  # noqa: E402  (after the torch importorskip guard)
+
+    hidden, num_heads, num_kv_heads, head_dim, seq, batch = 32, 8, 2, 8, 4, 1
+
+    class EagerGQA(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_proj = nn.Linear(hidden, num_heads * head_dim, bias=True)
+            self.k_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.v_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.o_proj = nn.Linear(num_heads * head_dim, hidden, bias=True)
+            self.scaling = head_dim**-0.5
+
+        def _repeat_kv(self, x, n_rep):
+            if n_rep == 1:
+                return x
+            b, kvh, s, d = x.shape
+            x = x[:, :, None, :, :].expand(b, kvh, n_rep, s, d)
+            return x.reshape(b, kvh * n_rep, s, d)
+
+        def forward(self, hidden_states, attn_mask):
+            b, s, _ = hidden_states.shape
+            q = (
+                self.q_proj(hidden_states)
+                .view(b, s, num_heads, head_dim)
+                .transpose(1, 2)
+            )
+            k = (
+                self.k_proj(hidden_states)
+                .view(b, s, num_kv_heads, head_dim)
+                .transpose(1, 2)
+            )
+            v = (
+                self.v_proj(hidden_states)
+                .view(b, s, num_kv_heads, head_dim)
+                .transpose(1, 2)
+            )
+            n_rep = num_heads // num_kv_heads
+            k = self._repeat_kv(k, n_rep)
+            v = self._repeat_kv(v, n_rep)
+            attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scaling
+            attn_weights = attn_weights + attn_mask
+            attn_weights = torch.softmax(attn_weights, dim=-1)
+            attn_output = torch.matmul(attn_weights, v)
+            attn_output = attn_output.transpose(1, 2).contiguous().reshape(b, s, -1)
+            return self.o_proj(attn_output)
+
+    x = torch.randn(batch, seq, hidden)
+    mask = torch.triu(torch.full((seq, seq), float("-inf")), diagonal=1)[
+        None, None, :, :
+    ]
+    simplified = _export_and_simplify_decomposed(
+        EagerGQA(), (x, mask), ["hidden_states", "attn_mask"]
+    )
+    assert not any(
+        n.op_type
+        in ("Attention", "GroupQueryAttention", "MultiHeadAttention", "PagedAttention")
+        for n in simplified.graph.node
+    )
+    _assert_cpp_matches_python_and_fires(simplified)
+
+
+def test_cpp_decomposed_attention_einsum_real_torch_export_pipeline_matches_python():
+    # Mirrors test_pruning.py's own
+    # test_decomposed_attention_einsum_real_torch_export_pipeline: same GQA +
+    # causal mask, but both the QK^T and AV products are literal
+    # `torch.einsum` calls.
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn  # noqa: E402  (after the torch importorskip guard)
+
+    hidden, num_heads, num_kv_heads, head_dim, seq, batch = 32, 8, 2, 8, 4, 1
+
+    class EinsumGQA(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_proj = nn.Linear(hidden, num_heads * head_dim, bias=True)
+            self.k_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.v_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.o_proj = nn.Linear(num_heads * head_dim, hidden, bias=True)
+            self.scaling = head_dim**-0.5
+
+        def _repeat_kv(self, x, n_rep):
+            if n_rep == 1:
+                return x
+            b, kvh, s, d = x.shape
+            x = x[:, :, None, :, :].expand(b, kvh, n_rep, s, d)
+            return x.reshape(b, kvh * n_rep, s, d)
+
+        def forward(self, hidden_states, attn_mask):
+            b, s, _ = hidden_states.shape
+            q = (
+                self.q_proj(hidden_states)
+                .view(b, s, num_heads, head_dim)
+                .transpose(1, 2)
+            )
+            k = (
+                self.k_proj(hidden_states)
+                .view(b, s, num_kv_heads, head_dim)
+                .transpose(1, 2)
+            )
+            v = (
+                self.v_proj(hidden_states)
+                .view(b, s, num_kv_heads, head_dim)
+                .transpose(1, 2)
+            )
+            n_rep = num_heads // num_kv_heads
+            k = self._repeat_kv(k, n_rep)
+            v = self._repeat_kv(v, n_rep)
+            attn_weights = torch.einsum("bhid,bhjd->bhij", q, k) * self.scaling
+            attn_weights = attn_weights + attn_mask
+            attn_weights = torch.softmax(attn_weights, dim=-1)
+            attn_output = torch.einsum("bhij,bhjd->bhid", attn_weights, v)
+            attn_output = attn_output.transpose(1, 2).contiguous().reshape(b, s, -1)
+            return self.o_proj(attn_output)
+
+    x = torch.randn(batch, seq, hidden)
+    mask = torch.triu(torch.full((seq, seq), float("-inf")), diagonal=1)[
+        None, None, :, :
+    ]
+    simplified = _export_and_simplify_decomposed(
+        EinsumGQA(), (x, mask), ["hidden_states", "attn_mask"]
+    )
+    assert any(n.op_type == "Einsum" for n in simplified.graph.node)
+    _assert_cpp_matches_python_and_fires(simplified)
+
+
+def test_cpp_decomposed_attention_rope_real_torch_export_pipeline_matches_python():
+    # Mirrors test_pruning.py's own
+    # test_decomposed_attention_rope_real_torch_export_pipeline: GQA + causal
+    # mask + HuggingFace-style decomposed RoPE on Q and K.
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn  # noqa: E402  (after the torch importorskip guard)
+
+    hidden, num_heads, num_kv_heads, head_dim, seq, batch = 32, 8, 2, 8, 4, 1
+
+    def rotate_half(x):
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        return torch.cat((-x2, x1), dim=-1)
+
+    def apply_rotary_pos_emb(q, k, cos, sin):
+        cos = cos.unsqueeze(1)
+        sin = sin.unsqueeze(1)
+        q_embed = (q * cos) + (rotate_half(q) * sin)
+        k_embed = (k * cos) + (rotate_half(k) * sin)
+        return q_embed, k_embed
+
+    class EagerGQARope(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_proj = nn.Linear(hidden, num_heads * head_dim, bias=True)
+            self.k_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.v_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.o_proj = nn.Linear(num_heads * head_dim, hidden, bias=True)
+            self.scaling = head_dim**-0.5
+
+        def _repeat_kv(self, x, n_rep):
+            if n_rep == 1:
+                return x
+            b, kvh, s, d = x.shape
+            x = x[:, :, None, :, :].expand(b, kvh, n_rep, s, d)
+            return x.reshape(b, kvh * n_rep, s, d)
+
+        def forward(self, hidden_states, cos, sin, attn_mask):
+            b, s, _ = hidden_states.shape
+            q = (
+                self.q_proj(hidden_states)
+                .view(b, s, num_heads, head_dim)
+                .transpose(1, 2)
+            )
+            k = (
+                self.k_proj(hidden_states)
+                .view(b, s, num_kv_heads, head_dim)
+                .transpose(1, 2)
+            )
+            v = (
+                self.v_proj(hidden_states)
+                .view(b, s, num_kv_heads, head_dim)
+                .transpose(1, 2)
+            )
+            q, k = apply_rotary_pos_emb(q, k, cos, sin)
+            n_rep = num_heads // num_kv_heads
+            k = self._repeat_kv(k, n_rep)
+            v = self._repeat_kv(v, n_rep)
+            attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scaling
+            attn_weights = attn_weights + attn_mask
+            attn_weights = torch.softmax(attn_weights, dim=-1)
+            attn_output = torch.matmul(attn_weights, v)
+            attn_output = attn_output.transpose(1, 2).contiguous().reshape(b, s, -1)
+            return self.o_proj(attn_output)
+
+    x = torch.randn(batch, seq, hidden)
+    cos = torch.randn(batch, seq, head_dim)
+    sin = torch.randn(batch, seq, head_dim)
+    mask = torch.triu(torch.full((seq, seq), float("-inf")), diagonal=1)[
+        None, None, :, :
+    ]
+    simplified = _export_and_simplify_decomposed(
+        EagerGQARope(),
+        (x, cos, sin, mask),
+        ["hidden_states", "cos", "sin", "attn_mask"],
+    )
+
+    from onnxsim.pruning import (
+        _find_decomposed_gqa_chains,
+        _shape_inferred_value_info_by_name,
+    )
+
+    chains = _find_decomposed_gqa_chains(
+        simplified.graph, _shape_inferred_value_info_by_name(simplified)
+    )
+    assert len(chains) == 1
+    assert chains[0].q_rope is not None
+    assert chains[0].k_rope is not None
+    _assert_cpp_matches_python_and_fires(simplified)
+
+
+def test_cpp_decomposed_attention_qk_norm_rope_real_torch_export_pipeline_matches_python():
+    # Mirrors test_pruning.py's own
+    # test_decomposed_attention_qk_norm_rope_real_torch_export_pipeline: a
+    # Qwen3-style module with per-head RMSNorm on Q/K on top of RoPE + GQA.
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn  # noqa: E402  (after the torch importorskip guard)
+
+    hidden, num_heads, num_kv_heads, head_dim, seq, batch = 32, 8, 2, 8, 4, 1
+
+    def rotate_half(x):
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        return torch.cat((-x2, x1), dim=-1)
+
+    def apply_rotary_pos_emb(q, k, cos, sin):
+        cos = cos.unsqueeze(1)
+        sin = sin.unsqueeze(1)
+        q_embed = (q * cos) + (rotate_half(q) * sin)
+        k_embed = (k * cos) + (rotate_half(k) * sin)
+        return q_embed, k_embed
+
+    class RMSNorm(nn.Module):
+        def __init__(self, dim, eps=1e-6):
+            super().__init__()
+            self.weight = nn.Parameter(torch.randn(dim) * 0.1 + 1.0)
+            self.eps = eps
+
+        def forward(self, x):
+            variance = x.pow(2).mean(-1, keepdim=True)
+            x = x * torch.rsqrt(variance + self.eps)
+            return self.weight * x
+
+    class Qwen3StyleGQA(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_proj = nn.Linear(hidden, num_heads * head_dim, bias=True)
+            self.k_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.v_proj = nn.Linear(hidden, num_kv_heads * head_dim, bias=True)
+            self.o_proj = nn.Linear(num_heads * head_dim, hidden, bias=True)
+            self.q_norm = RMSNorm(head_dim)
+            self.k_norm = RMSNorm(head_dim)
+            self.scaling = head_dim**-0.5
+
+        def _repeat_kv(self, x, n_rep):
+            if n_rep == 1:
+                return x
+            b, kvh, s, d = x.shape
+            x = x[:, :, None, :, :].expand(b, kvh, n_rep, s, d)
+            return x.reshape(b, kvh * n_rep, s, d)
+
+        def forward(self, hidden_states, cos, sin, attn_mask):
+            b, s, _ = hidden_states.shape
+            q = self.q_norm(
+                self.q_proj(hidden_states).view(b, s, num_heads, head_dim)
+            ).transpose(1, 2)
+            k = self.k_norm(
+                self.k_proj(hidden_states).view(b, s, num_kv_heads, head_dim)
+            ).transpose(1, 2)
+            v = (
+                self.v_proj(hidden_states)
+                .view(b, s, num_kv_heads, head_dim)
+                .transpose(1, 2)
+            )
+            q, k = apply_rotary_pos_emb(q, k, cos, sin)
+            n_rep = num_heads // num_kv_heads
+            k = self._repeat_kv(k, n_rep)
+            v = self._repeat_kv(v, n_rep)
+            attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scaling
+            attn_weights = attn_weights + attn_mask
+            attn_weights = torch.softmax(attn_weights, dim=-1)
+            attn_output = torch.matmul(attn_weights, v)
+            attn_output = attn_output.transpose(1, 2).contiguous().reshape(b, s, -1)
+            return self.o_proj(attn_output)
+
+    x = torch.randn(batch, seq, hidden)
+    cos = torch.randn(batch, seq, head_dim)
+    sin = torch.randn(batch, seq, head_dim)
+    mask = torch.triu(torch.full((seq, seq), float("-inf")), diagonal=1)[
+        None, None, :, :
+    ]
+    simplified = _export_and_simplify_decomposed(
+        Qwen3StyleGQA(),
+        (x, cos, sin, mask),
+        ["hidden_states", "cos", "sin", "attn_mask"],
+    )
+
+    from onnxsim.pruning import (
+        _find_decomposed_gqa_chains,
+        _shape_inferred_value_info_by_name,
+    )
+
+    chains = _find_decomposed_gqa_chains(
+        simplified.graph, _shape_inferred_value_info_by_name(simplified)
+    )
+    assert len(chains) == 1
+    assert chains[0].q_rope is not None
+    assert chains[0].k_rope is not None
+    assert chains[0].q_norm is not None
+    assert chains[0].k_norm is not None
+    _assert_cpp_matches_python_and_fires(simplified)
+
+
+def test_cpp_decomposed_attention_packed_qkv_real_torch_export_pipeline_matches_python():
+    # Mirrors test_pruning.py's own
+    # test_decomposed_attention_packed_qkv_real_torch_export_pipeline: a
+    # GPT-2-style single packed `c_attn` Linear feeding a `Split`.
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn  # noqa: E402  (after the torch importorskip guard)
+
+    hidden, num_heads, head_dim, seq, batch = 32, 4, 8, 4, 1
+
+    class GPT2StyleAttention(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.c_attn = nn.Linear(hidden, 3 * num_heads * head_dim, bias=True)
+            self.c_proj = nn.Linear(num_heads * head_dim, hidden, bias=True)
+            self.scaling = head_dim**-0.5
+
+        def forward(self, hidden_states, attn_mask):
+            b, s, _ = hidden_states.shape
+            qkv = self.c_attn(hidden_states)
+            q, k, v = qkv.split(num_heads * head_dim, dim=-1)
+            q = q.view(b, s, num_heads, head_dim).transpose(1, 2)
+            k = k.view(b, s, num_heads, head_dim).transpose(1, 2)
+            v = v.view(b, s, num_heads, head_dim).transpose(1, 2)
+            attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scaling
+            attn_weights = attn_weights + attn_mask
+            attn_weights = torch.softmax(attn_weights, dim=-1)
+            attn_output = torch.matmul(attn_weights, v)
+            attn_output = attn_output.transpose(1, 2).contiguous().reshape(b, s, -1)
+            return self.c_proj(attn_output)
+
+    x = torch.randn(batch, seq, hidden)
+    mask = torch.triu(torch.full((seq, seq), float("-inf")), diagonal=1)[
+        None, None, :, :
+    ]
+    simplified = _export_and_simplify_decomposed(
+        GPT2StyleAttention(), (x, mask), ["hidden_states", "attn_mask"]
+    )
+    assert any(n.op_type == "Split" for n in simplified.graph.node)
+    _assert_cpp_matches_python_and_fires(simplified)
 
 
 # --- FLOAT16 / BFLOAT16 weight support ---------------------------------------

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -3816,11 +3816,18 @@ def test_cpp_paged_attention_pruning_constant_per_channel_kv_scale_sliced_matche
 
 # --- Plain ai.onnx::LinearAttention (opset 27+) -----------------------------
 #
-# This port only ever matches this op's stateless "linear" update_rule shape
-# (no `past_state`/`decay`/`beta` connected at all) -- see
-# MatchLinearAttentionProducer's own comment for why this narrower-than-
-# pruning.py scope gives up essentially nothing over the realistic export
-# shape pruning.py's own docstring already narrows *its* real-world scope to.
+# This op's own optional `past_state`/`decay`/`beta` (indices 3/4/5) are now
+# validated-and-sliced when constant -- mirroring pruning.py's own
+# `_match_linear_attention_producer`/`_apply_one_gqa_chain` exactly for the
+# "linear"/"delta"/"gated" update_rule shapes -- rather than a blanket
+# decline of the whole match whenever any of the three is connected at all.
+# Still narrower than pruning.py's own matcher in one respect: a *dynamic*
+# `decay`/`beta` still declines the whole match here outright rather than
+# being deferred to a recognized `com.microsoft::LinearAttentionGate`
+# pass-through the way pruning.py's own `_find_linear_attention_chains`
+# (via `_match_linear_attention_gate`) does -- see
+# MatchLinearAttentionProducer's own comment for the documented scope
+# boundary this narrowing keeps.
 
 
 def _linear_attention_model(
@@ -3833,7 +3840,10 @@ def _linear_attention_model(
     wk=None,
     wv=None,
     wo=None,
-    decay=None,  # constant array, or None (unconnected) -- forces a decline
+    decay=None,  # constant array, or None (unconnected)
+    past_state=None,  # constant array, or None (unconnected)
+    beta=None,  # constant array, or None (unconnected)
+    update_rule=None,  # defaults to "gated" (decay set) or "linear" otherwise
 ):
     rng = np.random.default_rng(seed)
     Nq, Nkv = Hq * D, Hkv * D
@@ -3848,10 +3858,23 @@ def _linear_attention_model(
 
     initializer = [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wo, "Wo")]
     operands = ["q", "k", "v"]
-    if decay is not None:
-        operands.append("")  # past_state -- unconnected
-        initializer.append(_f32(np.asarray(decay), "Decay"))
-        operands.append("Decay")
+    if past_state is not None or decay is not None or beta is not None:
+        if past_state is not None:
+            initializer.append(_f32(np.asarray(past_state), "PastState"))
+            operands.append("PastState")
+        else:
+            operands.append("")
+    if decay is not None or beta is not None:
+        if decay is not None:
+            initializer.append(_f32(np.asarray(decay), "Decay"))
+            operands.append("Decay")
+        else:
+            operands.append("")
+    if beta is not None:
+        initializer.append(_f32(np.asarray(beta), "Beta"))
+        operands.append("Beta")
+    if update_rule is None:
+        update_rule = "gated" if decay is not None else "linear"
 
     body = f"""
         g (float[1,3,{K}] X) => (float[1,3,{K}] Y)
@@ -3859,7 +3882,7 @@ def _linear_attention_model(
           q = MatMul(X, Wq)
           k = MatMul(X, Wk)
           v = MatMul(X, Wv)
-          attn_out, ps = LinearAttention<q_num_heads={Hq}, kv_num_heads={Hkv}, update_rule="{"gated" if decay is not None else "linear"}">({", ".join(operands)})
+          attn_out, ps = LinearAttention<q_num_heads={Hq}, kv_num_heads={Hkv}, update_rule="{update_rule}">({", ".join(operands)})
           Y = MatMul(attn_out, Wo)
         }}
         """
@@ -3928,19 +3951,159 @@ def test_cpp_linear_attention_pruning_matches_oracle_exactly():
     np.testing.assert_array_equal(inits["Wo"], cfg["wo"][q_idx, :])
 
 
-def test_cpp_linear_attention_pruning_gated_mode_decay_present_is_left_untouched():
+def test_cpp_linear_attention_pruning_gated_mode_constant_decay_is_sliced_matches_python():
+    # A genuinely CONSTANT `decay` (the documented, `kv_num_heads`-wide
+    # DeltaNet/RetNet per-head-scalar shape) is now validated-and-sliced,
+    # not a whole-match decline -- mirrors pruning.py's own
+    # `_match_linear_attention_producer`/`_apply_one_gqa_chain` exactly
+    # (MatchLinearAttentionProducer/ApplyOneGqaChain's own `is_linear_
+    # attention` branch, see either's own comment). Only a genuinely
+    # DYNAMIC decay/beta still declines the whole match outright in this
+    # port (the LinearAttentionGate-fed pass-through pruning.py's own
+    # further upgrade recognizes is not ported here) -- see
+    # test_cpp_linear_attention_pruning_dynamic_decay_is_declined_matches_python
+    # below for that still-narrower scope boundary's own cpp-parity coverage.
     model, cfg = _linear_attention_model(
         Hq=4, Hkv=4, D=4, K=16, seed=63, decay=np.zeros((1, 3, 4), dtype=np.float32)
     )
-    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
-    inits_before = {
-        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _linear_attention_node(pruned_cpp)
+    q_num_heads, kv_num_heads = _linear_attention_attrs(node)
+    assert kv_num_heads == 2  # pruning genuinely fired -- not a no-op decline
+    assert q_num_heads == 2
+
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
     }
-    inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    assert inits["Decay"].shape == (1, 3, kv_num_heads)
+
+
+def test_cpp_linear_attention_pruning_delta_mode_slices_past_state_and_beta_matches_python():
+    # `update_rule="delta"`'s own `past_state` (rank-4 `(B, kv_num_heads,
+    # d_k, d_v)`, sliced along axis 1) and `beta` (rank-3,
+    # `kv_num_heads`-wide, sliced along its own last axis) -- mirrors
+    # pruning.py's own `_apply_one_gqa_chain` `is_linear_attention` branch
+    # exactly. Mirrors tests/test_pruning.py's own
+    # test_linear_attention_pruning_delta_mode_slices_past_state_and_beta_matches_oracle
+    # fixture, called through the C++ port instead and checked byte-for-byte
+    # against the live Python reference.
+    Hq, Hkv, D, K = 4, 2, 4, 16
+    rng = np.random.default_rng(2)
+    past_state = rng.standard_normal((1, Hkv, D, D)).astype(np.float32)
+    beta = (np.abs(rng.standard_normal((1, 3, Hkv))) * 0.1).astype(np.float32)
+    model, cfg = _linear_attention_model(
+        Hq=Hq,
+        Hkv=Hkv,
+        D=D,
+        K=K,
+        seed=2,
+        update_rule="delta",
+        past_state=past_state,
+        beta=beta,
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _linear_attention_node(pruned_cpp)
+    _, kv_num_heads = _linear_attention_attrs(node)
+    assert kv_num_heads == 1
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
     }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+    assert inits["PastState"].shape == (1, kv_num_heads, D, D)
+    assert inits["Beta"].shape == (1, 3, kv_num_heads)
+
+
+def test_cpp_linear_attention_pruning_gated_mode_gla_decay_matches_python():
+    # `update_rule="gated"`'s own GLA/RWKV-6 shape: `decay` is
+    # `kv_num_heads * head_size`-wide (per-key-dimension, not per-head
+    # scalar) -- sliced by the same per-head column expansion K's own
+    # producer weight gets (HeadColumnIndices), distinct from the
+    # DeltaNet/RetNet per-head-scalar shape
+    # test_cpp_linear_attention_pruning_gated_mode_constant_decay_is_sliced_matches_python
+    # above already covers. Mirrors tests/test_pruning.py's own
+    # test_linear_attention_pruning_gated_mode_slices_gla_decay_matches_oracle
+    # fixture, called through the C++ port instead.
+    Hq, Hkv, D, K = 4, 2, 4, 16
+    rng = np.random.default_rng(3)
+    decay = (-np.abs(rng.standard_normal((1, 3, Hkv * D))) * 0.1).astype(np.float32)
+    model, cfg = _linear_attention_model(
+        Hq=Hq, Hkv=Hkv, D=D, K=K, seed=3, update_rule="gated", decay=decay
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    onnx.checker.check_model(pruned_py)
+    assert pruned_cpp.SerializeToString() != model.SerializeToString()
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+    node = _linear_attention_node(pruned_cpp)
+    _, kv_num_heads = _linear_attention_attrs(node)
+    assert kv_num_heads == 1
+    inits = {
+        t.name: onnx.numpy_helper.to_array(t) for t in pruned_cpp.graph.initializer
+    }
+    assert inits["Decay"].shape == (1, 3, kv_num_heads * D)
+
+
+def test_cpp_linear_attention_pruning_dynamic_decay_is_declined_matches_python():
+    # A `decay` fed by anything other than a constant initializer still
+    # declines the whole match outright in this port -- the
+    # LinearAttentionGate-fed pass-through pruning.py's own further upgrade
+    # recognizes is not ported here (see MatchLinearAttentionProducer's own
+    # comment). Mirrors tests/test_pruning.py's own
+    # test_linear_attention_pruning_dynamic_decay_is_declined, called
+    # through the C++ port instead.
+    Hq, Hkv, D, K = 4, 2, 4, 16
+    body = f"""
+        g (float[1,3,{K}] X, float[1,3,{Hkv}] DecayIn) => (float[1,3,{K}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          attn_out, ps = LinearAttention<q_num_heads={Hq}, kv_num_heads={Hkv}, update_rule="gated">(q, k, v, , DecayIn)
+          Y = MatMul(attn_out, Wo)
+        }}
+        """
+    rng = np.random.default_rng(4)
+    wq = rng.standard_normal((K, Hq * D)).astype(np.float32) * 0.3
+    wk = rng.standard_normal((K, Hkv * D)).astype(np.float32) * 0.3
+    wv = rng.standard_normal((K, Hkv * D)).astype(np.float32) * 0.3
+    wo = rng.standard_normal((Hq * D, K)).astype(np.float32) * 0.3
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 27]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(
+        [_f32(wq, "Wq"), _f32(wk, "Wk"), _f32(wv, "Wv"), _f32(wo, "Wo")]
+    )
+    model_for_py = onnx.ModelProto()
+    model_for_py.CopyFrom(model)
+    pruned_cpp = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    pruned_py = onnxsim.apply_attention_head_pruning(model_for_py, sparsity=0.5)
+    onnx.checker.check_model(pruned_cpp)
+    assert pruned_cpp.SerializeToString() == model.SerializeToString()  # untouched
+    assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
 
 
 # --- com.microsoft::SparseAttention ------------------------------------------

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -1283,8 +1283,6 @@ def test_cpp_gqa_pruning_cross_attention_matches_oracle_exactly():
     assert not np.allclose(y_pruned, y_pruned2)
 
 
-
-
 # --- Packed-QKV-then-Split + RoPE/QK-norm walk-back (GroupQueryAttention/ ---
 # --- plain ai.onnx::Attention) -- FindSeparateQkvChains's own new
 # --- WalkBackThroughQkNormRope/WalkBackThroughGemmaRopePair machinery,

--- a/tests/test_attention_head_wanda_pruning_cpp.py
+++ b/tests/test_attention_head_wanda_pruning_cpp.py
@@ -921,8 +921,6 @@ def test_cpp_gqa_wanda_pruning_cross_attention_matches_oracle_exactly():
     np.testing.assert_allclose(y_pruned, y_oracle, rtol=1e-4, atol=1e-4)
 
 
-
-
 # --- Packed-QKV-then-Split + RoPE/QK-norm walk-back, Wanda-calibrated -------
 # --- (GroupQueryAttention/plain ai.onnx::Attention) -- mirrors
 # --- test_attention_head_pruning_cpp.py's own identically-named section,


### PR DESCRIPTION
## Summary

Two smaller, mostly-independent parity closures on top of PR 1 + PR 2:

- **Cluster C**: adds a `BuildConstantMap`/`BuildMutableConstantMap` helper so `FindDecomposedGqaChains`/`ApplyDecomposedGqaChains` recognize `Constant`-node values (not just `graph.initializer()` entries) — needed for real `torch.onnx.export` pipelines, which often emit `Constant` nodes rather than initializers for small tensors.
- **Cluster D**: ports partial `LinearAttention` `past_state`/`decay`/`beta` constant slicing to C++ (`MatchLinearAttentionProducer`/`ApplyOneGqaChain`) — closes the delta-mode and gated-mode (`decay` via GLA-style constant) cases exactly. The `LinearAttentionGate` dynamic pass-through case (gate-fed `decay`/`beta`) is a documented, deliberate remaining narrowing, out of scope for this round — see verification below.

Touches `FindDecomposedGqaChains`/`ApplyDecomposedGqaChains` and `MatchLinearAttentionProducer`, distinct functions/matchers from PR 2's `FindSeparateQkvChains`/`ApplyOneGqaChain`, so this merged cleanly with no conflicts.

## Verification

- Clean build, zero compile errors/warnings.
- Full test suite: 3289 passed, 0 failed, 142 skipped.
- `clang-format`/`ruff format`/`ruff check` clean on touched files.
- **33-test cross-check**: the 33 tests in `tests/test_pruning.py` that originally failed when `apply_attention_head_pruning`/`apply_attention_head_wanda_pruning` were tentatively aliased to their C++ ports were re-run against the live C++ implementation (`apply_attention_head_pruning_cpp`/`_wanda_cpp`, via a throwaway monkeypatch — `onnxsim/pruning.py`'s public Python names are untouched by this stack) at this branch's tip (all three clusters applied):
  - **31 of 33 now pass.**
  - The remaining 2 (`test_linear_attention_pruning_gate_fed_decay_and_beta_matches_oracle`, `test_linear_attention_pruning_gate_fed_decay_only_slices_wa_and_gate_weights`) still fail against the C++ port — confirmed as a **clean decline** (the node/weights are left untouched, matching pre-pruning shapes exactly — no crash, no corruption), the same failure mode as before this stack, for the documented `LinearAttentionGate` dynamic-pass-through narrowing. Both pass against the pure-Python reference.

## Stacking

PR 3 of 3, stacked on PR 2 (#1183) — should be merged after PR 1 (#1182) and PR 2 (#1183), in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_