### PR TITLE
Fix the GPTAQ "beats GPTQ" test: the corrupted model was never quantized

### DIFF
--- a/tests/test_gptaq.py
+++ b/tests/test_gptaq.py
@@ -83,7 +83,7 @@ def _upstream_corrupted_model(K0=32, N1=8, corruption=None, seed=0):
         if corruption is None
         else corruption.astype(np.float32)
     )
-    return _model(
+    model = _model(
         f"""
         g (float[batch,{K0}] X) => (float[batch,{N1}] Y2)
         {{
@@ -93,6 +93,16 @@ def _upstream_corrupted_model(K0=32, N1=8, corruption=None, seed=0):
         """,
         [_f32(w2, "W2"), _f32(corruption, "Corruption")],
     )
+    # `quantize_weight_only_int4` runs no shape inference of its own and
+    # rejects a MatMul whose activation's element type it cannot see. `Y1`
+    # is an intermediate tensor, so without a value_info its type is
+    # undefined to the pass, the MatMul is silently left unquantized, and
+    # both `apply_gptq` and `apply_gptaq` then return `quantized_model`
+    # unchanged -- which made the "beats" test below compare a model with
+    # itself (an exact tie, on every platform). Shape inference gives `Y1`
+    # the value_info the pass needs; `_matmul_model`'s MatMul reads the
+    # graph input directly and never had this problem.
+    return onnx.shape_inference.infer_shapes(model)
 
 
 def _correlated_calibration(K, num_samples=64, rank=6, seed=1):


### PR DESCRIPTION
`test_gptaq_beats_gptq_once_an_upstream_layer_is_already_corrected` (from #1185) fails deterministically on every platform -- ubuntu and Windows in CI, and locally -- with an exact tie: `assert 0.31504472079057905 < 0.31504472079057905`. This has been failing `Build and Test` on master since #1185 merged.

**Cause.** The tie is not numerical. `quantize_weight_only_int4` never quantizes the MatMul in `_upstream_corrupted_model`: the `weight_only_quantize_int4_matmul` pass runs no shape inference and rejects a MatMul whose activation's element type is not FLOAT, and `Y1` is an intermediate tensor with no value_info, so its type is undefined to the pass. With no INT4 candidate, both `apply_gptq` and `apply_gptaq` return `quantized_model` unchanged, and the test compares a model with itself. `_matmul_model`'s MatMul reads the graph input directly, which is why the other five tests never hit this.

**Fix.** Run `onnx.shape_inference.infer_shapes` on the test model so `Y1` carries a value_info. All six tests in the file pass locally, and the "beats" assertion now compares two genuinely different models.

**Worth a separate look.** The same predicate (`info.x->elemType() != FLOAT`) is in the int4, int8-block and MatMulNBits weight-only passes. A MatMul's type constraint ties the activation to the weight, so when the weight is float32 an undefined activation type could safely be accepted; as it stands, any exported model without intermediate value_info silently gets none of its interior MatMuls quantized. Not changed here -- this PR only fixes the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2usgepQwRi2s6ASVaHfk
