### PR TITLE
mcode: the whole field map generalizes to a second real architecture (mnasnet_small)

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2372,6 +2372,78 @@ op is dispatched by three required steps (`bit8`, `bit0` in either
 order, then `bit20`), followed by one step that can be dropped
 model-wide without changing a single output bit.
 
+### Five verbs, a readable per-op program, a variable-length preamble, and the arena size in the header
+
+Three local, zero-device-run checks that complete the structural
+picture -- and correct one earlier statement.
+
+**`a1` is one of five verbs over the same selector.** Tallying every
+phase-0 word of the shape `XX 00 <multiple of 0x10> yy` in the
+`resnet18d` blob, `a1` is joined by four more first bytes with the same
+`xx yy` field/bank selector and the same per-op multiples:
+
+```
+verb  writes  distinct selectors   what it writes
+a1     1197   68                   field writes (the map above)
+a8      365   5    -> 30 02 x181, 40 03 x181   one bank-2 and one bank-3 write per op
+a2      359   2    -> 00 00 x358               ~2 per op, fixed selector
+a3      185   4    -> 00 00 x182               1 per op
+a9      181   1    -> 00 00 x181               exactly 1 per op
+```
+
+**With all five verbs counted, the bulk is a uniform two-word stream.**
+From byte 328 there are 2,287 verb headers and **97.5% of consecutive
+headers are exactly two words apart** (2,228 of 2,285): `[verb 00 xx yy]
+[32-bit operand]`, eight bytes per instruction, throughout. The earlier
+"gaps of 4, 8, 10 words between `a1` headers" were other verbs in
+between, not longer instructions.
+
+**The per-op program is now readable.** Splitting at each `a1 40 02`
+(Wbt offset), 64 of 180 ops are exactly this eleven-instruction
+sequence, and 40 more differ only by one extra `a2`:
+
+```
+a1 40 02 <Wbt offset>      set weight offset
+a1 50 01 bit8              step 1 (required)
+a1 50 01 bit0              step 2 (required, order-free with step 1)
+a8 40 03 <...>             bank-3 write
+a1 50 03 <arena address>   set tile-arena address
+a1 50 01 bit20             step 3 (required)
+a3 00 00 <...>
+a1 50 01 bit24             step 4 (optional model-wide)
+a9 00 00 <...>
+a2 00 00 <...>
+a8 30 02 <...>             bank-2 write
+```
+
+Each of the four `50 01` steps sits immediately before a different verb,
+which reads naturally as "arm, then do" -- but that is an interpretation;
+the sequence itself is the measured fact (22 distinct per-op patterns
+in total, dominated by these two).
+
+**Correction, stated in place: the stream is not 4-byte aligned from the
+blob's first byte.** The first field write sits at byte 297 (phase 1):
+`a1 00 40 02 ff 00 00 00 | a8 00 50 02 00 00 00 00 | a1 00 60 02 80 14 03
+00 | a1 00 70 02 81 0a 03`, where that last slot is **seven** bytes -- a
+3-byte operand -- and only from about byte 328 onward do headers settle
+at phase 0 and stay there (1,192 of the bulk's 1,320 `a1 00` pairs; the
+scattered phase-1/2/3 ones lie inside packed operand words). So the
+preamble has variable-length instructions, the bulk does not, and a
+parser must not assume 8-byte slots from offset 0. The earlier word
+indexing from the blob start was right for the bulk by coincidence of
+where the preamble's odd slots happen to end.
+
+**The tile arena's size is declared in the FlatBuffers header.** Header
+words 72 and 76 hold `4096` and `0x002ff000` (3,141,632). The largest
+`50 03` operand, `0x2f7040`, sits 32,704 bytes below `0x2ff000` -- less
+than one typical tile (the most common `50 03` delta is 37,120) -- i.e.
+the last tile fits exactly under it. A declared size that bounds every
+arena address to within one tile is strong evidence that word 76 is the
+arena size and word 72 its page/alignment, which also links the header
+region (decoded first, long ago) to the field map for the first time.
+Whether `0x2ff000` is the physical on-chip memory size is still not
+checked against a spec.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2343,6 +2343,35 @@ sequencing (an out-of-range address is still a well-formed step). That
 also explains why it never fired on any `40 02` value and why a wholly
 absent step set runs.
 
+### The `50 01` step set is the op's dispatch, and its fourth step is inert model-wide
+
+Two device probes that each settle one question with a single decisive
+comparison.
+
+**An op with no step set does not execute.** Zeroing all four `50 01`
+writes of one real `resnet18d` op makes the model run with a changed
+result (argmax 305 -> 815). Doing the same *and* also pointing that
+op's `40 02` Wbt offset at a different instance's weights gives the
+**byte-identical** changed result. If the op still executed in some
+"default mode," its weights would matter and the two outputs would
+differ; they do not. So the four `50 01` writes are what dispatch the
+op -- remove them and the op is simply skipped, its weight offset never
+read, and the model's output is whatever the downstream layers make of
+a missing contribution. This also reinterprets the "removing all four
+does not fault" observation: there is no partial sequence left for the
+sequencer to reject, because there is no op.
+
+**`bit24` is inert for correctness across the entire model.** The
+per-op probe found that zeroing the fourth step (`bit24`) leaves one
+op's output bit-identical. Zeroing it in **all 181 ops at once**, in one
+patched model, leaves the whole network's output **bit-identical to the
+unpatched baseline**. Whatever the fourth write does -- a completion or
+profiling pulse is the natural guess -- no part of `resnet18d`'s
+computed result depends on it. Combined with the previous section: each
+op is dispatched by three required steps (`bit8`, `bit0` in either
+order, then `bit20`), followed by one step that can be dropped
+model-wide without changing a single output bit.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2444,6 +2444,56 @@ region (decoded first, long ago) to the field map for the first time.
 Whether `0x2ff000` is the physical on-chip memory size is still not
 checked against a spec.
 
+### The whole map generalizes to a second real architecture: `mnasnet_small`
+
+Everything above about mcode's structure was established on `resnet18d`
+(plus a tiny synthetic two-Conv model). A real second architecture,
+`mnasnet_small_Opset17` -- depthwise-separable, 133 NPU ops vs.
+`resnet18d`'s 181, a 2.77 MB weight table vs. 11.86 MB -- compiled fully
+on the NPU (one fused subgraph), ran on the real AX650N, and was
+bit-identical between the original and onnxsim-simplified graphs, as
+always. Its mcode (78,584 bytes) checked against every structural claim,
+all local:
+
+```
+claim                                   resnet18d            mnasnet_small
+header words 72 / 76                    4096 / 0x2ff000      4096 / 0x2ff000   (identical)
+largest 50 03 below the arena, by       32,704 B (< 1 tile)  26,848 B (< 1 tile)
+first field write                       byte 297, phase 1    byte 297, phase 1
+five verbs present                      yes                  yes
+40 02 / 50 03 / a9 / a8:3002 / a8:4003  181 each             133 each   (= op count)
+50 01 writes per op                     4.00                 4.00
+50 01 operand set                       {bit0,8,20,24}       {bit0,8,20,24}
+50 01 order per op                      bit8,bit0,bit20,bit24 (180/180)  same (132/132)
+dominant per-op template                64 of 180 ops        34 of 132 ops
+40 02 max / Wbt size                    0.997, all distinct  0.984, all distinct
+sdma4 trace events                      181 (= ops)          133 (= ops)
+two-word tiling of the bulk             97.5%                92.3%
+50 03 operands 64-byte aligned          175/176              112/133
+```
+
+**Every per-op invariant holds exactly on the second model**, with the
+op count simply changing from 181 to 133: the five verbs, the one write
+each of `40 02`/`50 03`/`a9`/both `a8` selectors per op, four `50 01`
+writes per op in the same one-hot set and the same fixed order, the same
+dominant eleven-instruction template, `40 02` spanning the weight table
+(all distinct, 98.4% of a Wbt one quarter the size), and one `sdma4` DMA
+per op. **The arena size `0x2ff000` is identical**, so it is a platform
+constant of the AX650N, not something the compiler sizes per model --
+and both models' arena addresses stay under it by less than one tile.
+The depthwise convs also show up where the engine-split finding said
+they would: both MAC engines busy (`conv0` 909, `conv1` 855 events).
+
+**Two honest deltas.** The bulk's two-word tiling is 92% here vs. 97.5%
+(a few 16-word gaps -- larger operands or a different verb the tally
+does not know), and `50 03` alignment is 84% vs. 99% (depthwise tiles
+plausibly use a finer granule). Neither touches the per-op invariants;
+both are worth knowing before treating the parser as complete.
+
+Net: the field-write reading, the verb set, the per-op program, and the
+two quantitatively decoded fields are properties of the compiler and
+the hardware, not of `resnet18d`.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2011,3 +2011,66 @@ def test_resnet18d_50_01_step_set_dispatches_the_op_and_bit24_is_inert_model_wid
     assert np.array_equal(all_bit24_zero, out_base), (
         "expected bit24 to be inert for correctness across every op"
     )
+
+
+_VERBS = {0xA1, 0xA2, 0xA3, 0xA8, 0xA9}
+
+
+def _verb_headers(mcode, start=328):
+    """Every verb header word in the phase-0 bulk of an mcode blob -- see
+    the README's "Five verbs, a readable per-op program" section. Returns
+    `(word_index, verb, xx, yy, operand)` for each `XX 00 <mult of 0x10>
+    yy` word whose first byte is a known verb, indexing words from
+    `start` (the preamble before it has variable-length slots)."""
+    words = [mcode[i : i + 4] for i in range(start, len(mcode) - 3, 4)]
+    return [
+        (k, w[0], w[2], w[3], int.from_bytes(words[k + 1], "little"))
+        for k, w in enumerate(words)
+        if w[0] in _VERBS and w[1] == 0 and w[2] % 0x10 == 0 and k + 1 < len(words)
+    ]
+
+
+def test_resnet18d_bulk_is_a_two_word_stream_of_five_verbs_with_a_per_op_program(
+    tmp_path,
+):
+    """Confirmed real (see the README's "Five verbs, a readable per-op
+    program" section), all local: with all five verbs counted, 97.5% of
+    consecutive headers in the bulk are exactly two words apart; `a9 00
+    00` and both `a8` selectors occur exactly once per op (181); and 64
+    of 180 ops are exactly one eleven-instruction template. Also locks in
+    the header-declared arena size 0x2ff000 bounding every `50 03`
+    address. Needs Docker for the build but no device.
+    """
+    from collections import Counter
+
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    hdrs = _verb_headers(mcode)
+    assert len(hdrs) >= 2200, len(hdrs)
+
+    gaps = Counter(b[0] - a[0] for a, b in zip(hdrs, hdrs[1:]))
+    assert gaps[2] / sum(gaps.values()) >= 0.95, gaps.most_common(5)
+
+    by_verb_sel = Counter((v, xx, yy) for _, v, xx, yy, _ in hdrs)
+    assert by_verb_sel[(0xA9, 0x00, 0x00)] == 181
+    assert by_verb_sel[(0xA8, 0x30, 0x02)] == by_verb_sel[(0xA8, 0x40, 0x03)] == 181
+    assert by_verb_sel[(0xA2, 0x00, 0x00)] >= 350
+    assert by_verb_sel[(0xA3, 0x00, 0x00)] >= 180
+
+    cuts = [k for k, v, xx, yy, _ in hdrs if (v, xx, yy) == (0xA1, 0x40, 0x02)]
+    template = "a1:5001 a1:5001 a8:4003 a1:5003 a1:5001 a3:0000 a1:5001 a9:0000 a2:0000 a8:3002"
+    patterns = Counter(
+        " ".join(f"{v:02x}:{xx:02x}{yy:02x}" for k, v, xx, yy, _ in hdrs if a < k < b)
+        for a, b in zip(cuts, cuts[1:])
+    )
+    assert patterns[template] >= 60, patterns.most_common(2)
+
+    arena = int.from_bytes(mcode[76:80], "little")
+    assert arena == 0x2FF000, hex(arena)
+    assert int.from_bytes(mcode[72:76], "little") == 4096
+    max_50_03 = max(
+        op for _, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x50, 0x03)
+    )
+    assert max_50_03 < arena and arena - max_50_03 < 40_000, (
+        hex(max_50_03),
+        hex(arena),
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1940,3 +1940,74 @@ def test_resnet18d_50_01_steps_three_required_one_optional_on_device(tmp_path):
     assert out is not None and not np.array_equal(out, out_base), (
         "expected an absent step set to run with a changed result, not fault"
     )
+
+
+def test_resnet18d_50_01_step_set_dispatches_the_op_and_bit24_is_inert_model_wide(
+    tmp_path,
+):
+    """Confirmed real on the device (see the README's "The `50 01` step set
+    is the op's dispatch" section): with all four `50 01` steps of one op
+    zeroed, the model runs with a changed result, and additionally
+    pointing that op's Wbt offset at another instance's weights gives the
+    byte-identical changed result -- the op no longer executes at all.
+    And zeroing `bit24` in all 181 ops at once leaves the whole output
+    bit-identical to the unpatched baseline.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    hdrs = [
+        (i, w[2], w[3], int.from_bytes(words[i + 1], "little"))
+        for i, w in enumerate(words)
+        if w[:2] == b"\xa1\x00" and i + 1 < len(words)
+    ]
+    cuts = [i for i, xx, yy, _ in hdrs if (xx, yy) == (0x40, 0x02)]
+    op_start = 8174
+    assert op_start in cuts
+    op_end = min(i for i in cuts if i > op_start)
+    steps = [
+        i for i, xx, yy, _ in hdrs if (xx, yy) == (0x50, 0x01) and op_start < i < op_end
+    ]
+    assert len(steps) == 4
+    other_offset = int.from_bytes(
+        mcode[48300:48304], "little"
+    )  # a different op's 40 02 value
+    bit24_writes = [
+        i for i, xx, yy, v in hdrs if (xx, yy) == (0x50, 0x01) and v == 0x1000000
+    ]
+    assert len(bit24_writes) == 181
+
+    x = np.random.RandomState(42).randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = _run_retry_once(path, x)
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+
+    def run_variant(edits, tag):
+        patched = bytearray(mcode)
+        for word_index, value in edits:
+            patched[(word_index + 1) * 4 : (word_index + 2) * 4] = struct.pack(
+                "<I", value
+            )
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"dispatch_{tag}.axmodel")
+        onnx.save(c, p)
+        dev = _run_retry_once(p, x)
+        assert not dev.error, (tag, dev.error)
+        return np.frombuffer(dev.outputs[0], dtype=np.float32)
+
+    no_steps = run_variant([(w, 0) for w in steps], "no_steps")
+    assert not np.array_equal(no_steps, out_base)
+    no_steps_other_weights = run_variant(
+        [(w, 0) for w in steps] + [(op_start, other_offset)], "no_steps_other_weights"
+    )
+    assert np.array_equal(no_steps, no_steps_other_weights), (
+        "expected an op with no step set to be skipped, so its weight offset is never read"
+    )
+
+    all_bit24_zero = run_variant([(w, 0) for w in bit24_writes], "all_bit24_zero")
+    assert np.array_equal(all_bit24_zero, out_base), (
+        "expected bit24 to be inert for correctness across every op"
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2074,3 +2074,103 @@ def test_resnet18d_bulk_is_a_two_word_stream_of_five_verbs_with_a_per_op_program
         hex(max_50_03),
         hex(arena),
     )
+
+
+def _build_real_zoo_model(work_dir, name):
+    """Fetch and really build any single-image-input onnxmodelzoo model
+    the same way `convert_onnxmodelzoo.py` does. Returns `(axmodel_path,
+    mcode_key, mcode_bytes, wbt_bytes)`. The resnet18d-specific
+    `_build_real_resnet18d` above predates this and keeps its exact-size
+    assertion; new multi-model tests should use this one."""
+    import convert_onnxmodelzoo  # also puts model_zoo on sys.path
+    import model_zoo
+
+    model = onnx.load(model_zoo.fetch_model(name))
+    tensor_name = convert_onnxmodelzoo._single_image_input(model)
+    assert tensor_name is not None, name
+
+    os.makedirs(os.path.join(work_dir, "model"), exist_ok=True)
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    pulsar2_docker.make_synthetic_calibration_tar(
+        os.path.join(work_dir, "dataset", "calib.tar")
+    )
+    onnx.save(model, os.path.join(work_dir, "model", f"{name}.onnx"))
+    result = pulsar2_docker.build(
+        work_dir,
+        f"model/{name}.onnx",
+        f"output/{name}",
+        tensor_name=tensor_name,
+        mean=convert_onnxmodelzoo._DEFAULT_MEAN,
+        std=convert_onnxmodelzoo._DEFAULT_STD,
+        calibration_dataset_rel_path="dataset/calib.tar",
+    )
+    assert result.success, (name, result.error)
+    compiled = onnx.load(result.axmodel_path)
+    inits = {i.name: i for i in compiled.graph.initializer}
+    key = _mcode_key(compiled)
+    return (
+        result.axmodel_path,
+        key,
+        bytes(inits[key].raw_data),
+        bytes(inits[_params_key(compiled)].raw_data),
+    )
+
+
+def test_mcode_field_map_generalizes_to_mnasnet_small(tmp_path):
+    """Confirmed real (see the README's "The whole map generalizes to a
+    second real architecture" section), all local on a real
+    `mnasnet_small_Opset17` build: the same header constants (4096,
+    0x2ff000 arena), the same five verbs, one `40 02`/`50 03`/`a9`/`a8`
+    write each per op with the op count simply changing (133), four
+    `50 01` writes per op in the same one-hot set and fixed order, `40 02`
+    spanning its (very different) Wbt, and the dominant per-op template.
+    Needs Docker for the build but no device.
+    """
+    from collections import Counter
+
+    _, _, mcode, wbt = _build_real_zoo_model(str(tmp_path), "mnasnet_small_Opset17")
+    assert int.from_bytes(mcode[72:76], "little") == 4096
+    assert int.from_bytes(mcode[76:80], "little") == 0x2FF000, (
+        "arena size is a platform constant"
+    )
+
+    hdrs = _verb_headers(mcode)
+    by = Counter((v, xx, yy) for _, v, xx, yy, _ in hdrs)
+    n_ops = by[(0xA1, 0x40, 0x02)]
+    assert 100 <= n_ops <= 160, n_ops
+    for sel in (
+        (0xA1, 0x50, 0x03),
+        (0xA9, 0x00, 0x00),
+        (0xA8, 0x30, 0x02),
+        (0xA8, 0x40, 0x03),
+    ):
+        assert by[sel] == n_ops, (sel, by[sel], n_ops)
+    assert by[(0xA1, 0x50, 0x01)] == 4 * n_ops
+    assert {op for _, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x50, 0x01)} == {
+        0x1,
+        0x100,
+        0x100000,
+        0x1000000,
+    }
+
+    ops4002 = [op for _, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x40, 0x02)]
+    assert len(set(ops4002)) == n_ops
+    assert 0.95 * len(wbt) <= max(ops4002) <= len(wbt), (max(ops4002), len(wbt))
+    max_50_03 = max(
+        op for _, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x50, 0x03)
+    )
+    assert max_50_03 < 0x2FF000 and 0x2FF000 - max_50_03 < 40_000, hex(max_50_03)
+
+    cuts = [k for k, v, xx, yy, _ in hdrs if (v, xx, yy) == (0xA1, 0x40, 0x02)]
+    flags = [(k, op) for k, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x50, 0x01)]
+    order = (0x100, 0x1, 0x100000, 0x1000000)
+    assert all(
+        tuple(op for k, op in flags if a < k < b) == order
+        for a, b in zip(cuts, cuts[1:])
+    ), "expected every op to write the same four-step sequence"
+    template = "a1:5001 a1:5001 a8:4003 a1:5003 a1:5001 a3:0000 a1:5001 a9:0000 a2:0000 a8:3002"
+    patterns = Counter(
+        " ".join(f"{v:02x}:{xx:02x}{yy:02x}" for k, v, xx, yy, _ in hdrs if a < k < b)
+        for a, b in zip(cuts, cuts[1:])
+    )
+    assert patterns.most_common(1)[0][0] == template, patterns.most_common(2)


### PR DESCRIPTION
## Summary
Stacked on #1188 (merge order: #1181 -> #1188 -> this). Generalizes the whole mcode structural map to a second real architecture, all local, zero device runs beyond the model's own build-and-run.

`mnasnet_small_Opset17` -- depthwise-separable, 133 NPU ops vs resnet18d's 181, a 2.77 MB Wbt vs 11.86 MB -- compiled fully on the NPU (one fused subgraph), ran on the real AX650N, and was bit-identical original vs onnxsim-simplified. Every structural claim checked against its mcode:

- **Identical header constants**: words 72/76 = `4096` / `0x2ff000` -- the tile arena size is a **platform constant**, not per-model -- with the largest `50 03` again under it by less than a tile.
- **Every per-op invariant holds exactly**, with the op count simply changing to 133: all five verbs; one `40 02` / `50 03` / `a9` / `a8:3002` / `a8:4003` write each per op; `50 01` exactly 4.00 per op in the same one-hot set and the same fixed order (132/132); the same dominant eleven-instruction template; `40 02` all distinct and spanning 98.4% of its (very different) Wbt; `sdma4` = 133 = one DMA per op; both MAC engines busy on the depthwise convs.
- **Two honest deltas**: two-word tiling 92% (vs 97.5%) and `50 03` 64-byte alignment 84% (vs 99%) -- neither touches the per-op invariants; both worth knowing before treating a parser as complete.

Adds `_build_real_zoo_model` (any single-image zoo model) and a device-free regression test (Docker only).

## Test plan
- [x] New test passes locally (Docker build, no device); the model also ran on the real device bit-identically via `convert_onnxmodelzoo.py --profile`
- [x] `ruff format --check` / `ruff check` clean
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2usgepQwRi2s6ASVaHfk