### PR TITLE
mcode: fourth correction -- 17 short-unit tags, trailing byte is the register, `23 00` was a prefix

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3092,6 +3092,37 @@ Their config-segment openers start `1e 00 00 00 00 a2 00 00 00 83 01
 c0` -- the `a7` marker's operand straddling the 8-byte segment
 boundary, so segment lengths are exact but not marker-aligned.
 
+**What `a7` does inside a program.** In the `llm_build` layer's 0x8801
+segment the two most common skeletons (85 of 112 programs in the decode
+subgraph, 67 of 151 in prefill) are the CNN core with two `a7` verbs
+inserted at fixed slots: `40.02 | 50.01 | 50.01 | a7.1e | a8 40.03 |
+50.03 | 50.01 | a3 | 50.01 | a9 | [a2] | a7.02 | a8 30.02`, where `a7.1e`
+carries operand 0 and `a7.02` operand 2. The same `a7.1e` with operand 0
+opens every segment of these mcodes (`a7.0a` in the CNNs, `a7.10` in the
+ONNX-path Mistral), so `a7` reads as a synchronization verb -- a wait
+or fence on channel `yy` before the engine-dispatch verbs and a signal
+on channel 2 after them -- that the CNN op programs never need and the
+BF16 layer programs use on every op. Untested on device: an `a7`-patch
+run is the obvious next experiment. The layer's two small segments (14
+and 15 programs on types 0x0c01/0xf001 in decode, 6 and 6 in prefill)
+hold the core followed by runs of 2..13 `a2 00.00` verbs, plus one
+program per segment that writes every field 0x40..0xe0 of banks 2, 3
+and 4 in order -- a full register load, presumably the KV-cache and
+I/O binding.
+
+**`llm_build` emits one instruction stream for all 30 layers.** Every
+per-layer file's two mcodes are byte-identical to layer 0's from the
+first byte of the FlatBuffers header to the tail vector; the only
+differing bytes are in the tail's name string (`llama_p512_l0_together_
+decode` / `_prefill_0` -- 1 byte for layers 1..9, 19 or 21 for the
+two-digit layers, where the longer string shifts what follows it) and,
+of course, in `npu_params` (3,963,652 bytes per layer, all different).
+So a transformer layer's mcode is position-independent: the program
+addresses its weights through the Wbt offsets the `40 02` writes carry,
+and a layer's identity lives entirely in the weight table. An emitter
+for this path has one 57,056-byte decode program and one 93,360-byte
+prefill program to get right, not thirty.
+
 Tests: `test_resnet18d_tail_segments_tile_the_stream_and_open_with_a7`,
 `test_llm_build_layer_mcode_keeps_the_layout_and_uses_a7`, and
 `test_onnx_path_llm_mcode_keeps_the_op_program_skeleton` in

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2883,6 +2883,56 @@ Test: `test_resnet18d_short_form_tags_are_seventeen_wide_and_trail_a_register`
 in `tests/test_axera_mcode_structure.py` (fresh `resnet18d` build,
 fixed-seed null, no device).
 
+### Fifth correction: every tag byte is real, so is the bare pair -- the explained-bytes null was the wrong null
+
+The section above rejected 14 tag bytes and the payload-less
+`[tag][even]` pair because admitting them raised the *shuffled* block's
+explained fraction almost as much as the real one's. That comparison is
+sound for a common form and useless for a rare one: shuffling the block
+leaves ~60% of it unexplained, and a rare pattern then matches by
+chance inside that residue about as often as it occurs for real. The
+right null for a rare form is conditional: given the form's own anchor
+byte, does the byte the rule constrains behave as the rule says, and
+does it do so in the shuffled block?
+
+**Every byte in 0x81..0x9f is a tag.** Admitting all 31 as p-unit tags,
+the trailing byte is even in essentially every real unit *for every
+tag*: 0x87 52/52, 0x88 95/95, 0x8e 26/26, 0x92 31/31, 0x93 22/22 in
+`resnet18d` (the "rejected" ones), alongside 0x84 601/601 and 0x9f
+416/416; `mnasnet` likewise (0x87 14/14, 0x88 50/50, 0x92 26/26, 0x93
+51/51, 0x9c 166/166). In the shuffled block the same units are even at
+50..70% for every tag (0x84 100/151, 0x9f 79/116). The 17-tag set was
+a false rejection of the rarer tags, not a property of the format.
+
+**The bare `[tag][register]` pair is real.** Among residue runs of
+exactly two bytes that begin with a tag byte, the second byte is even in
+**265 of 265** (`resnet18d`), **598 of 600** (`mnasnet`) and 29 of 29
+(tiny) -- against a 60% background inside the residue and 7 of 12 in
+the shuffled block. That is the `p = -1` width: a register touched with
+no payload. Two more forms show the same signature and are noted, not
+yet tokenized: `e1 XX` with `XX` *odd* in 13/14, 48/48 and 7/7 cases
+(the verb byte 0xa1 with bit 6 set), and 0xa1 itself acting as a tag
+when not followed by `00` -- bare `a1 5e`-style pairs are even 8/8 and
+20/20, and `01 70 04 a1 5e` is a `p = 1` unit on tag 0xa1.
+
+**Where block B stands.** With all tags, `p <= 4` and bare pairs, block
+B is **93.5%** explained in `resnet18d` (residue 1,267 of 19,383
+bytes), **93.3%** in `mnasnet` (3,004 of 44,695) and 85.9% in the tiny
+model. The shuffled block reaches 42.9% under the same rule -- the
+inflation that misled the section above, and the reason the parity
+counts, not that figure, carry the claim. The residue is now mostly the
+one-byte prefixes: 641 of 762 residue runs in `resnet18d` (`23` 150,
+`03` 118, `16` 72, `3c` 28, `05` 21, `0d` 19), 992 of 1,415 in `mnasnet`
+(`04` 115, `05` 99, `03` 62, `1c` 52, `2d` 50), and 559 + 63 of those
+641 are followed directly by a p-unit or a bare pair. The multi-byte
+leftovers are a few 6..7-byte runs that sit immediately before a verb
+(`09 20 02 00 00 01 00`, `09 c0 0c 80 fe 01 01`, `08 0b 55 fc 55 01`)
+-- a candidate pre-verb form with too few instances to test yet.
+
+Test: `test_resnet18d_every_tag_and_the_bare_pair_pass_the_parity_null`
+in `tests/test_axera_mcode_structure.py`; the previous test's bare-pair
+assertion is replaced by the corrected claim.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2974,6 +2974,57 @@ ops region carries proportionally more of those pre-verb runs.
 Test: `test_resnet18d_tag_9f_units_carry_one_extra_byte` in
 `tests/test_axera_mcode_structure.py` (fresh build, no device).
 
+### The op programs are fully tokenized; the "trailer" is a five-table FlatBuffers tail the header points to
+
+The op region's last residue turned out not to be instructions. Under
+the full rule its only leftovers were two runs at the very end whose
+bytes read `0c 00 10 00 0f 00 0e 00 08 00 04 00` (a FlatBuffers vtable)
+and `7b 7d` (the string `{}`), so the "252-byte trailer" every earlier
+section stopped short of was too short by about 230 bytes. Measured on
+all three models:
+
+- **The stream ends 7 bytes after its last verb** -- a 7-byte `a2`
+  verb -- at 48,583 (`resnet18d`), 78,103 (`mnasnet`) and 3,447 (tiny);
+  then 17, 1 and 1 zero bytes; then a FlatBuffers vector of five table
+  offsets (`05 00 00 00 | 20 | 2c | 50 | 74 | 98`) **480 bytes before
+  the end** (472 in the tiny model). The header's 32-bit word at offset
+  272 is a FlatBuffers offset to exactly that vector in all three
+  (272 + 48,328 = 48,600; 272 + 77,832 = 78,104; 272 + 3,176 = 3,448),
+  so the header and the tail are one FlatBuffers structure wrapped
+  around the instruction stream.
+- **With the boundary right, the op programs are 100% tokenized** in
+  all three models (0 residue bytes in 17,767, 13,431 and 311). The whole
+  stream is **98.1%** explained in `resnet18d` (block A 97.75%, block B
+  96.5%, ops 100%), 96.0% in `mnasnet` and 88.0% in the tiny model;
+  counting the untokenized header and tail against it, 96.5%, 95.1% and
+  70.7% of the whole blob.
+- **Every configuration block ends the same way the header does.** The
+  header's last 17 bytes, `2b a7 00 00 0a 00 00 00 00 a2 00 00 00 13 00
+  40 00`, reappear byte for byte as the last 17 bytes of block A in all
+  three models (`40` is `30` throughout `mnasnet`), preceded by zero
+  bytes. Their last 8 bytes are an 8-byte `a2 00 00 00` verb with
+  operand `0x00400013`; the stream's own final bytes are `a2` verbs of
+  the same shape with per-model low halves (`0x7b2`; `0x642`, `0x652`;
+  `0x12`, `0x22`). So the 297-byte "header" is a FlatBuffers header of
+  280 bytes plus the same block terminator the config blocks use.
+- **The five tables share one schema.** Table 0 has four fields
+  (`59393`, `260`, then two per-model words: 2,228 / 3,812 in
+  `resnet18d`); tables 1..4 have six: a type word (4,097 for tables
+  1..3, 2,561 for table 4), an id (257, 258, absent, absent), two
+  per-model counts, a packed word that is always the second count
+  shifted left 8 bits plus 1 (865,281 = 3,380 x 256 + 1, in every
+  table of every model), and a byte-count-sized value. Table 4's last
+  field is block A's length minus 21 in both large models (11,115 vs
+  11,136; 19,658 vs 19,680) -- the 21 bytes being the terminator above
+  plus four zeros -- but 606 vs 608 in the tiny model, so that reading
+  is a lead, not a result. `resnet18d`'s values, tables 1..4: counts
+  (432, 3,380), (612, 2,768), (1,376, 1,392), (1,392, --); sizes 3,455,
+  4,881, 11,000, 11,115. None equals a unit, verb or byte count measured
+  here; per-engine instruction budgets are the obvious guess.
+
+Test: `test_resnet18d_stream_ends_at_a_five_table_flatbuffers_tail` in
+`tests/test_axera_mcode_structure.py` (fresh build, no device).
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2804,6 +2804,85 @@ instruction forms with their own widths, and it is the next thing to
 validate with the permutation method -- the width-rule test above is
 exactly the template for it.
 
+### Fourth correction: seventeen tags, the trailing byte is the register, and `23 00` was a prefix byte
+
+Running that validation changed three earlier readings. All numbers are
+block B of the cached `resnet18d` and `mnasnet_small` builds plus the
+tiny two-conv model, against a shuffled copy of the same block.
+
+**The tag set is not 0x81..0x84.** Admitting any tag byte in
+0x81..0x9f (everything below the verb bytes 0xa1..0xa9) at offset
+`p + 2` lifts block B from 42.6% to **82.7%** explained in `resnet18d`
+while the null only moves from 10.7% to 23.3%. Per tag, the ratio over
+the null splits cleanly: 0x81..0x86, 0x89..0x8d, 0x94, 0x95, 0x9b..0x9d
+and 0x9f are 2x..9x above it in both models (0x9b 8.6x, 0x9d 6.0x, 0x95
+5.9x, 0x8b 4.8x, 0x9c 4.8x, 0x9f 3.6x in `resnet18d`, n = 416 for
+0x9f), while 0x90, 0x91, 0x96..0x99 sit *at or below* it (0.1x..0.5x)
+and 0x87, 0x88, 0x8e, 0x8f, 0x92, 0x93, 0x9a, 0x9e reach 2x in one
+model only. With that data-driven set of **17 tags** and `p <= 4`,
+block B is **76.1%** explained in `resnet18d` (null 19.5%, 3.9x),
+**81.8%** in `mnasnet` (null 22.7%, 3.6x) and 75.7% in the tiny model
+(null 26.5%); the residue falls from 11,134 to **4,636** bytes and from
+16,990 to **8,146** bytes. The `tag = 0x84 - p` pairing the third
+correction reported is the *dominant* pairing, not a rule: 0x84 takes
+`p = 0` in 539 of 601 units, but 0x81 takes `p = 3` in only 48 of 282
+`resnet18d` units (1,261 of 1,748 in `mnasnet`). The tag does not
+encode the width; `p` does.
+
+**The trailing byte is the register, and the payload is the value.**
+The byte after the tag is even in **2,909 of 2,911** `resnet18d` units,
+6,248 of 6,253 `mnasnet` units and 258 of 258 tiny-model units (99.9%),
+against a 64% background; the first payload byte is even at exactly the
+background rate (59.6%, 63.4%, 77.1% vs 64.5%, 63.8%, 71.7%). Only a
+2-byte-granular offset looks like that. So the short unit reads
+`[p][p+1-byte value][tag][register]`, not `[p][field][tag][value]` as
+the layout section had it -- the verb form `a1 00 xx yy <32-bit>`
+addresses at 16-byte granularity through `xx`, the short form at 2-byte
+granularity through its last byte. The test helper's tuple still
+returns the first payload byte in the slot it always did; only the name
+changed.
+
+**`23 00` is a prefix byte, not a header.** With the wide tag set,
+1-byte residue runs are the largest class (381 of 1,178 runs in
+`resnet18d`), and they sit *immediately before an ordinary unit*: `23`
+precedes a `p = 0` unit 139 times, `03` 102 times (plus 13 before a
+`p = 1` unit), `3c` 21 times; `mnasnet` uses `04` (104), `2d` (50),
+`03` (46), `05` (43), `1c` (42). The `23 00 ...` pairs the previous
+section counted are `23` followed by the `00` that opens a `p = 0`
+unit. That is a one-byte prefix with model-specific values on ordinary
+units -- what it modifies is open -- and not a second header family.
+The tiny model's four non-deterministic bytes are inside one such
+prefixed unit.
+
+**What does not validate.** A payload-less `[tag][even byte]` pair
+(the natural `p = -1`) would push `resnet18d` to 89.5% explained, but
+the null rises to 40.8% with it (ratio 2.2 from 3.9) and per tag it is
+at or below chance -- 0x84 pairs 59 real vs 266 shuffled, 0x9f 207 vs
+315, 0x81 126 vs 226; only 0x87 (112 vs 76; 183 vs 105) and 0x88 (154
+vs 101; 137 vs 86) exceed it, at ~1.5x. Not admitted. A 2-byte `e1 XX`
+pair (odd `XX`) is 21 vs 13 in `resnet18d` and 86 vs 31 in `mnasnet`
+-- a candidate, not a form. No tag byte has a fixed argument length
+(for every tag with n > 100 the modal distance to the next tag byte
+holds < 50% of cases), so the 0x85..0x9f family are tags in the same
+width rule, not opcodes of their own.
+
+**Both configuration blocks open with the same 158 bytes.** Block A
+and block B of `resnet18d` and of `mnasnet` all begin with the same
+158-byte prologue (four-way identical); the tiny model has the same
+prologue with one operand changed -- the `a1 00 60 02` write at +16
+carries `0x31480` (201,856) in both 224x224 models and `0xd80` (3,456)
+for the 1x4x16x16 input -- and its shorter blocks (608 and 2,231 bytes)
+lack the region that follows. The first per-model bytes after the
+prologue are `p = 2` units on tag 0x81/0x82 whose payloads are
+`09 bf 01` vs `09 c3 01` and `09 80 03` vs `09 3c 05` with `09 00 07`
+shared: 16-bit parts 447 vs 451, 896 vs 1,340, 1,792, the first model
+quantities in the block and unmatched to any count tracked here
+(op count, block sizes, token counts).
+
+Test: `test_resnet18d_short_form_tags_are_seventeen_wide_and_trail_a_register`
+in `tests/test_axera_mcode_structure.py` (fresh `resnet18d` build,
+fixed-seed null, no device).
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2933,6 +2933,47 @@ Test: `test_resnet18d_every_tag_and_the_bare_pair_pass_the_parity_null`
 in `tests/test_axera_mcode_structure.py`; the previous test's bare-pair
 assertion is replaced by the corrected claim.
 
+### Sixth correction: there is no prefix byte -- tag 0x9f's unit is one byte longer
+
+Asking what *precedes* the "prefix" bytes settles them. In `resnet18d`
+block B, 592 of the 641 one-byte residues follow a unit whose tag is
+0x9f (394 after a p-unit on 0x9f, 198 after a bare `9f reg` pair); in
+`mnasnet` it is 797 of 992. Per tag, the share of units followed by
+exactly one leftover byte is **592 of 624 for 0x9f** and at most 1% for
+every other tag (0x81 3/410, 0x84 0/661, 0x95 0/237, 0x8b 0/187);
+`mnasnet` 797 of 875 for 0x9f, at most 6% otherwise. A bare 0x9f pair is
+followed by one leftover byte in 198 of 208 cases where every other
+bare tag is followed by the next unit directly. So 0x9f's unit is
+`[p][value][9f][register][extra]` (and bare `9f reg extra`), one byte
+longer than any other tag's, and the fourth correction's "one-byte
+prefix with model-specific values" is that extra byte read as belonging
+to the wrong unit. Its values are the ones the prefix table listed
+(`23`, `03`, `16`, `3c`, `0d`, `26` in `resnet18d`; `04`, `05`, `03`,
+`1c`, `2d`, `00` in `mnasnet`), below 0x40 in 98.3% and 89.2% of cases
+and with no parity constraint (36% and 60% even) -- a small value, not
+a register. The 0x9f write shares its register with the *next* unit in
+320 of 544 and 315 of 647 cases, so 0x9f looks like a modifier issued
+just before a write to the same register; what the extra byte selects
+is open.
+
+**Where the blocks stand.** With every tag, `p <= 4`, bare pairs and the
+0x9f rule, block B is **96.5%** explained in `resnet18d` (673 of 19,383
+bytes left) and **95.2%** in `mnasnet` (2,152 of 44,695); the shuffled
+block stays at 44%. Under the same rule the whole mcode is covered
+region by region -- `resnet18d`: block A 93.8%, block B 96.5%, the op
+programs 98.7%, **95%+ of every tokenized byte** and 94% of the whole
+blob including the untokenized FlatBuffers header and trailer;
+`mnasnet` 92.6% / 95.2% / 98.5%. What remains in block B is a short
+list: `e1 XX` pairs (14, 48), `01 70 04 a1 5e`-style units on tag 0xa1
+(12, 37) and bare `a1 reg` pairs (8, 20), a handful of single `05`/`08`/
+`06` bytes, and the 6..7-byte runs that sit directly before a verb
+(`09 20 02 00 00 01 00`, `08 0b 55 fc 55 01`; 6 + 6 in `resnet18d`, 19 +
+17 in `mnasnet`). The tiny model's block B stays at 86% because its
+ops region carries proportionally more of those pre-verb runs.
+
+Test: `test_resnet18d_tag_9f_units_carry_one_extra_byte` in
+`tests/test_axera_mcode_structure.py` (fresh build, no device).
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3025,6 +3025,80 @@ all three models:
 Test: `test_resnet18d_stream_ends_at_a_five_table_flatbuffers_tail` in
 `tests/test_axera_mcode_structure.py` (fresh build, no device).
 
+### The tail is the segment table: the stream is its segments, in reverse, and `a7` is the sixth verb
+
+The five tail tables decoded themselves once a second model shape was
+in hand. Verified on seven mcodes -- `resnet18d`, `mnasnet_small`, the
+tiny two-conv model, a 1-layer Mistral compiled through the ONNX path
+(`build_from_hf_checkpoint()`, see the LLM sections below) and, from a
+real `pulsar2 llm_build` of `HuggingFaceTB/SmolLM2-135M`, both `neu
+mode` subgraphs of `llama_p512_l0_together.axmodel` and the LM head
+`llama_post.axmodel`:
+
+- **Field 2 is a segment length in 8-byte words and field 3 counts
+  down.** In every table of every mcode, `f3[k] = f3[k-1] - f2[k]`, and
+  table 0's `f3` is the sum of every later table's `f2`. The packed
+  field 4 is `f3 << 8 | 1` throughout.
+- **The segments tile the blob exactly, in reverse table order.** Take
+  the tail vector's offset, subtract 8 x the sum of every table's `f2`,
+  and you land on the end of the FlatBuffers header (280 bytes for every
+  one-input CNN, 436 for the ONNX-path Mistral with two inputs, 700 and
+  744 for the two `llm_build` subgraphs, 296 for the post model); lay
+  the segments out from there, last table first, and the last one ends
+  on the tail vector to the byte in all seven mcodes. The last table is
+  configuration block A exactly (11,136 = 1,392 x 8); the "block B" the
+  earlier sections treated as one region is really *three* segments in
+  `resnet18d` (11,008 + 4,896 + 3,456 bytes); the op programs are table
+  0's segment.
+- **Every segment opens with an `a7` verb, and `a7` is a verb.** The
+  17-byte "block terminator" was misread: `2b a7 00 00 0a 00 00 00 00`
+  is one leading byte (`2b`, `24`, `33`, `3b` -- segment-specific) and
+  an 8-byte `a7 00 00 NN <u32>` instruction of exactly the verb shape
+  (`NN` = 0x0a in the CNNs and the post model, 0x10 in the ONNX-path
+  Mistral, 0x1e in the `llm_build` layer), followed by the segment's
+  first real verb. `llm_build` op programs then use `a7 00 00 02 02 00
+  00 00` freely -- 205 and 261 times inside the two subgraphs' op
+  segments, where the five-verb tokenizer left 8-byte holes.
+- **Segment types.** Table field 0 is `X << 8 | 1`: 0x0a for the first
+  configuration segment, 0x10 for the others and 0xe8 for the op
+  programs in every CNN and the ONNX-path LLM; the `llm_build` layer's
+  fifteen segments use 0x0a, 0x10, 0xe8, 0xd0, 0xb8, 0xa0, 0x88, 0x0c,
+  0xf0 with its 112-program op segment on 0x88 and two 14/15-program
+  segments on 0x0c/0xf0 -- different engines or queues is the obvious
+  reading, untested.
+
+**Coverage, by segment, with `a7` admitted.** Op-program segments are
+**100% tokenized in all seven mcodes** past the 4..5 marker bytes that
+straddle a segment's opening word boundary (resnet18d 17,824 bytes; mnasnet
+13,472; the `llm_build` layer's 12,160 + 1,984 + 2,080 and 19,712 + 992
++ 992; the post model's 72,448 with 772 programs). Configuration
+segments run 90..99%. Whole streams (zero padding trimmed): `resnet18d`
+98.3%, `mnasnet` 96.3%, tiny 91.7%, ONNX-path Mistral 95.4%, `llm_build`
+layer 96.1% and 96.5%, post model 99.7%.
+
+**What the LLM builds add.** The ONNX-path Mistral (80 ONNX ops, 75 op
+programs, 21 s to compile) keeps the CNN op-program skeleton verb for
+verb -- `40.02, 50.01, 50.01, a8 40.03, 50.03, 50.01, a3, 50.01, a9,
+[a2], a8 30.02`, the two most common variants covering 57 of 74
+programs -- with the trailing slot varying by op: `a1 30.03` in 9
+programs, `a1 20.02` (a slot the CNN templates lack) in 8, neither in
+the rest; its two graph inputs get two `a2` verbs in the segment opener
+where the CNNs' one input gets one, but the `llm_build` layer (5 inputs)
+gets one and the post model (1 input) gets four, so that is not an
+input count. The `llm_build` subgraphs (decode and prefill, 145 and 167
+programs, 92 s for all 30 layers plus the head) are the first mcode
+with programs of 104..144 bytes: the skeleton plus `a7` verbs inside.
+Their config-segment openers start `1e 00 00 00 00 a2 00 00 00 83 01
+c0` -- the `a7` marker's operand straddling the 8-byte segment
+boundary, so segment lengths are exact but not marker-aligned.
+
+Tests: `test_resnet18d_tail_segments_tile_the_stream_and_open_with_a7`,
+`test_llm_build_layer_mcode_keeps_the_layout_and_uses_a7`, and
+`test_onnx_path_llm_mcode_keeps_the_op_program_skeleton` in
+`tests/test_axera_mcode_structure.py` (fresh builds, no device; the two
+LLM tests skip unless the checkpoints are already in the HuggingFace
+cache).
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3102,13 +3102,41 @@ opens every segment of these mcodes (`a7.0a` in the CNNs, `a7.10` in the
 ONNX-path Mistral), so `a7` reads as a synchronization verb -- a wait
 or fence on channel `yy` before the engine-dispatch verbs and a signal
 on channel 2 after them -- that the CNN op programs never need and the
-BF16 layer programs use on every op. Untested on device: an `a7`-patch
-run is the obvious next experiment. The layer's two small segments (14
+BF16 layer programs use on every op. The layer's two small segments (14
 and 15 programs on types 0x0c01/0xf001 in decode, 6 and 6 in prefill)
 hold the core followed by runs of 2..13 `a2 00.00` verbs, plus one
 program per segment that writes every field 0x40..0xe0 of banks 2, 3
 and 4 in order -- a full register load, presumably the KV-cache and
 I/O binding.
+
+**Confirmed on the AX650N: `a7` is a synchronization verb, and its
+operand is what matters.** The layer-0 decode subgraph runs on the real
+device only when fed valid inputs (`axcl_run_model`'s random bytes land
+in the `indices` gather input and fault it with `0x8030070C`, exactly
+as the harness's `run_on_device_with_inputs()` docstring warns); with
+zero K/V caches, a zero hidden state and in-range indices it runs in
+0.44 ms and its three outputs are bit-identical run to run. Hand-patching
+its decode mcode and re-running, every outcome reproduced 3 of 3 times:
+
+| patch (decode subgraph) | edits | result |
+|---|---|---|
+| in-program `a7.02` operand 2 -> 0 | 102 | runs, **all three outputs change** |
+| in-program `a7.02` operand 2 -> 1 | 102 | runs, outputs change differently (K and V outputs become identical) |
+| in-program `a7.02` channel 02 -> 1e | 102 | runs, outputs **identical** to baseline |
+| in-program `a7.02` channel 02 -> 03 | 102 | runs, outputs change (same as operand 0) |
+| in-program `a7.1e` operand 0 -> 1 | 103 | **fault `0x8030070C`** |
+| in-program `a7.1e` channel 1e -> 02 | 103 | runs, outputs identical |
+| segment-opening `a7.1e` markers, operand 0 -> 1 | 15 | **fault `0x8030070C`** |
+
+So the operand-0 form (`a7.1e`, at every segment start and before each
+op's dispatch verbs) is a wait or reset that must read 0, the operand-2
+form (`a7.02`, after each op's dispatch) is a post whose value fixes
+what the consumers of that op see -- change it and the pipeline still
+runs to completion but with a different (racy or stale) data ordering,
+producing wrong outputs with no fault -- and the channel byte
+distinguishes 0x02/0x1e from 0x03 but not from each other. The
+timing differences between variants were within run-to-run noise
+(0.43..0.54 ms) and are not claimed.
 
 **`llm_build` emits one instruction stream for all 30 layers.** Every
 per-layer file's two mcodes are byte-identical to layer 0's from the

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2457,15 +2457,26 @@ def test_short_bank_tagged_forms_are_far_above_a_permutation_null(tmp_path):
         assert all(r <= 1.8 for k, r in ratios.items() if k != peak), (prefix, ratios)
 
 
-def _tokenize_mcode(mcode, start=297):
+_WIDE_TAGS = frozenset(
+    {0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x89, 0x8A, 0x8B, 0x8C, 0x8D}
+    | {0x94, 0x95, 0x9B, 0x9C, 0x9D, 0x9F}
+)
+"""The 17 short-unit tag bytes that beat a shuffled null by >= 2x in both
+real models -- see the README's "Fourth correction" section."""
+
+
+def _tokenize_mcode(mcode, start=297, end=None, tags=None, pmax=3):
     """Tokenize an mcode blob's bulk with every validated form -- the 8/7-byte
-    verb instructions and the width-rule short units `[p][p+1 bytes][0x84-p]
-    [value]` (p+4 bytes) -- stepping one unknown byte otherwise. Returns
+    verb instructions and the width-rule short units `[p][p+1 bytes][tag]
+    [register]` (p+4 bytes) -- stepping one unknown byte otherwise. Returns
     `(byte_offset, kind, a, b, c)` tuples: kind 'V' (a=verb, b=xx, c=yy),
-    'S' (a=prefix, b=tag, c=field) or '?' (a=byte). See the README's "The
-    layout that explains all of it" section."""
-    tags = set(range(0x81, 0x85))
-    end = len(mcode) - 252
+    'S' (a=prefix, b=tag, c=first payload byte) or '?' (a=byte). The
+    defaults (tags 0x81..0x84, p <= 3, stop 252 bytes before the end) are
+    the original narrow rule; `tags=_WIDE_TAGS, pmax=4` is the corrected
+    one. See the README's "The layout that explains all of it" and "Fourth
+    correction" sections."""
+    tags = set(range(0x81, 0x85)) if tags is None else set(tags)
+    end = len(mcode) - 252 if end is None else end
 
     def is_verb(i):
         return (
@@ -2476,10 +2487,12 @@ def _tokenize_mcode(mcode, start=297):
         )
 
     def short_len(i):
+        if i >= len(mcode):
+            return 0
         p = mcode[i]
         return (
             p + 4
-            if (p <= 3 and i + p + 3 < len(mcode) and mcode[i + p + 2] in tags)
+            if (p <= pmax and i + p + 3 < len(mcode) and mcode[i + p + 2] in tags)
             else 0
         )
 
@@ -2593,3 +2606,64 @@ def test_resnet18d_config_block_b_residue_is_structured_and_headed(tmp_path):
     assert top_pair[1] == 0 and top_pair[0] in {0x23, 0x16, 0x03, 0x04, 0x01, 0x00}, (
         top_pair.hex()
     )
+
+
+def test_resnet18d_short_form_tags_are_seventeen_wide_and_trail_a_register(tmp_path):
+    """Confirmed real (see the README's "Fourth correction" section), on a
+    fresh resnet18d build with a fixed-seed shuffled null of config block B:
+    the 17-tag width rule explains most of the block where the 4-tag rule
+    explains under half; the byte after the tag is even in >= 99.5% of
+    units (a 2-byte-granular register) while the first payload byte is at
+    the background rate; `23` is a prefix byte sitting directly before
+    ordinary units; a payload-less `[0x84][even]` pair is a null-level
+    pattern; and blocks A and B share a 158-byte prologue. No device.
+    """
+    import random
+
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    narrow = _tokenize_mcode(mcode)
+    cuts = [k for k, t in enumerate(narrow) if t[1:] == ("V", 0xA1, 0x40, 0x02)]
+    a_lo, lo, hi = narrow[cuts[0]][0], narrow[cuts[1]][0], narrow[cuts[2]][0]
+    assert mcode[a_lo : a_lo + 158] == mcode[lo : lo + 158]
+    block = mcode[lo:hi]
+    shuffled = bytearray(block)
+    random.Random(0).shuffle(shuffled)
+    shuffled = bytes(shuffled)
+
+    def explained(blob, tags, pmax):
+        toks = _tokenize_mcode(blob, start=0, end=len(blob), tags=tags, pmax=pmax)
+        return 1 - sum(1 for t in toks if t[1] == "?") / len(blob), toks
+
+    e_narrow, _ = explained(block, None, 3)
+    e_wide, toks = explained(block, _WIDE_TAGS, 4)
+    e_null, null_toks = explained(shuffled, _WIDE_TAGS, 4)
+    assert e_narrow < 0.5 < 0.7 < e_wide and e_wide / e_null >= 3.0, (
+        e_narrow,
+        e_wide,
+        e_null,
+    )
+
+    units = [(o, p) for o, k, p, *_ in toks if k == "S"]
+    assert len(units) > 2000, len(units)
+    trailing_even = sum(1 for o, p in units if block[o + p + 3] % 2 == 0) / len(units)
+    payload_even = sum(1 for o, p in units if block[o + 1] % 2 == 0) / len(units)
+    assert trailing_even >= 0.995 and payload_even <= 0.75, (
+        trailing_even,
+        payload_even,
+    )
+
+    starts = {o for o, _ in units}
+    prefixed = sum(
+        1 for o, k, a, *_ in toks if k == "?" and a == 0x23 and o + 1 in starts
+    )
+    assert prefixed >= 100, prefixed
+
+    def bare_84(blob, toks):
+        unknown = {o for o, k, *_ in toks if k == "?"}
+        return sum(
+            1
+            for o in unknown
+            if blob[o] == 0x84 and o + 1 < len(blob) and blob[o + 1] % 2 == 0
+        )
+
+    assert bare_84(block, toks) <= 1.2 * bare_84(shuffled, null_toks)

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2461,20 +2461,29 @@ _WIDE_TAGS = frozenset(
     {0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x89, 0x8A, 0x8B, 0x8C, 0x8D}
     | {0x94, 0x95, 0x9B, 0x9C, 0x9D, 0x9F}
 )
-"""The 17 short-unit tag bytes that beat a shuffled null by >= 2x in both
-real models -- see the README's "Fourth correction" section."""
+"""The 17 short-unit tag bytes that beat a shuffled *explained-bytes* null
+by >= 2x in both real models -- the README's "Fourth correction" section.
+Superseded by `_ALL_TAGS`: the fifth correction's conditional-parity test
+showed the rejected tags were false rejections of rare forms."""
+
+_ALL_TAGS = frozenset(range(0x81, 0xA0))
+"""Every byte below the verb range: the full short-unit tag set. For every
+tag the byte after it is even in ~100% of real units against ~60% shuffled
+-- see the README's "Fifth correction" section."""
 
 
-def _tokenize_mcode(mcode, start=297, end=None, tags=None, pmax=3):
+def _tokenize_mcode(mcode, start=297, end=None, tags=None, pmax=3, bare=False):
     """Tokenize an mcode blob's bulk with every validated form -- the 8/7-byte
-    verb instructions and the width-rule short units `[p][p+1 bytes][tag]
-    [register]` (p+4 bytes) -- stepping one unknown byte otherwise. Returns
+    verb instructions, the width-rule short units `[p][p+1 bytes][tag]
+    [register]` (p+4 bytes) and, with `bare=True`, the payload-less 2-byte
+    `[tag][register]` pair -- stepping one unknown byte otherwise. Returns
     `(byte_offset, kind, a, b, c)` tuples: kind 'V' (a=verb, b=xx, c=yy),
-    'S' (a=prefix, b=tag, c=first payload byte) or '?' (a=byte). The
-    defaults (tags 0x81..0x84, p <= 3, stop 252 bytes before the end) are
-    the original narrow rule; `tags=_WIDE_TAGS, pmax=4` is the corrected
-    one. See the README's "The layout that explains all of it" and "Fourth
-    correction" sections."""
+    'S' (a=prefix, b=tag, c=first payload byte), 'B' (a=tag, b=register)
+    or '?' (a=byte). The defaults (tags 0x81..0x84, p <= 3, no bare pairs,
+    stop 252 bytes before the end) are the original narrow rule;
+    `tags=_ALL_TAGS, pmax=4, bare=True` is the corrected one. See the
+    README's "The layout that explains all of it", "Fourth correction" and
+    "Fifth correction" sections."""
     tags = set(range(0x81, 0x85)) if tags is None else set(tags)
     end = len(mcode) - 252 if end is None else end
 
@@ -2511,6 +2520,9 @@ def _tokenize_mcode(mcode, start=297, end=None, tags=None, pmax=3):
         elif short_len(i):
             n = short_len(i)
             out.append((i, "S", mcode[i], mcode[i + n - 2], mcode[i + 1]))
+        elif bare and i + 1 < end and mcode[i] in tags and mcode[i + 1] % 2 == 0:
+            n = 2
+            out.append((i, "B", mcode[i], mcode[i + 1], 0))
         else:
             n = 1
             out.append((i, "?", mcode[i], 0, 0))
@@ -2615,8 +2627,11 @@ def test_resnet18d_short_form_tags_are_seventeen_wide_and_trail_a_register(tmp_p
     explains under half; the byte after the tag is even in >= 99.5% of
     units (a 2-byte-granular register) while the first payload byte is at
     the background rate; `23` is a prefix byte sitting directly before
-    ordinary units; a payload-less `[0x84][even]` pair is a null-level
-    pattern; and blocks A and B share a 158-byte prologue. No device.
+    ordinary units; the payload-less `[tag][register]` pair is real (its
+    second byte is even in >= 99% of 2-byte tag-led residue runs -- the
+    fifth correction's claim, replacing the fourth's "null-level" verdict
+    that rested on the wrong null); and blocks A and B share a 158-byte
+    prologue. No device.
     """
     import random
 
@@ -2658,12 +2673,86 @@ def test_resnet18d_short_form_tags_are_seventeen_wide_and_trail_a_register(tmp_p
     )
     assert prefixed >= 100, prefixed
 
-    def bare_84(blob, toks):
-        unknown = {o for o, k, *_ in toks if k == "?"}
-        return sum(
-            1
-            for o in unknown
-            if blob[o] == 0x84 and o + 1 < len(blob) and blob[o + 1] % 2 == 0
-        )
+    def bare_pairs(blob, toks):
+        runs, last = [], None
+        for o, k, *_ in toks:
+            if k == "?":
+                if last == o:
+                    runs[-1][1] = o + 1
+                else:
+                    runs.append([o, o + 1])
+                last = o + 1
+        pairs = [blob[a + 1] for a, b in runs if b - a == 2 and blob[a] in _ALL_TAGS]
+        return len(pairs), sum(1 for x in pairs if x % 2 == 0)
 
-    assert bare_84(block, toks) <= 1.2 * bare_84(shuffled, null_toks)
+    n_real, even_real = bare_pairs(block, toks)
+    assert n_real >= 100 and even_real >= 0.99 * n_real, (n_real, even_real)
+    n_null, even_null = bare_pairs(shuffled, null_toks)
+    assert even_null <= 0.85 * n_null + 2, (n_null, even_null)
+
+
+def test_resnet18d_every_tag_and_the_bare_pair_pass_the_parity_null(tmp_path):
+    """Confirmed real (see the README's "Fifth correction" section), on a
+    fresh resnet18d build with a fixed-seed shuffled null of config block
+    B: with every byte in 0x81..0x9f admitted as a tag, the trailing byte
+    is even in >= 95% of units for *every* tag with n >= 20 (~60% when the
+    block is shuffled); with bare `[tag][register]` pairs admitted too the
+    block is >= 90% explained; `e1 XX` pairs have odd XX in every case;
+    and the residue is dominated by 1-byte prefixes that sit directly
+    before a unit. No device.
+    """
+    import random
+    from collections import defaultdict
+
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    narrow = _tokenize_mcode(mcode)
+    cuts = [k for k, t in enumerate(narrow) if t[1:] == ("V", 0xA1, 0x40, 0x02)]
+    lo, hi = narrow[cuts[1]][0], narrow[cuts[2]][0]
+    block = mcode[lo:hi]
+    shuffled = bytearray(block)
+    random.Random(0).shuffle(shuffled)
+    shuffled = bytes(shuffled)
+
+    def per_tag_even(blob):
+        toks = _tokenize_mcode(blob, start=0, end=len(blob), tags=_ALL_TAGS, pmax=4)
+        per = defaultdict(lambda: [0, 0])
+        for o, k, p, tag, _ in toks:
+            if k == "S":
+                per[tag][0] += 1
+                per[tag][1] += blob[o + p + 3] % 2 == 0
+        return per
+
+    real, null = per_tag_even(block), per_tag_even(shuffled)
+    tested = [t for t, (n, _) in real.items() if n >= 20]
+    assert len(tested) >= 15 and {0x87, 0x88, 0x8E, 0x92} <= set(tested), tested
+    for t in tested:
+        n, ev = real[t]
+        # 0x9c sits at 47/48 on this build -- one miss, well above the ~60% null.
+        assert ev >= 0.95 * n, (hex(t), n, ev)
+    null_even = sum(ev for n, ev in null.values()) / sum(n for n, ev in null.values())
+    assert null_even <= 0.8, null_even
+
+    toks = _tokenize_mcode(
+        block, start=0, end=len(block), tags=_ALL_TAGS, pmax=4, bare=True
+    )
+    explained = 1 - sum(1 for t in toks if t[1] == "?") / len(block)
+    assert explained >= 0.9, explained
+    assert sum(1 for t in toks if t[1] == "B") >= 500
+
+    runs, last = [], None
+    for o, k, *_ in toks:
+        if k == "?":
+            if last == o:
+                runs[-1][1] = o + 1
+            else:
+                runs.append([o, o + 1])
+            last = o + 1
+
+    # `e1 XX` as a 2-byte residue run: XX is odd (README: 13/14, 48/48, 7/7).
+    e1 = [block[a + 1] for a, b in runs if b - a == 2 and block[a] == 0xE1]
+    assert len(e1) >= 10 and sum(x % 2 for x in e1) >= 0.9 * len(e1), e1
+
+    starts = {o for o, k, *_ in toks if k != "?"}
+    singles = [a for a, b in runs if b - a == 1]
+    assert len(singles) >= 0.75 * len(runs), (len(singles), len(runs))
+    assert sum(1 for a in singles if a + 1 in starts) >= 0.9 * len(singles)

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2472,19 +2472,30 @@ tag the byte after it is even in ~100% of real units against ~60% shuffled
 -- see the README's "Fifth correction" section."""
 
 
-def _tokenize_mcode(mcode, start=297, end=None, tags=None, pmax=3, bare=False):
+def _tokenize_mcode(
+    mcode,
+    start=297,
+    end=None,
+    tags=None,
+    pmax=3,
+    bare=False,
+    extra_byte_tags=frozenset(),
+):
     """Tokenize an mcode blob's bulk with every validated form -- the 8/7-byte
     verb instructions, the width-rule short units `[p][p+1 bytes][tag]
     [register]` (p+4 bytes) and, with `bare=True`, the payload-less 2-byte
-    `[tag][register]` pair -- stepping one unknown byte otherwise. Returns
-    `(byte_offset, kind, a, b, c)` tuples: kind 'V' (a=verb, b=xx, c=yy),
-    'S' (a=prefix, b=tag, c=first payload byte), 'B' (a=tag, b=register)
-    or '?' (a=byte). The defaults (tags 0x81..0x84, p <= 3, no bare pairs,
-    stop 252 bytes before the end) are the original narrow rule;
-    `tags=_ALL_TAGS, pmax=4, bare=True` is the corrected one. See the
-    README's "The layout that explains all of it", "Fourth correction" and
-    "Fifth correction" sections."""
+    `[tag][register]` pair -- stepping one unknown byte otherwise. Units
+    whose tag is in `extra_byte_tags` take one extra trailing byte (the
+    sixth correction: tag 0x9f). Returns `(byte_offset, kind, a, b, c)`
+    tuples: kind 'V' (a=verb, b=xx, c=yy), 'S' (a=prefix, b=tag, c=first
+    payload byte), 'B' (a=tag, b=register) or '?' (a=byte). The defaults
+    (tags 0x81..0x84, p <= 3, no bare pairs, no extra bytes, stop 252 bytes
+    before the end) are the original narrow rule; `tags=_ALL_TAGS, pmax=4,
+    bare=True, extra_byte_tags={0x9F}` is the corrected one. See the
+    README's "The layout that explains all of it" and "Fourth" .. "Sixth
+    correction" sections."""
     tags = set(range(0x81, 0x85)) if tags is None else set(tags)
+    extra_byte_tags = set(extra_byte_tags)
     end = len(mcode) - 252 if end is None else end
 
     def is_verb(i):
@@ -2499,11 +2510,9 @@ def _tokenize_mcode(mcode, start=297, end=None, tags=None, pmax=3, bare=False):
         if i >= len(mcode):
             return 0
         p = mcode[i]
-        return (
-            p + 4
-            if (p <= pmax and i + p + 3 < len(mcode) and mcode[i + p + 2] in tags)
-            else 0
-        )
+        if p <= pmax and i + p + 3 < len(mcode) and mcode[i + p + 2] in tags:
+            return p + 4 + (1 if mcode[i + p + 2] in extra_byte_tags else 0)
+        return 0
 
     out, i = [], start
     while i < end:
@@ -2521,7 +2530,7 @@ def _tokenize_mcode(mcode, start=297, end=None, tags=None, pmax=3, bare=False):
             n = short_len(i)
             out.append((i, "S", mcode[i], mcode[i + n - 2], mcode[i + 1]))
         elif bare and i + 1 < end and mcode[i] in tags and mcode[i + 1] % 2 == 0:
-            n = 2
+            n = 2 + (1 if mcode[i] in extra_byte_tags else 0)
             out.append((i, "B", mcode[i], mcode[i + 1], 0))
         else:
             n = 1
@@ -2756,3 +2765,60 @@ def test_resnet18d_every_tag_and_the_bare_pair_pass_the_parity_null(tmp_path):
     singles = [a for a, b in runs if b - a == 1]
     assert len(singles) >= 0.75 * len(runs), (len(singles), len(runs))
     assert sum(1 for a in singles if a + 1 in starts) >= 0.9 * len(singles)
+
+
+def test_resnet18d_tag_9f_units_carry_one_extra_byte(tmp_path):
+    """Confirmed real (see the README's "Sixth correction" section), on a
+    fresh resnet18d build: a unit whose tag is 0x9f is followed by exactly
+    one leftover byte in >= 85% of cases while every other tag with n >= 30
+    is followed by one in <= 10%; that byte is below 0x40 in >= 95% of
+    cases; and admitting the extra byte (`extra_byte_tags={0x9f}`) takes
+    config block B to >= 95% explained while a shuffled copy stays under
+    55%. No device.
+    """
+    import random
+    from collections import Counter, defaultdict
+
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    narrow = _tokenize_mcode(mcode)
+    cuts = [k for k, t in enumerate(narrow) if t[1:] == ("V", 0xA1, 0x40, 0x02)]
+    lo, hi = narrow[cuts[1]][0], narrow[cuts[2]][0]
+    block = mcode[lo:hi]
+
+    toks = _tokenize_mcode(
+        block, start=0, end=len(block), tags=_ALL_TAGS, pmax=4, bare=True
+    )
+    follow = defaultdict(Counter)
+    extra = Counter()
+    for j, t in enumerate(toks[:-1]):
+        if t[1] not in ("S", "B"):
+            continue
+        tag = t[3] if t[1] == "S" else t[2]
+        nxt = toks[j + 1]
+        one = nxt[1] == "?" and (j + 2 >= len(toks) or toks[j + 2][1] != "?")
+        follow[tag][one] += 1
+        if one and tag == 0x9F:
+            extra[block[nxt[0]]] += 1
+    n9 = sum(follow[0x9F].values())
+    assert n9 >= 300 and follow[0x9F][True] >= 0.85 * n9, dict(follow[0x9F])
+    for tag, c in follow.items():
+        if tag != 0x9F and sum(c.values()) >= 30:
+            assert c[True] <= 0.1 * sum(c.values()), (hex(tag), dict(c))
+    assert sum(c for v, c in extra.items() if v < 0x40) >= 0.95 * sum(extra.values())
+
+    def explained(blob):
+        toks = _tokenize_mcode(
+            blob,
+            start=0,
+            end=len(blob),
+            tags=_ALL_TAGS,
+            pmax=4,
+            bare=True,
+            extra_byte_tags={0x9F},
+        )
+        return 1 - sum(1 for t in toks if t[1] == "?") / len(blob)
+
+    shuffled = bytearray(block)
+    random.Random(0).shuffle(shuffled)
+    e_real, e_null = explained(block), explained(bytes(shuffled))
+    assert e_real >= 0.95 and e_null <= 0.55, (e_real, e_null)

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -3190,3 +3190,139 @@ def test_onnx_path_llm_mcode_keeps_the_op_program_skeleton(tmp_path):
     for prog, _ in top:
         assert tuple(v for v in prog if v in core) == core, prog
     assert sum(c for prog, c in skeletons.items() if (0xA1, 0x20, 0x02) in prog) >= 5
+
+
+def _llm_layer_inputs(model):
+    """Valid inputs for an `llm_build` per-layer file's decode subgraph
+    (group 0: the graph inputs not suffixed `_1`): zero K/V caches, zero
+    hidden state and mask, and *in-range* `indices` -- `axcl_run_model`'s
+    own random bytes land in that gather input and fault the NPU."""
+    sizes = {onnx.TensorProto.BFLOAT16: 2, onnx.TensorProto.FLOAT: 4}
+    sizes.update(
+        {
+            onnx.TensorProto.INT32: 4,
+            onnx.TensorProto.UINT32: 4,
+            onnx.TensorProto.INT64: 8,
+        }
+    )
+    inputs = {}
+    for i in model.graph.input:
+        if i.name.endswith("_1"):
+            continue
+        n = int(np.prod([d.dim_value for d in i.type.tensor_type.shape.dim] or [1]))
+        size = sizes[i.type.tensor_type.elem_type]
+        if i.name.startswith("indices"):
+            inputs[i.name] = np.arange(
+                n, dtype=np.int32 if size == 4 else np.int64
+            ).tobytes()
+        else:
+            inputs[i.name] = b"\x00" * (n * size)
+    return inputs
+
+
+def _run_llm_layer(path, inputs, times):
+    """Run a per-layer file `times` times; returns a list of outcomes, each
+    either the string "fault" (a `0x8030070C` rejection) or the tuple of
+    output digests. Empty-output runs (the runtime's own transient) are
+    skipped, so callers judge on what actually came back."""
+    import hashlib
+
+    out = []
+    for _ in range(times):
+        r = pulsar2_docker.run_on_device_with_inputs(path, inputs, repeat=1, warmup=1)
+        if r.error and "0x8030070C" in r.error:
+            out.append("fault")
+        elif r.outputs:
+            out.append(tuple(hashlib.sha1(o).hexdigest() for o in r.outputs))
+    return out
+
+
+def test_llm_build_a7_is_a_sync_verb_on_device(tmp_path):
+    """Confirmed real on the AX650N (see the README's "Confirmed on the
+    AX650N: `a7` is a synchronization verb" table), on a fresh `llm_build`
+    of SmolLM2-135M: the layer-0 decode subgraph runs deterministically
+    with valid inputs; patching every in-program `a7.02` operand from 2 to
+    0 keeps it running but changes every output; patching every in-program
+    `a7.1e` operand from 0 to 1 faults; re-routing `a7.02` to channel 0x1e
+    leaves the outputs identical. Each outcome must reproduce on both of
+    two runs. Skips without a device or the cached checkpoint.
+    """
+    import shutil
+
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+    ckpt = _cached_hf_checkpoint("HuggingFaceTB/SmolLM2-135M")
+    if ckpt is None:
+        pytest.skip("HuggingFaceTB/SmolLM2-135M is not in the local HuggingFace cache")
+    work = tmp_path / "work"
+    work.mkdir()
+    shutil.copytree(ckpt, work / "SmolLM2-135M", symlinks=False)
+    result = pulsar2_docker.llm_build(str(work), "SmolLM2-135M", "output", parallel=8)
+    assert result.success, getattr(result, "error", None)
+    layer = str(work / "output" / "llama_p512_l0_together.axmodel")
+
+    model = onnx.load(layer)
+    inputs = _llm_layer_inputs(model)
+    neu0 = next(n for n in model.graph.node if n.op_type == "neu mode")
+    info = json.loads(
+        next(a for a in neu0.attribute if a.name == "npu_graph_info").s.decode()
+    )
+    key = info["dotneus"][0]["neu_key"]
+    mcode = bytes(next(i for i in model.graph.initializer if i.name == key).raw_data)
+    _, segs = _segments(mcode)
+    ops = next(s for s in segs if s[2][0] == 0x8801)
+    toks = _tokenize_mcode(mcode, start=ops[0], end=ops[0] + ops[1], **_FULL_RULE)
+    a7_02 = [t[0] for t in toks if t[1] == "V" and t[2] == 0xA7 and t[4] == 0x02]
+    a7_1e = [t[0] for t in toks if t[1] == "V" and t[2] == 0xA7 and t[4] == 0x1E]
+    assert len(a7_02) >= 50 and len(a7_1e) >= 50, (len(a7_02), len(a7_1e))
+
+    def patched(name, edit):
+        b = bytearray(mcode)
+        edit(b)
+        m2 = onnx.ModelProto()
+        m2.CopyFrom(model)
+        next(i for i in m2.graph.initializer if i.name == key).raw_data = bytes(b)
+        path = str(tmp_path / f"{name}.axmodel")
+        onnx.save(m2, path)
+        return path
+
+    def set_operand(offs, val):
+        def edit(b):
+            for o in offs:
+                struct.pack_into("<I", b, o + 4, val)
+
+        return edit
+
+    def set_channel(offs, ch):
+        def edit(b):
+            for o in offs:
+                b[o + 3] = ch
+
+        return edit
+
+    # The runtime can reject one run transiently with the same fault code
+    # (see `_run_retry_once`), so a variant that is *expected to run* is
+    # judged on its non-fault runs -- at least two, all equal -- while a
+    # variant expected to fault must fault on every run.
+    def good(outcomes):
+        return [o for o in outcomes if o != "fault"]
+
+    base = good(_run_llm_layer(layer, inputs, 3))
+    assert len(base) >= 2 and len(set(base)) == 1, base
+    baseline = base[0]
+
+    changed = good(
+        _run_llm_layer(patched("a7_02_operand_0", set_operand(a7_02, 0)), inputs, 3)
+    )
+    assert len(changed) >= 2 and len(set(changed)) == 1, changed
+    assert all(a != b for a, b in zip(changed[0], baseline)), (changed[0], baseline)
+
+    faulted = _run_llm_layer(
+        patched("a7_1e_operand_1", set_operand(a7_1e, 1)), inputs, 2
+    )
+    assert faulted == ["fault", "fault"], faulted
+
+    same = good(
+        _run_llm_layer(patched("a7_02_channel_1e", set_channel(a7_02, 0x1E)), inputs, 3)
+    )
+    assert len(same) >= 2 and all(s == baseline for s in same), same

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -3059,6 +3059,7 @@ def test_llm_build_layer_mcode_keeps_the_layout_and_uses_a7(tmp_path):
     checkpoint is already in the HuggingFace cache. No device.
     """
     import shutil
+    from collections import Counter
 
     ckpt = _cached_hf_checkpoint("HuggingFaceTB/SmolLM2-135M")
     if ckpt is None:
@@ -3078,6 +3079,37 @@ def test_llm_build_layer_mcode_keeps_the_layout_and_uses_a7(tmp_path):
         assert len(ops) == 1
         cov, programs, a7 = _segment_coverage(mcode, ops[0])
         assert cov == 1.0 and programs >= 100 and a7 >= 100, (cov, programs, a7)
+        # The op template: the CNN core with `a7.1e` (operand 0) after the
+        # two `50.01` writes and `a7.02` (operand 2) before the closing
+        # `a8 30.02`, in the two most common skeletons.
+        pos, length, _ = ops[0]
+        toks = _tokenize_mcode(mcode, start=pos, end=pos + length, **_FULL_RULE)
+        starts = [t[0] for t in toks if t[1:] == ("V", 0xA1, 0x40, 0x02)]
+        skeletons = Counter()
+        for a, b in zip(starts, starts[1:]):
+            prog = tuple(
+                (
+                    t[2],
+                    t[3],
+                    t[4],
+                    struct.unpack_from("<I", mcode, t[0] + 4)[0]
+                    if t[2] == 0xA7
+                    else None,
+                )
+                for t in toks
+                if a <= t[0] < b and t[1] == "V"
+            )
+            skeletons[prog] += 1
+        top = skeletons.most_common(2)
+        assert sum(c for _, c in top) >= 0.4 * sum(skeletons.values()), top
+        for prog, _ in top:
+            assert prog[3] == (0xA7, 0x00, 0x1E, 0) and prog[-2] == (
+                0xA7,
+                0x00,
+                0x02,
+                2,
+            ), prog
+            assert prog[-1][:3] == (0xA8, 0x30, 0x02)
         total_e = total_n = 0
         for seg in segs:
             pos, length, _ = seg
@@ -3088,6 +3120,23 @@ def test_llm_build_layer_mcode_keeps_the_layout_and_uses_a7(tmp_path):
             total_e += c * (end - pos)
             total_n += end - pos
         assert total_e / total_n >= 0.95, total_e / total_n
+
+    # One instruction stream for all 30 layers: header + stream identical
+    # byte for byte, only the tail's name string and the weights differ.
+    for other in (1, 29):
+        path = str(work / "output" / f"llama_p512_l{other}_together.axmodel")
+        for (_, m0), (_, m1) in zip(mcodes, _mcodes_of(path)):
+            _, segs = _segments(m0)
+            vec = segs[-1][0] + segs[-1][1]
+            assert len(m0) == len(m1) and m0[:vec] == m1[:vec]
+            diff = [i for i in range(vec, len(m0)) if m0[i] != m1[i]]
+            assert 1 <= len(diff) <= 24, len(diff)
+    w0 = onnx.load(layer)
+    w29 = onnx.load(str(work / "output" / "llama_p512_l29_together.axmodel"))
+    params0 = {t.name: bytes(t.raw_data) for t in w0.graph.initializer}
+    params29 = {t.name: bytes(t.raw_data) for t in w29.graph.initializer}
+    key = _params_key(w0)
+    assert len(params0[key]) == len(params29[key]) and params0[key] != params29[key]
 
 
 def test_onnx_path_llm_mcode_keeps_the_op_program_skeleton(tmp_path):

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2822,3 +2822,76 @@ def test_resnet18d_tag_9f_units_carry_one_extra_byte(tmp_path):
     random.Random(0).shuffle(shuffled)
     e_real, e_null = explained(block), explained(bytes(shuffled))
     assert e_real >= 0.95 and e_null <= 0.55, (e_real, e_null)
+
+
+_TAIL_VECTOR = bytes.fromhex("05000000200000002c000000500000007400000098000000")
+"""The FlatBuffers vector of five table offsets that opens an mcode blob's
+tail -- see the README's "The op programs are fully tokenized" section."""
+
+
+def _tail_tables(mcode):
+    """Walk the five FlatBuffers tables of an mcode blob's tail. Returns, per
+    table, a dict of `field index -> uint32 (or uint16) value` for present
+    fields, read through each table's vtable."""
+    vec = mcode.find(_TAIL_VECTOR)
+    assert vec > 0 and mcode.find(_TAIL_VECTOR, vec + 1) < 0
+    u32 = lambda o: struct.unpack_from("<I", mcode, o)[0]  # noqa: E731
+    i32 = lambda o: struct.unpack_from("<i", mcode, o)[0]  # noqa: E731
+    u16 = lambda o: struct.unpack_from("<H", mcode, o)[0]  # noqa: E731
+    tables = []
+    for k in range(u32(vec)):
+        p = vec + 4 + 4 * k
+        tpos = p + u32(p)
+        vt = tpos - i32(tpos)
+        vsz, tsz = u16(vt), u16(vt + 2)
+        fields = {}
+        for f in range((vsz - 4) // 2):
+            off = u16(vt + 4 + 2 * f)
+            if off:
+                fields[f] = u32(tpos + off) if off + 4 <= tsz else u16(tpos + off)
+        tables.append(fields)
+    return vec, tables
+
+
+def test_resnet18d_stream_ends_at_a_five_table_flatbuffers_tail(tmp_path):
+    """Confirmed real (see the README's "The op programs are fully
+    tokenized" section), on a fresh resnet18d build: the header's word at
+    offset 272 is a FlatBuffers offset landing exactly on the tail's
+    five-table vector, ~480 bytes before the end; the instruction stream
+    ends 7 bytes after its last verb, just before that vector's zero
+    padding; under the full rule the op region has zero residue and the
+    stream is >= 97% explained; the header's last 17 bytes close block A
+    too; and tables 1..3 carry type word 4097 with the packed field equal
+    to `count << 8 | 1`. No device.
+    """
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    vec, tables = _tail_tables(mcode)
+    assert 460 <= len(mcode) - vec <= 500, len(mcode) - vec
+    assert 272 + struct.unpack_from("<I", mcode, 272)[0] == vec
+
+    pad = 0
+    while mcode[vec - pad - 1] == 0:
+        pad += 1
+    stream_end = vec - pad
+
+    narrow = _tokenize_mcode(mcode)
+    cuts = [k for k, t in enumerate(narrow) if t[1:] == ("V", 0xA1, 0x40, 0x02)]
+    a_lo, b_lo, ops_lo = narrow[cuts[0]][0], narrow[cuts[1]][0], narrow[cuts[2]][0]
+    assert mcode[280:297] == mcode[b_lo - 17 : b_lo]
+    assert mcode[b_lo - 8 : b_lo - 4] == bytes.fromhex("a2000000")
+
+    full = dict(tags=_ALL_TAGS, pmax=4, bare=True, extra_byte_tags={0x9F})
+    toks = _tokenize_mcode(mcode, start=a_lo, end=stream_end, **full)
+    last = toks[-1]
+    assert last[1] == "V" and last[2] == 0xA2 and stream_end - last[0] == 7, last
+    ops = [t for t in toks if t[0] >= ops_lo]
+    assert ops and not any(t[1] == "?" for t in ops)
+    explained = 1 - sum(1 for t in toks if t[1] == "?") / (stream_end - a_lo)
+    assert explained >= 0.97, explained
+
+    assert len(tables) == 5
+    for k in (1, 2, 3):
+        assert tables[k][0] == 4097 and tables[k][4] == (tables[k][3] << 8) | 1, tables[
+            k
+        ]
+    assert tables[4][0] == 2561

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2466,6 +2466,11 @@ by >= 2x in both real models -- the README's "Fourth correction" section.
 Superseded by `_ALL_TAGS`: the fifth correction's conditional-parity test
 showed the rejected tags were false rejections of rare forms."""
 
+_VERBS6 = frozenset(_VERBS | {0xA7})
+"""The five verbs plus `a7`, the segment-marker verb every stream segment
+opens with and `llm_build` op programs use freely -- see the README's "The
+tail is the segment table" section. Pass as `verbs=` to `_tokenize_mcode`."""
+
 _ALL_TAGS = frozenset(range(0x81, 0xA0))
 """Every byte below the verb range: the full short-unit tag set. For every
 tag the byte after it is even in ~100% of real units against ~60% shuffled
@@ -2480,6 +2485,7 @@ def _tokenize_mcode(
     pmax=3,
     bare=False,
     extra_byte_tags=frozenset(),
+    verbs=None,
 ):
     """Tokenize an mcode blob's bulk with every validated form -- the 8/7-byte
     verb instructions, the width-rule short units `[p][p+1 bytes][tag]
@@ -2496,12 +2502,13 @@ def _tokenize_mcode(
     correction" sections."""
     tags = set(range(0x81, 0x85)) if tags is None else set(tags)
     extra_byte_tags = set(extra_byte_tags)
+    verbs = _VERBS if verbs is None else frozenset(verbs)
     end = len(mcode) - 252 if end is None else end
 
     def is_verb(i):
         return (
             i + 3 < len(mcode)
-            and mcode[i] in _VERBS
+            and mcode[i] in verbs
             and mcode[i + 1] == 0
             and mcode[i + 2] % 0x10 == 0
         )
@@ -2829,12 +2836,52 @@ _TAIL_VECTOR = bytes.fromhex("05000000200000002c000000500000007400000098000000")
 tail -- see the README's "The op programs are fully tokenized" section."""
 
 
+def _tail_vector(mcode):
+    """Offset of the FlatBuffers table vector that opens an mcode blob's
+    tail, found through the header word that points at it (a uoffset whose
+    target holds a small count followed by increasing table offsets) -- the
+    fixed five-entry `_TAIL_VECTOR` pattern only holds for graphs with one
+    input and one output. See the README's "The tail is the segment table"
+    section."""
+    u32 = lambda o: struct.unpack_from("<I", mcode, o)[0]  # noqa: E731
+    first_verb = mcode.find(b"\xa1\x00\x40\x02")
+    assert first_verb > 0
+    for o in range(0, first_verb - 3, 4):
+        t = o + u32(o)
+        if not (first_verb < t < len(mcode) - 8):
+            continue
+        n = u32(t)
+        if not (1 <= n <= 64) or t + 4 + 4 * n > len(mcode):
+            continue
+        offs = [u32(t + 4 + 4 * k) for k in range(n)]
+        if all(0 < x < 8192 for x in offs) and offs == sorted(offs):
+            return t
+    raise AssertionError("no header word points at a tail table vector")
+
+
+def _segments(mcode):
+    """The stream segments the tail table describes: `(offset, length,
+    table)` per segment in stream order, which is *reverse* table order.
+    Table field 2 is the segment length in 8-byte words; the segments tile
+    the blob exactly from the end of the FlatBuffers header to the tail
+    vector. Also returns the header length."""
+    vec, tables = _tail_tables(mcode)
+    words = [t.get(2, 0) for t in tables]
+    header = vec - 8 * sum(words)
+    segs, pos = [], header
+    for k in range(len(tables) - 1, -1, -1):
+        segs.append((pos, 8 * words[k], tables[k]))
+        pos += 8 * words[k]
+    assert pos == vec
+    return header, segs
+
+
 def _tail_tables(mcode):
-    """Walk the five FlatBuffers tables of an mcode blob's tail. Returns, per
-    table, a dict of `field index -> uint32 (or uint16) value` for present
-    fields, read through each table's vtable."""
-    vec = mcode.find(_TAIL_VECTOR)
-    assert vec > 0 and mcode.find(_TAIL_VECTOR, vec + 1) < 0
+    """Walk the FlatBuffers tables of an mcode blob's tail (five for a
+    one-input, one-output CNN; fifteen for an `llm_build` subgraph).
+    Returns, per table, a dict of `field index -> uint32 (or uint16) value`
+    for present fields, read through each table's vtable."""
+    vec = _tail_vector(mcode)
     u32 = lambda o: struct.unpack_from("<I", mcode, o)[0]  # noqa: E731
     i32 = lambda o: struct.unpack_from("<i", mcode, o)[0]  # noqa: E731
     u16 = lambda o: struct.unpack_from("<H", mcode, o)[0]  # noqa: E731
@@ -2895,3 +2942,202 @@ def test_resnet18d_stream_ends_at_a_five_table_flatbuffers_tail(tmp_path):
             k
         ]
     assert tables[4][0] == 2561
+
+
+_FULL_RULE = dict(
+    tags=_ALL_TAGS, pmax=4, bare=True, extra_byte_tags={0x9F}, verbs=_VERBS6
+)
+"""Every validated form: all tags, p <= 4, bare pairs, the 0x9f extra byte,
+six verbs -- the README's "The tail is the segment table" section."""
+
+
+def _segment_coverage(mcode, seg):
+    """Explained fraction of one stream segment under `_FULL_RULE`, with its
+    trailing zero padding trimmed; also the count of `a1 40 02` verbs (op
+    programs) and of `a7` verbs inside it."""
+    pos, length, _ = seg
+    end = pos + length
+    while end > pos and mcode[end - 1] == 0:
+        end -= 1
+    toks = _tokenize_mcode(mcode, start=pos, end=end, **_FULL_RULE)
+    # The segment's first 8 bytes can hold the tail of the `a7` marker verb
+    # that starts 4 bytes *before* the word boundary (`1e 00 00 00 00`);
+    # those are the marker's operand, not unexplained content. Zero bytes
+    # left over are padding (an `llm_build` op segment ends with 8 zero bytes
+    # before the next segment's marker), not content either.
+    unknown = sum(1 for t in toks if t[1] == "?" and t[0] >= pos + 8 and mcode[t[0]])
+    programs = sum(1 for t in toks if t[1:] == ("V", 0xA1, 0x40, 0x02))
+    a7 = sum(1 for t in toks if t[1] == "V" and t[2] == 0xA7)
+    return 1 - unknown / max(1, end - pos), programs, a7
+
+
+def _check_segment_table(mcode):
+    """The segment-table claims shared by every build: countdown, tiling,
+    an `a7` marker verb within the first 16 bytes of every segment."""
+    vec, tables = _tail_tables(mcode)
+    for k in range(1, len(tables)):
+        assert tables[k].get(3, 0) == tables[k - 1][3] - tables[k][2], (k, tables[k])
+    assert tables[0][3] == sum(t.get(2, 0) for t in tables[1:])
+    header, segs = _segments(mcode)
+    assert segs[-1][0] + segs[-1][1] == vec
+    # The marker's `a7 00 00` may sit in the 4 bytes before the 8-byte-word
+    # boundary (the `llm_build` subgraphs' segments open `1e 00 00 00 00 a2`,
+    # the marker's operand), so look from 4 bytes before each segment start.
+    for pos, length, _ in segs:
+        assert mcode.find(b"\xa7\x00\x00", pos - 4, pos + 16) >= 0, (
+            pos,
+            mcode[pos - 4 : pos + 16].hex(),
+        )
+    return header, segs
+
+
+def test_resnet18d_tail_segments_tile_the_stream_and_open_with_a7(tmp_path):
+    """Confirmed real (see the README's "The tail is the segment table"
+    section), on a fresh resnet18d build: the tail tables' field 2 is a
+    length in 8-byte words that tiles the blob exactly from the 280-byte
+    header to the tail vector in reverse table order; field 3 counts down;
+    the last segment is block A exactly; every segment opens with an `a7`
+    verb; the op-program segment (table 0) is 100% tokenized with six
+    verbs and holds every `a1 40 02` program; types are 0xa01, 0x1001 x3,
+    0xe801. No device.
+    """
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    header, segs = _check_segment_table(mcode)
+    assert header == 280 and len(segs) == 5
+    narrow = _tokenize_mcode(mcode)
+    cuts = [k for k, t in enumerate(narrow) if t[1:] == ("V", 0xA1, 0x40, 0x02)]
+    a_lo, b_lo = narrow[cuts[0]][0], narrow[cuts[1]][0]
+    assert segs[0][0] + segs[0][1] == b_lo - 17 and segs[0][1] == b_lo - a_lo
+    assert [s[2][0] for s in segs] == [0xA01, 0x1001, 0x1001, 0x1001, 0xE801]
+    cov, programs, _ = _segment_coverage(mcode, segs[-1])
+    assert cov == 1.0 and programs == len(cuts) - 2, (cov, programs, len(cuts))
+    for seg in segs[:-1]:
+        assert _segment_coverage(mcode, seg)[0] >= 0.9
+
+
+def _cached_hf_checkpoint(repo_id, fallback_dir=None):
+    """Local snapshot directory of a HuggingFace checkpoint already in the
+    cache (with its weights present), else `fallback_dir` if that holds a
+    checkpoint, else None. Never downloads -- these tests stay offline."""
+    try:
+        from huggingface_hub import snapshot_download
+
+        path = snapshot_download(repo_id, local_files_only=True)
+        if any(f.endswith((".safetensors", ".bin")) for f in os.listdir(path)):
+            return path
+    except Exception:
+        pass
+    if fallback_dir and os.path.exists(os.path.join(fallback_dir, "config.json")):
+        return os.path.abspath(fallback_dir)
+    return None
+
+
+def _mcodes_of(axmodel_path):
+    """Every `neu mode` node's mcode in an `.axmodel`, as `(node name,
+    bytes)` -- `llm_build` per-layer files carry two (decode and prefill)."""
+    m = onnx.load(axmodel_path)
+    out = []
+    for node in m.graph.node:
+        if node.op_type != "neu mode":
+            continue
+        info = json.loads(
+            next(a for a in node.attribute if a.name == "npu_graph_info").s.decode()
+        )
+        for d in info["dotneus"]:
+            init = next(i for i in m.graph.initializer if i.name == d["neu_key"])
+            out.append((node.name, bytes(init.raw_data)))
+    return out
+
+
+def test_llm_build_layer_mcode_keeps_the_layout_and_uses_a7(tmp_path):
+    """Confirmed real (see the README's "The tail is the segment table"
+    section), on a fresh `pulsar2 llm_build` of SmolLM2-135M: each of the
+    per-layer file's two subgraphs has a 15-segment tail whose segments
+    tile the stream, every segment opens with `a7`, the op-program segment
+    (table 2, type 0x8801) is 100% tokenized and uses `a7` inside its
+    programs, and the whole stream is >= 95% explained. Skips unless the
+    checkpoint is already in the HuggingFace cache. No device.
+    """
+    import shutil
+
+    ckpt = _cached_hf_checkpoint("HuggingFaceTB/SmolLM2-135M")
+    if ckpt is None:
+        pytest.skip("HuggingFaceTB/SmolLM2-135M is not in the local HuggingFace cache")
+    work = tmp_path / "work"
+    work.mkdir()
+    shutil.copytree(ckpt, work / "SmolLM2-135M", symlinks=False)
+    result = pulsar2_docker.llm_build(str(work), "SmolLM2-135M", "output", parallel=8)
+    assert result.success, getattr(result, "error", None)
+    layer = str(work / "output" / "llama_p512_l0_together.axmodel")
+    mcodes = _mcodes_of(layer)
+    assert len(mcodes) == 2, [n for n, _ in mcodes]
+    for _, mcode in mcodes:
+        _, segs = _check_segment_table(mcode)
+        assert len(segs) == 15
+        ops = [s for s in segs if s[2][0] == 0x8801]
+        assert len(ops) == 1
+        cov, programs, a7 = _segment_coverage(mcode, ops[0])
+        assert cov == 1.0 and programs >= 100 and a7 >= 100, (cov, programs, a7)
+        total_e = total_n = 0
+        for seg in segs:
+            pos, length, _ = seg
+            end = pos + length
+            while end > pos and mcode[end - 1] == 0:
+                end -= 1
+            c, _, _ = _segment_coverage(mcode, seg)
+            total_e += c * (end - pos)
+            total_n += end - pos
+        assert total_e / total_n >= 0.95, total_e / total_n
+
+
+def test_onnx_path_llm_mcode_keeps_the_op_program_skeleton(tmp_path):
+    """Confirmed real (see the README's "The tail is the segment table"
+    section), on a fresh ONNX-path build of the 1-layer tiny-random-mistral
+    checkpoint: five segments that tile the stream, a 436-byte header (two
+    graph inputs), a 100%-tokenized op segment with ~75 programs for 80
+    ONNX ops, and the CNN skeleton verb for verb with `a1 20.02` in place
+    of `a1 30.03`. Skips unless the checkpoint is in the HuggingFace
+    cache. No device.
+    """
+    from collections import Counter
+
+    ckpt = _cached_hf_checkpoint(
+        "distilabel-internal-testing/tiny-random-mistral",
+        fallback_dir=os.path.join(
+            os.path.dirname(__file__), "..", "tiny-random-mistral"
+        ),
+    )
+    if ckpt is None:
+        pytest.skip("tiny-random-mistral is not in the local HuggingFace cache")
+    work = tmp_path / "work"
+    work.mkdir()
+    result = pulsar2_docker.build_from_hf_checkpoint(ckpt, str(work), "output")
+    assert result.success, result.error
+    ((_, mcode),) = _mcodes_of(result.axmodel_path)
+    header, segs = _check_segment_table(mcode)
+    assert header == 436 and len(segs) == 5
+    cov, programs, _ = _segment_coverage(mcode, segs[-1])
+    assert cov == 1.0 and 60 <= programs <= 90, (cov, programs)
+    pos, length, _ = segs[-1]
+    toks = _tokenize_mcode(mcode, start=pos, end=pos + length, **_FULL_RULE)
+    starts = [t[0] for t in toks if t[1:] == ("V", 0xA1, 0x40, 0x02)]
+    skeletons = Counter()
+    for a, b in zip(starts, starts[1:]):
+        prog = tuple((t[2], t[3], t[4]) for t in toks if a <= t[0] < b and t[1] == "V")
+        skeletons[prog] += 1
+    core = (
+        (0xA1, 0x40, 0x02),
+        (0xA1, 0x50, 0x01),
+        (0xA1, 0x50, 0x01),
+        (0xA8, 0x40, 0x03),
+        (0xA1, 0x50, 0x03),
+        (0xA1, 0x50, 0x01),
+        (0xA3, 0x00, 0x00),
+        (0xA1, 0x50, 0x01),
+        (0xA9, 0x00, 0x00),
+    )
+    top = skeletons.most_common(2)
+    assert sum(c for _, c in top) >= 0.6 * sum(skeletons.values()), top
+    for prog, _ in top:
+        assert tuple(v for v in prog if v in core) == core, prog
+    assert sum(c for prog, c in skeletons.items() if (0xA1, 0x20, 0x02) in prog) >= 5


### PR DESCRIPTION
Validating the "`XX 00` second header family" from #1190 with the permutation method overturned three earlier readings of the mcode configuration blocks. All findings are documented in place in `scripts/axera/README.md` (new section "Fourth correction") and locked in by a device-free regression test on a fresh `resnet18d` build.

- **The width-rule tag set is 17 bytes wide**, not `0x81..0x84`: `{0x81..0x86, 0x89..0x8d, 0x94, 0x95, 0x9b..0x9d, 0x9f}` each beat a shuffled null by >= 2x in both real models. Block B goes from 42.6% to **76.1%** explained in `resnet18d` (null 19.5%) and 62.0% to **81.8%** in `mnasnet` (null 22.7%); residue 11,134 -> 4,636 and 16,990 -> 8,146 bytes. `tag = 0x84 - p` is the dominant pairing, not a rule.
- **The byte after the tag is the register**: even in 99.9% of units (2,909/2,911; 6,248/6,253; 258/258) against a 64% background, while the first payload byte sits at background. The unit is `[p][value][tag][register]`.
- **`23 00` is a one-byte, model-specific prefix** (`23`/`03`/`3c` in resnet18d; `04`/`2d`/`05`/`1c` in mnasnet) sitting directly before an ordinary `p = 0` unit -- not a header family.
- **Negative results**: payload-less `[tag][even]` pairs are null-level (0x84: 59 real vs 266 shuffled); `e1 XX` is a weak candidate only; no tag has a fixed argument length.
- **Both configuration blocks open with the same 158-byte prologue** in both models; the tiny model shares it with one operand changed (`60 02`: `0x31480` vs `0xd80`).

`_tokenize_mcode` gains optional `end`, `tags`, `pmax` parameters (defaults unchanged, existing tests unaffected) and a `_WIDE_TAGS` constant.

Stacks on #1190 (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2usgepQwRi2s6ASVaHfk
