### PR TITLE
mcode: five verbs, a readable per-op program, a variable-length preamble, and the arena size in the header

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2372,6 +2372,78 @@ op is dispatched by three required steps (`bit8`, `bit0` in either
 order, then `bit20`), followed by one step that can be dropped
 model-wide without changing a single output bit.
 
+### Five verbs, a readable per-op program, a variable-length preamble, and the arena size in the header
+
+Three local, zero-device-run checks that complete the structural
+picture -- and correct one earlier statement.
+
+**`a1` is one of five verbs over the same selector.** Tallying every
+phase-0 word of the shape `XX 00 <multiple of 0x10> yy` in the
+`resnet18d` blob, `a1` is joined by four more first bytes with the same
+`xx yy` field/bank selector and the same per-op multiples:
+
+```
+verb  writes  distinct selectors   what it writes
+a1     1197   68                   field writes (the map above)
+a8      365   5    -> 30 02 x181, 40 03 x181   one bank-2 and one bank-3 write per op
+a2      359   2    -> 00 00 x358               ~2 per op, fixed selector
+a3      185   4    -> 00 00 x182               1 per op
+a9      181   1    -> 00 00 x181               exactly 1 per op
+```
+
+**With all five verbs counted, the bulk is a uniform two-word stream.**
+From byte 328 there are 2,287 verb headers and **97.5% of consecutive
+headers are exactly two words apart** (2,228 of 2,285): `[verb 00 xx yy]
+[32-bit operand]`, eight bytes per instruction, throughout. The earlier
+"gaps of 4, 8, 10 words between `a1` headers" were other verbs in
+between, not longer instructions.
+
+**The per-op program is now readable.** Splitting at each `a1 40 02`
+(Wbt offset), 64 of 180 ops are exactly this eleven-instruction
+sequence, and 40 more differ only by one extra `a2`:
+
+```
+a1 40 02 <Wbt offset>      set weight offset
+a1 50 01 bit8              step 1 (required)
+a1 50 01 bit0              step 2 (required, order-free with step 1)
+a8 40 03 <...>             bank-3 write
+a1 50 03 <arena address>   set tile-arena address
+a1 50 01 bit20             step 3 (required)
+a3 00 00 <...>
+a1 50 01 bit24             step 4 (optional model-wide)
+a9 00 00 <...>
+a2 00 00 <...>
+a8 30 02 <...>             bank-2 write
+```
+
+Each of the four `50 01` steps sits immediately before a different verb,
+which reads naturally as "arm, then do" -- but that is an interpretation;
+the sequence itself is the measured fact (22 distinct per-op patterns
+in total, dominated by these two).
+
+**Correction, stated in place: the stream is not 4-byte aligned from the
+blob's first byte.** The first field write sits at byte 297 (phase 1):
+`a1 00 40 02 ff 00 00 00 | a8 00 50 02 00 00 00 00 | a1 00 60 02 80 14 03
+00 | a1 00 70 02 81 0a 03`, where that last slot is **seven** bytes -- a
+3-byte operand -- and only from about byte 328 onward do headers settle
+at phase 0 and stay there (1,192 of the bulk's 1,320 `a1 00` pairs; the
+scattered phase-1/2/3 ones lie inside packed operand words). So the
+preamble has variable-length instructions, the bulk does not, and a
+parser must not assume 8-byte slots from offset 0. The earlier word
+indexing from the blob start was right for the bulk by coincidence of
+where the preamble's odd slots happen to end.
+
+**The tile arena's size is declared in the FlatBuffers header.** Header
+words 72 and 76 hold `4096` and `0x002ff000` (3,141,632). The largest
+`50 03` operand, `0x2f7040`, sits 32,704 bytes below `0x2ff000` -- less
+than one typical tile (the most common `50 03` delta is 37,120) -- i.e.
+the last tile fits exactly under it. A declared size that bounds every
+arena address to within one tile is strong evidence that word 76 is the
+arena size and word 72 its page/alignment, which also links the header
+region (decoded first, long ago) to the field map for the first time.
+Whether `0x2ff000` is the physical on-chip memory size is still not
+checked against a spec.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2300,6 +2300,49 @@ with each op's Wbt-offset write being followed by one weight DMA on the
 system DMA engine. (`conv0`/`conv1` have 522 events each; `teng2` 46;
 `cv3` 162.)
 
+### The four `50 01` steps on the device: three required, one optional, and a correction about what the validator checks
+
+`50 01` is written four times per op in a fixed order (`bit8, bit0,
+bit20, bit24`). Editing those four writes for one real `resnet18d` op
+on the device, one variant per run, then repeating on a second op:
+
+```
+                                      op @ word 8174   op @ word 12074
+skip bit8   (write 0 instead)         FAULT            FAULT
+skip bit0                             FAULT            (not repeated)
+skip bit20                            FAULT            (not repeated)
+skip bit24                            identical        identical
+swap bit8 <-> bit0                    identical        identical
+swap bit20 <-> bit24                  FAULT            (not repeated)
+all four -> 0                         runs, D (815)    runs, D (832)
+```
+
+- **`bit8`, `bit0`, `bit20` are each required**: removing any one of
+  them faults with the usual `0x8030070C`.
+- **`bit24` is optional**: removing it leaves the output bit-identical
+  on both ops -- whatever the fourth step does, correctness does not
+  depend on it (a timing or profiling pulse is the natural guess).
+- **`bit8` and `bit0` are order-free** (swapped, identical output);
+  **`bit20` must precede `bit24`** (swapped, fault; one op).
+- **Removing all four does *not* fault** -- the op runs, with a
+  different result, on both ops. So the check is not "a step is
+  missing" but "the steps present are inconsistent": a partial
+  sequence is rejected, an absent one falls back to some default mode.
+
+**Correction, stated in place.** The `40 02` operand section above
+concluded that "every fault in this whole investigation came from a
+header/format byte, never from an operand value, however absurd." That
+held for every *address* value tried, and it is wrong as a general
+statement: the `50 01` step values above are operand values, and
+zeroing one of them faults. The consistent reading of all of it is that
+`0x8030070C` is a **runtime sequencing rejection** rather than a static
+format check -- it fires when the command stream is inconsistent as a
+*sequence* (a corrupted selector word, a partial step set, a
+misordered step), and stays silent for values that do not break
+sequencing (an out-of-range address is still a well-formed step). That
+also explains why it never fired on any `40 02` value and why a wholly
+absent step set runs.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2343,6 +2343,35 @@ sequencing (an out-of-range address is still a well-formed step). That
 also explains why it never fired on any `40 02` value and why a wholly
 absent step set runs.
 
+### The `50 01` step set is the op's dispatch, and its fourth step is inert model-wide
+
+Two device probes that each settle one question with a single decisive
+comparison.
+
+**An op with no step set does not execute.** Zeroing all four `50 01`
+writes of one real `resnet18d` op makes the model run with a changed
+result (argmax 305 -> 815). Doing the same *and* also pointing that
+op's `40 02` Wbt offset at a different instance's weights gives the
+**byte-identical** changed result. If the op still executed in some
+"default mode," its weights would matter and the two outputs would
+differ; they do not. So the four `50 01` writes are what dispatch the
+op -- remove them and the op is simply skipped, its weight offset never
+read, and the model's output is whatever the downstream layers make of
+a missing contribution. This also reinterprets the "removing all four
+does not fault" observation: there is no partial sequence left for the
+sequencer to reject, because there is no op.
+
+**`bit24` is inert for correctness across the entire model.** The
+per-op probe found that zeroing the fourth step (`bit24`) leaves one
+op's output bit-identical. Zeroing it in **all 181 ops at once**, in one
+patched model, leaves the whole network's output **bit-identical to the
+unpatched baseline**. Whatever the fourth write does -- a completion or
+profiling pulse is the natural guess -- no part of `resnet18d`'s
+computed result depends on it. Combined with the previous section: each
+op is dispatched by three required steps (`bit8`, `bit0` in either
+order, then `bit20`), followed by one step that can be dropped
+model-wide without changing a single output bit.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2011,3 +2011,66 @@ def test_resnet18d_50_01_step_set_dispatches_the_op_and_bit24_is_inert_model_wid
     assert np.array_equal(all_bit24_zero, out_base), (
         "expected bit24 to be inert for correctness across every op"
     )
+
+
+_VERBS = {0xA1, 0xA2, 0xA3, 0xA8, 0xA9}
+
+
+def _verb_headers(mcode, start=328):
+    """Every verb header word in the phase-0 bulk of an mcode blob -- see
+    the README's "Five verbs, a readable per-op program" section. Returns
+    `(word_index, verb, xx, yy, operand)` for each `XX 00 <mult of 0x10>
+    yy` word whose first byte is a known verb, indexing words from
+    `start` (the preamble before it has variable-length slots)."""
+    words = [mcode[i : i + 4] for i in range(start, len(mcode) - 3, 4)]
+    return [
+        (k, w[0], w[2], w[3], int.from_bytes(words[k + 1], "little"))
+        for k, w in enumerate(words)
+        if w[0] in _VERBS and w[1] == 0 and w[2] % 0x10 == 0 and k + 1 < len(words)
+    ]
+
+
+def test_resnet18d_bulk_is_a_two_word_stream_of_five_verbs_with_a_per_op_program(
+    tmp_path,
+):
+    """Confirmed real (see the README's "Five verbs, a readable per-op
+    program" section), all local: with all five verbs counted, 97.5% of
+    consecutive headers in the bulk are exactly two words apart; `a9 00
+    00` and both `a8` selectors occur exactly once per op (181); and 64
+    of 180 ops are exactly one eleven-instruction template. Also locks in
+    the header-declared arena size 0x2ff000 bounding every `50 03`
+    address. Needs Docker for the build but no device.
+    """
+    from collections import Counter
+
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    hdrs = _verb_headers(mcode)
+    assert len(hdrs) >= 2200, len(hdrs)
+
+    gaps = Counter(b[0] - a[0] for a, b in zip(hdrs, hdrs[1:]))
+    assert gaps[2] / sum(gaps.values()) >= 0.95, gaps.most_common(5)
+
+    by_verb_sel = Counter((v, xx, yy) for _, v, xx, yy, _ in hdrs)
+    assert by_verb_sel[(0xA9, 0x00, 0x00)] == 181
+    assert by_verb_sel[(0xA8, 0x30, 0x02)] == by_verb_sel[(0xA8, 0x40, 0x03)] == 181
+    assert by_verb_sel[(0xA2, 0x00, 0x00)] >= 350
+    assert by_verb_sel[(0xA3, 0x00, 0x00)] >= 180
+
+    cuts = [k for k, v, xx, yy, _ in hdrs if (v, xx, yy) == (0xA1, 0x40, 0x02)]
+    template = "a1:5001 a1:5001 a8:4003 a1:5003 a1:5001 a3:0000 a1:5001 a9:0000 a2:0000 a8:3002"
+    patterns = Counter(
+        " ".join(f"{v:02x}:{xx:02x}{yy:02x}" for k, v, xx, yy, _ in hdrs if a < k < b)
+        for a, b in zip(cuts, cuts[1:])
+    )
+    assert patterns[template] >= 60, patterns.most_common(2)
+
+    arena = int.from_bytes(mcode[76:80], "little")
+    assert arena == 0x2FF000, hex(arena)
+    assert int.from_bytes(mcode[72:76], "little") == 4096
+    max_50_03 = max(
+        op for _, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x50, 0x03)
+    )
+    assert max_50_03 < arena and arena - max_50_03 < 40_000, (
+        hex(max_50_03),
+        hex(arena),
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1940,3 +1940,74 @@ def test_resnet18d_50_01_steps_three_required_one_optional_on_device(tmp_path):
     assert out is not None and not np.array_equal(out, out_base), (
         "expected an absent step set to run with a changed result, not fault"
     )
+
+
+def test_resnet18d_50_01_step_set_dispatches_the_op_and_bit24_is_inert_model_wide(
+    tmp_path,
+):
+    """Confirmed real on the device (see the README's "The `50 01` step set
+    is the op's dispatch" section): with all four `50 01` steps of one op
+    zeroed, the model runs with a changed result, and additionally
+    pointing that op's Wbt offset at another instance's weights gives the
+    byte-identical changed result -- the op no longer executes at all.
+    And zeroing `bit24` in all 181 ops at once leaves the whole output
+    bit-identical to the unpatched baseline.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    hdrs = [
+        (i, w[2], w[3], int.from_bytes(words[i + 1], "little"))
+        for i, w in enumerate(words)
+        if w[:2] == b"\xa1\x00" and i + 1 < len(words)
+    ]
+    cuts = [i for i, xx, yy, _ in hdrs if (xx, yy) == (0x40, 0x02)]
+    op_start = 8174
+    assert op_start in cuts
+    op_end = min(i for i in cuts if i > op_start)
+    steps = [
+        i for i, xx, yy, _ in hdrs if (xx, yy) == (0x50, 0x01) and op_start < i < op_end
+    ]
+    assert len(steps) == 4
+    other_offset = int.from_bytes(
+        mcode[48300:48304], "little"
+    )  # a different op's 40 02 value
+    bit24_writes = [
+        i for i, xx, yy, v in hdrs if (xx, yy) == (0x50, 0x01) and v == 0x1000000
+    ]
+    assert len(bit24_writes) == 181
+
+    x = np.random.RandomState(42).randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = _run_retry_once(path, x)
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+
+    def run_variant(edits, tag):
+        patched = bytearray(mcode)
+        for word_index, value in edits:
+            patched[(word_index + 1) * 4 : (word_index + 2) * 4] = struct.pack(
+                "<I", value
+            )
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"dispatch_{tag}.axmodel")
+        onnx.save(c, p)
+        dev = _run_retry_once(p, x)
+        assert not dev.error, (tag, dev.error)
+        return np.frombuffer(dev.outputs[0], dtype=np.float32)
+
+    no_steps = run_variant([(w, 0) for w in steps], "no_steps")
+    assert not np.array_equal(no_steps, out_base)
+    no_steps_other_weights = run_variant(
+        [(w, 0) for w in steps] + [(op_start, other_offset)], "no_steps_other_weights"
+    )
+    assert np.array_equal(no_steps, no_steps_other_weights), (
+        "expected an op with no step set to be skipped, so its weight offset is never read"
+    )
+
+    all_bit24_zero = run_variant([(w, 0) for w in bit24_writes], "all_bit24_zero")
+    assert np.array_equal(all_bit24_zero, out_base), (
+        "expected bit24 to be inert for correctness across every op"
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1871,3 +1871,72 @@ def test_50_01_is_a_fixed_four_step_sequence_per_op_in_both_models(tmp_path):
         sum(1 for seg in segments if seg != order),
         "expected every op to write the same four-step sequence",
     )
+
+
+def test_resnet18d_50_01_steps_three_required_one_optional_on_device(tmp_path):
+    """Confirmed real on the device (see the README's "The four `50 01`
+    steps on the device" section), on two independent ops: zeroing the
+    `bit8` step faults (`0x8030070C`), zeroing the `bit24` step leaves
+    the output bit-identical, swapping `bit8` and `bit0` leaves it
+    bit-identical, and zeroing all four runs with a changed output. Also
+    the concrete counter-example to "the validator never faults on an
+    operand value": these are operand values, and one of them faults.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    hdrs = [
+        (i, w[2], w[3], int.from_bytes(words[i + 1], "little"))
+        for i, w in enumerate(words)
+        if w[:2] == b"\xa1\x00" and i + 1 < len(words)
+    ]
+    cuts = [i for i, xx, yy, _ in hdrs if (xx, yy) == (0x40, 0x02)]
+    op_start = 8174  # the op whose 40 02 write sits at byte 32696
+    assert op_start in cuts
+    op_end = min(i for i in cuts if i > op_start)
+    steps = [
+        (i, v)
+        for i, xx, yy, v in hdrs
+        if (xx, yy) == (0x50, 0x01) and op_start < i < op_end
+    ]
+    assert [v for _, v in steps] == [0x100, 0x1, 0x100000, 0x1000000], steps
+
+    x = np.random.RandomState(42).randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = _run_retry_once(path, x)
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+
+    def run_variant(edits, tag):
+        patched = bytearray(mcode)
+        for word_index, value in edits:
+            patched[(word_index + 1) * 4 : (word_index + 2) * 4] = struct.pack(
+                "<I", value
+            )
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"steps_{tag}.axmodel")
+        onnx.save(c, p)
+        dev = _run_retry_once(p, x)
+        if dev.error:
+            assert "0x8030070C" in dev.error, (tag, dev.error)
+            return None
+        return np.frombuffer(dev.outputs[0], dtype=np.float32)
+
+    (w8, v8), (w0, v0), _, (w24, _) = steps
+    assert run_variant([(w8, 0)], "skip_bit8") is None, (
+        "expected skipping bit8 to fault"
+    )
+    out = run_variant([(w24, 0)], "skip_bit24")
+    assert out is not None and np.array_equal(out, out_base), (
+        "expected bit24 to be optional"
+    )
+    out = run_variant([(w8, v0), (w0, v8)], "swap_bit8_bit0")
+    assert out is not None and np.array_equal(out, out_base), (
+        "expected bit8/bit0 order-free"
+    )
+    out = run_variant([(w, 0) for w, _ in steps], "all_zero")
+    assert out is not None and not np.array_equal(out, out_base), (
+        "expected an absent step set to run with a changed result, not fault"
+    )


### PR DESCRIPTION
## Summary
Stacked on #1181 (merge order: #1179 -> #1180 -> #1181 -> this). Three local, zero-device-run checks that complete mcode's structural picture and correct one earlier statement.

- **`a1` is one of five verbs** over the same `xx yy` field/bank selector: `a8` (365; exactly one bank-2 and one bank-3 write per op), `a2` (359), `a3` (185), `a9` (181, exactly one per op).
- **With all five counted, the bulk is a uniform two-word stream**: 97.5% of 2,287 consecutive headers are exactly two words apart -- the earlier a1-only "gaps" were other verbs in between.
- **The per-op program is readable**: 64 of 180 ops are exactly one eleven-instruction template (40 more differ by one extra `a2`), with each `50 01` step immediately before a different verb.
- **Correction, in place:** the stream is *not* 4-byte aligned from the blob's first byte -- the first field write is at byte 297 (phase 1) and the preamble has 7-byte slots (3-byte operands); phase-0 alignment settles from about byte 328. A parser must not assume 8-byte slots from offset 0.
- **The tile arena's size is in the FlatBuffers header**: words 72/76 hold `4096` and `0x2ff000`; the largest `50 03` operand sits 32,704 bytes below it (less than one tile) -- linking the header region to the field map for the first time.

Device-free regression test (Docker only) locks in the verb counts, the two-word tiling, the dominant template, and the arena bound.

## Test plan
- [x] New test passes locally (Docker build, no device)
- [x] `ruff format --check` / `ruff check` clean
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2usgepQwRi2s6ASVaHfk