### PR TITLE
mcode: correction -- verb runs are two-word but only 37% of the bulk; shared prologue and a short-form write

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2372,6 +2372,78 @@ op is dispatched by three required steps (`bit8`, `bit0` in either
 order, then `bit20`), followed by one step that can be dropped
 model-wide without changing a single output bit.
 
+### Five verbs, a readable per-op program, a variable-length preamble, and the arena size in the header
+
+Three local, zero-device-run checks that complete the structural
+picture -- and correct one earlier statement.
+
+**`a1` is one of five verbs over the same selector.** Tallying every
+phase-0 word of the shape `XX 00 <multiple of 0x10> yy` in the
+`resnet18d` blob, `a1` is joined by four more first bytes with the same
+`xx yy` field/bank selector and the same per-op multiples:
+
+```
+verb  writes  distinct selectors   what it writes
+a1     1197   68                   field writes (the map above)
+a8      365   5    -> 30 02 x181, 40 03 x181   one bank-2 and one bank-3 write per op
+a2      359   2    -> 00 00 x358               ~2 per op, fixed selector
+a3      185   4    -> 00 00 x182               1 per op
+a9      181   1    -> 00 00 x181               exactly 1 per op
+```
+
+**With all five verbs counted, the bulk is a uniform two-word stream.**
+From byte 328 there are 2,287 verb headers and **97.5% of consecutive
+headers are exactly two words apart** (2,228 of 2,285): `[verb 00 xx yy]
+[32-bit operand]`, eight bytes per instruction, throughout. The earlier
+"gaps of 4, 8, 10 words between `a1` headers" were other verbs in
+between, not longer instructions.
+
+**The per-op program is now readable.** Splitting at each `a1 40 02`
+(Wbt offset), 64 of 180 ops are exactly this eleven-instruction
+sequence, and 40 more differ only by one extra `a2`:
+
+```
+a1 40 02 <Wbt offset>      set weight offset
+a1 50 01 bit8              step 1 (required)
+a1 50 01 bit0              step 2 (required, order-free with step 1)
+a8 40 03 <...>             bank-3 write
+a1 50 03 <arena address>   set tile-arena address
+a1 50 01 bit20             step 3 (required)
+a3 00 00 <...>
+a1 50 01 bit24             step 4 (optional model-wide)
+a9 00 00 <...>
+a2 00 00 <...>
+a8 30 02 <...>             bank-2 write
+```
+
+Each of the four `50 01` steps sits immediately before a different verb,
+which reads naturally as "arm, then do" -- but that is an interpretation;
+the sequence itself is the measured fact (22 distinct per-op patterns
+in total, dominated by these two).
+
+**Correction, stated in place: the stream is not 4-byte aligned from the
+blob's first byte.** The first field write sits at byte 297 (phase 1):
+`a1 00 40 02 ff 00 00 00 | a8 00 50 02 00 00 00 00 | a1 00 60 02 80 14 03
+00 | a1 00 70 02 81 0a 03`, where that last slot is **seven** bytes -- a
+3-byte operand -- and only from about byte 328 onward do headers settle
+at phase 0 and stay there (1,192 of the bulk's 1,320 `a1 00` pairs; the
+scattered phase-1/2/3 ones lie inside packed operand words). So the
+preamble has variable-length instructions, the bulk does not, and a
+parser must not assume 8-byte slots from offset 0. The earlier word
+indexing from the blob start was right for the bulk by coincidence of
+where the preamble's odd slots happen to end.
+
+**The tile arena's size is declared in the FlatBuffers header.** Header
+words 72 and 76 hold `4096` and `0x002ff000` (3,141,632). The largest
+`50 03` operand, `0x2f7040`, sits 32,704 bytes below `0x2ff000` -- less
+than one typical tile (the most common `50 03` delta is 37,120) -- i.e.
+the last tile fits exactly under it. A declared size that bounds every
+arena address to within one tile is strong evidence that word 76 is the
+arena size and word 72 its page/alignment, which also links the header
+region (decoded first, long ago) to the field map for the first time.
+Whether `0x2ff000` is the physical on-chip memory size is still not
+checked against a spec.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2732,6 +2732,48 @@ units against a 20.4% shuffled null (25.3% vs 21.1% in `mnasnet`), so
 this is a per-bank distinction, not a property of the family --
 reported as the shape of the data, not a decoding of it.
 
+### The layout that explains all of it: two configuration blocks, then 180 clean op programs
+
+Splitting the whole token stream at every `a1 40 02` write and asking
+where the short units and unknown bytes actually are gives the blob's
+real layout, and it is simpler than the section-by-section picture
+suggested:
+
+```
+resnet18d (49,080 B)                       verbs  short units  unknown bytes
+  bytes    297 .. 11,433  config block A       50          750         7,282
+  bytes 11,433 .. 30,816  config block B      159        1,444        11,396
+  bytes 30,816 .. 48,496  180 op programs   ~2,160            0             0
+  bytes 48,496 .. 48,828  epilogue             11            0           244
+  (then the back FlatBuffers copy)
+
+mnasnet_small (78,584 B)
+  bytes    297 .. 19,977  config block A      141        1,574        10,756
+  bytes 19,977 .. 64,672  config block B      502        4,242        17,576
+  bytes 64,672 .. 78,008  132 op programs   ~1,650            0             0
+  bytes 78,008 .. 78,332  epilogue             12            0           228
+```
+
+**180 of 183 `resnet18d` segments, and 132 of 135 in `mnasnet`, contain
+no short unit and no unknown byte at all** -- each is exactly the
+eleven-instruction verb template (~96 bytes) and nothing else. Every
+short-form unit and every undecoded byte in the entire blob sits in two
+large configuration blocks at the front (bounded by two *setup* `40 02`
+writes whose operands -- `ff 00 00 00` and one more -- are not real
+op offsets) plus a ~330-byte epilogue. The blocks are 62% of
+`resnet18d`'s blob and 82% of `mnasnet`'s.
+
+This is why the coverage numbers looked the way they did: the "37%" of
+the bulk that the verb walker explained was, to first order, *the
+entire op-program region*, which is parsed end to end, while the
+"unexplained 63%" was the configuration blocks, where verbs are a
+minority among short units and undecoded bytes. It also corrects the
+earlier reading that the regions were interleaved "about one per four
+ops": they are not interleaved with ops at all. The per-op program is
+done; the frontier is precisely two configuration blocks whose short
+units follow the width rule and whose remaining bytes (18.9 KB in
+`resnet18d`) are the actual undecoded content of mcode.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2343,6 +2343,35 @@ sequencing (an out-of-range address is still a well-formed step). That
 also explains why it never fired on any `40 02` value and why a wholly
 absent step set runs.
 
+### The `50 01` step set is the op's dispatch, and its fourth step is inert model-wide
+
+Two device probes that each settle one question with a single decisive
+comparison.
+
+**An op with no step set does not execute.** Zeroing all four `50 01`
+writes of one real `resnet18d` op makes the model run with a changed
+result (argmax 305 -> 815). Doing the same *and* also pointing that
+op's `40 02` Wbt offset at a different instance's weights gives the
+**byte-identical** changed result. If the op still executed in some
+"default mode," its weights would matter and the two outputs would
+differ; they do not. So the four `50 01` writes are what dispatch the
+op -- remove them and the op is simply skipped, its weight offset never
+read, and the model's output is whatever the downstream layers make of
+a missing contribution. This also reinterprets the "removing all four
+does not fault" observation: there is no partial sequence left for the
+sequencer to reject, because there is no op.
+
+**`bit24` is inert for correctness across the entire model.** The
+per-op probe found that zeroing the fourth step (`bit24`) leaves one
+op's output bit-identical. Zeroing it in **all 181 ops at once**, in one
+patched model, leaves the whole network's output **bit-identical to the
+unpatched baseline**. Whatever the fourth write does -- a completion or
+profiling pulse is the natural guess -- no part of `resnet18d`'s
+computed result depends on it. Combined with the previous section: each
+op is dispatched by three required steps (`bit8`, `bit0` in either
+order, then `bit20`), followed by one step that can be dropped
+model-wide without changing a single output bit.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2544,6 +2544,52 @@ short-form write encoding, alongside the 8-byte `[VV 00 xx yy][32-bit]`
 form and the 7-byte 3-byte-operand slots already noted; a parser needs
 all three.
 
+### Second correction: the "verb-free regions" are the same instruction stream, drifted off the 4-byte grid
+
+The section above split the bulk into two-word verb runs (37%) and
+"verb-free regions" (63%) and floated "data/descriptor tables" for the
+latter. Testing that directly, locally, overturns it -- stated in place.
+
+**The regions are full of instructions the grid could not see.** Counting
+verb-shaped `VV 00 x0 yy` words *inside* the regions at every byte
+phase: `resnet18d` has 73 / 43 / 54 of them at phases 1 / 2 / 3 (and
+zero at phase 0 only because phase 0 is what defined the regions);
+`mnasnet` has 197 / 185 / 160. The compact `00 xx 84 vv` short-form
+write appears **417** times inside `resnet18d`'s regions and **580**
+times inside `mnasnet`'s, at any phase. The regions are not tables; they
+are stretches where the instruction stream's alignment has drifted off
+a fixed 4-byte grid -- exactly what 7-byte and 4-byte instructions
+interleaved with 8-byte ones must produce. Fixed-size records are also
+ruled out on their own terms: the regions' best internal periods are
+4-8 bytes with weak match (0.11 / 0.26), their sizes are rarely 32- or
+64-byte multiples, and only 0.7% / 2.9% of their 32-byte windows repeat.
+
+**A variable-length walker recovers what the grid missed -- and shows
+what is still unknown.** Walking from byte 297 and consuming an 8-byte
+verb instruction, a 7-byte one when the next header lands at +7, or a
+4-byte compact write, and otherwise stepping one unknown byte:
+
+```
+                       fixed 4-byte grid    variable-length walker (3 known forms)
+resnet18d  (48,531 B)  37.7% explained      43.8%   (2,443 x 8-byte, 16 x 7-byte, 398 x compact)
+mnasnet    (78,035 B)  19.2%                27.4%   (2,367, 49, 535)
+tiny       ( 3,371 B)  15.9%                39.4%   (  116,  8,  86)
+```
+
+The walker beats the grid everywhere, most on the tiny model, and the
+bytes it cannot explain sit overwhelmingly in **short** gaps (the most
+common unknown-run lengths are 5, 12, 1, 47, 6 and 7 bytes) with a few
+long stretches (the longest 1,352 bytes in `resnet18d`). Short gaps
+between recognized instructions are what additional, not-yet-known
+short instruction forms look like -- not what a data table looks like.
+
+So the corrected picture, replacing "37% two-word runs + 63% regions":
+**mcode's bulk is one variable-length instruction stream with at least
+three encodings, of which three forms are known and explain 27-44% of
+the bytes; the rest is further forms, mostly short, plus a few long
+stretches, all undecoded.** The "37%" and "verb-free" figures were
+artifacts of measuring a variable-length stream on a fixed grid.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2774,6 +2774,36 @@ done; the frontier is precisely two configuration blocks whose short
 units follow the width rule and whose remaining bytes (18.9 KB in
 `resnet18d`) are the actual undecoded content of mcode.
 
+### Into config block B: the width rule reaches prefix 4, and a candidate second header family
+
+First pass over the larger configuration block (`resnet18d` bytes
+11,433..30,816; `mnasnet` 19,977..64,672), asking what the undecoded
+residue is made of once every validated instruction is removed.
+
+**The width rule extends, a little.** Testing prefixes `p = 4..15` the
+same way (tag byte at offset `p + 2`, against a shuffled null of the
+block): `p = 4` holds in both models (2.6x, n = 68; 2.4x, n = 203);
+`p = 5` and `p = 9` reach ~2.2x in `mnasnet` only; `p = 6..8` and
+`10..15` sit at chance. Admitting `p <= 4` shrinks `resnet18d`'s block-B
+residue from 11,396 to 11,134 bytes -- the family is `p = 0..4` (units
+of 4..8 bytes), and it is not where most of the residue goes. Block B
+is **42.6%** explained in `resnet18d` and **63.4%** in `mnasnet`.
+
+**What remains is not records, and not noise.** The residue's runs are
+still instruction-sized (2, 4, 8, 6, 15, 13, 7, 5 bytes; longest 136),
+and its best internal period is weak in absolute terms (5 bytes, 8.3%
+matching) but **three times** the same residue shuffled (2.7%) -- real
+local structure, not fixed-size records. Its most common 2-byte pairs
+are `23 00` (139), `00 00`, `03 00`, `18 9f`, `8b 18`, `16 00` in
+`resnet18d` and `00 00`, `16 00`, `04 00`, `9f 16`, `01 00`, `16 04` in
+`mnasnet`: a set of `XX 00` pairs with `XX` in `{0x23, 0x16, 0x03,
+0x04, 0x01}` -- the same `23 00` family the tiny model's four
+non-deterministic noise bytes lived in. That reads as a **second header
+family** (`XX 00` with a first byte outside the verb set), i.e. more
+instruction forms with their own widths, and it is the next thing to
+validate with the permutation method -- the width-rule test above is
+exactly the template for it.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2590,6 +2590,148 @@ the bytes; the rest is further forms, mostly short, plus a few long
 stretches, all undecoded.** The "37%" and "verb-free" figures were
 artifacts of measuring a variable-length stream on a fixed grid.
 
+### The regions fault like instructions on the device -- and a chance baseline withdraws the "short-form family"
+
+**Device census: the former "verb-free regions" are validated
+structure.** Flipping one byte at the start, middle and end of each of
+the ten largest regions in the real `resnet18d` blob (30 flips, one
+patched model per run, retry-once on the known transient):
+
+```
+region (byte, len)   start / mid / end
+(18228, 4180)        F D =
+( 6844, 4160)        F F F
+(15436, 2744)        F D F
+(11812, 2032)        D F =
+( 4896, 1940)        F F F
+(  400, 1772)        = F F
+( 3200, 1688)        F F F
+(29188, 1352)        F F F
+(28032, 1148)        F F F
+( 2180, 1012)        F F F
+                     24 fault / 3 change output / 3 inert
+```
+
+**80% of flips inside these regions fault** with `0x8030070C` -- a
+higher rate than the original whole-blob sweep (61%). A data table
+answers corruption with wrong values (`D`) or nothing (`=`); a
+sequenced instruction stream answers it with the validator. This is the
+hardware-side confirmation of the previous section's reading, and it is
+the strongest single result in this arc: the regions are instructions.
+The device stayed healthy throughout (70 C, memory at baseline).
+One honest variance note: re-running the four largest regions' twelve
+flips on a *fresh* build gave 7 faults, not the 10 seen here -- per-flip
+outcomes at a fixed offset can differ between builds (the known
+non-deterministic label bytes are the obvious suspect), so the
+regression test asserts a majority of faults, not the exact count.
+
+**A chance baseline, applied late, withdraws a claim.** Tokenizing the
+bytes the walker could not explain suggested a family of short
+bank-tagged writes -- `00 ff TT vv` (4 B), `01 ff xx TT vv` (5 B),
+bare `TT vv` (2 B), tag `TT` in `0x81..0x84`, with the prefix and tag
+tending to sum to `0x84` -- and a walker taught those forms "explained"
+61-70% of the bulk. Checked against chance, that dissolves: `0x00` is
+28.5% of `resnet18d`'s bulk bytes and tag bytes 6.5%, so a `00 ?? TT`
+pattern arises at ~1.8% of positions by chance against 2.7% observed --
+**only 1.5x chance** (1.3x on `mnasnet`, 1.4x on the tiny model) -- and
+the bare 2-byte form is at or below chance. The verb forms, by
+contrast, are more than 100x chance (five specific first bytes, a zero,
+a multiple of 16). So: the compact `00 xx 84 vv` **prologue ladder** is
+real (a stepping field across three models is not chance), but
+generalizing it to a stream-wide short-form family is **not supported**
+at present, and the "a parser needs all three forms" sentence two
+sections up is too strong -- the third form is established in the
+prologue only. Coverage figures that lean on the loose short forms are
+inflated; the defensible number remains the three-form walker's 27-44%,
+of which the specific verb instructions are the reliable part.
+
+Net, stated carefully: the regions are instructions (device-confirmed),
+their alignment drifts (off-phase verbs), and their *encoding* is still
+mostly unknown -- the next real step is a form-by-form decoding with a
+chance baseline applied *before* each form is admitted, not after.
+
+### Third correction: with the right null, the short-form family is real after all
+
+Doing exactly that -- applying a chance baseline *properly* -- reverses
+the withdrawal just above. The "1.5x chance" figure came from an
+independence estimate (`P(byte == 00) x P(byte in 0x81..0x84)`) against
+the greedy walker's start rate. That is the wrong null for a
+*positional* pattern: what makes `00 ?? TT ??` an instruction form is
+that a tag byte sits at a fixed offset after a prefix byte, and an
+independence product says nothing about offsets. The right null keeps
+every byte and destroys only the order: shuffle the non-verb bytes of
+each bulk (20 permutations, identical byte histogram) and count each
+pattern in the shuffles.
+
+```
+pattern                       resnet18d: observed / null (+-sd)   ratio    z
+00 ?? TT ??  (4-byte form)    1485 /  382 (+-13)                  3.9x    82
+01 ?? ?? TT ??  (5-byte)       496 /  175 (+-12)                  2.8x    27
+02 ... TT ??  (6-byte)         229 /   68 (+- 5)                  3.4x    31
+03 ... TT ??  (7-byte)         154 /   63 (+- 8)                  2.4x    12
+00 x0 84 ??  (prologue ladder) 393 /   29 (+- 5)                 13.7x    72
+prefix + tag == 0x84          1286 /  191 (+-15)                  6.7x    75
+                              mnasnet: 3.9x / 4.1x / 3.8x / 4.8x / 9.4x / 8.3x, z up to 172
+```
+
+Every short form is far above its permutation null -- z-scores from 12
+to 172 -- and the prefix/tag complement (`00<->84`, `01<->83`,
+`02<->82`, `03<->81`) is 6.7-8.3x chance in both models. So the family
+of short bank-tagged writes **is real statistical structure**, the
+"withdrawal" above was an over-correction from a mis-specified
+baseline, and the honest state is: the forms exist; their exact widths
+are the best reading of where the tag byte lands (offset `prefix + 2`);
+and the coverage they add on top of the verb instructions (to ~61-63%
+of the bulk without the permissive 2-byte form) is legitimate. The
+bare 2-byte `TT vv` form remains unsupported (it has no positional
+structure to test) and stays out of the count.
+
+The methodological lesson is the durable part: three corrections in a
+row on one topic came from three different baselines -- a fixed grid,
+an independence estimate, and finally a permutation null. Only the last
+is appropriate for order-dependent structure, and it is the one this
+README should have reached for first.
+
+**The width rule, measured.** With the permutation null in hand, the
+"widths are the best reading" hedge can be replaced by a measurement:
+for each prefix `p` in `0..3`, where after the prefix does a tag byte
+sit more often than chance?
+
+```
+                         offset after the prefix (observed / null)
+prefix    k=1    k=2    k=3    k=4    k=5           mnasnet peak
+p=0      0.25   3.93   0.19   0.41   0.33           k=2  3.74x
+p=1      0.80   0.20   2.93   0.09   0.65           k=3  4.01x
+p=2      1.44   0.43   0.37   3.40   1.10           k=4  3.72x
+p=3      0.95   0.77   1.63   0.49   2.49           k=5  4.72x
+```
+
+The enrichment peaks at **exactly `k = p + 2`** for every prefix in
+both models, with every other offset at or below chance -- and at that
+offset the complement tag `0x84 - p` is elevated 5-12x while other tags
+are 0.9-3.3x. So the unit is `[p] [p+1 payload bytes] [0x84 - p]
+[value]`, **`p + 4` bytes long**: 4, 5, 6, 7 bytes for `p = 0..3`. The
+prefix encodes the payload length and, most of the time, the bank. That
+is a decoded *format* for the short instructions, not their semantics
+-- what the payload bytes and the value mean per bank is still open --
+but it is the first part of the non-verb encoding that can be stated as
+a rule rather than a pattern.
+
+**One step into the payload: the bank tag selects the payload's kind.**
+For the dominant 4-byte units `00 ff TT vv` (1,485 in `resnet18d`,
+3,500 in `mnasnet`), the field byte `ff` is a multiple of `0x10` far
+more often for tag `0x84` than for the others -- and bank `0x84`'s
+commonest fields are exactly the prologue ladder's (`0x80, 0xb0, 0x70,
+0xc0, 0xa0`), i.e. the same 16-byte-granular field space the `a1` verbs
+use. Banks `0x81..0x83` instead carry small integers in `ff` (`1, 5, 8,
+9, 0xe, 0xd`), which read as indices or counts rather than field
+offsets. Some units are constants (`00 b0 84 08` occurs 61 of 61 times
+in `resnet18d`); others carry a small numeric range (`00 80 84 vv` takes
+16 values, `0x56..0x5c`). Overall `ff` is 16-granular in only 35.6% of
+units against a 20.4% shuffled null (25.3% vs 21.1% in `mnasnet`), so
+this is a per-bank distinction, not a property of the family --
+reported as the shape of the data, not a decoding of it.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2444,6 +2444,56 @@ region (decoded first, long ago) to the field map for the first time.
 Whether `0x2ff000` is the physical on-chip memory size is still not
 checked against a spec.
 
+### The whole map generalizes to a second real architecture: `mnasnet_small`
+
+Everything above about mcode's structure was established on `resnet18d`
+(plus a tiny synthetic two-Conv model). A real second architecture,
+`mnasnet_small_Opset17` -- depthwise-separable, 133 NPU ops vs.
+`resnet18d`'s 181, a 2.77 MB weight table vs. 11.86 MB -- compiled fully
+on the NPU (one fused subgraph), ran on the real AX650N, and was
+bit-identical between the original and onnxsim-simplified graphs, as
+always. Its mcode (78,584 bytes) checked against every structural claim,
+all local:
+
+```
+claim                                   resnet18d            mnasnet_small
+header words 72 / 76                    4096 / 0x2ff000      4096 / 0x2ff000   (identical)
+largest 50 03 below the arena, by       32,704 B (< 1 tile)  26,848 B (< 1 tile)
+first field write                       byte 297, phase 1    byte 297, phase 1
+five verbs present                      yes                  yes
+40 02 / 50 03 / a9 / a8:3002 / a8:4003  181 each             133 each   (= op count)
+50 01 writes per op                     4.00                 4.00
+50 01 operand set                       {bit0,8,20,24}       {bit0,8,20,24}
+50 01 order per op                      bit8,bit0,bit20,bit24 (180/180)  same (132/132)
+dominant per-op template                64 of 180 ops        34 of 132 ops
+40 02 max / Wbt size                    0.997, all distinct  0.984, all distinct
+sdma4 trace events                      181 (= ops)          133 (= ops)
+two-word tiling of the bulk             97.5%                92.3%
+50 03 operands 64-byte aligned          175/176              112/133
+```
+
+**Every per-op invariant holds exactly on the second model**, with the
+op count simply changing from 181 to 133: the five verbs, the one write
+each of `40 02`/`50 03`/`a9`/both `a8` selectors per op, four `50 01`
+writes per op in the same one-hot set and the same fixed order, the same
+dominant eleven-instruction template, `40 02` spanning the weight table
+(all distinct, 98.4% of a Wbt one quarter the size), and one `sdma4` DMA
+per op. **The arena size `0x2ff000` is identical**, so it is a platform
+constant of the AX650N, not something the compiler sizes per model --
+and both models' arena addresses stay under it by less than one tile.
+The depthwise convs also show up where the engine-split finding said
+they would: both MAC engines busy (`conv0` 909, `conv1` 855 events).
+
+**Two honest deltas.** The bulk's two-word tiling is 92% here vs. 97.5%
+(a few 16-word gaps -- larger operands or a different verb the tally
+does not know), and `50 03` alignment is 84% vs. 99% (depthwise tiles
+plausibly use a finer granule). Neither touches the per-op invariants;
+both are worth knowing before treating the parser as complete.
+
+Net: the field-write reading, the verb set, the per-op program, and the
+two quantitatively decoded fields are properties of the compiler and
+the hardware, not of `resnet18d`.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2494,6 +2494,56 @@ Net: the field-write reading, the verb set, the per-op program, and the
 two quantitatively decoded fields are properties of the compiler and
 the hardware, not of `resnet18d`.
 
+### Correction: the instruction runs are two-word, but they are only 37% of the bulk -- the rest is verb-free regions
+
+Chasing the small residue in the two-word tiling (97.5% on `resnet18d`,
+92% on `mnasnet`) exposed an overstatement two sections up, which is
+corrected here in place rather than rewritten there.
+
+**What was overstated.** "With all five verbs counted, the bulk is a
+uniform two-word stream." The 97.5% figure is real, but it measures the
+spacing *between consecutive verb headers* -- and the gap histogram it
+came from listed only the most common gap sizes. The full histogram has
+a long tail of very large gaps (in `resnet18d`: 1,047; 1,042; 688; 510;
+487 words ...). Counting words instead of gaps:
+
+```
+                          resnet18d          mnasnet_small
+bulk words                12,188             19,564
+verb-header + operand     4,574   (37.5%)    3,742   (19.1%)
+verb-free regions (>=8w)  44 regions,        127 regions,
+                          7,494 w (61.5%)    15,680 w (80.3%)
+regions per op            0.24               0.95
+largest region            1,047 words        1,597 words
+```
+
+So the correct statement is: **the five-verb instruction runs are
+tightly two-word (97.5%) but make up only 37% of `resnet18d`'s bulk and
+19% of `mnasnet`'s; the remainder is 44 (resp. 127) verb-free regions
+of other word families** -- `23 00`, `16 00`, `84 08`, `00 80` in
+`resnet18d`; `81 20` and `20 03` dominating in `mnasnet` -- whose
+content is high-entropy and whose format is not decoded. That family is
+where the tiny model's four non-deterministic noise bytes lived (`23 00
+xx 82` words), which fits these regions being data/descriptor tables
+rather than instructions, but "table" is an inference; only the
+counts, sizes and families are measured. `mnasnet`'s ~one region per op
+(0.95), versus `resnet18d`'s one per four ops, is also why its tiling
+residue was larger -- not a sixth verb: no other first byte >= 0x80
+occurs more than 5 times in the `VV 00 x0 yy` shape in either model.
+
+**Two more prologue facts from the same pass.** From the first field
+write at byte 297, the two real classifiers share a **byte-identical
+158-byte prologue** (they share only 21 bytes with the tiny synthetic
+model, whose input is float `4x16x16` rather than `uint8` NHWC
+`224x224` -- so the prologue plausibly carries input/preprocessing
+setup). Inside it, all three models carry the same compact ladder
+`00 90 84 08, 00 a0 84 0a, 00 b0 84 08, ... 00 f0 84 08`: seven 4-byte
+units of the shape `00 xx 84 vv` -- field `xx` stepping `0x10`, bank
+`0x84`, a **one-byte value** and **no verb byte**. That is a second,
+short-form write encoding, alongside the 8-byte `[VV 00 xx yy][32-bit]`
+form and the 7-byte 3-byte-operand slots already noted; a parser needs
+all three.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2011,3 +2011,66 @@ def test_resnet18d_50_01_step_set_dispatches_the_op_and_bit24_is_inert_model_wid
     assert np.array_equal(all_bit24_zero, out_base), (
         "expected bit24 to be inert for correctness across every op"
     )
+
+
+_VERBS = {0xA1, 0xA2, 0xA3, 0xA8, 0xA9}
+
+
+def _verb_headers(mcode, start=328):
+    """Every verb header word in the phase-0 bulk of an mcode blob -- see
+    the README's "Five verbs, a readable per-op program" section. Returns
+    `(word_index, verb, xx, yy, operand)` for each `XX 00 <mult of 0x10>
+    yy` word whose first byte is a known verb, indexing words from
+    `start` (the preamble before it has variable-length slots)."""
+    words = [mcode[i : i + 4] for i in range(start, len(mcode) - 3, 4)]
+    return [
+        (k, w[0], w[2], w[3], int.from_bytes(words[k + 1], "little"))
+        for k, w in enumerate(words)
+        if w[0] in _VERBS and w[1] == 0 and w[2] % 0x10 == 0 and k + 1 < len(words)
+    ]
+
+
+def test_resnet18d_bulk_is_a_two_word_stream_of_five_verbs_with_a_per_op_program(
+    tmp_path,
+):
+    """Confirmed real (see the README's "Five verbs, a readable per-op
+    program" section), all local: with all five verbs counted, 97.5% of
+    consecutive headers in the bulk are exactly two words apart; `a9 00
+    00` and both `a8` selectors occur exactly once per op (181); and 64
+    of 180 ops are exactly one eleven-instruction template. Also locks in
+    the header-declared arena size 0x2ff000 bounding every `50 03`
+    address. Needs Docker for the build but no device.
+    """
+    from collections import Counter
+
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    hdrs = _verb_headers(mcode)
+    assert len(hdrs) >= 2200, len(hdrs)
+
+    gaps = Counter(b[0] - a[0] for a, b in zip(hdrs, hdrs[1:]))
+    assert gaps[2] / sum(gaps.values()) >= 0.95, gaps.most_common(5)
+
+    by_verb_sel = Counter((v, xx, yy) for _, v, xx, yy, _ in hdrs)
+    assert by_verb_sel[(0xA9, 0x00, 0x00)] == 181
+    assert by_verb_sel[(0xA8, 0x30, 0x02)] == by_verb_sel[(0xA8, 0x40, 0x03)] == 181
+    assert by_verb_sel[(0xA2, 0x00, 0x00)] >= 350
+    assert by_verb_sel[(0xA3, 0x00, 0x00)] >= 180
+
+    cuts = [k for k, v, xx, yy, _ in hdrs if (v, xx, yy) == (0xA1, 0x40, 0x02)]
+    template = "a1:5001 a1:5001 a8:4003 a1:5003 a1:5001 a3:0000 a1:5001 a9:0000 a2:0000 a8:3002"
+    patterns = Counter(
+        " ".join(f"{v:02x}:{xx:02x}{yy:02x}" for k, v, xx, yy, _ in hdrs if a < k < b)
+        for a, b in zip(cuts, cuts[1:])
+    )
+    assert patterns[template] >= 60, patterns.most_common(2)
+
+    arena = int.from_bytes(mcode[76:80], "little")
+    assert arena == 0x2FF000, hex(arena)
+    assert int.from_bytes(mcode[72:76], "little") == 4096
+    max_50_03 = max(
+        op for _, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x50, 0x03)
+    )
+    assert max_50_03 < arena and arena - max_50_03 < 40_000, (
+        hex(max_50_03),
+        hex(arena),
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2315,3 +2315,143 @@ def test_verb_free_regions_are_drifted_instructions_and_a_walker_beats_the_grid(
                 and r18[i + 2] % 0x10 == 0
             )
     assert off_phase >= 100, off_phase
+
+
+def test_resnet18d_verb_free_regions_fault_like_instructions_on_device(tmp_path):
+    """Confirmed real on the device (see the README's "The regions fault
+    like instructions on the device" section): flipping single bytes at
+    the start, middle and end of the largest "verb-free regions" of the
+    real resnet18d mcode mostly faults with 0x8030070C (24 of 30 in the
+    ten largest; 10 of 12 in the four largest used here on one build, 7
+    of 12 on a fresh rebuild -- per-flip outcomes vary between builds, the
+    majority does not) -- the answer of a validated instruction stream,
+    not of a data table, which would give wrong values or nothing.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+    hdrs = _verb_headers(mcode)
+    regions = sorted(
+        (
+            (328 + 4 * (a[0] + 2), 4 * (b[0] - a[0] - 2))
+            for a, b in zip(hdrs, hdrs[1:])
+            if b[0] - a[0] >= 8
+        ),
+        key=lambda r: -r[1],
+    )[:4]
+    assert regions and regions[0][1] >= 2000, regions
+
+    x = np.random.RandomState(42).randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = _run_retry_once(path, x)
+    assert not dev_base.error, dev_base.error
+
+    faults = 0
+    for start, length in regions:
+        for off in (start + 8, start + length // 2, start + length - 8):
+            patched = bytearray(mcode)
+            patched[off] ^= 0xFF
+            c = onnx.load(path)
+            {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+            p = os.path.join(str(tmp_path), f"region_{off}.axmodel")
+            onnx.save(c, p)
+            dev = _run_retry_once(p, x)
+            if dev.error:
+                assert "0x8030070C" in dev.error, (off, dev.error)
+                faults += 1
+    assert faults >= 7, (
+        faults,
+        "expected a majority of flips inside the regions to fault",
+    )
+
+
+def _permutation_ratio(non_verb_bytes, pattern, shuffles=10, seed=0):
+    """Observed count of `pattern(b, i)` over the bytes vs. its mean count
+    over byte-shuffled copies (same histogram, order destroyed) -- the
+    chance baseline the README's "Third correction" section shows is the
+    right one for positional patterns."""
+    import random
+
+    rng = random.Random(seed)
+
+    def count(b):
+        return sum(1 for i in range(len(b)) if pattern(b, i))
+
+    observed = count(non_verb_bytes)
+    nulls = []
+    for _ in range(shuffles):
+        s = bytearray(non_verb_bytes)
+        rng.shuffle(s)
+        nulls.append(count(bytes(s)))
+    return observed / (sum(nulls) / len(nulls))
+
+
+def test_short_bank_tagged_forms_are_far_above_a_permutation_null(tmp_path):
+    """Confirmed real (see the README's "Third correction" section), all
+    local: against a permutation null (the non-verb bytes shuffled, same
+    histogram), the 4-byte `00 ?? TT ??` form, the prologue ladder
+    `00 x0 84 ??`, and the prefix + tag == 0x84 rule are each far above
+    chance on the real resnet18d blob -- unlike an independence estimate,
+    which understated them. Deterministic (fixed seed). Needs Docker for
+    the build but no device.
+    """
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    tags = set(range(0x81, 0x85))
+
+    def is_verb(i):
+        return (
+            i + 3 < len(mcode)
+            and mcode[i] in _VERBS
+            and mcode[i + 1] == 0
+            and mcode[i + 2] % 0x10 == 0
+        )
+
+    non_verb = bytearray()
+    i, end = 297, len(mcode) - 252
+    while i < end:
+        if is_verb(i):
+            i += 8
+        else:
+            non_verb.append(mcode[i])
+            i += 1
+    non_verb = bytes(non_verb)
+    assert len(non_verb) > 20_000
+
+    w4 = _permutation_ratio(
+        non_verb, lambda b, i: i + 3 < len(b) and b[i] == 0 and b[i + 2] in tags
+    )
+    ladder = _permutation_ratio(
+        non_verb,
+        lambda b, i: i + 3 < len(b)
+        and b[i] == 0
+        and b[i + 1] % 0x10 == 0
+        and b[i + 2] == 0x84,
+    )
+    complement = _permutation_ratio(
+        non_verb,
+        lambda b, i: i + 3 < len(b)
+        and b[i] <= 3
+        and i + 2 + b[i] < len(b)
+        and b[i + 2 + b[i]] == 0x84 - b[i],
+    )
+    assert w4 >= 2.5, w4
+    assert ladder >= 5.0, ladder
+    assert complement >= 4.0, complement
+
+    # The width rule: for prefix p, the tag byte is enriched at offset
+    # exactly p + 2 and nowhere else nearby -- the unit is p + 4 bytes long.
+    for prefix in range(4):
+        ratios = {
+            k: _permutation_ratio(
+                non_verb,
+                lambda b, i, k=k, p=prefix: i + k < len(b)
+                and b[i] == p
+                and b[i + k] in tags,
+                shuffles=5,
+            )
+            for k in range(1, 6)
+        }
+        peak = max(ratios, key=ratios.get)
+        assert peak == prefix + 2, (prefix, ratios)
+        assert ratios[peak] >= 2.0, (prefix, ratios)
+        assert all(r <= 1.8 for k, r in ratios.items() if k != peak), (prefix, ratios)

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2455,3 +2455,85 @@ def test_short_bank_tagged_forms_are_far_above_a_permutation_null(tmp_path):
         assert peak == prefix + 2, (prefix, ratios)
         assert ratios[peak] >= 2.0, (prefix, ratios)
         assert all(r <= 1.8 for k, r in ratios.items() if k != peak), (prefix, ratios)
+
+
+def _tokenize_mcode(mcode, start=297):
+    """Tokenize an mcode blob's bulk with every validated form -- the 8/7-byte
+    verb instructions and the width-rule short units `[p][p+1 bytes][0x84-p]
+    [value]` (p+4 bytes) -- stepping one unknown byte otherwise. Returns
+    `(byte_offset, kind, a, b, c)` tuples: kind 'V' (a=verb, b=xx, c=yy),
+    'S' (a=prefix, b=tag, c=field) or '?' (a=byte). See the README's "The
+    layout that explains all of it" section."""
+    tags = set(range(0x81, 0x85))
+    end = len(mcode) - 252
+
+    def is_verb(i):
+        return (
+            i + 3 < len(mcode)
+            and mcode[i] in _VERBS
+            and mcode[i + 1] == 0
+            and mcode[i + 2] % 0x10 == 0
+        )
+
+    def short_len(i):
+        p = mcode[i]
+        return (
+            p + 4
+            if (p <= 3 and i + p + 3 < len(mcode) and mcode[i + p + 2] in tags)
+            else 0
+        )
+
+    out, i = [], start
+    while i < end:
+        if is_verb(i):
+            n = (
+                7
+                if (
+                    not (is_verb(i + 8) or short_len(i + 8))
+                    and (is_verb(i + 7) or short_len(i + 7))
+                )
+                else 8
+            )
+            out.append((i, "V", mcode[i], mcode[i + 2], mcode[i + 3]))
+        elif short_len(i):
+            n = short_len(i)
+            out.append((i, "S", mcode[i], mcode[i + n - 2], mcode[i + 1]))
+        else:
+            n = 1
+            out.append((i, "?", mcode[i], 0, 0))
+        i += n
+    return out
+
+
+def test_mcode_layout_is_two_config_blocks_then_clean_op_programs(tmp_path):
+    """Confirmed real (see the README's "The layout that explains all of
+    it" section), all local on real resnet18d and mnasnet_small builds:
+    splitting the token stream at every `a1 40 02` write, the op-program
+    region (the last 180 / 132 segments) contains no short unit and no
+    unknown byte -- each op is exactly the verb template -- while at least
+    90% of all short units and unknown bytes sit in the first two
+    segments, the configuration blocks. Needs Docker for the builds but
+    no device.
+    """
+    _, _, r18 = _build_real_resnet18d(str(tmp_path))
+    _, _, mnas, _ = _build_real_zoo_model(str(tmp_path), "mnasnet_small_Opset17")
+
+    for name, mcode, min_clean_ops in (("resnet18d", r18, 178), ("mnasnet", mnas, 130)):
+        toks = _tokenize_mcode(mcode)
+        cuts = [k for k, t in enumerate(toks) if t[1:] == ("V", 0xA1, 0x40, 0x02)]
+        assert len(cuts) >= min_clean_ops + 2, (name, len(cuts))
+        segments = [toks[a:b] for a, b in zip(cuts, cuts[1:])]
+
+        def noise(seg):
+            return sum(1 for t in seg if t[1] in "S?")
+
+        clean = sum(1 for seg in segments[2:] if noise(seg) == 0)
+        assert clean >= min_clean_ops, (name, clean, len(segments))
+
+        total_noise = sum(noise(seg) for seg in segments) + noise(toks[cuts[-1] :])
+        front_noise = noise(segments[0]) + noise(segments[1])
+        assert front_noise >= 0.9 * total_noise, (name, front_noise, total_noise)
+        assert toks[cuts[2]][0] > 20_000, (
+            name,
+            "expected the op region to start after the config blocks",
+        )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2537,3 +2537,59 @@ def test_mcode_layout_is_two_config_blocks_then_clean_op_programs(tmp_path):
             name,
             "expected the op region to start after the config blocks",
         )
+
+
+def test_resnet18d_config_block_b_residue_is_structured_and_headed(tmp_path):
+    """Confirmed real (see the README's "Into config block B" section),
+    all local on a real resnet18d build: within the larger configuration
+    block, the width rule extends to prefix 4 (tag at offset 6, >= 2x a
+    shuffled null); the undecoded residue left after removing every
+    validated instruction has a best internal period that beats its own
+    shuffle by >= 2x (real local structure, not fixed records); and its
+    most common 2-byte pair is an `XX 00` header-like pair from the
+    candidate second family. Deterministic (fixed seed). Needs Docker for
+    the build but no device.
+    """
+    import random
+    from collections import Counter
+
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    toks = _tokenize_mcode(mcode)
+    cuts = [k for k, t in enumerate(toks) if t[1:] == ("V", 0xA1, 0x40, 0x02)]
+    lo, hi = toks[cuts[1]][0], toks[cuts[2]][0]
+    block = mcode[lo:hi]
+    assert 15_000 <= len(block) <= 25_000, len(block)
+
+    rng = random.Random(0)
+    tags = set(range(0x81, 0x85))
+
+    def count_p4(b):
+        return sum(1 for i in range(len(b) - 7) if b[i] == 4 and b[i + 6] in tags)
+
+    shuffled = bytearray(block)
+    rng.shuffle(shuffled)
+    observed, null = count_p4(block), count_p4(bytes(shuffled))
+    assert observed >= 40 and null > 0 and observed / null >= 2.0, (observed, null)
+
+    residue = bytes(mcode[i] for i, kind, *_ in toks if kind == "?" and lo <= i < hi)
+    assert 8_000 <= len(residue) <= 14_000, len(residue)
+
+    def best_period(b):
+        best = 0.0
+        for q in range(2, 65):
+            best = max(
+                best,
+                sum(1 for i in range(q, len(b)) if b[i] == b[i - q]) / (len(b) - q),
+            )
+        return best
+
+    res_shuffled = bytearray(residue)
+    rng.shuffle(res_shuffled)
+    assert best_period(residue) >= 2.0 * best_period(bytes(res_shuffled))
+
+    top_pair = Counter(residue[i : i + 2] for i in range(len(residue) - 1)).most_common(
+        1
+    )[0][0]
+    assert top_pair[1] == 0 and top_pair[0] in {0x23, 0x16, 0x03, 0x04, 0x01, 0x00}, (
+        top_pair.hex()
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2174,3 +2174,53 @@ def test_mcode_field_map_generalizes_to_mnasnet_small(tmp_path):
         for a, b in zip(cuts, cuts[1:])
     )
     assert patterns.most_common(1)[0][0] == template, patterns.most_common(2)
+
+
+def _verb_free_regions(mcode, min_words=8):
+    """Gaps between consecutive verb headers larger than a [header][operand]
+    pair, as `(extra_words)` per gap -- the verb-free regions of the README's
+    "Correction: the instruction runs are two-word, but they are only 37% of
+    the bulk" section."""
+    hdrs = _verb_headers(mcode)
+    return [b[0] - a[0] - 2 for a, b in zip(hdrs, hdrs[1:]) if b[0] - a[0] >= min_words]
+
+
+def test_verb_runs_are_a_minority_of_the_bulk_and_the_prologue_is_shared(tmp_path):
+    """Confirmed real (see the README's "Correction: the instruction runs
+    are two-word, but they are only 37% of the bulk" section), all local
+    on real resnet18d and mnasnet_small builds: the five-verb pairs cover
+    ~37% / ~19% of the bulk words; the rest sits in 44 / 127 verb-free
+    regions; both prologues carry the compact `00 xx 84 vv` ladder (a
+    short-form write with no verb byte); and the two real classifiers
+    share a byte-identical prologue of 150+ bytes from the first field
+    write. Needs Docker for the builds but no device.
+    """
+    _, _, r18 = _build_real_resnet18d(str(tmp_path))
+    _, _, mnas, _ = _build_real_zoo_model(str(tmp_path), "mnasnet_small_Opset17")
+
+    for name, mcode, cover_lo, cover_hi, min_regions in (
+        ("resnet18d", r18, 0.30, 0.45, 40),
+        ("mnasnet", mnas, 0.15, 0.25, 120),
+    ):
+        n_words = (len(mcode) - 328) // 4
+        coverage = 2 * len(_verb_headers(mcode)) / n_words
+        assert cover_lo <= coverage <= cover_hi, (name, coverage)
+        assert len(_verb_free_regions(mcode)) >= min_regions, (
+            name,
+            len(_verb_free_regions(mcode)),
+        )
+        seg = mcode[297 : 297 + 120]
+        ladder = [
+            seg[i + 1]
+            for i in range(len(seg) - 3)
+            if seg[i] == 0 and seg[i + 2] == 0x84 and seg[i + 1] % 0x10 == 0
+        ]
+        assert ladder == [0x90, 0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0], (name, ladder)
+
+    shared = 0
+    while (
+        297 + shared < min(len(r18), len(mnas))
+        and r18[297 + shared] == mnas[297 + shared]
+    ):
+        shared += 1
+    assert shared >= 150, shared

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -1940,3 +1940,74 @@ def test_resnet18d_50_01_steps_three_required_one_optional_on_device(tmp_path):
     assert out is not None and not np.array_equal(out, out_base), (
         "expected an absent step set to run with a changed result, not fault"
     )
+
+
+def test_resnet18d_50_01_step_set_dispatches_the_op_and_bit24_is_inert_model_wide(
+    tmp_path,
+):
+    """Confirmed real on the device (see the README's "The `50 01` step set
+    is the op's dispatch" section): with all four `50 01` steps of one op
+    zeroed, the model runs with a changed result, and additionally
+    pointing that op's Wbt offset at another instance's weights gives the
+    byte-identical changed result -- the op no longer executes at all.
+    And zeroing `bit24` in all 181 ops at once leaves the whole output
+    bit-identical to the unpatched baseline.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+
+    path, key, mcode = _build_real_resnet18d(str(tmp_path))
+    words = [mcode[i : i + 4] for i in range(0, len(mcode) - 3, 4)]
+    hdrs = [
+        (i, w[2], w[3], int.from_bytes(words[i + 1], "little"))
+        for i, w in enumerate(words)
+        if w[:2] == b"\xa1\x00" and i + 1 < len(words)
+    ]
+    cuts = [i for i, xx, yy, _ in hdrs if (xx, yy) == (0x40, 0x02)]
+    op_start = 8174
+    assert op_start in cuts
+    op_end = min(i for i in cuts if i > op_start)
+    steps = [
+        i for i, xx, yy, _ in hdrs if (xx, yy) == (0x50, 0x01) and op_start < i < op_end
+    ]
+    assert len(steps) == 4
+    other_offset = int.from_bytes(
+        mcode[48300:48304], "little"
+    )  # a different op's 40 02 value
+    bit24_writes = [
+        i for i, xx, yy, v in hdrs if (xx, yy) == (0x50, 0x01) and v == 0x1000000
+    ]
+    assert len(bit24_writes) == 181
+
+    x = np.random.RandomState(42).randint(0, 256, size=(1, 224, 224, 3), dtype=np.uint8)
+    dev_base = _run_retry_once(path, x)
+    assert not dev_base.error, dev_base.error
+    out_base = np.frombuffer(dev_base.outputs[0], dtype=np.float32)
+
+    def run_variant(edits, tag):
+        patched = bytearray(mcode)
+        for word_index, value in edits:
+            patched[(word_index + 1) * 4 : (word_index + 2) * 4] = struct.pack(
+                "<I", value
+            )
+        c = onnx.load(path)
+        {i.name: i for i in c.graph.initializer}[key].raw_data = bytes(patched)
+        p = os.path.join(str(tmp_path), f"dispatch_{tag}.axmodel")
+        onnx.save(c, p)
+        dev = _run_retry_once(p, x)
+        assert not dev.error, (tag, dev.error)
+        return np.frombuffer(dev.outputs[0], dtype=np.float32)
+
+    no_steps = run_variant([(w, 0) for w in steps], "no_steps")
+    assert not np.array_equal(no_steps, out_base)
+    no_steps_other_weights = run_variant(
+        [(w, 0) for w in steps] + [(op_start, other_offset)], "no_steps_other_weights"
+    )
+    assert np.array_equal(no_steps, no_steps_other_weights), (
+        "expected an op with no step set to be skipped, so its weight offset is never read"
+    )
+
+    all_bit24_zero = run_variant([(w, 0) for w in bit24_writes], "all_bit24_zero")
+    assert np.array_equal(all_bit24_zero, out_base), (
+        "expected bit24 to be inert for correctness across every op"
+    )

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2074,3 +2074,103 @@ def test_resnet18d_bulk_is_a_two_word_stream_of_five_verbs_with_a_per_op_program
         hex(max_50_03),
         hex(arena),
     )
+
+
+def _build_real_zoo_model(work_dir, name):
+    """Fetch and really build any single-image-input onnxmodelzoo model
+    the same way `convert_onnxmodelzoo.py` does. Returns `(axmodel_path,
+    mcode_key, mcode_bytes, wbt_bytes)`. The resnet18d-specific
+    `_build_real_resnet18d` above predates this and keeps its exact-size
+    assertion; new multi-model tests should use this one."""
+    import convert_onnxmodelzoo  # also puts model_zoo on sys.path
+    import model_zoo
+
+    model = onnx.load(model_zoo.fetch_model(name))
+    tensor_name = convert_onnxmodelzoo._single_image_input(model)
+    assert tensor_name is not None, name
+
+    os.makedirs(os.path.join(work_dir, "model"), exist_ok=True)
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    pulsar2_docker.make_synthetic_calibration_tar(
+        os.path.join(work_dir, "dataset", "calib.tar")
+    )
+    onnx.save(model, os.path.join(work_dir, "model", f"{name}.onnx"))
+    result = pulsar2_docker.build(
+        work_dir,
+        f"model/{name}.onnx",
+        f"output/{name}",
+        tensor_name=tensor_name,
+        mean=convert_onnxmodelzoo._DEFAULT_MEAN,
+        std=convert_onnxmodelzoo._DEFAULT_STD,
+        calibration_dataset_rel_path="dataset/calib.tar",
+    )
+    assert result.success, (name, result.error)
+    compiled = onnx.load(result.axmodel_path)
+    inits = {i.name: i for i in compiled.graph.initializer}
+    key = _mcode_key(compiled)
+    return (
+        result.axmodel_path,
+        key,
+        bytes(inits[key].raw_data),
+        bytes(inits[_params_key(compiled)].raw_data),
+    )
+
+
+def test_mcode_field_map_generalizes_to_mnasnet_small(tmp_path):
+    """Confirmed real (see the README's "The whole map generalizes to a
+    second real architecture" section), all local on a real
+    `mnasnet_small_Opset17` build: the same header constants (4096,
+    0x2ff000 arena), the same five verbs, one `40 02`/`50 03`/`a9`/`a8`
+    write each per op with the op count simply changing (133), four
+    `50 01` writes per op in the same one-hot set and fixed order, `40 02`
+    spanning its (very different) Wbt, and the dominant per-op template.
+    Needs Docker for the build but no device.
+    """
+    from collections import Counter
+
+    _, _, mcode, wbt = _build_real_zoo_model(str(tmp_path), "mnasnet_small_Opset17")
+    assert int.from_bytes(mcode[72:76], "little") == 4096
+    assert int.from_bytes(mcode[76:80], "little") == 0x2FF000, (
+        "arena size is a platform constant"
+    )
+
+    hdrs = _verb_headers(mcode)
+    by = Counter((v, xx, yy) for _, v, xx, yy, _ in hdrs)
+    n_ops = by[(0xA1, 0x40, 0x02)]
+    assert 100 <= n_ops <= 160, n_ops
+    for sel in (
+        (0xA1, 0x50, 0x03),
+        (0xA9, 0x00, 0x00),
+        (0xA8, 0x30, 0x02),
+        (0xA8, 0x40, 0x03),
+    ):
+        assert by[sel] == n_ops, (sel, by[sel], n_ops)
+    assert by[(0xA1, 0x50, 0x01)] == 4 * n_ops
+    assert {op for _, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x50, 0x01)} == {
+        0x1,
+        0x100,
+        0x100000,
+        0x1000000,
+    }
+
+    ops4002 = [op for _, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x40, 0x02)]
+    assert len(set(ops4002)) == n_ops
+    assert 0.95 * len(wbt) <= max(ops4002) <= len(wbt), (max(ops4002), len(wbt))
+    max_50_03 = max(
+        op for _, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x50, 0x03)
+    )
+    assert max_50_03 < 0x2FF000 and 0x2FF000 - max_50_03 < 40_000, hex(max_50_03)
+
+    cuts = [k for k, v, xx, yy, _ in hdrs if (v, xx, yy) == (0xA1, 0x40, 0x02)]
+    flags = [(k, op) for k, v, xx, yy, op in hdrs if (v, xx, yy) == (0xA1, 0x50, 0x01)]
+    order = (0x100, 0x1, 0x100000, 0x1000000)
+    assert all(
+        tuple(op for k, op in flags if a < k < b) == order
+        for a, b in zip(cuts, cuts[1:])
+    ), "expected every op to write the same four-step sequence"
+    template = "a1:5001 a1:5001 a8:4003 a1:5003 a1:5001 a3:0000 a1:5001 a9:0000 a2:0000 a8:3002"
+    patterns = Counter(
+        " ".join(f"{v:02x}:{xx:02x}{yy:02x}" for k, v, xx, yy, _ in hdrs if a < k < b)
+        for a, b in zip(cuts, cuts[1:])
+    )
+    assert patterns.most_common(1)[0][0] == template, patterns.most_common(2)

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2224,3 +2224,94 @@ def test_verb_runs_are_a_minority_of_the_bulk_and_the_prologue_is_shared(tmp_pat
     ):
         shared += 1
     assert shared >= 150, shared
+
+
+def _walk_variable_length(mcode, start=297, end=None):
+    """Greedy variable-length walk over an mcode blob's bulk with the three
+    known instruction forms (8-byte verb, 7-byte verb when the next header
+    lands at +7, 4-byte compact `00 xx 84 vv` write), stepping one unknown
+    byte otherwise -- see the README's "Second correction: the verb-free
+    regions are the same instruction stream, drifted off the 4-byte grid"
+    section. Returns `(explained_bytes, total_bytes, Counter of forms)`."""
+    from collections import Counter
+
+    end = len(mcode) - 252 if end is None else end
+
+    def is_verb(i):
+        return (
+            i + 3 < len(mcode)
+            and mcode[i] in _VERBS
+            and mcode[i + 1] == 0
+            and mcode[i + 2] % 0x10 == 0
+        )
+
+    def is_compact(i):
+        return (
+            i + 3 < len(mcode)
+            and mcode[i] == 0
+            and mcode[i + 2] == 0x84
+            and mcode[i + 1] % 0x10 == 0
+        )
+
+    forms, explained, i = Counter(), 0, start
+    while i < end:
+        if is_verb(i):
+            n = (
+                7
+                if (
+                    not (is_verb(i + 8) or is_compact(i + 8))
+                    and (is_verb(i + 7) or is_compact(i + 7))
+                )
+                else 8
+            )
+            forms[f"verb{n}"] += 1
+        elif is_compact(i):
+            n = 4
+            forms["compact4"] += 1
+        else:
+            n = 1
+            forms["unknown"] += 1
+        explained += n if n > 1 else 0
+        i += n
+    return explained, end - start, forms
+
+
+def test_verb_free_regions_are_drifted_instructions_and_a_walker_beats_the_grid(
+    tmp_path,
+):
+    """Confirmed real (see the README's "Second correction" section), all
+    local on real resnet18d and mnasnet_small builds: the "verb-free
+    regions" hold verb-shaped words at byte phases 1-3 (>= 100 in
+    resnet18d) and hundreds of compact `00 xx 84 vv` writes, and a
+    variable-length walker knowing only three forms explains more of the
+    bulk than the fixed 4-byte grid on both models, recovering 7-byte and
+    compact instructions the grid cannot see. Needs Docker for the builds
+    but no device.
+    """
+    _, _, r18 = _build_real_resnet18d(str(tmp_path))
+    _, _, mnas, _ = _build_real_zoo_model(str(tmp_path), "mnasnet_small_Opset17")
+
+    for name, mcode in (("resnet18d", r18), ("mnasnet", mnas)):
+        explained, total, forms = _walk_variable_length(mcode)
+        grid = 8 * len(_verb_headers(mcode)) / total
+        assert explained / total > grid + 0.05, (name, explained / total, grid)
+        assert forms["verb7"] > 0 and forms["compact4"] > 300, (name, dict(forms))
+        assert explained / total < 0.6, (
+            name,
+            "walker should not claim near-complete coverage",
+        )
+
+    hdrs = _verb_headers(r18)
+    off_phase = 0
+    for a, b in zip(hdrs, hdrs[1:]):
+        if b[0] - a[0] >= 8:
+            lo, hi = 328 + 4 * (a[0] + 2), 328 + 4 * b[0]
+            off_phase += sum(
+                1
+                for i in range(lo, hi - 3)
+                if (i - 328) % 4 != 0
+                and r18[i] in _VERBS
+                and r18[i + 1] == 0
+                and r18[i + 2] % 0x10 == 0
+            )
+    assert off_phase >= 100, off_phase


### PR DESCRIPTION
## Summary
Stacked on #1189 (merge order: #1181 -> #1188 -> #1189 -> this). A correction, stated in place, to a claim shipped in #1188, plus two prologue facts. All local, zero device runs.

- **Correction:** "the bulk is a uniform two-word stream" overstated it. The 97.5% figure measured spacing *between consecutive verb headers* from a gap histogram that listed only the most common sizes; the full histogram has a long tail (1,047; 1,042; 688 words ...). Counting words: the five-verb `[header][operand]` pairs cover **37.5%** of resnet18d's bulk (4,574 of 12,188 words) and **19.1%** of mnasnet's; the rest is **44 / 127 verb-free regions** of other word families (`23 00`, `16 00`, `84 08` in resnet18d; `81 20`, `20 03` dominating in mnasnet), high-entropy and undecoded. mnasnet has ~one region per op (0.95) vs resnet18d's one per four -- that, not a sixth verb, is the tiling delta (no other first byte >= 0x80 occurs more than 5 times in the `VV 00 x0 yy` shape).
- The two real classifiers share a **byte-identical 158-byte prologue** from the first field write (21 bytes with the tiny synthetic model, whose input differs), plausibly input/preprocessing setup.
- All three models carry the compact ladder `00 90 84 08 ... 00 f0 84 08`: 4-byte units with a **one-byte value and no verb byte** -- a second, short-form write encoding a parser must handle alongside the 8-byte and 7-byte forms.

Device-free regression test (Docker only) locks in the coverage bounds, region counts, the compact ladder in both prologues, and the shared prologue.

## Test plan
- [x] New test passes locally (Docker builds, no device)
- [x] `ruff format --check` / `ruff check` clean
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2usgepQwRi2s6ASVaHfk