### PR TITLE
Recognize GhostModule cheap-operation concat fan-out in structured pruning

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -13764,6 +13764,29 @@ class _ConcatBranch:
     # (possibly-multi-producer) output actually feeds the `Concat` node --
     # a perfectly well-defined probe point either way.
     operand_name: str
+    # Set only for GhostModule's own "cheap operation" shape (see this
+    # section's own comment just above :func:`_match_ghost_module_cheap_op_concat`):
+    # the index, into this branch's own :class:`_ConcatChain.branches`, of
+    # the "primary" branch this one must reuse the *exact* local `keep`
+    # index set of -- never independently ranked/chosen -- because this
+    # branch's own real "producer" is a depthwise Conv fed *directly* by
+    # that primary branch's own output, so channel `i` here is, by
+    # construction, the exact same logical channel as channel `i` there (a
+    # depthwise Conv mixes no channels at all -- see
+    # :func:`_match_depthwise_conv_pass_through`'s own docstring). `None`
+    # (the default) for every other branch kind -- including a plain
+    # producer branch and a composed residual/merge-group branch -- both of
+    # which still rank and choose their own independent `keep` exactly as
+    # :func:`_apply_concat_chains`'s own docstring describes. Always `None`
+    # for a MatMul/Gemm branch (:func:`_find_matmul_concat_chains` never
+    # sets it). The referenced branch is always at a strictly lower index
+    # and always already resolved to its own `keep` by the time
+    # :func:`_apply_concat_chains` reaches this one, since `Concat` operand
+    # order is preserved in `branches` and this shape is only ever matched
+    # with the primary branch as the *first* operand (see that matcher's
+    # own docstring for why the narrower, exact operand-order scope is
+    # safe).
+    mirror_of: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -13834,6 +13857,43 @@ def _branch_walk_has_fanout(
         prev_consumer = node
         cur = new_cur
     consumers = consumers_of.get(cur, [])
+    return len(consumers) != 1 or consumers[0] is not prev_consumer
+
+
+def _branch_walk_has_fanout_tolerating(
+    start: str,
+    edges: Tuple[Tuple[str, onnx.NodeProto], ...],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    forward_node: onnx.NodeProto,
+    tolerated_tensor: str,
+    tolerated_consumers: Set[int],
+) -> bool:
+    """:func:`_branch_walk_has_fanout`, except `tolerated_tensor` -- wherever
+    this walk crosses it, including as `start` itself -- is allowed to have
+    exactly `tolerated_consumers` (node identities, via ``id()``) as its own
+    consumer set, instead of the single in-walk consumer the general bar
+    otherwise requires; every OTHER tensor crossed is still held to that
+    exact same strict single-consumer bar. Used only by
+    :func:`_match_ghost_module_cheap_op_concat` for the one confirmed real
+    shape where a tensor legitimately has two real consumers at once -- see
+    that function's own docstring and this section's own comment. Return
+    sense matches :func:`_branch_walk_has_fanout` exactly: `True` means an
+    (unresolved) fan-out was found, so the caller should decline.
+    """
+    prev_consumer = forward_node
+    cur = start
+    for new_cur, node in edges:
+        consumers = consumers_of.get(cur, [])
+        if cur == tolerated_tensor:
+            if {id(c) for c in consumers} != tolerated_consumers:
+                return True
+        elif len(consumers) != 1 or consumers[0] is not prev_consumer:
+            return True
+        prev_consumer = node
+        cur = new_cur
+    consumers = consumers_of.get(cur, [])
+    if cur == tolerated_tensor:
+        return {id(c) for c in consumers} != tolerated_consumers
     return len(consumers) != 1 or consumers[0] is not prev_consumer
 
 
@@ -14354,6 +14414,193 @@ def _concat_branches_align_to_consumer_group(
     return all(b.offset % block == 0 for b in branches)
 
 
+# --- GhostNet "GhostModule" cheap-operation concat fan-out -----------------
+#
+# GhostNet/GhostNetV2's own `GhostModule` (the verbatim reference
+# implementation, `huawei-noah/Efficient-AI-Backbones/ghostnet_pytorch/
+# ghostnet.py`, used by GhostNet and several derivative mobile backbones)
+# runs a "primary" Conv, then derives a SECOND set of channels from the
+# primary's own output via a cheap depthwise Conv, and concatenates the two:
+#
+#     r1 = relu(primary_conv(x))                    # group=1 Conv
+#     r2 = relu(cheap_operation(r1))                 # group=Cinit depthwise
+#     out = concat([r1, r2], axis=1)
+#
+# confirmed live via a real `torch.onnx.export` of that exact class (see
+# `tests/test_pruning.py`'s own fixture) -- `r1` feeds BOTH the `Concat`
+# directly AND the depthwise "cheap operation" Conv that produces `r2`, the
+# `Concat`'s *other* operand. Every other matcher in this section (and
+# :func:`_find_matmul_concat_chains`) resolves each `Concat` operand's own
+# backward walk *independently*, then declines the whole match outright
+# (:func:`_branch_walk_has_fanout`) the instant any tensor it crosses has
+# more than the one forward consumer that operand's own walk already
+# accounts for -- exactly what `r1` trips here, on BOTH operands' own walks
+# (`r1` directly, since it's also read by the cheap-operation Conv; and `r2`'s
+# own walk, since it crosses `r1` as a depthwise pass-through hop mid-walk
+# and finds the same second reader). That decline is correct in general --
+# resolving a shared tensor between two *independently, differently* ranked
+# branches has no safe meaning -- but this one specific shape is safe
+# precisely because it *isn't* independent: `r2`'s producer role is a
+# depthwise Conv fed directly by `r1`, which mixes no channels at all
+# (output channel `i` depends only on input channel `i`, see
+# :func:`_match_depthwise_conv_pass_through`'s own docstring), so `r2`'s
+# channel `i` is, by construction, the exact same logical channel as `r1`'s
+# channel `i`. There is no independent ranking to reconcile: whichever
+# channels `r1`'s own primary Conv survives ranking on, `r2`'s matching
+# channels must survive right alongside them, chosen once and reused, not
+# ranked a second, possibly-disagreeing time.
+#
+# What :func:`_match_ghost_module_cheap_op_concat` matches, conservatively:
+#
+#   - The `Concat` has EXACTLY TWO operands, in EXACTLY the order
+#     `[r1, r2]` -- matching the reference implementation's own literal
+#     `torch.cat([x1, x2], dim=1)` call, never the reverse order or a third
+#     operand. No trailing `Slice` (GhostNet's own `ratio != 2` case, which
+#     trims the merged tensor to an exact target channel count) is
+#     recognized at all here -- `_find_conv_concat_chains`'s own forward
+#     walk (:func:`_walk_to_conv_consumer`) has no `Slice` pass-through hop,
+#     so that shape simply fails to resolve a consumer and is declined the
+#     same "unmatched topology" way any other un-recognized forward hop
+#     already is; not specially detected or called out, just not reached.
+#   - `r1` resolves (:func:`_walk_conv_producer_backward`, reused unchanged)
+#     to a real, ordinary (`group == 1`) Conv producer with NO depthwise
+#     pass-through hop of its own -- the "primary" conv. Zero or more unary
+#     activations between it and `r1` are tolerated, exactly like any other
+#     plain Concat branch.
+#   - `r2` resolves the same way, but crossing EXACTLY ONE depthwise
+#     pass-through hop, landing on the *exact same* real producer weight as
+#     `r1`'s own (confirmed by initializer NAME equality) -- i.e. `r2`'s own
+#     depthwise Conv reads `r1` directly as its input (`dw_node.input[0] ==
+#     r1`, not merely "some upstream tensor that happens to also reach the
+#     same Conv"). A `Concat` branch normally declines two branches naming
+#     the same producer weight as degenerate (see
+#     :func:`_find_conv_concat_chains`'s own `seen_weights` check) -- that
+#     bar still applies to every OTHER branch shape; this one specific
+#     shape is recognized before that check is ever reached, specifically
+#     because `r2` carries its OWN extra depthwise weight distinguishing it
+#     from a genuine duplicate.
+#   - `r1`'s own two consumers must be EXACTLY the `Concat` node and that
+#     one depthwise Conv -- checked by node identity, not merely count.
+#     Every OTHER tensor either branch's own walk crosses is still held to
+#     the exact same strict single-consumer bar as any other Concat branch
+#     (:func:`_branch_walk_has_fanout_tolerating`, `_branch_walk_has_fanout`
+#     with the one `r1` checkpoint's own bar relaxed to that tolerated pair).
+#
+# Representation: two `_ConcatBranch` entries, exactly like an ordinary
+# plain-producer match -- branch A (`r1`, the primary conv) ranked and
+# pruned completely normally, and branch B (`r2`) carrying NO `producers` of
+# its own at all (nothing to independently rank) but the depthwise Conv as
+# its own `conv_pass_through` hop, and `mirror_of=0` -- telling
+# :func:`_apply_concat_chains` to skip ranking it and instead copy branch
+# A's own `keep` verbatim (see :class:`_ConcatBranch.mirror_of`'s own
+# docstring). This reuses the existing per-branch `_ConcatBranch`/
+# `_ConcatChain` machinery unchanged beyond that one new field -- no new
+# `_Chain`-like type, and no change to any *other* branch's own resolution
+# or slicing.
+#
+# What's declined, deliberately narrower than a hypothetical fully-general
+# matcher might reach: more than two `Concat` operands; the reverse operand
+# order (`[r2, r1]`); a non-depthwise (or grouped-but-not-fully-depthwise)
+# second branch; more than one depthwise hop on `r2`'s own path (e.g. a
+# "cheap operation" chained through two convs); a primary branch (`r1`)
+# that is itself a general grouped (`1 < group < n_channels`) Conv, or that
+# crosses a depthwise pass-through hop of its own; a trailing `Slice`
+# (GhostNet's own `ratio != 2` case -- see above); and every other topology
+# already declined by the ordinary per-operand loop below, which this
+# matcher's own failure falls straight through to.
+
+
+def _match_ghost_module_cheap_op_concat(
+    concat_node: onnx.NodeProto,
+    node_by_output: Dict[str, onnx.NodeProto],
+    initializer_map: Dict[str, onnx.TensorProto],
+    consumers_of: Dict[str, List[onnx.NodeProto]],
+    graph_outputs: Set[str],
+) -> Optional[Tuple[_ConcatBranch, _ConcatBranch]]:
+    """Matches GhostModule's own "cheap operation" concat fan-out shape --
+    see this section's own comment above for the exact topology and safety
+    argument. Returns `(branch_a, branch_b)` on success -- `branch_a` the
+    primary producer branch (operand 0, `r1`), `branch_b` the depthwise-
+    derived branch (operand 1, `r2`, `mirror_of=0`) -- or `None` on any
+    deviation, the caller falling through to the ordinary per-operand
+    resolution loop.
+    """
+    if len(concat_node.input) != 2:
+        return None
+    r1_name, r2_name = concat_node.input[0], concat_node.input[1]
+    if r1_name == r2_name:
+        return None
+
+    kind1, payload1, pass_through1, unary_ops1, edges1 = _walk_conv_producer_backward(
+        r1_name,
+        node_by_output,
+        initializer_map,
+        consumers_of,
+        graph_outputs,
+        _MAX_CHAIN_HOPS,
+    )
+    if kind1 != "producer" or pass_through1:
+        return None  # branch A must be a direct, plain producer branch
+    producer1, n_channels = cast(Tuple[_Producer, int], payload1)
+    if producer1.group != 1:
+        return None  # narrow scope -- an ordinary group=1 primary conv only
+
+    kind2, payload2, pass_through2, unary_ops2, edges2 = _walk_conv_producer_backward(
+        r2_name,
+        node_by_output,
+        initializer_map,
+        consumers_of,
+        graph_outputs,
+        _MAX_CHAIN_HOPS,
+    )
+    if kind2 != "producer" or len(pass_through2) != 1:
+        return None  # exactly one depthwise hop expected on r2's own path
+    producer2, n_channels2 = cast(Tuple[_Producer, int], payload2)
+    if n_channels2 != n_channels or producer2.weight != producer1.weight:
+        return None  # both branches must land on the exact same real producer
+
+    dw_hop = pass_through2[0]
+    dw_node = dw_hop.node
+    if dw_node.input[0] != r1_name:
+        return None  # the depthwise conv must read r1 directly, not some
+        # other upstream tensor that happens to reach the same producer
+    dw_w_init = initializer_map.get(dw_hop.weight)
+    if dw_w_init is None or dw_w_init.dims[0] != n_channels:
+        return None  # re-validate against the now-known real channel count
+
+    tolerated = {id(concat_node), id(dw_node)}
+    if {id(c) for c in consumers_of.get(r1_name, [])} != tolerated:
+        return None
+
+    if _branch_walk_has_fanout_tolerating(
+        r1_name, edges1, consumers_of, concat_node, r1_name, tolerated
+    ):
+        return None
+    if _branch_walk_has_fanout_tolerating(
+        r2_name, edges2, consumers_of, concat_node, r1_name, tolerated
+    ):
+        return None
+
+    branch_a = _ConcatBranch(
+        (producer1,),
+        tuple((op, None) for op in unary_ops1),
+        (),
+        n_channels,
+        0,
+        r1_name,
+    )
+    branch_b = _ConcatBranch(
+        (),
+        tuple((op, None) for op in unary_ops2),
+        (dw_hop,),
+        n_channels,
+        n_channels,
+        r2_name,
+        mirror_of=0,
+    )
+    return branch_a, branch_b
+
+
 def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
     """The Conv analogue of :func:`_find_matmul_concat_chains`: every operand
     of a channel-axis `Concat` (`axis in (1, -3)` -- the channel axis of a
@@ -14398,91 +14645,109 @@ def _find_conv_concat_chains(graph: onnx.GraphProto) -> List[_ConcatChain]:
         seen_weights: Set[str] = set()
         offset = 0
         declined = False
-        for operand in node.input:
-            kind, payload, pass_through, unary_ops, edges = (
-                _walk_conv_producer_backward(
-                    operand,
-                    node_by_output,
-                    initializer_map,
-                    consumers_of,
-                    graph_outputs,
-                    _MAX_CHAIN_HOPS,
+
+        # GhostModule's own "cheap operation" concat fan-out (see this
+        # section's own comment above :func:`_match_ghost_module_cheap_op_concat`)
+        # is tried FIRST, since its own two branches are declined outright by
+        # the ordinary per-operand loop below (`r1`'s own extra consumer --
+        # the depthwise "cheap operation" Conv -- trips
+        # :func:`_branch_walk_has_fanout` on both operands' own walks). Any
+        # deviation from that one exact confirmed shape falls straight
+        # through to the ordinary loop, completely unaffected.
+        ghost_match = _match_ghost_module_cheap_op_concat(
+            node, node_by_output, initializer_map, consumers_of, graph_outputs
+        )
+        if ghost_match is not None:
+            branch_a, branch_b = ghost_match
+            branches = [branch_a, branch_b]
+            offset = branch_a.n_channels + branch_b.n_channels
+            declined = False
+        else:
+            for operand in node.input:
+                kind, payload, pass_through, unary_ops, edges = (
+                    _walk_conv_producer_backward(
+                        operand,
+                        node_by_output,
+                        initializer_map,
+                        consumers_of,
+                        graph_outputs,
+                        _MAX_CHAIN_HOPS,
+                    )
                 )
-            )
-            if kind == "fail":
-                declined = True
-                break
-            if _branch_walk_has_fanout(operand, edges, consumers_of, node):
-                declined = True
-                break
-            if kind == "add":
-                assert isinstance(payload, onnx.NodeProto)
-                resolved = _resolve_conv_residual_group_for_concat(
-                    payload,
-                    node_by_output,
-                    initializer_map,
-                    consumers_of,
-                    graph_outputs,
-                )
-                if resolved is None:
+                if kind == "fail":
                     declined = True
                     break
-                (
-                    producers,
-                    group_pass_through,
-                    group_unary_ops,
-                    n_channels,
-                    backbone,
-                    accounted,
-                ) = resolved
-                extra = _resolve_conv_fanout_branches(
-                    backbone,
-                    accounted,
-                    initializer_map,
-                    consumers_of,
-                    graph_outputs,
-                    n_channels,
-                )
-                # See _find_matmul_concat_chains's own matching comment --
-                # only an exactly-empty result confirms no fan-out anywhere
-                # else in the group.
-                if extra is None or extra:
+                if _branch_walk_has_fanout(operand, edges, consumers_of, node):
                     declined = True
                     break
-                if any(p.weight in seen_weights for p in producers):
+                if kind == "add":
+                    assert isinstance(payload, onnx.NodeProto)
+                    resolved = _resolve_conv_residual_group_for_concat(
+                        payload,
+                        node_by_output,
+                        initializer_map,
+                        consumers_of,
+                        graph_outputs,
+                    )
+                    if resolved is None:
+                        declined = True
+                        break
+                    (
+                        producers,
+                        group_pass_through,
+                        group_unary_ops,
+                        n_channels,
+                        backbone,
+                        accounted,
+                    ) = resolved
+                    extra = _resolve_conv_fanout_branches(
+                        backbone,
+                        accounted,
+                        initializer_map,
+                        consumers_of,
+                        graph_outputs,
+                        n_channels,
+                    )
+                    # See _find_matmul_concat_chains's own matching comment --
+                    # only an exactly-empty result confirms no fan-out anywhere
+                    # else in the group.
+                    if extra is None or extra:
+                        declined = True
+                        break
+                    if any(p.weight in seen_weights for p in producers):
+                        declined = True
+                        break
+                    seen_weights.update(p.weight for p in producers)
+                    branches.append(
+                        _ConcatBranch(
+                            producers,
+                            tuple((op, None) for op in group_unary_ops)
+                            + tuple((op, None) for op in unary_ops),
+                            group_pass_through + pass_through,
+                            n_channels,
+                            offset,
+                            operand,
+                        )
+                    )
+                    offset += n_channels
+                    continue
+                assert payload is not None and not isinstance(payload, onnx.NodeProto)
+                producer, n_channels = payload
+                if producer.weight in seen_weights:
                     declined = True
                     break
-                seen_weights.update(p.weight for p in producers)
+                seen_weights.add(producer.weight)
                 branches.append(
                     _ConcatBranch(
-                        producers,
-                        tuple((op, None) for op in group_unary_ops)
-                        + tuple((op, None) for op in unary_ops),
-                        group_pass_through + pass_through,
+                        (producer,),
+                        tuple((op, None) for op in unary_ops),
+                        pass_through,
                         n_channels,
                         offset,
                         operand,
                     )
                 )
                 offset += n_channels
-                continue
-            assert payload is not None and not isinstance(payload, onnx.NodeProto)
-            producer, n_channels = payload
-            if producer.weight in seen_weights:
-                declined = True
-                break
-            seen_weights.add(producer.weight)
-            branches.append(
-                _ConcatBranch(
-                    (producer,),
-                    tuple((op, None) for op in unary_ops),
-                    pass_through,
-                    n_channels,
-                    offset,
-                    operand,
-                )
-            )
-            offset += n_channels
         if declined:
             continue
 
@@ -14675,6 +14940,19 @@ def _apply_concat_chains(
         branch_keeps: List[np.ndarray] = []
         any_pruned = False
         for b in chain.branches:
+            if b.mirror_of is not None:
+                # GhostModule's own "cheap operation" branch (see
+                # :class:`_ConcatBranch.mirror_of`'s own docstring and
+                # :func:`_match_ghost_module_cheap_op_concat`'s own section
+                # comment) -- never independently ranked: reuses the
+                # mirrored branch's own already-computed local `keep`
+                # verbatim (both branches share the exact same `n_channels`
+                # by construction, so no reshaping/validation is needed).
+                # `any_pruned` already reflects whether that branch pruned
+                # anything, since it's always resolved earlier in `branches`
+                # (operand order) and so already iterated this same loop.
+                branch_keeps.append(branch_keeps[b.mirror_of])
+                continue
             n = b.n_channels
             if group > 1:
                 # Whole number by construction -- see
@@ -16449,6 +16727,14 @@ def _wanda_structured_calibration_stats(
     }
     for cchain in concat_chains:
         for b in cchain.branches:
+            if not b.producers:
+                # GhostModule's own "cheap operation" branch (see
+                # :class:`_ConcatBranch.mirror_of`'s own docstring) has no
+                # producer of its own to rank at all -- it's never
+                # independently probed/ranked, always mirroring another
+                # branch's own already-decided `keep` verbatim -- so no
+                # probe point is registered for it here.
+                continue
             # Every producer of a given branch is always uniformly Conv or
             # uniformly MatMul/Gemm (a residual/merge-group-composed branch
             # is only ever discovered by the one walker family that finder

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -14042,6 +14042,176 @@ def test_structured_wanda_pruning_conv_concat_admits_block_aligned_grouped_conv_
     np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
 
 
+# --- GhostModule "cheap operation" concat fan-out --------------------------
+#
+# GhostNet/GhostNetV2's own `GhostModule` (the verbatim reference
+# implementation, `huawei-noah/Efficient-AI-Backbones/ghostnet_pytorch/
+# ghostnet.py`) -- confirmed live via a real `torch.onnx.export` of that
+# exact class (TorchScript exporter, opset 17): a "primary" Conv `h1 ->
+# Relu -> r1`, then a depthwise "cheap operation" Conv fed directly by `r1`
+# (`group == r1`'s own channel count) `-> Relu -> r2`, and
+# `Concat([r1, r2], axis=1)`. `r1` feeds BOTH the `Concat` directly and the
+# depthwise Conv -- the exact shape `_match_ghost_module_cheap_op_concat`
+# recognizes (see `onnxsim/pruning.py`'s own section comment just above it).
+# The real export always also appends `out[:, :oup, :, :]` (a `Slice`) --
+# even in the exact-division (`ratio=2`) case this section's own matcher
+# supports, where it's a structural no-op -- so the *positive* (matched)
+# test below builds the topology directly via `onnx.parser` (per this
+# file's own module docstring/CLAUDE.md's convention) with no trailing
+# `Slice`, and a separate decline test below confirms that real,
+# `Slice`-terminated shape is (deliberately, for now) still declined
+# outright, unpruned, exactly as it already was.
+
+
+def _ghost_module_model(w1, w2, wout, b1=None, bd=None, trailing_slice=False):
+    Cin = w1.shape[1]
+    Cinit = w1.shape[0]
+    n_channels = 2 * Cinit
+    Cout = wout.shape[0]
+    initializer = [_f32(w1, "W1"), _f32(w2, "W2"), _f32(wout, "WOUT")]
+    h1_inputs = "X, W1, B1" if b1 is not None else "X, W1"
+    if b1 is not None:
+        initializer.append(_f32(b1, "B1"))
+    d1_inputs = "r1, W2, BD" if bd is not None else "r1, W2"
+    if bd is not None:
+        initializer.append(_f32(bd, "BD"))
+    lines = [
+        f"h1 = Conv<kernel_shape=[1,1]>({h1_inputs})",
+        "r1 = Relu(h1)",
+        f"d1 = Conv<kernel_shape=[3,3], group={Cinit}, pads=[1,1,1,1]>({d1_inputs})",
+        "r2 = Relu(d1)",
+        "merged = Concat<axis=1>(r1, r2)",
+    ]
+    consumer_input = "merged"
+    if trailing_slice:
+        lines += [
+            "starts = Constant<value = int64[1] {0}>()",
+            f"ends = Constant<value = int64[1] {{{n_channels}}}>()",
+            "axes = Constant<value = int64[1] {1}>()",
+            "sliced = Slice(merged, starts, ends, axes)",
+        ]
+        consumer_input = "sliced"
+    lines.append(
+        f"Y = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>({consumer_input}, WOUT)"
+    )
+    body = "\n          ".join(lines)
+    return _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},10,10] Y)
+        {{
+          {body}
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+def test_structured_pruning_conv_concat_ghost_module_matches_oracle():
+    Cin, Cinit, Cout = 3, 8, 4
+    rng = np.random.default_rng(240)
+    w1 = rng.standard_normal((Cinit, Cin, 1, 1)).astype(np.float32)
+    b1 = rng.standard_normal((Cinit,)).astype(np.float32)
+    w2 = rng.standard_normal((Cinit, 1, 3, 3)).astype(np.float32)
+    bd = rng.standard_normal((Cinit,)).astype(np.float32)
+    wout = rng.standard_normal((Cout, 2 * Cinit, 3, 3)).astype(np.float32)
+    model = _ghost_module_model(w1, w2, wout, b1=b1, bd=bd)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    # Both W1 (the primary conv) and W2 (the depthwise cheap-operation conv)
+    # must be co-sliced by the EXACT same local keep set -- driven solely by
+    # W1's own importance ranking, W2 contributing no independent ranking of
+    # its own (see this section's own comment and `_ConcatBranch.mirror_of`'s
+    # own docstring).
+    keep = _oracle_keep_indices_conv(w1, Cinit // 2)
+    global_keep = np.concatenate([keep, keep + Cinit])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1[keep])
+    np.testing.assert_array_equal(inits["B1"], b1[keep])
+    np.testing.assert_array_equal(inits["W2"], w2[keep])
+    np.testing.assert_array_equal(inits["BD"], bd[keep])
+    np.testing.assert_array_equal(inits["WOUT"], wout[:, global_keep])
+
+    dw_node = next(n for n in pruned.graph.node if "W2" in n.input)
+    group_attr = next(a.i for a in dw_node.attribute if a.name == "group")
+    assert group_attr == len(keep)
+
+    oracle = _ghost_module_model(
+        w1[keep], w2[keep], wout[:, global_keep], b1=b1[keep], bd=bd[keep]
+    )
+    rng_x = np.random.default_rng(241)
+    x = rng_x.standard_normal((2, Cin, 10, 10)).astype(np.float32)
+    (y,) = _run(pruned, {"X": x})
+    (y_oracle,) = _run(oracle, {"X": x})
+    np.testing.assert_allclose(y, y_oracle, rtol=1e-5, atol=1e-5)
+
+
+def test_structured_pruning_conv_concat_declines_ghost_module_non_depthwise_cheap_op():
+    # The would-be "cheap operation" conv here is an ordinary (group=1) Conv,
+    # not a depthwise one -- `_match_ghost_module_cheap_op_concat` requires
+    # crossing EXACTLY one depthwise pass-through hop on r2's own path, so
+    # this doesn't match; the ordinary per-operand loop then also declines
+    # (r1 still fans out to both the Concat and this second Conv), so the
+    # whole match is declined outright, exactly as before this feature
+    # existed -- W1 stays completely unpruned.
+    Cin, Cinit, Cb, Cout = 3, 8, 6, 4
+    rng = np.random.default_rng(242)
+    w1 = rng.standard_normal((Cinit, Cin, 1, 1)).astype(np.float32)
+    w2 = rng.standard_normal((Cb, Cinit, 3, 3)).astype(
+        np.float32
+    )  # group=1, not depthwise
+    wout = rng.standard_normal((Cout, Cinit + Cb, 3, 3)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[N,{Cin},10,10] X) => (float[N,{Cout},10,10] Y)
+        {{
+          h1 = Conv<kernel_shape=[1,1]>(X, W1)
+          r1 = Relu(h1)
+          d1 = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(r1, W2)
+          r2 = Relu(d1)
+          merged = Concat<axis=1>(r1, r2)
+          Y = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(merged, WOUT)
+        }}
+        """,
+        initializer=[_f32(w1, "W1"), _f32(w2, "W2"), _f32(wout, "WOUT")],
+    )
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
+def test_structured_pruning_conv_concat_declines_ghost_module_trailing_slice():
+    # The real GhostModule export (see this section's own comment) always
+    # appends `out[:, :oup, :, :]` -- a Slice -- even in the exact-division
+    # case matched here, where it's a structural no-op. `_walk_to_conv_consumer`
+    # has no Slice pass-through hop, so the forward walk to a real consumer
+    # simply fails to resolve and the whole match declines, unpruned --
+    # deliberately out of scope for this round (see this section's own
+    # comment and `_match_ghost_module_cheap_op_concat`'s own docstring).
+    Cin, Cinit, Cout = 3, 8, 4
+    rng = np.random.default_rng(243)
+    w1 = rng.standard_normal((Cinit, Cin, 1, 1)).astype(np.float32)
+    w2 = rng.standard_normal((Cinit, 1, 3, 3)).astype(np.float32)
+    wout = rng.standard_normal((Cout, 2 * Cinit, 3, 3)).astype(np.float32)
+    model = _ghost_module_model(w1, w2, wout, trailing_slice=True)
+    onnx.checker.check_model(model)
+
+    pruned = onnxsim.apply_structured_pruning(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["W1"], w1)
+    np.testing.assert_array_equal(inits["W2"], w2)
+    np.testing.assert_array_equal(inits["WOUT"], wout)
+
+
 # --- apply_structured_wanda_pruning ------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Adds recognition of GhostNet/GhostNetV2's `GhostModule` "cheap operation" concat fan-out pattern, so the primary producing Conv is no longer left completely unpruned. This is real: confirmed via `torch.onnx.export` of the verbatim reference `GhostModule` class (`huawei-noah/Efficient-AI-Backbones/ghostnet_pytorch/ghostnet.py`, used by GhostNet and several derivative mobile backbones).

## Empirically confirmed facts

- The confirmed export shape: `r1 = Relu(primary_conv(x))` (a `group=1` Conv), then `r2 = Relu(cheap_operation(r1))` (a **depthwise** Conv, `group == r1`'s own channel count, fed directly by `r1`), then `Concat([r1, r2], axis=1)`. `r1` feeds **both** the `Concat` directly and the depthwise Conv.
- Every existing Concat-branch matcher in this module resolves each operand's own backward walk independently, then declines the whole match the instant any crossed tensor has more than the one forward consumer that operand's own walk accounts for — exactly what `r1` trips here, on **both** operands' own walks. That decline is correct in general (two independently, differently-ranked branches sharing a tensor has no safe meaning) — but this one specific shape is safe precisely because it isn't independent: a depthwise Conv mixes no channels at all, so `r2`'s channel `i` is, by construction, the exact same logical channel as `r1`'s channel `i`. There's no independent ranking to reconcile.
- The real export always additionally appends `out[:, :oup, :, :]` (a trailing `Slice`) — even in the exact-division (`ratio=2`) case this PR's own matcher supports, where it's a structural no-op. This PR's matcher does not recognize that trailing `Slice` at all (see Risks below) — an honest, deliberate scope limit, not an oversight.

## What's added

- `_branch_walk_has_fanout_tolerating`: like the existing `_branch_walk_has_fanout`, but lets one named tensor (`r1`) have a specific 2-element consumer set instead of the usual single one.
- `_match_ghost_module_cheap_op_concat`: narrowly matches exactly the confirmed shape — a 2-operand `Concat` in order `[r1, r2]`, `r1` a plain `group=1` producer, `r2` crossing exactly one depthwise hop back to the *same* producer weight, `r1`'s consumers being exactly `{Concat, depthwise Conv}`. Declines on any deviation (reverse order, >2 operands, non-depthwise second branch, extra hops, trailing `Slice`).
- A new `_ConcatBranch.mirror_of: Optional[int]` field: the depthwise-derived branch carries no `producers` of its own (nothing independently ranked) plus the depthwise Conv as its `conv_pass_through` hop; `_apply_concat_chains` copies the mirrored branch's already-computed `keep` verbatim instead of ranking it — the primary conv's own ranking drives both weight slices.
- `_find_conv_concat_chains` tries this matcher first per `Concat` node, falling through unchanged to the existing per-operand loop on any decline.
- A defensive guard in `_wanda_structured_calibration_stats` (a branch can now legitimately have zero producers).
- Three regression tests in `tests/test_pruning.py`: an end-to-end oracle-matching test (`onnxruntime`-verified, both `W1` and the depthwise weight+bias co-sliced, `group` attribute updated), a decline case for a non-depthwise second branch, and a decline case for the real export's own trailing `Slice`.

## Test plan

- `pytest tests/test_pruning.py -k "ghost"` — 3 passed.
- `pytest tests/test_pruning.py -k "ghost or depth_to_space or grn or spatial_gate or cbam or se_gate"` — 28 passed — confirms this feature coexists correctly with every other recently-added Conv-chain hop.
- `pytest tests/test_pruning.py` (full suite, post-merge with `origin/master`) — 164 failed / 869 passed, matching the pre-existing baseline (164 failed) exactly.
- `ruff format --check`, `ruff check`, `mypy onnxsim/pruning.py` — all clean.
- Independently reverted `onnxsim/pruning.py` to its pre-fix state and confirmed the oracle test genuinely fails (wrong shape on `W1`), then restored and confirmed all 3 pass again. Also confirmed the 5 pre-existing `wanda`+`concat` test failures are identical before and after this change (a known, unrelated missing-C++-extension-symbol baseline category, not a regression).

## Risks for reviewer

- Scope is intentionally narrow: exact-division (`ratio=2`, no trailing `Slice`) only. A real GhostModule export (which always carries that trailing `Slice`, even when it's a structural no-op) is **not** recognized by this PR — it keeps its current, pre-existing behavior (fully unpruned), never partially or incorrectly pruned. Extending to tolerate a structurally-no-op trailing `Slice` is a reasonable, tractable follow-on but out of scope here.
- Given the recent history of independently-added hops silently conflicting at a shared dispatch point, I specifically ran this feature's own tests together with every other recently-added Conv-chain hop's tests (28 passed, see above) to confirm no interaction issues.
- This branch also carries a merge of `origin/master` (bringing in PR #1177's own PixelShuffle/DepthToSpace work, which also touches `pruning.py`, plus unrelated Qwen3.5/axera work) — the merge was auto-resolved cleanly by git with no conflicts, and re-verified via mypy, ruff, and the full test suite above (not just trusted as clean, given this session's own prior near-misses with textually-clean-but-semantically-broken merges).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh

---
_Generated by [Claude Code](https://claude.ai/code/session_013NwYxKS4ugp8NQ8teVoyXh)_