### PR TITLE
mcode: llm_build follow-ups -- 0xa1 as a tag, bit-6 odd-register tags

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3158,6 +3158,22 @@ Admitting them takes the config segments' non-zero bytes from 97.4% to
 segments stay at ~46% under the same rule). `_tokenize_mcode` takes
 these as `odd_tags`.
 
+**Confirmed on the AX650N: the segment table is a loader manifest the
+runtime validates field by field.** Patching one field of the decode
+subgraph's tail tables and re-running with valid inputs, every variant
+faulted with `0x8030070C` on every run (3 of 3 each, baseline
+bit-identical 3 of 3): the op segment's type word `0x8801 -> 0xe801`;
+its word count `f2 + 1`; its remaining count `f3 + 1`; table 0's total
+`f3 + 1`; a 6-field table's byte size `f5 - 64`; the same table's
+packed word `f4 + 1`; and table 0's own `f2 + 1`. Two of them (the type
+word's first run and the total-count patch) first hung the runtime for
+about two minutes -- `axcl_run_model` in uninterruptible sleep and
+`axcl-smi` blocked behind it -- before the fault surfaced, so a wrong
+segment table is the one patch class found so far that can stall the
+device rather than fail fast. Treat the table as load-bearing: an
+emitter must write the word counts, the countdown, the packed
+`f3 << 8 | 1` and the byte sizes exactly, not as metadata.
+
 **`llm_build` emits one instruction stream for all 30 layers.** Every
 per-layer file's two mcodes are byte-identical to layer 0's from the
 first byte of the FlatBuffers header to the tail vector; the only

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3138,6 +3138,26 @@ distinguishes 0x02/0x1e from 0x03 but not from each other. The
 timing differences between variants were within run-to-run noise
 (0.43..0.54 ms) and are not claimed.
 
+**0xa1 is also a tag, and bit 6 of a tag flips the register's parity.**
+The config-segment residue that remained is mostly three forms, and the
+conditional-parity null settles all three (counts are the `llm_build`
+layer's decode and prefill subgraphs; a fresh `resnet18d` build has 15
+of 16 and 18 of 19 for the first and third): bare `a1 XX` pairs have an
+even `XX` in
+37 of 37 and 65 of 65 cases against 28:13 and 36:31 in the shuffled
+segments; `01 .. a1 XX` p-units have an even register 31 of 31 and 76
+of 76 times; and bare `e1 XX` pairs have an **odd** `XX` in 71 of 71 and
+116 of 116 cases (`c1 XX` 4 of 4 and 10 of 10) against 4:2 and 8:2
+shuffled. So the verb
+byte 0xa1 doubles as a tag whenever it is not in verb position (`a1 00
+x0`), and the 0x40 bit of a tag (0x81 -> 0xc1, 0xa1 -> 0xe1) selects the
+odd register -- the other half of a 2-byte register pair, presumably.
+Admitting them takes the config segments' non-zero bytes from 97.4% to
+98.1% explained in `resnet18d`, 95.6% to 97.2% in `mnasnet`, and 95.9% /
+95.5% to 97.0% / 97.2% in the two `llm_build` subgraphs (shuffled
+segments stay at ~46% under the same rule). `_tokenize_mcode` takes
+these as `odd_tags`.
+
 **`llm_build` emits one instruction stream for all 30 layers.** Every
 per-layer file's two mcodes are byte-identical to layer 0's from the
 first byte of the FlatBuffers header to the tail vector; the only

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2486,6 +2486,7 @@ def _tokenize_mcode(
     bare=False,
     extra_byte_tags=frozenset(),
     verbs=None,
+    odd_tags=frozenset(),
 ):
     """Tokenize an mcode blob's bulk with every validated form -- the 8/7-byte
     verb instructions, the width-rule short units `[p][p+1 bytes][tag]
@@ -2538,6 +2539,10 @@ def _tokenize_mcode(
             out.append((i, "S", mcode[i], mcode[i + n - 2], mcode[i + 1]))
         elif bare and i + 1 < end and mcode[i] in tags and mcode[i + 1] % 2 == 0:
             n = 2 + (1 if mcode[i] in extra_byte_tags else 0)
+            out.append((i, "B", mcode[i], mcode[i + 1], 0))
+        elif bare and i + 1 < end and mcode[i] in odd_tags and mcode[i + 1] % 2 == 1:
+            # Tags with bit 6 set (0xc1, 0xe1) pair with an *odd* register byte.
+            n = 2
             out.append((i, "B", mcode[i], mcode[i + 1], 0))
         else:
             n = 1
@@ -3326,3 +3331,60 @@ def test_llm_build_a7_is_a_sync_verb_on_device(tmp_path):
         _run_llm_layer(patched("a7_02_channel_1e", set_channel(a7_02, 0x1E)), inputs, 3)
     )
     assert len(same) >= 2 and all(s == baseline for s in same), same
+
+
+def test_resnet18d_a1_is_a_tag_and_bit6_tags_take_odd_registers(tmp_path):
+    """Confirmed real (see the README's "0xa1 is also a tag" paragraph), on
+    a fresh resnet18d build's configuration segments under the full rule:
+    among the 2-byte non-zero residue runs, `a1 XX` has an even XX in
+    >= 95% of cases and `e1 XX`/`c1 XX` an odd XX in every case, while the
+    same runs in the shuffled segments split about evenly; admitting them
+    (`tags | {0xa1}`, `odd_tags={0xc1, 0xe1}`) lowers the non-zero residue.
+    No device.
+    """
+    import random
+    from collections import Counter
+
+    _, _, mcode = _build_real_resnet18d(str(tmp_path))
+    _, segs = _segments(mcode)
+    blob = b"".join(mcode[p : p + n] for p, n, t in segs if t[0] != 0xE801)
+    shuffled = bytearray(blob)
+    random.Random(0).shuffle(shuffled)
+    shuffled = bytes(shuffled)
+
+    def pair_parity(b):
+        toks = _tokenize_mcode(b, start=0, end=len(b), **_FULL_RULE)
+        runs, last = [], None
+        for o, k, *_ in toks:
+            if k == "?" and b[o]:
+                if last == o:
+                    runs[-1][1] = o + 1
+                else:
+                    runs.append([o, o + 1])
+                last = o + 1
+        par = Counter()
+        for a, e in runs:
+            if e - a == 2 and b[a] in (0xA1, 0xC1, 0xE1):
+                par[(b[a], b[a + 1] % 2)] += 1
+        return par
+
+    real, null = pair_parity(blob), pair_parity(shuffled)
+    a1_even, a1_odd = real[(0xA1, 0)], real[(0xA1, 1)]
+    # resnet18d has ~15 such pairs (the llm_build subgraphs 37 and 65).
+    assert a1_even >= 10 and a1_even >= 0.9 * (a1_even + a1_odd), (a1_even, a1_odd)
+    odd = real[(0xE1, 1)] + real[(0xC1, 1)]
+    even = real[(0xE1, 0)] + real[(0xC1, 0)]
+    # 18 of 19 on a fresh resnet18d build; 71/71 and 116/116 in llm_build.
+    assert odd >= 10 and odd >= 0.9 * (odd + even), (odd, even)
+    null_a1 = null[(0xA1, 0)] + null[(0xA1, 1)]
+    assert null_a1 == 0 or null[(0xA1, 0)] <= 0.8 * null_a1 + 2, dict(null)
+
+    def nonzero_residue(b, **extra):
+        rule = dict(_FULL_RULE)
+        rule.update(extra)
+        toks = _tokenize_mcode(b, start=0, end=len(b), **rule)
+        return sum(1 for t in toks if t[1] == "?" and b[t[0]])
+
+    before = nonzero_residue(blob)
+    after = nonzero_residue(blob, tags=_ALL_TAGS | {0xA1}, odd_tags={0xC1, 0xE1})
+    assert after <= 0.85 * before, (before, after)


### PR DESCRIPTION
Follow-ups to #1191 on the `llm_build` mcode, stacked as commits on this PR as they land.

**0xa1 is also a tag; bit 6 of a tag selects the odd register.** The configuration-segment residue that remained was mostly three forms, and the conditional-parity null settles all three on the `llm_build` layer's subgraphs: bare `a1 XX` pairs have an even `XX` 37/37 and 65/65 (shuffled 28:13, 36:31); `01 .. a1 XX` p-units an even register 31/31 and 76/76; bare `e1 XX` pairs an odd `XX` 71/71 and 116/116, `c1 XX` 4/4 and 10/10 (shuffled 4:2, 8:2); a fresh resnet18d build 15/16 and 18/19. So the verb byte doubles as a tag outside verb position and the 0x40 bit of a tag flips the register's parity. Admitting them takes the config segments' non-zero bytes to 97..98% explained across the builds. `_tokenize_mcode` gains `odd_tags`; a device-free resnet18d test locks in the parities and the residue reduction.

Documented in `scripts/axera/README.md` next to the segment-table section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2usgepQwRi2s6ASVaHfk
