### PR TITLE
Fix silent no-op on 3-D activations across 26 PTQ passes; QuaRot/LLM-FP4 follow-ups; NNCF benchmark

### DIFF
--- a/bench/RESULTS_nncf_comparison.md
+++ b/bench/RESULTS_nncf_comparison.md
@@ -1,0 +1,121 @@
+# onnxsim vs. NNCF: INT4 weight-only compression
+
+Measured with `bench/nncf_comparison.py`. This answers candidate future-work
+item 3 in `docs/nncf-comparison-future-work.md`, which noted that the
+onnxsim-vs-NNCF comparison recorded there was architectural and that "no
+benchmark in this repo actually runs the same model through both onnxsim and
+NNCF."
+
+**Environment**: NNCF 3.3.0, onnxruntime 1.29.0 (CPUExecutionProvider), onnx
+1.20.0, numpy 2.3.5, x86_64, Python 3.11. onnxsim built from this checkout.
+
+**Model**: `bench/nncf_comparison.py`'s synthetic 4-layer MatMul stack,
+`in_dim = hidden = 256` (1024 KiB of float32 weights). See "Caveats" — the
+synthetic model is the main limitation of these numbers.
+
+## Results
+
+`rel L2` is the quantized model's output error against the float model's on
+shared random evaluation data; `KiB` counts only initializers a node actually
+references; `dtypes` is the referenced-initializer element-type histogram.
+
+| configuration | rel L2 | KiB | x smaller | quant s | weight dtypes |
+|---|---|---|---|---|---|
+| onnxsim int4 (RTN) | 0.1953 | 160.1 | 6.40 | 0.03 | FLOATx4, INT4x4 |
+| **onnxsim int4 + GPTQ** | **0.1571** | 160.1 | 6.40 | 0.12 | FLOATx4, INT4x4 |
+| onnxsim int4 + AWQ | 0.1926 | 164.0 | 6.24 | 0.20 | FLOATx8, INT4x4 |
+| onnxsim int4 + AWQ + GPTQ | 0.1650 | 164.0 | 6.24 | 0.36 | FLOATx8, INT4x4 |
+| nncf int4_sym (NNCF defaults) | 0.1765 | 167.2 | 6.12 | 0.18 | FLOATx4, INT4x3, UINT8x2 |
+| nncf int4_sym all_layers g32 | 0.1698 | 160.0 | 6.40 | 0.07 | FLOATx4, INT4x4 |
+| nncf int4_sym g32 + AWQ | 0.1698 | 160.0 | 6.40 | 0.24 | FLOATx4, INT4x4 |
+| nncf int4_sym g32 + ScaleEstimation | 0.1765 | 160.0 | 6.40 | 0.16 | FLOATx4, INT4x4 |
+
+At matched settings (`all_layers=True`, `group_size=32`) both tools reach the
+same 6.40x compression and emit the same graph shape, so the accuracy column
+is the comparison. **onnxsim + GPTQ is the most accurate configuration
+measured** (0.1571), ahead of NNCF's best (0.1698). onnxsim's plain
+round-to-nearest is the *least* accurate (0.1953) — see finding 1.
+
+## Findings
+
+### 1. onnxsim's INT4 gives up the `-8` code; NNCF does not
+
+Decoding the INT4 initializers each tool emits for the same weight:
+
+```
+onnxsim INT4 code range: (-7, 7)
+nncf    INT4 code range: (-8, 7)
+```
+
+`passes/quantize_matmul_common.h`'s `TryQuantizeWeightBlockwiseInt4InPlace`
+uses `scale = max(|w|) / 7` and clamps to `[-7, 7]`, forgoing the
+representable `-8`. NNCF uses the full `[-8, 7]`. For identical storage that
+makes onnxsim's quantization step about 12.5% coarser, which is enough to
+account for the plain-RTN gap in the table (0.1953 vs 0.1698) at byte-identical
+size. Whether to change this is a real decision, not an oversight to fix
+blindly: a symmetric `[-7, 7]` grid keeps `-x` representable whenever `x` is,
+which several onnxsim passes' own reasoning (and `_gptq_quantize_columns`'s
+clip bounds) already assume. But the cost is now measured rather than
+theoretical.
+
+### 2. GPTQ needs more calibration rows than the reduction dimension
+
+An earlier run of this benchmark reported onnxsim + GPTQ at **0.2384** —
+*worse* than plain RTN. That was an artifact of the benchmark, not of GPTQ:
+the calibration set had 64 rows for a `K = 256` reduction dimension, leaving
+GPTQ's `[K, K]` Hessian rank-deficient. Raising the calibration set above `K`
+moved the same configuration to 0.1571, the best result in the table. The
+script now sizes calibration data at `2 * in_dim` rows for this reason.
+
+Anyone comparing GPTQ-style methods should check this first; it inverts the
+conclusion.
+
+### 3. NNCF quantizes the last layer to INT8 unless told otherwise
+
+NNCF classifies a model's final MatMul as a non-"ratio-defining" layer (the
+`lm_head` convention) and leaves it at `int8_asym` per-channel. That is
+visible in the `dtypes` column: NNCF's default row is `INT4x3, UINT8x2` on a
+4-layer model, versus `INT4x4` with `all_layers=True`. onnxsim's INT4 pass
+quantizes every eligible layer unconditionally. Comparing the two defaults
+head-to-head would compare different bit widths and misattribute the
+difference to quantization quality — the benchmark passes `all_layers=True`
+for the matched rows and reports NNCF's default separately.
+
+### 4. onnxsim's INT4 pass silently skips layers with no `value_info`
+
+`weight_only_quantize_int4_matmul.h` requires the activation's element type
+(`info.x->elemType() != FLOAT` → no match), and a hand-built ONNX graph has no
+`value_info` for intermediate tensors. On the first version of this benchmark
+onnxsim quantized **1 of 4** layers (1.27x) against NNCF's 4 of 4 (6.40x) —
+which looks like a capability gap and is actually a missing-type-annotation
+gap. `onnx.shape_inference.infer_shapes` fixes it, and the script now runs it
+on both the synthetic and the user-supplied model. (The same issue produced a
+misleading exact tie in `tests/test_gptaq.py`; see PR #1192.) Real exported
+models normally carry this `value_info`, but any tooling that hand-builds
+graphs will hit it.
+
+## Caveats
+
+- **The model is synthetic.** A plain Gaussian MatMul stack has none of the
+  per-channel activation outliers that AWQ and Scale Estimation exist to
+  exploit, so both tools' data-aware modes are understated here: NNCF's AWQ
+  changed nothing at all (0.1698 → 0.1698) and its Scale Estimation was
+  slightly worse (0.1765); onnxsim's AWQ moved 0.1953 → 0.1926. These numbers
+  say nothing about how those methods behave on a real transformer, and should
+  not be read as ranking AWQ against GPTQ. `bench/nncf_comparison.py` accepts a
+  path to a real `.onnx` model for exactly this reason.
+- **Accuracy is output relative L2, not a task metric.** No perplexity or
+  downstream-accuracy evaluation is involved.
+- **Latency is not measured.** At matched settings both tools emit the same
+  `DequantizeLinear`-based graph, so a latency number would measure
+  onnxruntime's kernel rather than either quantizer.
+- **One model, one seed.** These are single-configuration measurements, not a
+  sweep; treat the ordering as indicative and re-run on your own model.
+
+## Reproducing
+
+```bash
+pip install nncf
+python bench/nncf_comparison.py --layers 4 --hidden 256 --in-dim 256
+python bench/nncf_comparison.py path/to/real_model.onnx   # far more meaningful
+```

--- a/bench/nncf_comparison.py
+++ b/bench/nncf_comparison.py
@@ -73,6 +73,7 @@ import numpy as np
 import onnx
 import onnx.helper
 import onnx.numpy_helper
+import onnx.shape_inference
 
 BLOCK_SIZE = 32
 
@@ -115,7 +116,16 @@ def _synthetic_mlp(
         graph, opset_imports=[onnx.helper.make_opsetid("", 21)]
     )
     model.ir_version = 10
-    return model
+    # Shape inference is not cosmetic here. onnxsim's INT4 pass refuses a
+    # MatMul whose activation's element type it cannot see
+    # (``info.x->elemType() != FLOAT`` in
+    # passes/weight_only_quantize_int4_matmul.h), and a hand-built graph has
+    # no value_info for its intermediate tensors -- so without this only the
+    # *first* layer (whose input is the typed graph input) would be
+    # quantized, and this benchmark would report onnxsim compressing 1 of N
+    # layers against NNCF's N of N. A real exported model carries this
+    # value_info already; a synthetic one has to be given it.
+    return onnx.shape_inference.infer_shapes(model)
 
 
 def _referenced_initializer_bytes(model: onnx.ModelProto) -> int:
@@ -282,9 +292,16 @@ def compare(model: onnx.ModelProto, num_eval: int = 32, seed: int = 0) -> None:
     in_dim = model.graph.input[0].type.tensor_type.shape.dim[-1].dim_value
     rng = np.random.default_rng(seed)
     eval_x = {in_name: rng.standard_normal((num_eval, in_dim)).astype(np.float32)}
+    # GPTQ-style methods build a ``[K, K]`` Hessian from these activations, so
+    # a calibration set with fewer rows than ``K`` leaves it rank-deficient and
+    # its correction unreliable -- which shows up, misleadingly, as GPTQ
+    # *hurting* accuracy. Default to comfortably more rows than the reduction
+    # dimension.
+    per_batch = 64
+    num_batches = max(4, -(-2 * in_dim // per_batch))
     calibration = [
-        {in_name: rng.standard_normal((16, in_dim)).astype(np.float32)}
-        for _ in range(4)
+        {in_name: rng.standard_normal((per_batch, in_dim)).astype(np.float32)}
+        for _ in range(num_batches)
     ]
 
     float_y = _run(model, eval_x)
@@ -341,7 +358,10 @@ def main() -> None:
     args = ap.parse_args()
 
     if args.model and os.path.exists(args.model):
-        model = onnx.load(args.model)
+        # Same reason as _synthetic_mlp: onnxsim's INT4 pass needs the
+        # activation's element type on every candidate MatMul. Exported
+        # models normally carry it; inferring is a no-op when they do.
+        model = onnx.shape_inference.infer_shapes(onnx.load(args.model))
         print(f"model: {args.model}")
     else:
         model = _synthetic_mlp(

--- a/bench/nncf_comparison.py
+++ b/bench/nncf_comparison.py
@@ -287,11 +287,53 @@ def _nncf_configs(
 # --------------------------------------------------------------------------- #
 
 
+def _feed(
+    model: onnx.ModelProto, batch: int, rng: np.random.Generator
+) -> Dict[str, np.ndarray]:
+    """One feed dict covering *every* graph input, with symbolic dimensions
+    resolved.
+
+    A hand-built synthetic model has a single float32 input whose only
+    symbolic dimension is the batch, but a real exported model routinely has
+    several inputs, integer ones (token ids, masks), and symbolic dims beyond
+    the batch. Reading ``dim_value`` blindly yields 0 for a symbolic dim and
+    would build empty arrays; assuming float32 would feed the wrong dtype to
+    an integer input. Both make the advertised
+    ``python bench/nncf_comparison.py model.onnx`` usage fail rather than
+    measure anything.
+    """
+    feeds: Dict[str, np.ndarray] = {}
+    initializer_names = {t.name for t in model.graph.initializer}
+    for value in model.graph.input:
+        if value.name in initializer_names:
+            continue  # an initializer also listed as an input: not a real feed
+        tensor_type = value.type.tensor_type
+        shape = []
+        for i, d in enumerate(tensor_type.shape.dim):
+            if d.HasField("dim_value") and d.dim_value > 0:
+                shape.append(d.dim_value)
+            else:
+                # Symbolic (or 0) dim: the leading one is the batch, any other
+                # is a sequence-like axis that just needs *some* concrete size.
+                shape.append(batch if i == 0 else 8)
+        np_dtype = onnx.helper.tensor_dtype_to_np_dtype(tensor_type.elem_type)
+        if np.issubdtype(np_dtype, np.floating):
+            feeds[value.name] = rng.standard_normal(shape).astype(np_dtype)
+        elif np_dtype == np.bool_:
+            feeds[value.name] = np.ones(shape, dtype=np.bool_)
+        else:
+            # Integer input (token ids, masks, ...). Zeros are always in range;
+            # this benchmark measures weight quantization error, for which the
+            # exact token values do not matter.
+            feeds[value.name] = np.zeros(shape, dtype=np_dtype)
+    return feeds
+
+
 def compare(model: onnx.ModelProto, num_eval: int = 32, seed: int = 0) -> None:
-    in_name = model.graph.input[0].name
-    in_dim = model.graph.input[0].type.tensor_type.shape.dim[-1].dim_value
     rng = np.random.default_rng(seed)
-    eval_x = {in_name: rng.standard_normal((num_eval, in_dim)).astype(np.float32)}
+    eval_x = _feed(model, num_eval, rng)
+    in_name = model.graph.input[0].name
+    in_dim = int(eval_x[in_name].shape[-1])
     # GPTQ-style methods build a ``[K, K]`` Hessian from these activations, so
     # a calibration set with fewer rows than ``K`` leaves it rank-deficient and
     # its correction unreliable -- which shows up, misleadingly, as GPTQ
@@ -299,10 +341,7 @@ def compare(model: onnx.ModelProto, num_eval: int = 32, seed: int = 0) -> None:
     # dimension.
     per_batch = 64
     num_batches = max(4, -(-2 * in_dim // per_batch))
-    calibration = [
-        {in_name: rng.standard_normal((per_batch, in_dim)).astype(np.float32)}
-        for _ in range(num_batches)
-    ]
+    calibration = [_feed(model, per_batch, rng) for _ in range(num_batches)]
 
     float_y = _run(model, eval_x)
     float_bytes = _referenced_initializer_bytes(model)
@@ -357,7 +396,12 @@ def main() -> None:
     ap.add_argument("--seed", type=int, default=0)
     args = ap.parse_args()
 
-    if args.model and os.path.exists(args.model):
+    if args.model and not os.path.exists(args.model):
+        # Falling back to the synthetic model here would silently report
+        # synthetic numbers under a real model's name.
+        raise SystemExit(f"no such model file: {args.model}")
+
+    if args.model:
         # Same reason as _synthetic_mlp: onnxsim's INT4 pass needs the
         # activation's element type on every candidate MatMul. Exported
         # models normally carry it; inferring is a no-op when they do.

--- a/bench/nncf_comparison.py
+++ b/bench/nncf_comparison.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Head-to-head: onnxsim vs. Intel NNCF on INT4 weight-only compression.
+
+``docs/nncf-comparison-future-work.md`` records an *architectural* comparison
+of onnxsim's quantization series against `NNCF
+<https://github.com/openvinotoolkit/nncf>`_, and lists as candidate future
+work item 3 the thing that comparison could not answer: "no benchmark in this
+repo actually runs the same model through both onnxsim and NNCF and compares
+accuracy/latency/size." This script is that benchmark.
+
+The two tools' surfaces overlap most directly on **INT4 weight-only
+compression**, so that is what is measured here: onnxsim's
+:func:`onnxsim.quantize_weight_only_int4` (optionally refined by
+:func:`onnxsim.apply_gptq` / :func:`onnxsim.apply_awq`, reached through
+:class:`onnxsim.QuantizationConfig`'s own composable flags) against NNCF's
+``compress_weights(mode=INT4_SYM, ...)``.
+
+Two semantic differences have to be neutralized before any number here means
+anything; both were established empirically against NNCF 3.3.0 while writing
+this script, not assumed:
+
+1. **NNCF keeps the last layer at INT8 by default.** NNCF classifies a
+   model's final MatMul as a non-"ratio-defining" layer (the ``lm_head``
+   convention) and leaves it at ``int8_asym`` per-channel unless
+   ``all_layers=True`` is passed. onnxsim's ``quantize_weight_only_int4``
+   quantizes *every* eligible layer unconditionally. Comparing NNCF's
+   default against onnxsim's therefore compares INT4-plus-an-INT8-layer
+   against INT4-everywhere -- a size and accuracy difference that has
+   nothing to do with either tool's quantization quality. This script
+   reports the ``all_layers=True`` configuration as the apples-to-apples
+   one, and NNCF's own default alongside it (clearly labeled), since the
+   default is what an NNCF user actually gets.
+2. **Group size.** onnxsim's INT4 pass is fixed at ``block_size=32`` (see
+   ``onnxsim/passes/weight_only_quantize_int4_matmul.h``'s ``kBlockSize``);
+   NNCF's ``group_size`` defaults to 128. They are compared at a matched
+   group size of 32, with NNCF's own 128 default reported separately.
+
+With ``all_layers=True`` and ``group_size=32``, NNCF's ONNX backend emits
+exactly the layout onnxsim's own pass does -- INT4 codes ``[K, N]`` plus a
+float32 scale ``[K / 32, N]`` feeding a ``DequantizeLinear`` -- so the
+comparison really is like-for-like.
+
+**What is and isn't measured.** Accuracy (relative L2 of each quantized
+model's output against the float model's, on shared random evaluation data)
+and size (bytes of initializers actually referenced by a node -- the same
+definition :func:`onnxsim.accuracy.recommend_quantization` uses internally,
+so an unpruned dead float weight left behind by a quantizer is not counted
+as if it shipped) and quantization wall-clock. **Inference latency is not
+measured**: both tools emit the same ``DequantizeLinear``-based graph shape
+here, so latency would be measuring onnxruntime's kernel, not either
+quantizer, and on a synthetic model at that.
+
+Usage::
+
+    python bench/nncf_comparison.py                 # synthetic MLP stack
+    python bench/nncf_comparison.py --layers 8 --hidden 512
+    python bench/nncf_comparison.py model.onnx      # a real model
+
+Dependencies: ``onnxsim`` (built, i.e. with its compiled extension --
+``quantize_weight_only_int4`` is a C++ pass), ``nncf``, ``onnx``,
+``onnxruntime``, ``numpy``. NNCF configurations are skipped with a printed
+note if ``nncf`` is not importable, so the onnxsim half still runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from typing import Callable, Dict, List, Sequence, Tuple
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+
+BLOCK_SIZE = 32
+
+
+def _synthetic_mlp(
+    layers: int = 4, hidden: int = 256, in_dim: int = 256, seed: int = 0
+) -> onnx.ModelProto:
+    """A plain stack of ``MatMul``s -- no activations between them, so every
+    layer is INT4-eligible for both tools and the measured error is purely
+    quantization error rather than a nonlinearity's own conditioning.
+    """
+    rng = np.random.default_rng(seed)
+    inits = []
+    nodes = []
+    prev = "X"
+    dim = in_dim
+    for i in range(layers):
+        out_dim = hidden
+        w = (rng.standard_normal((dim, out_dim)) / np.sqrt(dim)).astype(np.float32)
+        inits.append(onnx.numpy_helper.from_array(w, f"W{i}"))
+        out = "Y" if i == layers - 1 else f"H{i}"
+        nodes.append(onnx.helper.make_node("MatMul", [prev, f"W{i}"], [out]))
+        prev, dim = out, out_dim
+    graph = onnx.helper.make_graph(
+        nodes,
+        "mlp",
+        [
+            onnx.helper.make_tensor_value_info(
+                "X", onnx.TensorProto.FLOAT, ["b", in_dim]
+            )
+        ],
+        [
+            onnx.helper.make_tensor_value_info(
+                "Y", onnx.TensorProto.FLOAT, ["b", hidden]
+            )
+        ],
+        inits,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 21)]
+    )
+    model.ir_version = 10
+    return model
+
+
+def _referenced_initializer_bytes(model: onnx.ModelProto) -> int:
+    """Bytes of initializers actually referenced by some node input.
+
+    Matches :func:`onnxsim.accuracy._initializer_nbytes`: onnxsim's
+    ``quantize_*`` passes rewrite a node to point at new (smaller) quantized
+    initializers but do not themselves prune the now-dead original float
+    weight -- counting unreferenced initializers would make a successful
+    quantization look like it grew the model.
+    """
+    referenced = {name for n in model.graph.node for name in n.input}
+    total = 0
+    for t in model.graph.initializer:
+        if t.name not in referenced:
+            continue
+        total += (
+            len(t.raw_data) if t.HasField("raw_data") else len(t.SerializeToString())
+        )
+    return total
+
+
+def _weight_dtypes(model: onnx.ModelProto) -> Dict[str, int]:
+    """Referenced-initializer element-type histogram, as ``{type name: count}``
+    -- how the "NNCF left the last layer at INT8" effect shows up concretely.
+    """
+    referenced = {name for n in model.graph.node for name in n.input}
+    hist: Dict[str, int] = {}
+    for t in model.graph.initializer:
+        if t.name not in referenced:
+            continue
+        name = onnx.TensorProto.DataType.Name(t.data_type)
+        hist[name] = hist.get(name, 0) + 1
+    return hist
+
+
+def _run(model: onnx.ModelProto, feeds: Dict[str, np.ndarray]) -> np.ndarray:
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)[0]
+
+
+def _rel_l2(reference: np.ndarray, actual: np.ndarray) -> float:
+    a = np.asarray(reference, dtype=np.float64).ravel()
+    b = np.asarray(actual, dtype=np.float64).ravel()
+    return float(np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-12))
+
+
+# --------------------------------------------------------------------------- #
+# The two tools' configurations
+# --------------------------------------------------------------------------- #
+
+
+def _onnxsim_configs(
+    calibration: Sequence[Dict[str, np.ndarray]],
+) -> List[Tuple[str, Callable[[onnx.ModelProto], onnx.ModelProto]]]:
+    import onnxsim
+
+    def rtn(m):
+        return onnxsim.quantize_weight_only_int4(m)
+
+    def gptq(m):
+        return onnxsim.quantize(
+            m,
+            onnxsim.QuantizationConfig(
+                scheme="weight_only",
+                dtype="int4",
+                gptq=True,
+                calibration_data=list(calibration),
+            ),
+        )
+
+    def awq(m):
+        return onnxsim.quantize(
+            m,
+            onnxsim.QuantizationConfig(
+                scheme="weight_only",
+                dtype="int4",
+                awq=True,
+                calibration_data=list(calibration),
+            ),
+        )
+
+    def awq_gptq(m):
+        return onnxsim.quantize(
+            m,
+            onnxsim.QuantizationConfig(
+                scheme="weight_only",
+                dtype="int4",
+                awq=True,
+                gptq=True,
+                calibration_data=list(calibration),
+            ),
+        )
+
+    return [
+        ("onnxsim int4 (RTN)", rtn),
+        ("onnxsim int4 + GPTQ", gptq),
+        ("onnxsim int4 + AWQ", awq),
+        ("onnxsim int4 + AWQ + GPTQ", awq_gptq),
+    ]
+
+
+def _nncf_configs(
+    calibration: Sequence[Dict[str, np.ndarray]],
+) -> List[Tuple[str, Callable[[onnx.ModelProto], onnx.ModelProto]]]:
+    import nncf
+
+    mode = nncf.CompressWeightsMode.INT4_SYM
+
+    def dataset():
+        # NNCF's ONNX backend takes the same {input_name: array} feed dicts
+        # onnxruntime does.
+        return nncf.Dataset(list(calibration))
+
+    def default(m):
+        # NNCF exactly as an NNCF user gets it out of the box: group_size 128
+        # and the final layer left at int8_asym. Not comparable to onnxsim's
+        # own INT4-everywhere -- reported for reference, not as the
+        # head-to-head number.
+        return nncf.compress_weights(m, mode=mode)
+
+    def matched(m):
+        return nncf.compress_weights(
+            m, mode=mode, group_size=BLOCK_SIZE, all_layers=True
+        )
+
+    def matched_awq(m):
+        return nncf.compress_weights(
+            m,
+            mode=mode,
+            group_size=BLOCK_SIZE,
+            all_layers=True,
+            awq=True,
+            dataset=dataset(),
+        )
+
+    def matched_se(m):
+        return nncf.compress_weights(
+            m,
+            mode=mode,
+            group_size=BLOCK_SIZE,
+            all_layers=True,
+            scale_estimation=True,
+            dataset=dataset(),
+        )
+
+    return [
+        ("nncf int4_sym (NNCF defaults)", default),
+        ("nncf int4_sym all_layers g32", matched),
+        ("nncf int4_sym g32 + AWQ", matched_awq),
+        ("nncf int4_sym g32 + ScaleEstimation", matched_se),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+
+
+def compare(model: onnx.ModelProto, num_eval: int = 32, seed: int = 0) -> None:
+    in_name = model.graph.input[0].name
+    in_dim = model.graph.input[0].type.tensor_type.shape.dim[-1].dim_value
+    rng = np.random.default_rng(seed)
+    eval_x = {in_name: rng.standard_normal((num_eval, in_dim)).astype(np.float32)}
+    calibration = [
+        {in_name: rng.standard_normal((16, in_dim)).astype(np.float32)}
+        for _ in range(4)
+    ]
+
+    float_y = _run(model, eval_x)
+    float_bytes = _referenced_initializer_bytes(model)
+
+    configs: List[Tuple[str, Callable[[onnx.ModelProto], onnx.ModelProto]]] = []
+    try:
+        configs += _onnxsim_configs(calibration)
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        print(f"! skipping onnxsim configurations: {exc}")
+    try:
+        configs += _nncf_configs(calibration)
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        print(f"! skipping NNCF configurations (pip install nncf): {exc}")
+
+    print(f"float model: {float_bytes / 1024:.1f} KiB of referenced weights\n")
+    header = f"{'configuration':<34}{'rel L2':>10}{'KiB':>10}{'x smaller':>11}{'quant s':>9}  dtypes"
+    print(header)
+    print("-" * len(header))
+
+    for name, fn in configs:
+        start = time.perf_counter()
+        try:
+            quantized = fn(model)
+        except Exception as exc:  # pragma: no cover - reported, not raised
+            print(f"{name:<34}{'FAILED':>10}  {type(exc).__name__}: {exc}")
+            continue
+        elapsed = time.perf_counter() - start
+        try:
+            y = _run(quantized, eval_x)
+            err = f"{_rel_l2(float_y, y):.4f}"
+        except Exception as exc:  # pragma: no cover - reported, not raised
+            err = f"run:{type(exc).__name__}"
+        nbytes = _referenced_initializer_bytes(quantized)
+        dtypes = ",".join(
+            f"{k}x{v}" for k, v in sorted(_weight_dtypes(quantized).items())
+        )
+        print(
+            f"{name:<34}{err:>10}{nbytes / 1024:>10.1f}"
+            f"{float_bytes / max(nbytes, 1):>11.2f}{elapsed:>9.2f}  {dtypes}"
+        )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "model", nargs="?", help="path to a .onnx model (default: synthetic)"
+    )
+    ap.add_argument("--layers", type=int, default=4)
+    ap.add_argument("--hidden", type=int, default=256)
+    ap.add_argument("--in-dim", type=int, default=256)
+    ap.add_argument("--eval-samples", type=int, default=32)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    if args.model and os.path.exists(args.model):
+        model = onnx.load(args.model)
+        print(f"model: {args.model}")
+    else:
+        model = _synthetic_mlp(
+            layers=args.layers, hidden=args.hidden, in_dim=args.in_dim, seed=args.seed
+        )
+        print(
+            f"model: synthetic MLP, {args.layers} layers, "
+            f"in_dim={args.in_dim}, hidden={args.hidden}"
+        )
+    compare(model, num_eval=args.eval_samples, seed=args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/llm-fp4.md
+++ b/docs/llm-fp4.md
@@ -55,21 +55,51 @@ pairs against MSE).
 
 ## Scope
 
-**Weight-only.** The paper's other headline contribution -- migrating a
-per-channel real-valued *activation* scale into the preceding weight or
-LayerNormalization (via exactly the algebra `onnxsim.apply_smoothquant`/
+**Weight-only quantization (`quantize_weight_only_llm_fp4`).** The paper's
+other headline contribution -- migrating a per-channel real-valued
+*activation* scale into the preceding weight or LayerNormalization (via
+exactly the algebra `onnxsim.apply_smoothquant`/
 `onnxsim.apply_outlier_suppression` already implement), so that a single
 shared exponent bias suffices for a per-tensor FP4 *activation* quantizer,
 enabling full W4A4 -- is **not implemented here**. That migration machinery
 already exists in this repo and composes with this module unchanged (run
-either migration pass first); building the activation-side FP4 QDQ
-insertion itself (a new graph-run-time quantize/dequantize subgraph,
-analogous to `onnxsim.apply_zeroquant`'s own runtime INT8 activation
-quantization but emitting FP4 codes) is real additional scope, left as a
-follow-up. See `onnxsim/llm_fp4.py`'s own module docstring for the full
-rationale.
+either migration pass first). See `onnxsim/llm_fp4.py`'s own module
+docstring for the full rationale.
 
-Handled:
+**Activation quantization (`apply_llm_fp4_activation_quantization`) -- a
+different granularity than the paper's own design.** This module now also
+provides an activation-side pass, but it is **not** a port of the paper's
+per-tensor-via-migration scheme above. It computes a **per-token**
+(per-row), data-free scale fresh at graph-run time from each token's own
+values -- no calibration data, no cross-layer migration pass -- exactly the
+convention `onnxsim.zeroquant`/`onnxsim.quarot`/`onnxsim.duquant`/
+`onnxsim.attention_quantization` already use for their own per-token
+runtime quantizers, just against FP4's non-uniform 16-value codebook
+instead of a uniform integer grid. For every layer
+`quantize_weight_only_llm_fp4` already weight-quantized (found by walking
+its weight input backward through that function's own exact
+`Gather`/`Reshape`/`Mul`/`Cast` dequantization pattern -- the winning
+format isn't recorded anywhere else, so this is the only robust way to
+recover it), it inserts:
+
+```
+scale = max(ReduceMax(Abs(X), axis=-1, keepdims=1), epsilon) / max(abs(Codebook))
+x_normalized = X / scale
+nearest = Gather(Codebook, ArgMin(Abs(Unsqueeze(x_normalized, -1) - Codebook), axis=-1))
+x_dequant = nearest * scale
+```
+
+using that same layer's own recovered codebook, and rewires the MatMul/Gemm
+node's activation input to `x_dequant`. A layer not already matched by
+`quantize_weight_only_llm_fp4`'s exact pattern is left completely
+untouched -- this pass never runs the weight-side quantization itself.
+Composing with `apply_smoothquant`/`apply_outlier_suppression` beforehand
+remains possible (they act on the weight/LayerNorm side, which this pass
+never touches) but is not required by this simpler design. See
+`apply_llm_fp4_activation_quantization`'s own docstring in
+`onnxsim/llm_fp4.py` for the full honesty note.
+
+Handled (weight-only quantization):
 
 - `MatMul(X, W)` with `W` a constant 2-D float32 tensor whose reduction
   dimension `K` is divisible by `block_size`, or `Gemm(X, W)` with
@@ -83,6 +113,10 @@ Left untouched (safe no-op, node passes through as-is):
 
 - Non-constant weights, non-2-D weights, or a reduction dimension not
   divisible by `block_size`.
+- (Activation quantization) any layer whose weight input isn't fed by
+  `quantize_weight_only_llm_fp4`'s own exact dequantization pattern, and
+  any model whose opset is older than 18 (`ReduceMax`'s `axes`-as-input
+  form).
 
 ## Usage
 
@@ -93,6 +127,12 @@ import onnxsim
 model = onnx.load("model.onnx")
 quantized = onnxsim.quantize_weight_only_llm_fp4(model)  # block_size=32
 onnx.save(quantized, "model.llm_fp4.onnx")
+
+# Optional: complete W4A4 with a per-token, data-free activation quantizer
+# (a different granularity than the paper's own per-tensor-via-migration
+# design -- see "Scope" above).
+w4a4 = onnxsim.apply_llm_fp4_activation_quantization(quantized)
+onnx.save(w4a4, "model.llm_fp4.w4a4.onnx")
 ```
 
 Needs no calibration data: both the per-tensor format choice and the

--- a/docs/llm-fp4.md
+++ b/docs/llm-fp4.md
@@ -55,21 +55,70 @@ pairs against MSE).
 
 ## Scope
 
-**Weight-only quantization (`quantize_weight_only_llm_fp4`).** The paper's
-other headline contribution -- migrating a per-channel real-valued
-*activation* scale into the preceding weight or LayerNormalization (via
-exactly the algebra `onnxsim.apply_smoothquant`/
-`onnxsim.apply_outlier_suppression` already implement), so that a single
-shared exponent bias suffices for a per-tensor FP4 *activation* quantizer,
-enabling full W4A4 -- is **not implemented here**. That migration machinery
-already exists in this repo and composes with this module unchanged (run
-either migration pass first). See `onnxsim/llm_fp4.py`'s own module
-docstring for the full rationale.
+**Weight-only quantization (`quantize_weight_only_llm_fp4`).** This
+function quantizes weights only. The paper's activation side is provided by
+two *separate* passes in the same module, described below --
+`apply_llm_fp4_activation_quantization_per_tensor` (the paper's own
+calibrated per-tensor quantizer) and
+`apply_llm_fp4_activation_quantization` (a simpler per-token, data-free
+alternative). Neither performs the paper's **per-channel outlier
+migration**; that half stays where it already lives in this repo, as
+`onnxsim.apply_smoothquant`/`onnxsim.apply_outlier_suppression`, run first
+by the caller. See `onnxsim/llm_fp4.py`'s own module docstring for the full
+rationale.
 
-**Activation quantization (`apply_llm_fp4_activation_quantization`) -- a
-different granularity than the paper's own design.** This module now also
-provides an activation-side pass, but it is **not** a port of the paper's
-per-tensor-via-migration scheme above. It computes a **per-token**
+**Activation quantization, option A
+(`apply_llm_fp4_activation_quantization_per_tensor`) -- the paper's own
+quantizer.** One real-valued **per-tensor** scale per activation, fit
+offline from calibration data and emitted as a **constant initializer**.
+The scale is found by the *same* clip-ratio-vs-reconstruction-MSE grid
+search the weight side uses (`_search_fp4_clip_ratio`, shared by both):
+`scale = max_abs * ratio / max(abs(Codebook))`, keeping whichever `ratio`
+minimizes the codebook round-trip MSE of the captured activation. The FP4
+*format* is **not** re-searched -- it was already fixed for that layer by
+`quantize_weight_only_llm_fp4`'s own per-weight-tensor search, and the
+recovered codebook is exactly what encodes that choice. Activations are
+captured with the `_add_probe_outputs` + `onnxsim.backend.run_model`
+pattern every calibration-driven pass in this repo uses (see
+`onnxsim.apply_gptq`); `onnxsim.generate_random_calibration_data` supplies
+the default batches when `calibration_data` is omitted. For every layer
+`quantize_weight_only_llm_fp4` already weight-quantized, it inserts:
+
+```
+scale   -- constant float32 initializer, fit offline
+x_normalized = X / scale
+nearest = Gather(Codebook, ArgMin(Abs(Unsqueeze(x_normalized, -1) - Codebook), axis=-1))
+x_dequant = nearest * scale
+```
+
+Because `scale` is a compile-time constant, this emits **no**
+`Abs`/`ReduceMax`/`Max` range reduction at all: 7 nodes per layer (`Div`,
+`Unsqueeze`, `Sub`, `Abs`, `ArgMin`, `Gather`, `Mul`) against the per-token
+pass's 11, which is the practical point of the per-tensor design. It needs
+only **opset 13** (`Unsqueeze`'s `axes`-as-input form; `ArgMin`, `Gather`,
+`Sub`, `Abs`, `Div`, `Mul` are older) rather than the per-token pass's 18.
+
+**This is the quantizer half only.** The paper pairs it with per-channel
+outlier migration, which this function does **not** perform -- the caller
+composes it, migration first:
+
+```python
+import onnxsim
+
+migrated = onnxsim.apply_smoothquant(model)          # or apply_outlier_suppression
+weight_q = onnxsim.quantize_weight_only_llm_fp4(migrated)
+w4a4 = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(weight_q)
+```
+
+Running it without the migration step is supported and produces a valid
+model, but then quantizes an unmigrated activation with a single shared
+scale -- precisely the case the paper's migration exists to avoid.
+
+**Activation quantization, option B
+(`apply_llm_fp4_activation_quantization`) -- a
+different granularity than the paper's own design.** A second,
+self-contained activation-side pass, **not** a port of the paper's
+per-tensor scheme above. It computes a **per-token**
 (per-row), data-free scale fresh at graph-run time from each token's own
 values -- no calibration data, no cross-layer migration pass -- exactly the
 convention `onnxsim.zeroquant`/`onnxsim.quarot`/`onnxsim.duquant`/
@@ -99,6 +148,23 @@ never touches) but is not required by this simpler design. See
 `apply_llm_fp4_activation_quantization`'s own docstring in
 `onnxsim/llm_fp4.py` for the full honesty note.
 
+**Choosing between the two activation passes:**
+
+| | `..._per_tensor` (option A) | per-token (option B) |
+|---|---|---|
+| Scale fit from | calibration data, offline | the tensor itself, at graph-run time |
+| Granularity | one scale per tensor | one scale per token (row) |
+| Scale lives in | a constant initializer | runtime `Abs`/`ReduceMax`/`Max` nodes |
+| Nodes added per layer | 7 | 11 |
+| Minimum opset | 13 | 18 (`ReduceMax` axes-as-input) |
+| Paper fidelity | the paper's own quantizer (migration half is the caller's) | a repo-convention alternative, explicitly not the paper's design |
+
+Neither pass emits a native FP4 tensor (ONNX has no FP4 type): both are
+simulated ("fake") quantization -- values are snapped onto the FP4 codebook
+grid and immediately dequantized back to float32, so the `MatMul` still
+runs in float, exactly as `onnxsim.mx_quantization`/`onnxsim.nf4`/
+`onnxsim.zeroquant` already do.
+
 Handled (weight-only quantization):
 
 - `MatMul(X, W)` with `W` a constant 2-D float32 tensor whose reduction
@@ -113,10 +179,15 @@ Left untouched (safe no-op, node passes through as-is):
 
 - Non-constant weights, non-2-D weights, or a reduction dimension not
   divisible by `block_size`.
-- (Activation quantization) any layer whose weight input isn't fed by
-  `quantize_weight_only_llm_fp4`'s own exact dequantization pattern, and
-  any model whose opset is older than 18 (`ReduceMax`'s `axes`-as-input
-  form).
+- (Both activation passes) any layer whose weight input isn't fed by
+  `quantize_weight_only_llm_fp4`'s own exact dequantization pattern.
+- (Per-token activation pass) any model whose opset is older than 18
+  (`ReduceMax`'s `axes`-as-input form).
+- (Per-tensor activation pass) any model whose opset is older than 13
+  (`Unsqueeze`'s `axes`-as-input form), and any layer whose activation no
+  calibration batch reached, or for which every captured value was zero or
+  non-finite -- that layer is left untouched rather than silently falling
+  back to a different scale scheme.
 
 ## Usage
 
@@ -129,15 +200,36 @@ quantized = onnxsim.quantize_weight_only_llm_fp4(model)  # block_size=32
 onnx.save(quantized, "model.llm_fp4.onnx")
 
 # Optional: complete W4A4 with a per-token, data-free activation quantizer
-# (a different granularity than the paper's own per-tensor-via-migration
-# design -- see "Scope" above).
+# (a different granularity than the paper's own design -- see "Scope").
 w4a4 = onnxsim.apply_llm_fp4_activation_quantization(quantized)
 onnx.save(w4a4, "model.llm_fp4.w4a4.onnx")
 ```
 
-Needs no calibration data: both the per-tensor format choice and the
-per-block scale are fit directly to each weight's own values, by exhaustive
-grid search minimizing reconstruction MSE.
+Or, for the paper's own activation scheme -- per-channel outlier migration
+first, then the calibrated per-tensor FP4 activation quantizer:
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+migrated = onnxsim.apply_smoothquant(model)  # or apply_outlier_suppression
+weight_q = onnxsim.quantize_weight_only_llm_fp4(migrated)  # block_size=32
+w4a4 = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(weight_q)
+onnx.save(w4a4, "model.llm_fp4.w4a4.onnx")
+```
+
+The **weight** side needs no calibration data: both the per-tensor format
+choice and the per-block scale are fit directly to each weight's own
+values, by exhaustive grid search minimizing reconstruction MSE. The same
+is true of the **per-token** activation pass. Only
+`apply_llm_fp4_activation_quantization_per_tensor` (and the
+`apply_smoothquant`/`apply_outlier_suppression` migration it composes with)
+uses calibration data -- random batches from
+`onnxsim.generate_random_calibration_data` by default, or real batches
+passed as `calibration_data` (see
+`onnxsim.load_huggingface_calibration_data`), which give a much more
+representative activation range.
 
 ## Relationship to onnxsim's other 4-bit floating-point modules
 

--- a/docs/nncf-comparison-future-work.md
+++ b/docs/nncf-comparison-future-work.md
@@ -59,14 +59,33 @@ that dispatcher rather than a new concept -- the missing piece is the
 iterate-until-target-met control loop and a formal target-metric API, not new
 math.
 
-### 3. A real onnxsim-vs-NNCF benchmark
-The comparison above is architectural, not empirical -- no benchmark in this
-repo actually runs the same model through both onnxsim and NNCF and compares
-accuracy/latency/size. Given the algorithm surfaces overlap most directly on
-int4 weight-only compression (onnxsim's `quantize_weight_only_int4` + GPTQ/AWQ
-vs. NNCF's `compress_weights(mode=INT4_*, awq=True, gptq=True)`), that's the
-most tractable starting point for a head-to-head benchmark script under
-`bench/`, producing numbers instead of a qualitative comparison.
+### 3. A real onnxsim-vs-NNCF benchmark -- **done**
+This is now `bench/nncf_comparison.py`, with measured results and their
+caveats in `bench/RESULTS_nncf_comparison.md`. It runs the same model through
+both tools on int4 weight-only compression (onnxsim's
+`quantize_weight_only_int4` + GPTQ/AWQ vs. NNCF's
+`compress_weights(mode=INT4_SYM, ...)`) and reports accuracy, size and
+quantization wall-clock. Note NNCF's ONNX backend rejects its own `gptq=`
+option, so the GPTQ comparison is onnxsim's GPTQ against NNCF's other
+data-aware modes (AWQ, Scale Estimation), not GPTQ against GPTQ.
+
+Three things that comparison surfaced, recorded here because they outlive the
+benchmark run itself:
+
+- onnxsim's INT4 pass emits codes in `[-7, 7]`, giving up the representable
+  `-8` that NNCF uses; at identical storage that is a ~12.5% coarser step, and
+  it accounts for onnxsim's plain-RTN accuracy trailing NNCF's at byte-identical
+  size. Whether to change it is a genuine trade-off (a symmetric grid keeps
+  `-x` representable whenever `x` is, which other passes assume) -- but the
+  cost is now measured.
+- onnxsim's INT4 pass silently skips any MatMul whose activation has no
+  `value_info` to read an element type from, so hand-built graphs get partially
+  quantized with no diagnostic. Running `onnx.shape_inference.infer_shapes`
+  first avoids it.
+- GPTQ-style methods need more calibration rows than the reduction dimension,
+  or the `[K, K]` Hessian is rank-deficient and the correction *hurts*
+  accuracy. Undersized calibration data inverted the benchmark's conclusion
+  before this was caught.
 
 ### 4. Structured pruning parity (lower priority)
 onnxsim's pruning (`pruning.py`) covers magnitude + Wanda + N:M sparsity but

--- a/docs/quarot.md
+++ b/docs/quarot.md
@@ -62,7 +62,9 @@ Fusing one global rotation across an entire model needs a model-level
 graph walk this module does not attempt; instead, matching
 `apply_spinquant`'s own scope, this module fits one independent rotation
 **per matched layer**, at the cost of an explicit `MatMul(X, U)` per layer
-rather than a fused rotation. The real QuaRot also offers an optional
+rather than a fused rotation. `apply_quarot_fused` (below) recovers the
+"free at inference" half of that gap on the subset of edges where the
+algebra allows it, without the model-level walk. The real QuaRot also offers an optional
 GPTQ-based weight quantizer for a tighter error bound; `apply_quarot`
 itself always uses plain round-to-nearest for the weight, but see
 `apply_quarot_gptq` below for the GPTQ-based variant.
@@ -139,3 +141,98 @@ No `calibration_data` argument exists -- unlike `apply_spinquant`,
 fit to data, and both quantization scales come from the rotated values
 themselves (offline for the weight, at graph-run time for the activation),
 so there is nothing to calibrate.
+
+## Fusing the rotation into the producer (`apply_quarot_fused`)
+
+`apply_quarot` pays an explicit `MatMul(X, U)` at run time for every
+layer it quantizes. `onnxsim.apply_quarot_fused` does the same matching,
+draws the same rotations from the same seed, and quantizes the same way --
+but wherever the graph allows it, it folds that `MatMul(X, U)` into the
+*producing* layer's weight offline, so the rotation costs nothing at
+inference. That is the "free at inference" property the real QuaRot gets
+from its residual-stream-wide rotation, here obtained one edge at a time.
+
+### The algebra
+
+If layer `P` produces the tensor `T` that layer `L` consumes, and `P`'s
+weight is constant:
+
+```
+P's output:  T = X_prev @ W_P            (+ b_P)
+Fold:        W_P' = W_P @ U    and (if P has a bias)  b_P' = b_P @ U
+Then:        X_prev @ W_P' (+ b_P')  ==  (X_prev @ W_P + b_P) @ U  ==  T @ U
+```
+
+so `P` directly emits the rotated activation `L` wants. `L`'s own weight
+is rotated exactly as `apply_quarot` rotates it, so
+`(T @ U) @ (U.T @ W_L) == T @ W_L` still holds. The fold is exact
+algebra: nothing is lost by it, and the only lossy steps remain the same
+two INT4 roundings. The result is `apply_quarot`'s accuracy with one
+`MatMul` node and one `[K, K]` float initializer fewer per fused layer.
+
+Note the two rotations act on **different axes** of a weight: a layer's
+own input-side rotation acts on its reduction dim `K` (right-multiply,
+`W @ U`), while an output-side fold acts on its output dim `N`. A layer
+that is both a fused producer and a quantized consumer -- the middle of a
+chain `A -> B -> C` -- gets **both**, and both are applied while its
+weight is still float, before it is quantized. Chains of any length are
+handled: the pass plans every rotation first, then rotates every weight,
+and only then quantizes.
+
+### Exactly which edges are fusable
+
+`L`'s activation edge is fused only when **all** of these hold:
+
+- the activation tensor is produced by a node in the main graph that the
+  same matcher accepts (a `MatMul`, or a `Gemm` with `transA=0`,
+  `alpha=1`, `beta=1`) whose weight is a constant 2-D float32
+  initializer. The producer does *not* itself need to be quantizable --
+  a producer whose own `K` is not divisible by `block_size` stays in
+  float and simply gets its rotated float weight written back;
+- that tensor is referenced by exactly one node input in the whole model,
+  subgraph bodies included. A tensor consumed twice cannot be rotated for
+  one consumer without corrupting the other;
+- that tensor is not a graph output -- a graph output must keep its
+  unrotated value;
+- the producer's output dimension equals `L`'s reduction dimension `K`;
+- if the producer has a bias, that bias is a constant float32 initializer
+  shaped `[N]` or `[1, N]` -- the only shapes whose last axis is
+  unambiguously the output-channel axis, and so the only ones `b @ U` is
+  defined for. A scalar/broadcast `Gemm` bias is not folded, and its edge
+  is not fused.
+
+An edge that fails any of these is **not** skipped and **not** silently
+mis-rotated: its layer falls back to `apply_quarot`'s explicit runtime
+`MatMul(X, U)`, exactly as before. When no edge in a model is fusable,
+`apply_quarot_fused` returns byte-for-byte what `apply_quarot` returns.
+Original initializers are never edited in place -- a rotated producer
+weight or bias is written under a fresh `_quarot_folded` name -- so a
+weight shared by several nodes stays exact for the nodes that were not
+folded into.
+
+### What this still is not
+
+This is still a **per-layer** rotation, not the real QuaRot's single
+residual-stream-wide one: each matched layer keeps its own independent
+`U`. What `apply_quarot_fused` removes is only the *runtime cost* of that
+rotation, on the subset of edges where the algebra above applies. Layers
+fed by anything other than another constant-weight `MatMul`/`Gemm` -- a
+model input, a normalization, an activation function, a residual `Add`,
+an attention softmax -- are not fusable and keep their explicit
+`MatMul(X, U)`. In a real transformer that means the projections that
+immediately follow a LayerNorm or a residual add (i.e. most of them) still
+pay for their rotation; fusing those needs the model-level residual-stream
+walk this module still does not attempt.
+
+### Usage
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+quantized = onnxsim.apply_quarot_fused(model, block_size=32, seed=0)
+onnx.save(quantized, "model.quarot.onnx")
+```
+
+Same signature as `apply_quarot`, and still no `calibration_data`.

--- a/docs/quarot.md
+++ b/docs/quarot.md
@@ -63,11 +63,48 @@ graph walk this module does not attempt; instead, matching
 `apply_spinquant`'s own scope, this module fits one independent rotation
 **per matched layer**, at the cost of an explicit `MatMul(X, U)` per layer
 rather than a fused rotation. The real QuaRot also offers an optional
-GPTQ-based weight quantizer for a tighter error bound; this module always
-uses plain round-to-nearest (GPTQ itself is already ported faithfully in
-`onnxsim.gptq` -- composing it with a rotation is future work, not part of
-what makes QuaRot's own idea distinct from every other onnxsim INT4
-scheme).
+GPTQ-based weight quantizer for a tighter error bound; `apply_quarot`
+itself always uses plain round-to-nearest for the weight, but see
+`apply_quarot_gptq` below for the GPTQ-based variant.
+
+## `apply_quarot_gptq`: GPTQ-based weight quantization
+
+`onnxsim.apply_quarot_gptq` is identical to `apply_quarot` in every
+respect -- same candidate matching, same per-layer rotation `U` (for a
+given `seed`, byte-identical to `apply_quarot`'s own), same data-free
+per-token INT4 activation quantization -- except the *weight* is
+quantized via `onnxsim.gptq`'s Hessian-based column algorithm instead of
+independent round-to-nearest, using real calibration activations:
+
+```python
+import onnx
+import onnxsim
+
+model = onnx.load("model.onnx")
+quantized = onnxsim.apply_quarot_gptq(model, block_size=32, seed=0)
+onnx.save(quantized, "model.quarot_gptq.onnx")
+```
+
+The composition: each matched layer's own (pre-rotation) activation `X`
+is captured from `model` via calibration data (the same
+`_add_probe_outputs` + `backend.run_model` pattern `apply_gptq` uses),
+then rotated by that layer's own `U` (`X_rotated = X @ U`) so the
+Hessian `H = X_rotated.T @ X_rotated` GPTQ's column algorithm needs is
+computed in the same (rotated) space as the weight it is quantizing,
+`Wtilde = W @ U` -- not the original, unrotated activation space, since
+that is not the space GPTQ's reconstruction objective is being evaluated
+in here. The per-block scale is still the one
+`_quantize_blockwise_int4_with_clip` computes (unchanged from
+`apply_quarot`); GPTQ only changes which integer each element rounds to.
+
+A matched layer with no calibration data reaching it, or whose captured
+activation isn't a plain 2-D array, or whose feature dimension doesn't
+match the weight's own `K`, is left completely untouched by
+`apply_quarot_gptq` -- no rotation, no quantization -- rather than
+silently falling back to plain round-to-nearest under GPTQ's own name.
+`calibration_data=None` generates it via
+`onnxsim.generate_random_calibration_data`, the same convention as
+`apply_gptq`/`apply_awq`/every other calibration-driven onnxsim pass.
 
 ## Scope
 

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -114,6 +114,7 @@ from onnxsim.leptoquant import apply_leptoquant
 from onnxsim.llm_fp4 import (
     FP4_FORMATS,
     apply_llm_fp4_activation_quantization,
+    apply_llm_fp4_activation_quantization_per_tensor,
     quantize_weight_only_llm_fp4,
 )
 from onnxsim.llm_int8 import apply_llm_int8
@@ -413,6 +414,7 @@ __all__ = [
     "MXFP4_CODEBOOK",
     "quantize_weight_only_llm_fp4",
     "apply_llm_fp4_activation_quantization",
+    "apply_llm_fp4_activation_quantization_per_tensor",
     "FP4_FORMATS",
     "quantize_weight_only_squeezellm",
     "quantize_weight_only_aqlm",

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -245,7 +245,7 @@ from onnxsim.ptq4vit import apply_ptq4vit_quantization
 from onnxsim.qoq import apply_smooth_attention, quantize_weight_only_qoq
 from onnxsim.qronos import apply_qronos
 from onnxsim.quantease import apply_quantease
-from onnxsim.quarot import apply_quarot, apply_quarot_gptq
+from onnxsim.quarot import apply_quarot, apply_quarot_fused, apply_quarot_gptq
 from onnxsim.quip_sharp import apply_quip_sharp
 from onnxsim.qwen3_5_reconstruct import (
     reconstruct_qwen3_5_language_model,
@@ -331,6 +331,7 @@ __all__ = [
     "apply_slim_llm",
     "apply_quip_sharp",
     "apply_quarot",
+    "apply_quarot_fused",
     "apply_quarot_cpp",
     "apply_quarot_gptq",
     "apply_any_precision_llm_cpp",

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -111,7 +111,11 @@ from onnxsim.kbvq_moe import apply_kbvq_moe
 from onnxsim.kmeans_quantization import quantize_weight_only_kmeans
 from onnxsim.kv_cache_quantization import quantize_kv_cache
 from onnxsim.leptoquant import apply_leptoquant
-from onnxsim.llm_fp4 import FP4_FORMATS, quantize_weight_only_llm_fp4
+from onnxsim.llm_fp4 import (
+    FP4_FORMATS,
+    apply_llm_fp4_activation_quantization,
+    quantize_weight_only_llm_fp4,
+)
 from onnxsim.llm_int8 import apply_llm_int8
 from onnxsim.lo_bcq import quantize_weight_only_lo_bcq
 from onnxsim.low_rank_compensation import apply_low_rank_compensation
@@ -408,6 +412,7 @@ __all__ = [
     "FLOAT8_E4M3_MAX",
     "MXFP4_CODEBOOK",
     "quantize_weight_only_llm_fp4",
+    "apply_llm_fp4_activation_quantization",
     "FP4_FORMATS",
     "quantize_weight_only_squeezellm",
     "quantize_weight_only_aqlm",

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -240,7 +240,7 @@ from onnxsim.ptq4vit import apply_ptq4vit_quantization
 from onnxsim.qoq import apply_smooth_attention, quantize_weight_only_qoq
 from onnxsim.qronos import apply_qronos
 from onnxsim.quantease import apply_quantease
-from onnxsim.quarot import apply_quarot
+from onnxsim.quarot import apply_quarot, apply_quarot_gptq
 from onnxsim.quip_sharp import apply_quip_sharp
 from onnxsim.qwen3_5_reconstruct import (
     reconstruct_qwen3_5_language_model,
@@ -327,6 +327,7 @@ __all__ = [
     "apply_quip_sharp",
     "apply_quarot",
     "apply_quarot_cpp",
+    "apply_quarot_gptq",
     "apply_any_precision_llm_cpp",
     "apply_duquant",
     "apply_easyquant",

--- a/onnxsim/adaquant.py
+++ b/onnxsim/adaquant.py
@@ -100,7 +100,7 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _GAMMA, _ZETA, _h_and_dhdv, _node_outputs
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 _WEIGHT_N_MIN = -127.0
@@ -424,9 +424,9 @@ def apply_adaquant(
     optimized_zp: Dict[str, int] = {}
 
     for c in candidates:
-        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue  # not a plain 2-D activation (batched/broadcast MatMul); skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/adaquant.py
+++ b/onnxsim/adaquant.py
@@ -409,7 +409,7 @@ def apply_adaquant(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/adaround.py
+++ b/onnxsim/adaround.py
@@ -319,7 +319,7 @@ def apply_adaround(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/adaround.py
+++ b/onnxsim/adaround.py
@@ -49,7 +49,7 @@ import onnx
 import onnx.numpy_helper
 
 from onnxsim import backend
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 # The rectified-sigmoid relaxation's own shape parameters (Nagel et al.
@@ -330,10 +330,9 @@ def apply_adaround(
 
     optimized: Dict[str, np.ndarray] = {}
     for c in candidates:
-        acts = activations[c.float_node.input[0]]
-        acts = [a for a in acts if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue  # not a plain 2-D activation (batched/broadcast MatMul); skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/affinequant.py
+++ b/onnxsim/affinequant.py
@@ -106,7 +106,12 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _find_int4_matmul_candidates, _node_outputs, _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
 
@@ -208,7 +213,9 @@ def apply_affinequant(
             ModelProto or file path), produced by
             :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
             any other scheme (or left unquantized), or whose activation
-            input isn't a plain 2-D tensor, are left untouched.
+            input has no feature axis at all (rank < 2) are left
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact.
     :param calibration_data: representative input batches to search and
             measure the transform on. Each batch is a
             ``{input_name: np.ndarray}`` dict matching ``float_model``'s
@@ -277,9 +284,9 @@ def apply_affinequant(
 
     rewrites: List[_AffineQuantRewrite] = []
     for c in candidates:
-        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/affinequant.py
+++ b/onnxsim/affinequant.py
@@ -263,7 +263,7 @@ def apply_affinequant(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/autoround.py
+++ b/onnxsim/autoround.py
@@ -66,7 +66,7 @@ from onnxsim.adaround import (
     _optimize_rounding,
     _pack_int4,
 )
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 
@@ -318,10 +318,9 @@ def apply_autoround(
     optimized_codes: Dict[str, np.ndarray] = {}
     optimized_scale: Dict[str, np.ndarray] = {}
     for cand in candidates:
-        acts = activations[cand.float_node.input[0]]
-        acts = [a for a in acts if a.ndim == 2]
+        acts = _activation_rows(activations[cand.float_node.input[0]])
         if not acts:
-            continue  # not a plain 2-D activation (batched/broadcast MatMul); skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(cand.w_float_init).astype(np.float64)

--- a/onnxsim/autoround.py
+++ b/onnxsim/autoround.py
@@ -306,7 +306,7 @@ def apply_autoround(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/awq.py
+++ b/onnxsim/awq.py
@@ -56,7 +56,12 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _find_int4_matmul_candidates, _node_outputs, _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 
@@ -114,7 +119,9 @@ def apply_awq(
             ModelProto or file path), produced by
             :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
             any other scheme (or left unquantized), or whose activation
-            input isn't a plain 2-D tensor, are left untouched. Assumes
+            input has no feature axis at all (rank < 2) are left
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact. Assumes
             ``quantized_model`` was produced from ``float_model`` without
             renaming any MatMul/Gemm node's own output tensor -- true of
             every onnxsim ``quantize_*`` function.
@@ -170,9 +177,9 @@ def apply_awq(
 
     rewrites: List[_AwqRewrite] = []
     for c in candidates:
-        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue  # not a plain 2-D activation; skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/awq.py
+++ b/onnxsim/awq.py
@@ -157,7 +157,7 @@ def apply_awq(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/bias_correction.py
+++ b/onnxsim/bias_correction.py
@@ -34,7 +34,7 @@ guarantees (downstream consumers are never rewired by name).
 
 from __future__ import annotations
 
-from typing import Dict, Optional, Sequence, Set, Union
+from typing import Dict, List, Optional, Sequence, Set, Union
 
 import numpy as np
 import onnx
@@ -87,6 +87,32 @@ def _add_probe_outputs(model: onnx.ModelProto, names: Sequence[str]) -> onnx.Mod
             probe.graph.output.append(onnx.ValueInfoProto(name=name))
             existing.add(name)
     return probe
+
+
+def _activation_rows(arrays: Sequence[np.ndarray]) -> List[np.ndarray]:
+    """Flattens each captured activation to 2-D ``[rows, K]``, dropping any
+    that has no feature axis at all.
+
+    A MatMul/Gemm activation is ``[..., K]``: 2-D ``[tokens, K]`` for a plain
+    MLP, but ``[batch, seq, K]`` for essentially every real transformer, since
+    ONNX's MatMul broadcasts over leading dimensions. Every calibration-driven
+    pass in this repo wants the same thing from it -- the set of rows that
+    multiply ``W`` -- and a layer's reconstruction objective
+    ``||W X^T - Ŵ X^T||²`` sums over all of those rows however the leading
+    dimensions happen to group them. So collapsing the leading dimensions is
+    exact, not an approximation: it is the same set of rows in the same order.
+
+    This exists because filtering to ``ndim == 2`` instead (the previous
+    convention here) silently skipped every layer of a ``[batch, seq, hidden]``
+    model, i.e. made GPTQ/AWQ and friends no-ops on exactly the models they
+    are for, with no diagnostic.
+    """
+    rows = []
+    for a in arrays:
+        if a.ndim < 2:
+            continue  # no feature axis to multiply W with
+        rows.append(a.reshape(-1, a.shape[-1]) if a.ndim > 2 else a)
+    return rows
 
 
 def correct_bias(

--- a/onnxsim/billm.py
+++ b/onnxsim/billm.py
@@ -146,7 +146,12 @@ import onnx.helper
 import onnx.numpy_helper
 
 from onnxsim import backend
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.gptq import _inverse_hessian_cholesky
 from onnxsim.quip_sharp import _match_matmul_like
@@ -360,8 +365,10 @@ def quantize_weight_only_billm(
             ``Add(Mul(Cast(Code1), Scale1), Mul(Cast(Code2), Scale2))``
             feeding the original MatMul/Gemm node -- ordinary ONNX ops
             only, opset 11+. Layers with a non-constant, non-2-D, or
-            non-float32 weight, or whose activation input isn't a plain
-            2-D tensor, are left untouched.
+            non-float32 weight, or whose activation input has no feature
+            axis at all (rank < 2), are left untouched; a higher-rank
+            ``[batch, seq, K]`` activation is flattened to
+            ``[batch * seq, K]``, which is exact.
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
@@ -407,9 +414,9 @@ def quantize_weight_only_billm(
             activations[name].append(np.asarray(result[name], dtype=np.float64))
 
     for node, x_name, w_name, weight_transposed in candidates:
-        acts = [a for a in activations[x_name] if a.ndim == 2]
+        acts = _activation_rows(activations[x_name])
         if not acts:
-            continue  # not a plain 2-D activation; skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w_init = initializer_map[w_name]

--- a/onnxsim/billm.py
+++ b/onnxsim/billm.py
@@ -397,7 +397,7 @@ def quantize_weight_only_billm(
     if not candidates:
         return out
 
-    probe_names = [c[1] for c in candidates]
+    probe_names = sorted({c[1] for c in candidates})
     probe_model = _add_probe_outputs(model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/brecq.py
+++ b/onnxsim/brecq.py
@@ -109,7 +109,7 @@ from onnxsim.adaround import (
     _node_outputs,
     _pack_int4,
 )
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 _N_MIN = -7.0
@@ -418,19 +418,24 @@ def apply_brecq(
     optimized: Dict[str, np.ndarray] = {}
     for block_input_name, block_output_name, chain, has_residual in discovered:
         # Keep each batch's block-input/block-output pair together: only a
-        # batch where *both* probed tensors came back plain 2-D is usable,
-        # and concatenating them independently (rather than pairwise) could
-        # silently misalign samples if the two ever disagreed per batch.
+        # batch whose two probed tensors flatten to the *same* number of
+        # rows is usable, and concatenating them independently (rather
+        # than pairwise) could silently misalign samples if the two ever
+        # disagreed per batch. A block preserves its token axis, so a
+        # [batch, seq, K] input and its [batch, seq, N] output both
+        # flatten to batch * seq rows, in the same order.
         x0_batches = []
         final_batches = []
         for xa, fa in zip(
             activations[block_input_name], activations[block_output_name]
         ):
-            if xa.ndim == 2 and fa.ndim == 2:
-                x0_batches.append(xa)
-                final_batches.append(fa)
+            xr = _activation_rows([xa])
+            fr = _activation_rows([fa])
+            if xr and fr and xr[0].shape[0] == fr[0].shape[0]:
+                x0_batches.append(xr[0])
+                final_batches.append(fr[0])
         if not x0_batches:
-            continue  # not plain 2-D activations; skip this block
+            continue  # no usable activation pair; skip this block
         x0 = np.concatenate(x0_batches, axis=0)
         final_float = np.concatenate(final_batches, axis=0)
 

--- a/onnxsim/bwa_ptq.py
+++ b/onnxsim/bwa_ptq.py
@@ -82,7 +82,12 @@ import onnx.helper
 import onnx.numpy_helper
 
 from onnxsim import backend
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.quip_sharp import _match_matmul_like
 
@@ -216,8 +221,10 @@ def apply_bwa_ptq(
             ``Mul(Cast(Sign), Add(Scale0, Mul(Cast(GroupSelect), Sub(Scale1,
             Scale0))))`` feeding the original MatMul/Gemm node -- ordinary
             ONNX ops only, opset 11+. Layers with a non-constant, non-2-D,
-            or non-float32 weight, or whose activation input isn't a plain
-            2-D tensor, are left untouched.
+            or non-float32 weight, or whose activation input has no
+            feature axis at all (rank < 2), are left untouched; a
+            higher-rank ``[batch, seq, K]`` activation is flattened to
+            ``[batch * seq, K]``, which is exact.
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
@@ -263,9 +270,9 @@ def apply_bwa_ptq(
             activations[name].append(np.asarray(result[name], dtype=np.float64))
 
     for node, x_name, w_name, weight_transposed in candidates:
-        acts = [a for a in activations[x_name] if a.ndim == 2]
+        acts = _activation_rows(activations[x_name])
         if not acts:
-            continue  # not a plain 2-D activation; skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w_init = initializer_map[w_name]

--- a/onnxsim/bwa_ptq.py
+++ b/onnxsim/bwa_ptq.py
@@ -253,7 +253,7 @@ def apply_bwa_ptq(
     if not candidates:
         return out
 
-    probe_names = [c[1] for c in candidates]
+    probe_names = sorted({c[1] for c in candidates})
     probe_model = _add_probe_outputs(model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/easyquant.py
+++ b/onnxsim/easyquant.py
@@ -82,7 +82,12 @@ import onnx.helper
 import onnx.numpy_helper
 
 from onnxsim import backend
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.llm_int8 import _match_matmul_like
 
@@ -183,8 +188,11 @@ def apply_easyquant(
             its quantize-dequantize round-tripped float32 version, and a
             ``Div``/``Round``/``Clip``/``Mul`` round-trip inserted before
             its activation input -- layers with a non-constant, non-2-D
-            weight, a non-2-D activation, or whose activation's feature
-            dimension doesn't match the weight's own reduction size, are
+            weight, an activation with no feature axis at all (rank < 2;
+            a higher-rank ``[batch, seq, K]`` one is flattened to
+            ``[batch * seq, K]``, which is exact), or whose activation's
+            feature dimension doesn't match the weight's own reduction
+            size, are
             left untouched
     """
     if isinstance(float_model, str):
@@ -232,9 +240,9 @@ def apply_easyquant(
     node_by_output = {n.output[0]: n for n in out.graph.node if n.output}
 
     for x_name, w_init, weight_transposed, out_name in candidates:
-        acts = [a for a in activations[x_name] if a.ndim == 2]
+        acts = _activation_rows(activations[x_name])
         if not acts:
-            continue
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(w_init).astype(np.float64)

--- a/onnxsim/finetune.py
+++ b/onnxsim/finetune.py
@@ -79,9 +79,11 @@ an ordinary (convex) least-squares problem with no relaxation needed.
 :func:`onnxsim.apply_adaround`'s own scope exactly -- no Conv support (a
 Conv layer's own im2col expansion, and the padding/stride/dilation
 bookkeeping ``pruning.py``'s own Wanda-calibrated Conv path already needs,
-is real extra work this module doesn't yet do). A captured activation that
-isn't a plain 2-D array (e.g. an un-flattened ``[batch, seq, K]`` tensor)
-is skipped, the same boundary :func:`onnxsim.apply_adaround` already has.
+is real extra work this module doesn't yet do). A captured activation with
+no feature axis at all (rank < 2) is skipped; a higher-rank
+``[batch, seq, K]`` one is flattened to ``[batch * seq, K]`` -- exact, as
+the fit sums over the same rows either way -- the same boundary
+:func:`onnxsim.apply_adaround` already has.
 This also does not, itself, touch attention-head-pruned Q/K/V/output-
 projection weights that live inside a fused ``com.microsoft::Attention``/
 ``GroupQueryAttention``/``ai.onnx::Attention`` node (no MatMul/Gemm node
@@ -107,7 +109,7 @@ import onnx
 import onnx.numpy_helper
 
 from onnxsim import backend
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.smoothquant import _match_matmul_like
 
@@ -322,7 +324,9 @@ def apply_pruning_finetune(
             if it has one) replaced by its fine-tuned fit; a layer whose
             weight isn't a clean row/column subsequence of its own
             ``original_model`` counterpart, or whose captured activation
-            isn't a plain 2-D array, is left completely untouched
+            has no feature axis at all (rank < 2), is left completely
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact
     """
     if isinstance(original_model, str):
         original_model = onnx.load(original_model, load_external_data=False)
@@ -349,9 +353,9 @@ def apply_pruning_finetune(
     optimized_w: Dict[str, np.ndarray] = {}
     optimized_b: Dict[str, np.ndarray] = {}
     for c in candidates:
-        acts = [a for a in activations[c.x_name] if a.ndim == 2]
+        acts = _activation_rows(activations[c.x_name])
         if not acts:
-            continue  # not a plain 2-D activation -- skip, see this module's own docstring
+            continue  # no usable activation (no feature axis); skip
         x_full = np.concatenate(acts, axis=0)
 
         w_orig = onnx.numpy_helper.to_array(c.w_orig).astype(np.float64)

--- a/onnxsim/flexround.py
+++ b/onnxsim/flexround.py
@@ -276,7 +276,7 @@ def apply_flexround(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/flexround.py
+++ b/onnxsim/flexround.py
@@ -98,7 +98,7 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _find_int4_matmul_candidates, _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 
@@ -226,7 +226,9 @@ def apply_flexround(
             ModelProto or file path), produced by
             :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
             any other scheme (or left unquantized), or whose activation
-            input isn't a plain 2-D tensor, are left untouched. Assumes
+            input has no feature axis at all (rank < 2) are left
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact. Assumes
             ``quantized_model`` was produced from ``float_model`` without
             renaming any MatMul/Gemm node's own output tensor -- true of
             every onnxsim ``quantize_*`` function.
@@ -287,10 +289,9 @@ def apply_flexround(
 
     optimized: Dict[str, np.ndarray] = {}
     for c in candidates:
-        acts = activations[c.float_node.input[0]]
-        acts = [a for a in acts if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue  # not a plain 2-D activation (batched/broadcast MatMul); skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/foem.py
+++ b/onnxsim/foem.py
@@ -194,7 +194,7 @@ def apply_foem(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/foem.py
+++ b/onnxsim/foem.py
@@ -68,7 +68,7 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _find_int4_matmul_candidates, _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.gptq import _inverse_hessian_cholesky
 
@@ -152,7 +152,9 @@ def apply_foem(
             ModelProto or file path), produced by
             :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
             any other scheme (or left unquantized), or whose activation
-            input isn't a plain 2-D tensor, are left untouched. Assumes
+            input has no feature axis at all (rank < 2) are left
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact. Assumes
             ``quantized_model`` was produced from ``float_model`` without
             renaming any MatMul/Gemm node's own output tensor -- true of
             every onnxsim ``quantize_*`` function.
@@ -205,9 +207,9 @@ def apply_foem(
 
     optimized: Dict[str, np.ndarray] = {}
     for c in candidates:
-        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue  # not a plain 2-D activation; skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/gptaq.py
+++ b/onnxsim/gptaq.py
@@ -145,7 +145,7 @@ def apply_gptaq(
         if qn is not None and len(qn.input) >= 1:
             quant_probe_name[c.output_name] = qn.input[0]
 
-    float_probe_names = [c.float_node.input[0] for c in candidates]
+    float_probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, float_probe_names)
     quant_probe = _add_probe_outputs(quantized_model, list(quant_probe_name.values()))
 

--- a/onnxsim/gptaq.py
+++ b/onnxsim/gptaq.py
@@ -67,7 +67,7 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _find_int4_matmul_candidates, _node_outputs, _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.gptq import _gptq_quantize_columns, _inverse_hessian_cholesky
 
@@ -100,7 +100,9 @@ def apply_gptaq(
             activations at a candidate layer's input reflect whatever
             upstream layers' quantization already did. Layers quantized by
             any other scheme (or left unquantized), or whose activation
-            input isn't a plain 2-D tensor, are left untouched. Assumes
+            input has no feature axis at all (rank < 2) are left
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact. Assumes
             ``quantized_model`` was produced from ``float_model`` without
             renaming any MatMul/Gemm node's own output tensor -- true of
             every onnxsim ``quantize_*`` function.
@@ -166,8 +168,8 @@ def apply_gptaq(
         quant_name = quant_probe_name.get(c.output_name)
         if quant_name is None:
             continue
-        x_true_parts = [a for a in float_acts[c.float_node.input[0]] if a.ndim == 2]
-        x_quant_parts = [a for a in quant_acts[quant_name] if a.ndim == 2]
+        x_true_parts = _activation_rows(float_acts[c.float_node.input[0]])
+        x_quant_parts = _activation_rows(quant_acts[quant_name])
         if not x_true_parts or len(x_true_parts) != len(x_quant_parts):
             continue
         if any(a.shape != b.shape for a, b in zip(x_true_parts, x_quant_parts)):

--- a/onnxsim/gptq.py
+++ b/onnxsim/gptq.py
@@ -187,7 +187,7 @@ def apply_gptq(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/gptq.py
+++ b/onnxsim/gptq.py
@@ -43,7 +43,7 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _find_int4_matmul_candidates, _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 
@@ -142,7 +142,9 @@ def apply_gptq(
             ModelProto or file path), produced by
             :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
             any other scheme (or left unquantized), or whose activation
-            input isn't a plain 2-D tensor, are left untouched. Assumes
+            input has no feature axis at all (rank < 2) are left
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact. Assumes
             ``quantized_model`` was produced from ``float_model`` without
             renaming any MatMul/Gemm node's own output tensor -- true of
             every onnxsim ``quantize_*`` function.
@@ -198,9 +200,9 @@ def apply_gptq(
 
     optimized: Dict[str, np.ndarray] = {}
     for c in candidates:
-        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue  # not a plain 2-D activation; skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/gptvq.py
+++ b/onnxsim/gptvq.py
@@ -65,7 +65,12 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.aqlm import _fit_kmeans_codebook
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.gptq import _inverse_hessian_cholesky
 
@@ -258,9 +263,9 @@ def quantize_weight_only_gptvq(
     rng = np.random.default_rng(seed)
 
     for node, x_name, w_name, weight_transposed in candidates:
-        acts = [a for a in activations[x_name] if a.ndim == 2]
+        acts = _activation_rows(activations[x_name])
         if not acts:
-            continue  # not a plain 2-D activation; skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w_init = initializer_map[w_name]

--- a/onnxsim/llm_fp4.py
+++ b/onnxsim/llm_fp4.py
@@ -86,6 +86,26 @@ use for their own codebook formats -- this module builds the dequantization
 out of ordinary ONNX ops any opset-11+ runtime already supports: ``Gather``
 the per-element code out of a 16-entry constant codebook, then ``Mul`` by
 the per-block real-valued scale.
+
+**Update: a self-contained activation-side pass now exists, but it is NOT
+the paper's own per-tensor-via-migration design.** The "deliberately not
+ported" section above still accurately describes the real LLM-FP4 paper's
+own activation-quantization scheme: a per-*channel* real-valued scale fit
+from calibration data and migrated into the preceding weight/
+LayerNormalization (via :func:`onnxsim.apply_smoothquant`/:func:`onnxsim.
+apply_outlier_suppression`) so that a single shared exponent bias suffices
+for a per-*tensor* FP4 activation quantizer -- that migration-based design
+is still not implemented here. :func:`apply_llm_fp4_activation_quantization`
+below instead completes W4A4 with a *different*, simpler granularity: a
+per-*token* (per-row), data-free scale computed fresh from each token's own
+values at graph-run time -- exactly the convention every other per-token
+runtime quantizer in this repo already uses (:mod:`onnxsim.zeroquant`,
+:mod:`onnxsim.quarot`, :mod:`onnxsim.duquant`, :mod:`onnxsim.
+attention_quantization`, :mod:`onnxsim.kv_cache_quantization`'s Value-style
+rewrite), just against FP4's non-uniform 16-value codebook instead of a
+uniform integer grid, and needing no cross-layer migration pass first. See
+that function's own docstring for the full honesty note on this
+difference.
 """
 
 from __future__ import annotations
@@ -424,5 +444,238 @@ def quantize_weight_only_llm_fp4(
         for i, inp in enumerate(node.input):
             if inp == w_name:
                 node.input[i] = dq_out
+
+    return out
+
+
+def _has_min_opset(model: onnx.ModelProto, min_version: int) -> bool:
+    return any(
+        o.domain in ("", "ai.onnx") and o.version >= min_version
+        for o in model.opset_import
+    )
+
+
+def _find_llm_fp4_weight_codebook(
+    w_name: str,
+    producer_map: Dict[str, onnx.NodeProto],
+    initializer_map: Dict[str, onnx.TensorProto],
+) -> Optional[str]:
+    """Walks backward from a MatMul/Gemm's own weight input through the
+    *exact* dequantization pattern :func:`quantize_weight_only_llm_fp4`
+    builds above -- ``Reshape(Mul(Reshape(Gather(Codebook,
+    Cast(Wq))), Reshape(Ws)), orig_shape)`` -- and returns that layer's own
+    ``Codebook`` initializer name, or ``None`` if ``w_name`` isn't fed by
+    exactly this pattern (an unquantized layer, or one quantized by a
+    different onnxsim scheme entirely).
+
+    Matched structurally, op-by-op, against the real node-construction
+    order in :func:`quantize_weight_only_llm_fp4` above -- not by
+    initializer/node naming convention -- because the winning format isn't
+    recorded anywhere else in the graph: the ``Gather`` node's own first
+    input is the only source of truth for which codebook a given layer
+    actually used.
+    """
+    reshape3 = producer_map.get(w_name)
+    if reshape3 is None or reshape3.op_type != "Reshape" or len(reshape3.input) != 2:
+        return None
+    mul = producer_map.get(reshape3.input[0])
+    if mul is None or mul.op_type != "Mul" or len(mul.input) != 2:
+        return None
+    reshape1 = producer_map.get(mul.input[0])
+    reshape2 = producer_map.get(mul.input[1])
+    if reshape1 is None or reshape1.op_type != "Reshape" or len(reshape1.input) != 2:
+        return None
+    if reshape2 is None or reshape2.op_type != "Reshape" or len(reshape2.input) != 2:
+        return None
+    if reshape2.input[0] not in initializer_map:  # Ws: constant per-block scale
+        return None
+    gather = producer_map.get(reshape1.input[0])
+    if gather is None or gather.op_type != "Gather" or len(gather.input) != 2:
+        return None
+    codebook_name = gather.input[0]
+    if codebook_name not in initializer_map:
+        return None
+    cast = producer_map.get(gather.input[1])
+    if cast is None or cast.op_type != "Cast" or len(cast.input) != 1:
+        return None
+    if cast.input[0] not in initializer_map:  # Wq: constant codebook indices
+        return None
+    return codebook_name
+
+
+def apply_llm_fp4_activation_quantization(
+    model: Union[str, onnx.ModelProto],
+    epsilon: float = 1e-12,
+) -> onnx.ModelProto:
+    """Completes W4A4 for every layer :func:`quantize_weight_only_llm_fp4`
+    has already weight-quantized, by inserting a **per-token, data-free**
+    FP4 quantize/dequantize round-trip on that layer's own activation
+    input, using that same layer's own (byte-identical, recovered -- not
+    re-derived) codebook.
+
+    **Honesty note -- this is NOT the paper's own activation-quantization
+    design; read before using.** The real LLM-FP4 paper's headline
+    activation contribution is a *per-channel* real-valued scale, fit from
+    calibration data and migrated into the preceding weight or
+    LayerNormalization (via :func:`onnxsim.apply_smoothquant`/
+    :func:`onnxsim.apply_outlier_suppression`), so that a single shared
+    exponent bias suffices for a *per-tensor* FP4 activation quantizer --
+    see this module's own docstring and ``docs/llm-fp4.md``'s "Scope"
+    section. This function does **not** reproduce that design: it computes
+    a **per-token** (per-row) scale fresh, at graph-run time, from each
+    token's own values -- no calibration data, no migration pass, no
+    stored statistics -- exactly the convention every other per-token
+    runtime quantizer in this repo already uses (:mod:`onnxsim.zeroquant`,
+    :mod:`onnxsim.quarot`, :mod:`onnxsim.duquant`, :mod:`onnxsim.
+    attention_quantization`, :mod:`onnxsim.kv_cache_quantization`'s
+    Value-style rewrite). It is a simpler, self-contained alternative that
+    completes W4A4 without requiring either migration pass first --
+    composing with :func:`onnxsim.apply_smoothquant`/:func:`onnxsim.
+    apply_outlier_suppression` beforehand remains possible (they act on the
+    weight/LayerNorm side and are unaffected by this pass, since it never
+    touches those), but this simpler design does not require it.
+
+    For each layer already matched by :func:`quantize_weight_only_llm_fp4`
+    (found by walking its weight input backward through that function's
+    exact dequantization pattern -- see :func:`_find_llm_fp4_weight_codebook`
+    -- so a layer this module didn't itself weight-quantize is left
+    completely untouched), the activation ``X`` is quantized as::
+
+        scale = max(ReduceMax(Abs(X), axis=-1, keepdims=1), epsilon)
+                / max(abs(Codebook))                    -- one scale per token
+        x_normalized = X / scale
+        nearest = Gather(Codebook, ArgMin(Abs(Unsqueeze(x_normalized, -1)
+                                              - Codebook), axis=-1))
+        x_dequant = nearest * scale
+
+    "Nearest codebook value" is found by broadcasting every element against
+    all 16 codebook entries and taking ``ArgMin`` over the distances, then
+    gathering the codebook by that index -- the same "distance to every
+    codebook entry, then argmin" idea this module's own (offline, numpy)
+    weight-side search and :mod:`onnxsim.iq4_nl`'s own codebook search
+    already use, just expressed as runtime ONNX ops since ``X`` is not a
+    compile-time constant here. This construction was checked directly
+    against a numpy reference via ``onnxruntime`` before being committed to
+    this module (see ``tests/test_llm_fp4.py``).
+
+    :param model: the original or weight-quantized onnx ModelProto or file
+            path -- must already have been passed through
+            :func:`quantize_weight_only_llm_fp4` for this function to do
+            anything, since it only recognizes that function's own exact
+            weight-dequantization pattern
+    :param epsilon: floor applied to a token's own max-abs value before
+            using it as a scale, avoiding a divide-by-zero on an all-zero
+            token
+    :returns: ``model`` with every already-FP4-weight-quantized layer's
+            activation input replaced by its own per-token FP4
+            quantize/dequantize round-trip; every other input (weight,
+            bias) and the node's own output name are left exactly as
+            :func:`quantize_weight_only_llm_fp4` left them. A layer whose
+            weight input isn't fed by exactly that function's own
+            dequantization pattern is left completely untouched. A model
+            with no such layer, or with an opset older than 18
+            (``ReduceMax``'s ``axes``-as-input form needs opset 18, the
+            same gate :func:`onnxsim.apply_zeroquant` uses), is returned
+            unchanged.
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if not _has_min_opset(model, 18):
+        return model
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    producer_map = {output: node for node in graph.node for output in node.output}
+    taken_names = _all_names(graph)
+
+    candidates = []
+    for node in graph.node:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        w_name, _weight_transposed = match
+        x_name = node.input[0]  # guaranteed by _match_matmul_like's transA=0 check
+        codebook_name = _find_llm_fp4_weight_codebook(
+            w_name, producer_map, initializer_map
+        )
+        if codebook_name is None:
+            continue
+        candidates.append((node, x_name, w_name, codebook_name))
+
+    if not candidates:
+        return out
+
+    axes_last_name = _unique_name("llmfp4act_axes_last", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array([-1], dtype=np.int64), name=axes_last_name
+        )
+    )
+    eps_name = _unique_name("llmfp4act_eps", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(np.array(epsilon, dtype=np.float32), name=eps_name)
+    )
+
+    codebook_max_names: Dict[str, str] = {}  # codebook initializer name -> maxabs const
+
+    for node, x_name, w_name, codebook_name in candidates:
+        if codebook_name not in codebook_max_names:
+            codebook_values = onnx.numpy_helper.to_array(initializer_map[codebook_name])
+            codebook_max = float(np.max(np.abs(codebook_values)))
+            max_name = _unique_name(f"{codebook_name}_maxabs", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    np.array(codebook_max, dtype=np.float32), name=max_name
+                )
+            )
+            codebook_max_names[codebook_name] = max_name
+        codebook_max_name = codebook_max_names[codebook_name]
+
+        prefix = f"{w_name}_llmfp4act"
+        new_nodes: List[onnx.NodeProto] = []
+
+        def _new(op_type, inputs, out_suffix, **attrs):
+            out_name = _unique_name(f"{prefix}_{out_suffix}", taken_names)
+            n_ = onnx.helper.make_node(
+                op_type,
+                inputs,
+                [out_name],
+                name=_unique_name(f"{prefix}_{out_suffix}_node", taken_names),
+                **attrs,
+            )
+            new_nodes.append(n_)
+            return out_name
+
+        # Per-token scale: max(|x|) over the token's own last axis, floored
+        # by epsilon, normalized by the codebook's own max magnitude (the
+        # FP4 analogue of onnxsim.zeroquant's/onnxsim.quarot's own
+        # "scale = max(|x|) / <format max>" per-token quantizer).
+        x_abs = _new("Abs", [x_name], "x_abs")
+        x_max = _new("ReduceMax", [x_abs, axes_last_name], "x_max", keepdims=1)
+        x_safe_max = _new("Max", [x_max, eps_name], "x_safe_max")
+        x_scale = _new("Div", [x_safe_max, codebook_max_name], "x_scale")
+        x_norm = _new("Div", [x_name, x_scale], "x_norm")
+
+        # Nearest-codebook-value lookup: broadcast every normalized element
+        # against all 16 codebook entries, ArgMin the distances, Gather the
+        # codebook back -- the runtime-ops analogue of this module's own
+        # (offline, numpy) nearest-codebook search in
+        # _search_llm_fp4_blockwise above.
+        x_norm_unsq = _new("Unsqueeze", [x_norm, axes_last_name], "x_norm_unsq")
+        diff = _new("Sub", [x_norm_unsq, codebook_name], "diff")
+        diff_abs = _new("Abs", [diff], "diff_abs")
+        nearest_idx = _new("ArgMin", [diff_abs], "nearest_idx", axis=-1, keepdims=0)
+        nearest_val = _new(
+            "Gather", [codebook_name, nearest_idx], "nearest_val", axis=0
+        )
+        x_dequant = _new("Mul", [nearest_val, x_scale], "x_dequant")
+
+        insertion_point = next(i for i, n in enumerate(graph.node) if n is node)
+        for offset, new_node in enumerate(new_nodes):
+            graph.node.insert(insertion_point + offset, new_node)
+
+        node.input[0] = x_dequant
 
     return out

--- a/onnxsim/llm_fp4.py
+++ b/onnxsim/llm_fp4.py
@@ -148,6 +148,18 @@ FP4_FORMATS: Dict[str, Tuple[int, int]] = {
     "e3m0": (3, 0),
 }
 
+# Cap on how many activation elements
+# :func:`apply_llm_fp4_activation_quantization_per_tensor` feeds into its
+# per-tensor scale search. That search allocates a ``size x 16`` float64
+# distance tensor per candidate clip ratio, and its input is every
+# calibration sample concatenated -- unbounded, unlike the weight side,
+# whose input is bounded by the weight. 2**18 elements caps the search at a
+# few tens of MB while still estimating a *single* scalar's MSE objective
+# from a quarter-million samples. See that function for how it is applied
+# (``max_abs`` stays exact over the full data; only the MSE estimate is
+# subsampled).
+_PER_TENSOR_FIT_MAX_ELEMENTS = 1 << 18
+
 
 def _fp4_magnitudes(e_bits: int, m_bits: int) -> List[float]:
     """The 8 non-negative magnitudes an ``e_bits``-exponent/``m_bits``-
@@ -317,10 +329,14 @@ def quantize_weight_only_llm_fp4(
     """Quantizes every MatMul/vanilla-Gemm layer with a constant 2-D float32
     weight (whose reduction dimension ``K`` is evenly divisible by
     ``block_size``) into LLM-FP4's weight format -- see this module's own
-    docstring for the technique and its scope (weight-only; W4A4 activation
-    quantization is out of scope, but composes with this repo's existing
-    :func:`onnxsim.apply_smoothquant`/:func:`onnxsim.apply_outlier_suppression`
-    migrations, run first). Needs no calibration data: both the per-tensor
+    docstring for the technique and its scope. This function itself is
+    **weight-only**; to also quantize the activation (W4A4), follow it with
+    either :func:`apply_llm_fp4_activation_quantization_per_tensor` (the
+    paper's own calibrated per-tensor quantizer, which composes with
+    :func:`onnxsim.apply_smoothquant`/
+    :func:`onnxsim.apply_outlier_suppression` run first) or
+    :func:`apply_llm_fp4_activation_quantization` (a data-free per-token
+    alternative). Needs no calibration data: both the per-tensor
     format choice and the per-block scale are fit directly to each weight's
     own values, by exhaustive grid search minimizing reconstruction MSE.
 
@@ -614,6 +630,16 @@ def apply_llm_fp4_activation_quantization(
     against a numpy reference via ``onnxruntime`` before being committed to
     this module (see ``tests/test_llm_fp4.py``).
 
+    **Runtime cost, beyond node count.** That broadcast is the price of a
+    *non-uniform* codebook: unlike a uniform integer grid (which quantizes
+    with plain arithmetic, as :mod:`onnxsim.quarot`/:mod:`onnxsim.zeroquant`
+    do), finding the nearest of 16 arbitrary values needs each element
+    compared against all 16, so the ``Sub``/``Abs`` intermediates are **16x
+    the activation's own size** while the lookup executes. On a large
+    activation that transient dominates this pass's memory, and no count of
+    inserted nodes reflects it. ONNX has no non-uniform-codebook
+    quantization op that would avoid the materialization.
+
     :param model: the original or weight-quantized onnx ModelProto or file
             path -- must already have been passed through
             :func:`quantize_weight_only_llm_fp4` for this function to do
@@ -821,7 +847,14 @@ def apply_llm_fp4_activation_quantization_per_tensor(
       ``Abs``, ``ArgMin``, ``Gather``, ``Mul``) -- versus 11 for the
       per-token pass (those same 7, plus ``Abs``, ``ReduceMax``, ``Max``
       and a second ``Div`` to derive the scale). Strictly fewer runtime
-      ops is the practical point of the per-tensor design.
+      ops is the practical point of the per-tensor design. Note node count
+      is not the whole cost: **both** passes share the
+      ``Unsqueeze``/``Sub``/``Abs``/``ArgMin`` nearest-codebook broadcast,
+      whose intermediates are 16x the activation's own size while it
+      executes -- inherent to a non-uniform codebook, and unchanged by
+      moving the scale to a constant. See
+      :func:`apply_llm_fp4_activation_quantization`'s own "Runtime cost"
+      note.
     * *Paper fidelity*: this is the paper's own quantizer (its migration
       half being the caller's job, above) -- the per-token pass is a
       simpler repo-convention alternative
@@ -989,8 +1022,25 @@ def apply_llm_fp4_activation_quantization_per_tensor(
         # activation as a single group instead of one group per weight
         # block -- that single group's winning scale *is* the per-tensor
         # scale being fit here.
+        #
+        # _search_fp4_clip_ratio materializes a ``values.size x 16`` float64
+        # distance tensor per candidate ratio. On the weight side that is
+        # bounded by the weight itself, but here ``values`` is *every*
+        # calibration sample concatenated, which is unbounded (more
+        # calibration data would mean more memory, up to tens of GB on a
+        # realistic model). Fitting a single scalar does not need every
+        # sample: ``max_abs`` above is computed exactly over all of them,
+        # and the MSE objective is estimated on a large, deterministic
+        # random subsample, which bounds the search's peak memory
+        # regardless of how much calibration data was supplied.
+        fit_values = values
+        if fit_values.size > _PER_TENSOR_FIT_MAX_ELEMENTS:
+            picks = np.random.default_rng(0).choice(
+                fit_values.size, size=_PER_TENSOR_FIT_MAX_ELEMENTS, replace=False
+            )
+            fit_values = fit_values[picks]
         _error, scale, _codes = _search_fp4_clip_ratio(
-            values, np.asarray(max_abs), codebook, ratios
+            fit_values, np.asarray(max_abs), codebook, ratios
         )
         scale_value = float(scale)
         if not np.isfinite(scale_value) or scale_value <= 0.0:

--- a/onnxsim/llm_fp4.py
+++ b/onnxsim/llm_fp4.py
@@ -87,25 +87,42 @@ out of ordinary ONNX ops any opset-11+ runtime already supports: ``Gather``
 the per-element code out of a 16-entry constant codebook, then ``Mul`` by
 the per-block real-valued scale.
 
-**Update: a self-contained activation-side pass now exists, but it is NOT
-the paper's own per-tensor-via-migration design.** The "deliberately not
-ported" section above still accurately describes the real LLM-FP4 paper's
-own activation-quantization scheme: a per-*channel* real-valued scale fit
-from calibration data and migrated into the preceding weight/
-LayerNormalization (via :func:`onnxsim.apply_smoothquant`/:func:`onnxsim.
-apply_outlier_suppression`) so that a single shared exponent bias suffices
-for a per-*tensor* FP4 activation quantizer -- that migration-based design
-is still not implemented here. :func:`apply_llm_fp4_activation_quantization`
-below instead completes W4A4 with a *different*, simpler granularity: a
-per-*token* (per-row), data-free scale computed fresh from each token's own
-values at graph-run time -- exactly the convention every other per-token
-runtime quantizer in this repo already uses (:mod:`onnxsim.zeroquant`,
-:mod:`onnxsim.quarot`, :mod:`onnxsim.duquant`, :mod:`onnxsim.
-attention_quantization`, :mod:`onnxsim.kv_cache_quantization`'s Value-style
-rewrite), just against FP4's non-uniform 16-value codebook instead of a
-uniform integer grid, and needing no cross-layer migration pass first. See
-that function's own docstring for the full honesty note on this
-difference.
+**Update: two activation-side passes now exist.** The "deliberately not
+ported" section above is no longer wholly accurate: this paragraph
+supersedes its closing "is not implemented here"/"W4A4 is a legitimate
+follow-up, not attempted in this module" claims (its description of what
+the paper's own activation scheme *is* remains accurate, and is what
+:func:`apply_llm_fp4_activation_quantization_per_tensor` below implements
+the quantizer half of). Both passes act only on layers
+:func:`quantize_weight_only_llm_fp4` has already weight-quantized (found by
+walking the weight input backward through that function's own exact
+dequantization pattern -- see :func:`_find_llm_fp4_weight_codebook`), and
+both reuse that layer's own recovered codebook rather than re-deriving one:
+
+* :func:`apply_llm_fp4_activation_quantization` -- **per-token,
+  data-free**, and *not* the paper's own design. It computes the scale
+  fresh from each token's own values at graph-run time, exactly the
+  convention every other per-token runtime quantizer in this repo already
+  uses (:mod:`onnxsim.zeroquant`, :mod:`onnxsim.quarot`,
+  :mod:`onnxsim.duquant`, :mod:`onnxsim.attention_quantization`,
+  :mod:`onnxsim.kv_cache_quantization`'s Value-style rewrite), just against
+  FP4's non-uniform 16-value codebook instead of a uniform integer grid.
+  No calibration data and no migration pass needed.
+* :func:`apply_llm_fp4_activation_quantization_per_tensor` -- the
+  **calibrated per-tensor** half of the paper's own design. It fits one
+  real-valued scale per activation tensor offline, from calibration data,
+  by the *same* ``(clip ratio -> reconstruction MSE)`` grid search the
+  weight side already uses (:func:`_search_fp4_clip_ratio`, shared by both),
+  and bakes it into the graph as a constant initializer -- so the emitted
+  quantize/dequantize subgraph contains no runtime range reduction at all.
+  The *other* half of the paper's design -- migrating the per-channel
+  outliers into the preceding weight/LayerNormalization, which is what
+  makes a single shared exponent bias sufficient in the first place -- is
+  still **not** performed by that function; the caller composes it by
+  running :func:`onnxsim.apply_smoothquant` or
+  :func:`onnxsim.apply_outlier_suppression` first, as the "deliberately not
+  ported" section above already anticipated. See that function's own
+  docstring for the three-call sequence and the full honesty note.
 """
 
 from __future__ import annotations
@@ -117,7 +134,9 @@ import onnx
 import onnx.helper
 import onnx.numpy_helper
 
-from onnxsim.bias_correction import _all_names, _unique_name
+from onnxsim import backend
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 # Every way to split FP4's 3 non-sign bits between exponent and mantissa --
 # the paper's own candidate set for its per-tensor format search. Named
@@ -194,6 +213,57 @@ def _match_matmul_like(node: onnx.NodeProto):
     return None
 
 
+def _search_fp4_clip_ratio(
+    values: np.ndarray,
+    max_abs: np.ndarray,
+    codebook: np.ndarray,
+    clip_ratios: np.ndarray,
+) -> "tuple[np.ndarray, np.ndarray, np.ndarray]":
+    """The clip-ratio half of this module's own ``(format, clip ratio)`` grid
+    search, for one *fixed* ``codebook``: for each group along ``values``'
+    leading axes, scans ``clip_ratios`` and keeps whichever
+    ``scale = max_abs * ratio / max(codebook)`` minimizes that group's own
+    codebook round-trip MSE (in the original, unnormalized units).
+
+    ``values`` has shape ``group_shape + (group_size,)`` and ``max_abs``
+    shape ``group_shape`` -- so the same routine serves both the weight
+    side (``group_shape == (N, K // block_size)``: one scale per
+    ``(output channel, block)`` group, see :func:`_search_llm_fp4_blockwise`)
+    and the activation side (``group_shape == ()``: a single per-tensor
+    scale over one flat calibration sample, see
+    :func:`apply_llm_fp4_activation_quantization_per_tensor`). Returns
+    ``(best_error, best_scale, best_codes)`` with shapes ``group_shape``,
+    ``group_shape`` and ``values.shape`` respectively; ``codebook`` must be
+    ascending so its last entry is the largest magnitude.
+    """
+    max_mag = codebook[-1]
+    group_shape = values.shape[:-1]
+    best_error = np.full(group_shape, np.inf)
+    best_scale = np.zeros(group_shape)
+    best_codes = np.zeros(values.shape, dtype=np.int64)
+
+    for r in clip_ratios:
+        # The "pre-shifted exponent bias" search, realized as a real-valued
+        # scale: r < 1 clips outliers harder but sharpens resolution for the
+        # bulk of the group, exactly the clip-vs-resolution trade
+        # _mse_threshold's own cutoff search makes for INT8 ranges.
+        scale = np.maximum(max_abs * r / max_mag, 1e-30)  # group_shape
+        normalized = values / scale[..., np.newaxis]
+        diffs = np.abs(normalized[..., np.newaxis] - codebook)
+        codes = np.argmin(diffs, axis=-1)  # values.shape
+        dequant_normalized = codebook[codes]
+        error = (
+            np.sum((dequant_normalized - normalized) ** 2, axis=-1) * scale**2
+        )  # group_shape, in the original (unnormalized) units
+
+        improved = error < best_error
+        best_error = np.where(improved, error, best_error)
+        best_scale = np.where(improved, scale, best_scale)
+        best_codes = np.where(improved[..., np.newaxis], codes, best_codes)
+
+    return best_error, best_scale, best_codes
+
+
 def _search_llm_fp4_blockwise(
     w_nk: np.ndarray,
     block_size: int,
@@ -221,31 +291,10 @@ def _search_llm_fp4_blockwise(
     for fmt in formats:
         e_bits, m_bits = FP4_FORMATS[fmt]
         codebook = np.asarray(_fp4_codebook(e_bits, m_bits), dtype=np.float64)
-        max_mag = codebook[-1]
 
-        fmt_best_error = np.full((n, num_blocks), np.inf)
-        fmt_best_scale = np.zeros((n, num_blocks))
-        fmt_best_codes = np.zeros((n, num_blocks, block_size), dtype=np.int64)
-
-        for r in clip_ratios:
-            # The "pre-shifted exponent bias" search, realized as a
-            # real-valued per-block scale: r < 1 clips outliers harder but
-            # sharpens resolution for the bulk of the block, exactly the
-            # clip-vs-resolution trade _mse_threshold's own cutoff search
-            # makes for INT8 ranges.
-            scale = np.maximum(max_abs * r / max_mag, 1e-30)  # [N, num_blocks]
-            normalized = blocks / scale[:, :, np.newaxis]
-            diffs = np.abs(normalized[..., np.newaxis] - codebook)
-            codes = np.argmin(diffs, axis=-1)  # [N, num_blocks, block_size]
-            dequant_normalized = codebook[codes]
-            error = (
-                np.sum((dequant_normalized - normalized) ** 2, axis=-1) * scale**2
-            )  # [N, num_blocks], in the original (unnormalized) units
-
-            improved = error < fmt_best_error
-            fmt_best_error = np.where(improved, error, fmt_best_error)
-            fmt_best_scale = np.where(improved, scale, fmt_best_scale)
-            fmt_best_codes = np.where(improved[:, :, np.newaxis], codes, fmt_best_codes)
+        fmt_best_error, fmt_best_scale, fmt_best_codes = _search_fp4_clip_ratio(
+            blocks, max_abs, codebook, clip_ratios
+        )
 
         total_error = float(fmt_best_error.sum())
         if total_error < best_total_error:
@@ -521,7 +570,14 @@ def apply_llm_fp4_activation_quantization(
     :func:`onnxsim.apply_outlier_suppression`), so that a single shared
     exponent bias suffices for a *per-tensor* FP4 activation quantizer --
     see this module's own docstring and ``docs/llm-fp4.md``'s "Scope"
-    section. This function does **not** reproduce that design: it computes
+    section. The *quantizer* half of that design --  one calibrated,
+    real-valued **per-tensor** scale, baked into the graph as a constant --
+    is implemented by this module's own
+    :func:`apply_llm_fp4_activation_quantization_per_tensor`, which is the
+    function to use if you want the paper's own scheme (compose it after
+    :func:`onnxsim.apply_smoothquant`/
+    :func:`onnxsim.apply_outlier_suppression` for the migration half). This
+    function does **not** reproduce that design: it computes
     a **per-token** (per-row) scale fresh, at graph-run time, from each
     token's own values -- no calibration data, no migration pass, no
     stored statistics -- exactly the convention every other per-token
@@ -671,6 +727,324 @@ def apply_llm_fp4_activation_quantization(
             "Gather", [codebook_name, nearest_idx], "nearest_val", axis=0
         )
         x_dequant = _new("Mul", [nearest_val, x_scale], "x_dequant")
+
+        insertion_point = next(i for i, n in enumerate(graph.node) if n is node)
+        for offset, new_node in enumerate(new_nodes):
+            graph.node.insert(insertion_point + offset, new_node)
+
+        node.input[0] = x_dequant
+
+    return out
+
+
+def apply_llm_fp4_activation_quantization_per_tensor(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    clip_ratios: Optional[Sequence[float]] = None,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Completes W4A4 for every layer :func:`quantize_weight_only_llm_fp4`
+    has already weight-quantized, by fitting **one real-valued per-tensor
+    scale** to that layer's own activation from calibration data and baking
+    it into the graph as a **constant initializer**, then inserting a
+    *static* FP4 quantize/dequantize round-trip against that same layer's
+    own (byte-identical, recovered -- not re-derived) codebook.
+
+    This is the **calibrated per-tensor** half of the LLM-FP4 paper's own
+    activation-quantization design -- the quantizer "pre-shifted exponent
+    bias" is built for. The paper's per-tensor FP4 activation quantizer
+    works because a *single* shared exponent bias (here: a single
+    real-valued per-tensor scale -- the same degree of freedom, see this
+    module's own docstring) suffices once the activation's per-channel
+    outliers have been migrated away, and it fits that bias offline from
+    calibration data rather than recomputing a range at graph-run time.
+    This function does exactly that fitting and that insertion, reusing the
+    weight side's own search: :func:`_search_fp4_clip_ratio` scans the same
+    ``scale = max_abs * ratio / max(abs(codebook))`` clip-ratio grid against
+    the same codebook-round-trip MSE objective
+    :func:`_search_llm_fp4_blockwise` already uses per weight block, just
+    with the whole captured activation as a single group.
+
+    **Honesty note -- this implements the quantizer, NOT the migration;
+    read before using.** The paper's activation scheme is *two* pieces, and
+    this function is only the second one:
+
+    1. **Per-channel outlier migration** -- compute a per-channel
+       real-valued scale from calibration data and push it algebraically
+       into the preceding weight or LayerNormalization, so that what
+       reaches this layer no longer carries per-channel outliers and a
+       single shared scale/exponent bias actually suffices. This function
+       does **not** do this, and does not check whether it has been done.
+    2. **The per-tensor FP4 quantizer itself** -- this function.
+
+    Piece 1 already exists in this repo, as
+    :func:`onnxsim.apply_smoothquant` and
+    :func:`onnxsim.apply_outlier_suppression` (their INT8 migration algebra
+    is exactly the migration the paper describes, with FP4's real-valued
+    scale-as-bias standing in for those modules' INT8 quantization range),
+    so the paper's actual pipeline is a **three-call sequence** the caller
+    composes, migration first::
+
+        import onnxsim
+
+        # 1. migrate the per-channel activation outliers into the preceding
+        #    weight/LayerNormalization (apply_outlier_suppression is the
+        #    alternative)
+        migrated = onnxsim.apply_smoothquant(model)
+        # 2. weight-side FP4, with the paper's own (format, scale) search
+        weight_q = onnxsim.quantize_weight_only_llm_fp4(migrated)
+        # 3. this function: one calibrated, constant per-tensor FP4 scale
+        #    per activation
+        w4a4 = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(
+            weight_q
+        )
+
+    Running this function *without* step 1 is supported and produces a
+    valid model, but it is then quantizing an unmigrated activation with a
+    single shared scale -- precisely the case the paper's migration exists
+    to avoid, and on outlier-heavy transformer activations it will be
+    noticeably worse than the paper's own reported numbers.
+
+    **How this differs from
+    :func:`apply_llm_fp4_activation_quantization`** (the per-token pass in
+    this same module):
+
+    * *Scale source*: calibration data, fit offline -- versus data-free,
+      recomputed from the tensor's own values at graph-run time.
+    * *Granularity*: one scale for the whole activation tensor -- versus
+      one scale per token (per row of the last axis).
+    * *Where the scale lives*: a constant initializer -- versus runtime
+      ``Abs``/``ReduceMax``/``Max`` nodes.
+    * *Runtime cost*: 7 nodes per layer (``Div``, ``Unsqueeze``, ``Sub``,
+      ``Abs``, ``ArgMin``, ``Gather``, ``Mul``) -- versus 11 for the
+      per-token pass (those same 7, plus ``Abs``, ``ReduceMax``, ``Max``
+      and a second ``Div`` to derive the scale). Strictly fewer runtime
+      ops is the practical point of the per-tensor design.
+    * *Paper fidelity*: this is the paper's own quantizer (its migration
+      half being the caller's job, above) -- the per-token pass is a
+      simpler repo-convention alternative
+      (:mod:`onnxsim.zeroquant`/:mod:`onnxsim.quarot`/
+      :mod:`onnxsim.duquant` all quantize activations per-token) that is
+      explicitly *not* the paper's design.
+
+    Neither pass emits a native FP4 tensor (ONNX has no FP4 type): both are
+    simulated ("fake") quantization -- values are snapped onto the FP4
+    codebook grid and immediately dequantized back to float32, so the
+    ``MatMul`` still runs in float. That is the same simulation
+    :mod:`onnxsim.mx_quantization`/:mod:`onnxsim.nf4`/
+    :mod:`onnxsim.zeroquant` already use, and it measures the accuracy
+    effect of FP4 activations without needing runtime FP4 kernels.
+
+    For each layer already matched by :func:`quantize_weight_only_llm_fp4`
+    (found by walking its weight input backward through that function's
+    exact dequantization pattern -- see
+    :func:`_find_llm_fp4_weight_codebook` -- so a layer this module didn't
+    itself weight-quantize is left completely untouched), the activation
+    ``X`` is quantized as::
+
+        scale   -- constant float32 initializer, fit offline (see below)
+        x_normalized = X / scale
+        nearest = Gather(Codebook, ArgMin(Abs(Unsqueeze(x_normalized, -1)
+                                              - Codebook), axis=-1))
+        x_dequant = nearest * scale
+
+    -- the same ``Unsqueeze``/``Sub``/``Abs``/``ArgMin``/``Gather``
+    nearest-codebook construction the per-token pass already uses (and
+    which was verified against a hand-computed numpy reference through
+    ``onnxruntime``; see ``tests/test_llm_fp4.py``), but with a
+    compile-time-constant ``scale``, so **no** ``Abs``/``ReduceMax``/
+    ``Max`` range-reduction node is emitted at all.
+
+    ``scale`` itself is fit by capturing ``X`` over ``calibration_data``
+    (the ``_add_probe_outputs`` + :func:`onnxsim.backend.run_model` capture
+    every calibration-driven pass in this repo uses -- see
+    :func:`onnxsim.apply_gptq`), concatenating every captured batch into
+    one flat sample, and grid-searching ``clip_ratios`` against that
+    sample's own codebook round-trip MSE. The FP4 *format* is **not**
+    re-searched: it was already fixed for this layer by
+    :func:`quantize_weight_only_llm_fp4`'s own per-weight-tensor search,
+    and the recovered codebook is exactly what encodes that choice.
+
+    :param model: a weight-quantized onnx ModelProto or file path -- must
+            already have been passed through
+            :func:`quantize_weight_only_llm_fp4` for this function to do
+            anything, since it only recognizes that function's own exact
+            weight-dequantization pattern
+    :param calibration_data: representative input batches to fit each
+            activation's scale on. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative activation range than random input)
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param clip_ratios: per-tensor clip-ratio candidates to grid-search --
+            ``1.0`` puts the activation's own observed max-abs value
+            exactly at the codebook's largest magnitude (no clipping),
+            values below ``1.0`` trade a harder clip on outliers for
+            sharper resolution on the bulk. Defaults to the weight side's
+            own default grid: 17 points evenly spaced over ``[0.5, 1.0]``
+            (:func:`quantize_weight_only_llm_fp4`'s own ``min_clip_ratio``/
+            ``num_scale_candidates`` defaults)
+    :param providers: onnxruntime execution providers to run ``model`` on
+            when capturing calibration activations
+    :returns: ``model`` with every already-FP4-weight-quantized layer's
+            activation input replaced by a static, per-tensor FP4
+            quantize/dequantize round-trip driven by a constant scale
+            initializer; every other input (weight, bias) and the node's
+            own output name are left exactly as
+            :func:`quantize_weight_only_llm_fp4` left them. A layer whose
+            weight input isn't fed by exactly that function's own
+            dequantization pattern, or whose activation no calibration
+            batch reached (or for which every captured value was zero or
+            non-finite), is left completely untouched -- this function
+            never silently falls back to a different scale scheme under its
+            own name. A model with no such layer, or with an opset older
+            than 13, is returned unchanged. (Opset 13, not the per-token
+            pass's 18: the ops emitted here are ``Unsqueeze`` -- whose
+            ``axes``-as-input form is what needs 13 -- plus ``ArgMin``/
+            ``Gather``/``Sub``/``Abs``/``Div``/``Mul``, all older. The
+            per-token pass needs 18 only for ``ReduceMax``'s own
+            ``axes``-as-input form, and this pass emits no ``ReduceMax``.)
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if not _has_min_opset(model, 13):
+        return model
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    producer_map = {output: node for node in graph.node for output in node.output}
+    taken_names = _all_names(graph)
+
+    candidates = []
+    for node in graph.node:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        w_name, _weight_transposed = match
+        x_name = node.input[0]  # guaranteed by _match_matmul_like's transA=0 check
+        codebook_name = _find_llm_fp4_weight_codebook(
+            w_name, producer_map, initializer_map
+        )
+        if codebook_name is None:
+            continue
+        candidates.append((node, x_name, w_name, codebook_name))
+
+    if not candidates:
+        return out
+
+    if clip_ratios is None:
+        ratios = np.linspace(0.5, 1.0, 17)
+    else:
+        ratios = np.asarray(list(clip_ratios), dtype=np.float64)
+    if ratios.size == 0:
+        raise ValueError("clip_ratios must be non-empty")
+
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    probe_names = sorted({x_name for _node, x_name, _w, _cb in candidates})
+    probe_model = _add_probe_outputs(model, probe_names)
+    activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        captured = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            value = captured.get(name)
+            if value is None:
+                continue
+            array = np.asarray(value)
+            if np.issubdtype(array.dtype, np.floating):
+                activations[name].append(array.astype(np.float64).ravel())
+
+    # Fit every scale before touching the graph, so a run in which no
+    # layer's activation turns out usable leaves `out` byte-identical to
+    # `model` rather than half-rewritten.
+    fitted: List[Tuple[onnx.NodeProto, str, str, str, float]] = []
+    for node, x_name, w_name, codebook_name in candidates:
+        samples = [a for a in activations[x_name] if a.size]
+        if not samples:
+            continue  # no calibration batch reached this activation
+        values = np.concatenate(samples)
+        values = values[np.isfinite(values)]
+        if values.size == 0:
+            continue
+        max_abs = float(np.abs(values).max())
+        if max_abs <= 0.0:
+            continue  # an all-zero activation has no meaningful scale
+
+        codebook = onnx.numpy_helper.to_array(initializer_map[codebook_name]).astype(
+            np.float64
+        )
+        # The weight side's own clip-ratio search, with the whole flattened
+        # activation as a single group instead of one group per weight
+        # block -- that single group's winning scale *is* the per-tensor
+        # scale being fit here.
+        _error, scale, _codes = _search_fp4_clip_ratio(
+            values, np.asarray(max_abs), codebook, ratios
+        )
+        scale_value = float(scale)
+        if not np.isfinite(scale_value) or scale_value <= 0.0:
+            continue
+        fitted.append((node, x_name, w_name, codebook_name, scale_value))
+
+    if not fitted:
+        return out
+
+    axes_last_name = _unique_name("llmfp4act_pt_axes_last", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array([-1], dtype=np.int64), name=axes_last_name
+        )
+    )
+
+    for node, x_name, w_name, codebook_name, scale_value in fitted:
+        # w_name (this layer's own dequantized-weight tensor) is unique per
+        # layer, unlike x_name -- two layers can share one activation.
+        prefix = f"{w_name}_llmfp4act_pt"
+        scale_name = _unique_name(f"{prefix}_scale", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array(scale_value, dtype=np.float32), name=scale_name
+            )
+        )
+
+        new_nodes: List[onnx.NodeProto] = []
+
+        def _new(op_type, inputs, out_suffix, **attrs):
+            out_name = _unique_name(f"{prefix}_{out_suffix}", taken_names)
+            n_ = onnx.helper.make_node(
+                op_type,
+                inputs,
+                [out_name],
+                name=_unique_name(f"{prefix}_{out_suffix}_node", taken_names),
+                **attrs,
+            )
+            new_nodes.append(n_)
+            return out_name
+
+        # No Abs/ReduceMax/Max anywhere in the scale path: the scale is a
+        # compile-time constant, which is the whole practical point of the
+        # per-tensor design over the per-token one. The single Abs below is
+        # the codebook-distance one, shared with the per-token pass.
+        x_norm = _new("Div", [x_name, scale_name], "x_norm")
+        x_norm_unsq = _new("Unsqueeze", [x_norm, axes_last_name], "x_norm_unsq")
+        diff = _new("Sub", [x_norm_unsq, codebook_name], "diff")
+        diff_abs = _new("Abs", [diff], "diff_abs")
+        nearest_idx = _new("ArgMin", [diff_abs], "nearest_idx", axis=-1, keepdims=0)
+        nearest_val = _new(
+            "Gather", [codebook_name, nearest_idx], "nearest_val", axis=0
+        )
+        x_dequant = _new("Mul", [nearest_val, scale_name], "x_dequant")
 
         insertion_point = next(i for i, n in enumerate(graph.node) if n is node)
         for offset, new_node in enumerate(new_nodes):

--- a/onnxsim/moequant.py
+++ b/onnxsim/moequant.py
@@ -109,7 +109,7 @@ import onnx
 import onnx.numpy_helper
 
 from onnxsim import backend
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.gptq import _gptq_quantize_columns
 from onnxsim.pruning import _find_moe_chains, _MoEChain
@@ -274,9 +274,8 @@ def apply_moequant(
     for batch in calibration_data:
         out = backend.run_model(probe_model, batch, providers=providers)
         for name in probe_names:
-            arr = np.asarray(out[name])
-            if arr.ndim == 2:
-                collected[name].append(arr.astype(np.float64))
+            arr = np.asarray(out[name], dtype=np.float64)
+            collected[name].extend(_activation_rows([arr]))
 
     result = onnx.ModelProto()
     result.CopyFrom(model)
@@ -301,7 +300,7 @@ def apply_moequant(
         x_chunks = collected.get(chain.node.input[0], [])
         r_chunks = collected.get(chain.node.input[1], [])
         if not x_chunks or not r_chunks:
-            continue  # no usable (2-D) calibration activation observed
+            continue  # no usable calibration activation observed
 
         x_all = np.concatenate(x_chunks, axis=0)
         r_all = np.concatenate(r_chunks, axis=0)

--- a/onnxsim/omniquant.py
+++ b/onnxsim/omniquant.py
@@ -79,7 +79,12 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _find_int4_matmul_candidates, _node_outputs, _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 
@@ -155,7 +160,9 @@ def apply_omniquant(
             ModelProto or file path), produced by
             :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
             any other scheme (or left unquantized), or whose activation
-            input isn't a plain 2-D tensor, are left untouched.
+            input has no feature axis at all (rank < 2) are left
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact.
     :param calibration_data: representative input batches to search and
             measure the transform on. Each batch is a
             ``{input_name: np.ndarray}`` dict matching ``float_model``'s
@@ -214,9 +221,9 @@ def apply_omniquant(
 
     rewrites: List[_OmniQuantRewrite] = []
     for c in candidates:
-        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/omniquant.py
+++ b/onnxsim/omniquant.py
@@ -200,7 +200,7 @@ def apply_omniquant(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/owq.py
+++ b/onnxsim/owq.py
@@ -174,7 +174,7 @@ def apply_owq(
 
     wq_init_map = {t.name: t for t in quantized_model.graph.initializer}
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/owq.py
+++ b/onnxsim/owq.py
@@ -78,7 +78,12 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _find_int4_matmul_candidates
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.gptq import _inverse_hessian_cholesky
 
@@ -125,7 +130,9 @@ def apply_owq(
             ModelProto or file path), produced by
             :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
             any other scheme (or left unquantized), or whose activation
-            input isn't a plain 2-D tensor, are left untouched. Assumes
+            input has no feature axis at all (rank < 2) are left
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact. Assumes
             ``quantized_model`` was produced from ``float_model`` without
             renaming any MatMul/Gemm node's own output tensor -- true of
             every onnxsim ``quantize_*`` function.
@@ -190,9 +197,9 @@ def apply_owq(
     node_by_output = {n.output[0]: n for n in graph.node if n.output}
 
     for c in candidates:
-        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue  # not a plain 2-D activation; skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/pb_llm.py
+++ b/onnxsim/pb_llm.py
@@ -261,7 +261,7 @@ def quantize_weight_only_pb_llm(
     if not candidates:
         return out
 
-    probe_names = [c[1] for c in candidates]
+    probe_names = sorted({c[1] for c in candidates})
     probe_model = _add_probe_outputs(model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/pb_llm.py
+++ b/onnxsim/pb_llm.py
@@ -134,7 +134,12 @@ import onnx.helper
 import onnx.numpy_helper
 
 from onnxsim import backend
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.billm import _sign
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.quip_sharp import _match_matmul_like
@@ -225,7 +230,9 @@ def quantize_weight_only_pb_llm(
             ``Mul(Cast(Code), Scale)`` feeding the original MatMul/Gemm
             node -- ordinary ONNX ops only, opset 11+. Layers with a
             non-constant, non-2-D, or non-float32 weight, or whose
-            activation input isn't a plain 2-D tensor, are left untouched.
+            activation input has no feature axis at all (rank < 2), are
+            left untouched; a higher-rank ``[batch, seq, K]`` activation
+            is flattened to ``[batch * seq, K]``, which is exact.
     """
     if isinstance(model, str):
         model = onnx.load(model, load_external_data=False)
@@ -271,9 +278,9 @@ def quantize_weight_only_pb_llm(
             activations[name].append(np.asarray(result[name], dtype=np.float64))
 
     for node, x_name, w_name, weight_transposed in candidates:
-        acts = [a for a in activations[x_name] if a.ndim == 2]
+        acts = _activation_rows(activations[x_name])
         if not acts:
-            continue  # not a plain 2-D activation; skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w_init = initializer_map[w_name]

--- a/onnxsim/qronos.py
+++ b/onnxsim/qronos.py
@@ -181,7 +181,7 @@ def apply_qronos(
     node_order = {id(n): i for i, n in enumerate(float_model.graph.node)}
     candidates = sorted(candidates, key=lambda c: node_order[id(c.float_node)])
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
     float_activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
     for batch in calibration_data:

--- a/onnxsim/qronos.py
+++ b/onnxsim/qronos.py
@@ -113,7 +113,7 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _find_int4_matmul_candidates, _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.gptq import _gptq_quantize_columns, _inverse_hessian_cholesky
 
@@ -143,7 +143,9 @@ def apply_qronos(
             ModelProto or file path), produced by
             :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
             any other scheme (or left unquantized), or whose activation
-            input isn't a plain 2-D tensor, are left untouched. Assumes
+            input has no feature axis at all (rank < 2) are left
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact. Assumes
             ``quantized_model`` was produced from ``float_model`` without
             renaming any MatMul/Gemm node's own output tensor -- true of
             every onnxsim ``quantize_*`` function.
@@ -196,9 +198,9 @@ def apply_qronos(
     any_optimized = False
     for c in candidates:
         probe_name = c.float_node.input[0]
-        x_float_batches = [a for a in float_activations[probe_name] if a.ndim == 2]
+        x_float_batches = _activation_rows(float_activations[probe_name])
         if not x_float_batches:
-            continue  # not a plain 2-D activation; skip
+            continue  # no usable activation (no feature axis); skip
         x_float = np.concatenate(x_float_batches, axis=0)
 
         working_probe = _add_probe_outputs(working, [probe_name])
@@ -206,9 +208,12 @@ def apply_qronos(
         for batch in calibration_data:
             out = backend.run_model(working_probe, batch, providers=providers)
             x_quant_batches.append(np.asarray(out[probe_name], dtype=np.float64))
-        x_quant_batches = [a for a in x_quant_batches if a.ndim == 2]
-        if not x_quant_batches:
-            continue  # not a plain 2-D activation; skip
+        x_quant_batches = _activation_rows(x_quant_batches)
+        # Keep the float and quantized row sets aligned: `dx` below is their
+        # elementwise difference, so a batch usable on one side but not the
+        # other (no feature axis) would misalign samples.
+        if len(x_quant_batches) != len(x_float_batches):
+            continue
         x_quant = np.concatenate(x_quant_batches, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/quantease.py
+++ b/onnxsim/quantease.py
@@ -71,7 +71,7 @@ import onnx.numpy_helper
 from onnxsim import backend
 from onnxsim.adaround import _find_int4_matmul_candidates, _pack_int4
 from onnxsim.awq import _quantize_blockwise_int4
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 
@@ -140,7 +140,9 @@ def apply_quantease(
             ModelProto or file path), produced by
             :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
             any other scheme (or left unquantized), or whose activation
-            input isn't a plain 2-D tensor, are left untouched. Assumes
+            input has no feature axis at all (rank < 2) are left
+            untouched; a higher-rank ``[batch, seq, K]`` activation is
+            flattened to ``[batch * seq, K]``, which is exact. Assumes
             ``quantized_model`` was produced from ``float_model`` without
             renaming any MatMul/Gemm node's own output tensor -- true of
             every onnxsim ``quantize_*`` function.
@@ -191,9 +193,9 @@ def apply_quantease(
 
     optimized: Dict[str, np.ndarray] = {}
     for c in candidates:
-        acts = [a for a in activations[c.float_node.input[0]] if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue  # not a plain 2-D activation; skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/quantease.py
+++ b/onnxsim/quantease.py
@@ -180,7 +180,7 @@ def apply_quantease(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/onnxsim/quarot.py
+++ b/onnxsim/quarot.py
@@ -838,7 +838,7 @@ def apply_quarot_gptq(
     # Pass 2: capture every rotation-eligible layer's own (pre-rotation)
     # activation from the *original* model -- same probe pattern as
     # onnxsim.gptq.apply_gptq.
-    probe_names = [r[1] for r in rotated]  # x_name
+    probe_names = sorted({r[1] for r in rotated})  # x_name
     probe_model = _add_probe_outputs(model, probe_names)
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
     for batch in calibration_data:

--- a/onnxsim/quarot.py
+++ b/onnxsim/quarot.py
@@ -84,11 +84,24 @@ rotation **per matched layer**, at the cost of an explicit ``MatMul(X, U)``
 per layer rather than a fused, "free" rotation -- the same graph-simplicity
 trade-off :mod:`onnxsim.quip_sharp` already makes for its own two
 rotations.
+
+:func:`apply_quarot_fused` recovers the "free at inference" half of that
+gap without the model-level residual-stream walk: it keeps the per-layer
+rotation, but wherever a layer's activation comes straight out of another
+constant-weight MatMul/Gemm that feeds nothing else, it folds that layer's
+``U`` into the *producer's* weight offline (``W_P' = W_P @ U``,
+``b_P' = b_P @ U``) so the producer already emits the rotated activation
+and no runtime rotation node is emitted at all. That fold is exact
+algebra, so the accuracy is :func:`apply_quarot`'s; only the runtime cost
+goes away. It is still a per-layer rotation, and layers fed by anything
+else (a model input, a LayerNorm, an activation, a residual ``Add``) still
+pay for their explicit ``MatMul(X, U)`` -- see that function's own
+docstring for the exact fusability conditions.
 """
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
 import onnx
@@ -103,12 +116,155 @@ from onnxsim.gptq import _gptq_quantize_columns
 from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
 from onnxsim.quip_sharp import _match_matmul_like, _random_orthogonal_matrix
 
+# (node, activation name, weight name, bias name or None, weight_transposed)
+_Candidate = Tuple[onnx.NodeProto, str, str, Optional[str], bool]
+
 
 def _has_min_opset(model: onnx.ModelProto, min_version: int) -> bool:
     return any(
         o.domain in ("", "ai.onnx") and o.version >= min_version
         for o in model.opset_import
     )
+
+
+def _emit_quarot_layer(
+    graph: onnx.GraphProto,
+    taken_names: Set[str],
+    node: onnx.NodeProto,
+    prefix: str,
+    w_tilde_nk: np.ndarray,
+    u: Optional[np.ndarray],
+    bias_name: Optional[str],
+    block_size: int,
+    epsilon: float,
+) -> None:
+    """Replaces ``node`` in ``graph`` with QuaRot's quantized layer: an
+    INT4 ``DequantizeLinear`` of the already-rotated weight ``w_tilde_nk``
+    ([N, K], output channel first), a data-free per-token INT4
+    round-trip of the activation, the core MatMul, and the original bias
+    (if any).
+
+    ``u`` is the layer's input-side rotation ([K, K]). When it is not
+    ``None`` the activation is rotated at graph-run time by an explicit
+    ``MatMul(X, U)`` (what :func:`apply_quarot` does). When it is ``None``
+    the caller has already folded that rotation into the *producer's*
+    weight, so the incoming tensor is rotated already and neither the
+    ``MatMul`` node nor the ``U`` initializer is emitted at all (what
+    :func:`apply_quarot_fused` does).
+    """
+    n, k = w_tilde_nk.shape
+
+    codes_nk, scale_blocks_nk = _quantize_blockwise_int4_with_clip(
+        w_tilde_nk, block_size, 1.0
+    )
+    codes_kn = codes_nk.T.astype(np.int64)  # [K, N], ready for a plain MatMul
+    scale_kn = scale_blocks_nk.T.astype(np.float32)  # [K/block_size, N]
+
+    codes_name = _unique_name(f"{prefix}_codes", taken_names)
+    codes_tensor = onnx.TensorProto()
+    codes_tensor.name = codes_name
+    codes_tensor.data_type = onnx.TensorProto.INT4
+    codes_tensor.dims.extend([k, n])
+    codes_tensor.raw_data = _pack_int4(codes_kn)
+    graph.initializer.append(codes_tensor)
+
+    scale_name = _unique_name(f"{prefix}_scale", taken_names)
+    graph.initializer.append(onnx.numpy_helper.from_array(scale_kn, name=scale_name))
+    u_name: Optional[str] = None
+    if u is not None:
+        u_name = _unique_name(f"{prefix}_u", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(u.astype(np.float32), name=u_name)
+        )
+    eps_name = _unique_name(f"{prefix}_eps", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(np.array(epsilon, dtype=np.float32), name=eps_name)
+    )
+    seven_name = _unique_name(f"{prefix}_seven", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(np.array(7.0, dtype=np.float32), name=seven_name)
+    )
+    clip_min_name = _unique_name(f"{prefix}_clip_min", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array(-7.0, dtype=np.float32), name=clip_min_name
+        )
+    )
+    clip_max_name = _unique_name(f"{prefix}_clip_max", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            np.array(7.0, dtype=np.float32), name=clip_max_name
+        )
+    )
+    axes_name = _unique_name(f"{prefix}_reduce_axes", taken_names)
+    graph.initializer.append(
+        onnx.numpy_helper.from_array(np.array([-1], dtype=np.int64), name=axes_name)
+    )
+
+    new_nodes: List[onnx.NodeProto] = []
+
+    def _new(op_type, inputs, out_suffix, **attrs):
+        out_name = _unique_name(f"{prefix}_{out_suffix}", taken_names)
+        n_ = onnx.helper.make_node(
+            op_type,
+            inputs,
+            [out_name],
+            name=_unique_name(f"{prefix}_{out_suffix}_node", taken_names),
+            **attrs,
+        )
+        new_nodes.append(n_)
+        return out_name
+
+    if u_name is None:
+        # Fused: the producer's own weight already emits the rotated
+        # activation, so there is nothing to rotate at run time.
+        x_rotated = node.input[0]
+    else:
+        x_rotated = _new("MatMul", [node.input[0], u_name], "x_rotated")
+
+    # Data-free, per-token round-to-nearest INT4 activation
+    # quantization -- simulated via an immediate dequantize (kept in
+    # float32) rather than a true packed INT4 tensor, since X isn't
+    # constant: scale = max(reduce_max(abs(x_rotated), axis=-1), eps) / 7
+    abs_name = _new("Abs", [x_rotated], "x_abs")
+    max_name = _new("ReduceMax", [abs_name, axes_name], "x_max", keepdims=1)
+    safe_max_name = _new("Clip", [max_name, eps_name], "x_safe_max")
+    x_scale = _new("Div", [safe_max_name, seven_name], "x_scale")
+    x_scaled = _new("Div", [x_rotated, x_scale], "x_scaled")
+    x_rounded = _new("Round", [x_scaled], "x_rounded")
+    x_clipped = _new("Clip", [x_rounded, clip_min_name, clip_max_name], "x_clipped")
+    x_dequant = _new("Mul", [x_clipped, x_scale], "x_dequant")
+
+    w_dequant = _new(
+        "DequantizeLinear",
+        [codes_name, scale_name],
+        "w_dequant",
+        axis=0,
+        block_size=block_size,
+    )
+    core = _new("MatMul", [x_dequant, w_dequant], "core")
+
+    old_output = node.output[0]
+    if bias_name is not None:
+        final = onnx.helper.make_node(
+            "Add",
+            [core, bias_name],
+            [old_output],
+            name=_unique_name(f"{prefix}_bias_add_node", taken_names),
+        )
+    else:
+        final = onnx.helper.make_node(
+            "Identity",
+            [core],
+            [old_output],
+            name=_unique_name(f"{prefix}_identity_node", taken_names),
+        )
+    new_nodes.append(final)
+
+    node_idx = next(i for i, n_ in enumerate(graph.node) if n_ is node)
+    for offset, new_node in enumerate(new_nodes):
+        graph.node.insert(node_idx + offset, new_node)
+    del graph.node[node_idx + len(new_nodes)]
 
 
 def apply_quarot(
@@ -220,124 +376,311 @@ def apply_quarot(
         w_init = initializer_map[w_name]
         w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
         w_nk = w if weight_transposed else w.T  # [N, K], output channel first
-        n, k = w_nk.shape
+        k = w_nk.shape[1]
         if k % block_size != 0:
             continue
 
         u = _random_orthogonal_matrix(k, rng)  # [K, K]
         w_tilde_nk = w_nk @ u  # [N, K] -- exact before quantization
 
-        codes_nk, scale_blocks_nk = _quantize_blockwise_int4_with_clip(
-            w_tilde_nk, block_size, 1.0
+        _emit_quarot_layer(
+            graph,
+            taken_names,
+            node,
+            f"{w_name}_quarot",
+            w_tilde_nk,
+            u,
+            bias_name,
+            block_size,
+            epsilon,
         )
-        codes_kn = codes_nk.T.astype(np.int64)  # [K, N], ready for a plain MatMul
-        scale_kn = scale_blocks_nk.T.astype(np.float32)  # [K/block_size, N]
 
-        prefix = f"{w_name}_quarot"
-        codes_name = _unique_name(f"{prefix}_codes", taken_names)
-        codes_tensor = onnx.TensorProto()
-        codes_tensor.name = codes_name
-        codes_tensor.data_type = onnx.TensorProto.INT4
-        codes_tensor.dims.extend([k, n])
-        codes_tensor.raw_data = _pack_int4(codes_kn)
-        graph.initializer.append(codes_tensor)
+    return out
 
-        scale_name = _unique_name(f"{prefix}_scale", taken_names)
+
+def _count_tensor_uses(graph: onnx.GraphProto) -> Dict[str, int]:
+    """Counts how many *node inputs* across the whole model reference each
+    tensor name. Subgraphs (``If``/``Loop``/``Scan`` bodies) are walked
+    too, since an inner node may capture an outer-scope tensor by name --
+    a tensor referenced from a subgraph must not be treated as
+    single-consumer.
+    """
+    counts: Dict[str, int] = {}
+    stack = [graph]
+    while stack:
+        g = stack.pop()
+        for node in g.node:
+            for name in node.input:
+                if name:
+                    counts[name] = counts.get(name, 0) + 1
+            for attr in node.attribute:
+                if attr.HasField("g"):
+                    stack.append(attr.g)
+                stack.extend(attr.graphs)
+    return counts
+
+
+def _fold_bias(b: np.ndarray, u: np.ndarray) -> np.ndarray:
+    """``b @ u`` on the bias's last (output-channel) axis, preserving its
+    original ``[N]`` or ``[1, N]`` shape.
+    """
+    return (b.reshape(-1) @ u).reshape(b.shape)
+
+
+def apply_quarot_fused(
+    model: Union[str, onnx.ModelProto],
+    seed: int = 0,
+    block_size: int = 32,
+    epsilon: float = 1e-12,
+) -> onnx.ModelProto:
+    """QuaRot with the activation rotation **fused into the producing
+    layer's weight** wherever the graph allows it, so that rotation costs
+    nothing at inference -- the "free at inference" property of the real
+    QuaRot that :func:`apply_quarot` gives up (see this module's own
+    docstring's scope note).
+
+    Same matching, same rotations, same INT4 quantization as
+    :func:`apply_quarot`; the only difference is *where* the rotation
+    happens. If layer ``L``'s activation ``T`` is produced by another
+    MatMul/vanilla-Gemm layer ``P`` with a constant weight, and ``T`` goes
+    nowhere else, then instead of emitting ``MatMul(T, U)`` at run time
+    the rotation is folded into ``P``'s own weight offline::
+
+        T   = X_prev @ W_P  (+ b_P)
+        W_P' = W_P @ U,  b_P' = b_P @ U
+        =>  X_prev @ W_P' (+ b_P')  ==  (X_prev @ W_P + b_P) @ U  ==  T @ U
+
+    so ``P`` directly emits the rotated activation ``L`` wants. This is
+    exact algebra -- the fold itself loses nothing, and ``L``'s own weight
+    is rotated exactly as :func:`apply_quarot` rotates it
+    (``w_tilde_nk = w_nk @ u``), so ``(T @ U) @ (U.T @ W_L) == T @ W_L``
+    still holds. The result is the same accuracy as
+    :func:`apply_quarot` with strictly fewer runtime nodes (one
+    ``MatMul`` and one ``[K, K]`` initializer fewer per fused layer).
+
+    Note that the two rotations act on *different axes* of a weight: a
+    layer's own input-side rotation acts on its reduction dim ``K``
+    (right-multiply, ``w_nk @ u``), while an output-side fold acts on its
+    output dim ``N`` (left-multiply, ``u_consumer.T @ w_nk``). A layer
+    that is both a fused producer and a quantized consumer -- the middle
+    layer of a chain ``A -> B -> C`` -- therefore gets **both**, and both
+    are applied while the weight is still float, before it is quantized.
+    Chains of any length are handled: this function plans every rotation
+    first, then rotates every weight, and only then quantizes.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param seed: seed for the random rotation matrices. Sequenced exactly
+            as :func:`apply_quarot` does it (a single
+            ``numpy.random.Generator``, advanced once per quantized layer
+            in graph node order), so for a given model and seed both
+            functions fit the *same* rotation to the same layer
+    :param block_size: elements per weight quantization block along ``K``
+    :param epsilon: floor applied to a token's own max-abs activation
+            value before using it as a scale
+    :returns: ``model`` with every matched layer quantized as
+            :func:`apply_quarot` does, except that a layer whose
+            activation edge is fusable carries no runtime rotation node
+            and no ``U`` initializer at all
+
+    **Which edges are fusable.** ``L``'s activation edge is fused only
+    when *all* of these hold; otherwise ``L`` falls back to
+    :func:`apply_quarot`'s explicit ``MatMul(X, U)`` (never skipped, never
+    silently mis-rotated):
+
+    - the activation tensor is produced by a node in the main graph that
+      :func:`onnxsim.quip_sharp._match_matmul_like` matches (a MatMul, or
+      a Gemm with ``transA=0``/``alpha=1``/``beta=1``) whose weight is a
+      constant 2-D float32 initializer;
+    - that tensor is referenced by exactly one node input in the whole
+      model (subgraph bodies included) -- a tensor consumed twice cannot
+      be rotated for one consumer without corrupting the other;
+    - that tensor is not a graph output (a graph output must keep its
+      unrotated value);
+    - the producer's own output dimension equals ``L``'s reduction
+      dimension ``K``;
+    - if the producer has a bias, that bias is a constant float32
+      initializer shaped ``[N]`` or ``[1, N]`` -- the only shapes whose
+      last axis is unambiguously the output channel axis, and so the only
+      ones ``b @ U`` is defined for. A broadcast/scalar Gemm bias is not
+      folded, and its layer is not fused.
+
+    **Scope, stated plainly.** This is still a *per-layer* rotation, not
+    the real QuaRot's single residual-stream-wide one: each matched layer
+    still gets its own independent ``U``. What this function removes is
+    only the *runtime cost* of that rotation, on the subset of edges where
+    the algebra above applies. Layers fed by anything other than another
+    constant-weight MatMul/Gemm -- a model input, a normalization, an
+    activation function, a residual ``Add``, an attention softmax -- are
+    not fusable and keep their explicit ``MatMul(X, U)``. In a real
+    transformer that means the projections that immediately follow a
+    LayerNorm or a residual add (i.e. most of them) still pay for their
+    rotation; fusing those needs the model-level residual-stream walk this
+    module still does not attempt.
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if not _has_min_opset(model, 21):
+        return model
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    # --- Phase 1: plan ------------------------------------------------
+    # Matching is identical to apply_quarot's, and so is the RNG
+    # sequencing, so a given (model, seed) fits the very same rotation to
+    # the very same layer in both functions.
+    candidates: List[_Candidate] = []
+    for node in list(graph.node):
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, bias_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, x_name, w_name, bias_name, weight_transposed))
+
+    if not candidates:
+        return out
+
+    # Every constant-weight MatMul/Gemm is a potential fold target, even
+    # one that is itself skipped for quantization (k % block_size != 0):
+    # folding only needs its weight to be constant, not quantizable.
+    producer_of: Dict[str, _Candidate] = {}
+    for cand in candidates:
+        producer_of[cand[0].output[0]] = cand
+
+    rng = np.random.default_rng(seed)
+    # Candidate indices that will actually be quantized, in graph node
+    # order, each with its own input-side rotation U.
+    quantized_order: List[int] = []
+    own_rotation: Dict[int, np.ndarray] = {}
+    for idx, (_node, _x_name, w_name, _bias_name, weight_transposed) in enumerate(
+        candidates
+    ):
+        w_init = initializer_map[w_name]
+        k = w_init.dims[1] if weight_transposed else w_init.dims[0]
+        if k % block_size != 0:
+            continue
+        quantized_order.append(idx)
+        own_rotation[idx] = _random_orthogonal_matrix(k, rng)
+
+    graph_output_names = {o.name for o in graph.output}
+    use_counts = _count_tensor_uses(graph)
+
+    # id(producer node) -> the consumer rotation to fold into its output
+    # axis. At most one entry per producer, since a fusable edge is by
+    # definition single-consumer.
+    fold_into: Dict[int, np.ndarray] = {}
+    fused_indices: Set[int] = set()
+
+    for idx in quantized_order:
+        x_name = candidates[idx][1]
+        u = own_rotation[idx]
+        producer = producer_of.get(x_name)
+        if producer is None:
+            continue
+        if x_name in graph_output_names or use_counts.get(x_name, 0) != 1:
+            continue
+        p_node, _p_x, p_w_name, p_bias_name, p_transposed = producer
+        p_w_init = initializer_map[p_w_name]
+        p_n = p_w_init.dims[0] if p_transposed else p_w_init.dims[1]
+        if p_n != u.shape[0]:
+            continue
+        if p_bias_name is not None:
+            p_b_init = initializer_map.get(p_bias_name)
+            if p_b_init is None or p_b_init.data_type != onnx.TensorProto.FLOAT:
+                continue
+            if list(p_b_init.dims) not in ([p_n], [1, p_n]):
+                continue
+        fold_into[id(p_node)] = u
+        fused_indices.add(idx)
+
+    # --- Phase 2: rotate, all in float --------------------------------
+    # Every weight that takes part -- as a quantized consumer, as a fused
+    # producer, or (in an A -> B -> C chain) as both -- is rotated from
+    # its original float values here, before anything is quantized.
+    rotated_nk: Dict[int, np.ndarray] = {}
+    rotated_bias: Dict[int, np.ndarray] = {}
+    for idx, (node, _x_name, w_name, bias_name, weight_transposed) in enumerate(
+        candidates
+    ):
+        fold_u = fold_into.get(id(node))
+        own_u = own_rotation.get(idx)
+        if fold_u is None and own_u is None:
+            continue
+        w = onnx.numpy_helper.to_array(initializer_map[w_name]).astype(np.float64)
+        w_nk = w if weight_transposed else w.T  # [N, K], output channel first
+        if fold_u is not None:
+            # Output-side fold, on the N axis: the layer now emits T @ U.
+            w_nk = fold_u.T @ w_nk
+            if bias_name is not None:
+                b = onnx.numpy_helper.to_array(initializer_map[bias_name]).astype(
+                    np.float64
+                )
+                rotated_bias[idx] = _fold_bias(b, fold_u)
+        if own_u is not None:
+            # Input-side rotation, on the K axis: exactly apply_quarot's.
+            w_nk = w_nk @ own_u
+        rotated_nk[idx] = w_nk
+
+    # --- Phase 3: emit -------------------------------------------------
+    # A fused producer that is not itself quantized just gets its rotated
+    # float weight (and bias) written back under fresh names -- the
+    # original initializers may be shared with other nodes, so they are
+    # never edited in place.
+    quantized_indices = set(quantized_order)
+    for idx, (node, _x_name, w_name, bias_name, weight_transposed) in enumerate(
+        candidates
+    ):
+        if idx in quantized_indices or idx not in rotated_nk:
+            continue
+        w_nk = rotated_nk[idx]
+        w_new = w_nk if weight_transposed else w_nk.T
+        new_w_name = _unique_name(f"{w_name}_quarot_folded", taken_names)
         graph.initializer.append(
-            onnx.numpy_helper.from_array(scale_kn, name=scale_name)
+            onnx.numpy_helper.from_array(w_new.astype(np.float32), name=new_w_name)
         )
-        u_name = _unique_name(f"{prefix}_u", taken_names)
-        graph.initializer.append(
-            onnx.numpy_helper.from_array(u.astype(np.float32), name=u_name)
-        )
-        eps_name = _unique_name(f"{prefix}_eps", taken_names)
-        graph.initializer.append(
-            onnx.numpy_helper.from_array(
-                np.array(epsilon, dtype=np.float32), name=eps_name
+        node.input[1] = new_w_name
+        if idx in rotated_bias:
+            assert bias_name is not None
+            new_b_name = _unique_name(f"{bias_name}_quarot_folded", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    rotated_bias[idx].astype(np.float32), name=new_b_name
+                )
             )
-        )
-        seven_name = _unique_name(f"{prefix}_seven", taken_names)
-        graph.initializer.append(
-            onnx.numpy_helper.from_array(
-                np.array(7.0, dtype=np.float32), name=seven_name
+            node.input[2] = new_b_name
+
+    for idx in quantized_order:
+        node, _x_name, w_name, bias_name, _weight_transposed = candidates[idx]
+        effective_bias = bias_name
+        if idx in rotated_bias:
+            assert bias_name is not None
+            effective_bias = _unique_name(f"{bias_name}_quarot_folded", taken_names)
+            graph.initializer.append(
+                onnx.numpy_helper.from_array(
+                    rotated_bias[idx].astype(np.float32), name=effective_bias
+                )
             )
+        _emit_quarot_layer(
+            graph,
+            taken_names,
+            node,
+            f"{w_name}_quarot",
+            rotated_nk[idx],
+            None if idx in fused_indices else own_rotation[idx],
+            effective_bias,
+            block_size,
+            epsilon,
         )
-        clip_min_name = _unique_name(f"{prefix}_clip_min", taken_names)
-        graph.initializer.append(
-            onnx.numpy_helper.from_array(
-                np.array(-7.0, dtype=np.float32), name=clip_min_name
-            )
-        )
-        clip_max_name = _unique_name(f"{prefix}_clip_max", taken_names)
-        graph.initializer.append(
-            onnx.numpy_helper.from_array(
-                np.array(7.0, dtype=np.float32), name=clip_max_name
-            )
-        )
-        axes_name = _unique_name(f"{prefix}_reduce_axes", taken_names)
-        graph.initializer.append(
-            onnx.numpy_helper.from_array(np.array([-1], dtype=np.int64), name=axes_name)
-        )
-
-        new_nodes: List[onnx.NodeProto] = []
-
-        def _new(op_type, inputs, out_suffix, **attrs):
-            out_name = _unique_name(f"{prefix}_{out_suffix}", taken_names)
-            n_ = onnx.helper.make_node(
-                op_type,
-                inputs,
-                [out_name],
-                name=_unique_name(f"{prefix}_{out_suffix}_node", taken_names),
-                **attrs,
-            )
-            new_nodes.append(n_)
-            return out_name
-
-        x_rotated = _new("MatMul", [x_name, u_name], "x_rotated")
-
-        # Data-free, per-token round-to-nearest INT4 activation
-        # quantization -- simulated via an immediate dequantize (kept in
-        # float32) rather than a true packed INT4 tensor, since X isn't
-        # constant: scale = max(reduce_max(abs(x_rotated), axis=-1), eps) / 7
-        abs_name = _new("Abs", [x_rotated], "x_abs")
-        max_name = _new("ReduceMax", [abs_name, axes_name], "x_max", keepdims=1)
-        safe_max_name = _new("Clip", [max_name, eps_name], "x_safe_max")
-        x_scale = _new("Div", [safe_max_name, seven_name], "x_scale")
-        x_scaled = _new("Div", [x_rotated, x_scale], "x_scaled")
-        x_rounded = _new("Round", [x_scaled], "x_rounded")
-        x_clipped = _new("Clip", [x_rounded, clip_min_name, clip_max_name], "x_clipped")
-        x_dequant = _new("Mul", [x_clipped, x_scale], "x_dequant")
-
-        w_dequant = _new(
-            "DequantizeLinear",
-            [codes_name, scale_name],
-            "w_dequant",
-            axis=0,
-            block_size=block_size,
-        )
-        core = _new("MatMul", [x_dequant, w_dequant], "core")
-
-        old_output = node.output[0]
-        if bias_name is not None:
-            final = onnx.helper.make_node(
-                "Add",
-                [core, bias_name],
-                [old_output],
-                name=_unique_name(f"{prefix}_bias_add_node", taken_names),
-            )
-        else:
-            final = onnx.helper.make_node(
-                "Identity",
-                [core],
-                [old_output],
-                name=_unique_name(f"{prefix}_identity_node", taken_names),
-            )
-        new_nodes.append(final)
-
-        node_idx = next(i for i, n_ in enumerate(graph.node) if n_ is node)
-        for offset, new_node in enumerate(new_nodes):
-            graph.node.insert(node_idx + offset, new_node)
-        del graph.node[node_idx + len(new_nodes)]
 
     return out
 

--- a/onnxsim/quarot.py
+++ b/onnxsim/quarot.py
@@ -110,7 +110,12 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.gptq import _gptq_quantize_columns
 from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
@@ -737,8 +742,9 @@ def apply_quarot_gptq(
 
     **Fallback for a layer with no usable calibration data.** A candidate
     layer whose captured activation is empty (no calibration batch reached
-    it) or isn't a plain 2-D array, or whose feature dimension doesn't
-    match the weight's own ``K``, is left completely alone by this
+    it) or has no feature axis at all (rank < 2), or whose feature
+    dimension doesn't match the weight's own ``K``, is left completely
+    alone by this
     function -- no rotation, no quantization -- rather than silently
     falling back to plain round-to-nearest quantization under GPTQ's own
     name (mirrors :func:`onnxsim.gptq.apply_gptq`'s own
@@ -847,7 +853,7 @@ def apply_quarot_gptq(
             activations[name].append(np.asarray(result[name], dtype=np.float64))
 
     for node, x_name, w_name, bias_name, w_nk, n, k, u in rotated:
-        acts = [a for a in activations[x_name] if a.ndim == 2]
+        acts = _activation_rows(activations[x_name])
         if not acts:
             continue  # no usable calibration activation -- leave untouched
         x = np.concatenate(acts, axis=0)

--- a/onnxsim/quarot.py
+++ b/onnxsim/quarot.py
@@ -55,20 +55,22 @@ Transform -- the same trade-off already made, and already explained, in
 :mod:`onnxsim.spinquant` does.
 
 **Why the activation needs no calibration but the real QuaRot's weight
-quantization can optionally use GPTQ.** This module quantizes *both*
-operands with plain round-to-nearest: the weight offline (from the
+quantization can optionally use GPTQ.** :func:`apply_quarot` quantizes
+*both* operands with plain round-to-nearest: the weight offline (from the
 rotated weight's own values, like :mod:`onnxsim.spinquant`), the
 activation online, per token, from that token's own rotated values (the
 same data-free pattern :mod:`onnxsim.kv_cache_quantization`'s Value-style
 KV-cache rewrite already uses -- ``scale = max(|x|) / 7`` computed at
 graph-run time, no stored calibration statistics). The real QuaRot paper
 additionally offers a GPTQ-based weight quantizer for a tighter error
-bound; this module does not reproduce that (GPTQ's own column-by-column
-Hessian update is already ported faithfully in :mod:`onnxsim.gptq`, and
-composing it with a rotation is future work, not part of what makes
-QuaRot's own idea -- rotate the whole residual stream so *activations*,
-not just weights, can drop to INT4 -- distinct from every other onnxsim
-INT4 scheme).
+bound; :func:`apply_quarot_gptq` (below) provides it: it is identical to
+:func:`apply_quarot` in every respect (same candidate matching, same
+per-layer rotation ``U``, same data-free per-token activation
+quantization) except the *weight* is quantized via :mod:`onnxsim.gptq`'s
+own Hessian-based column algorithm (evaluated in the *rotated* activation
+space -- see :func:`apply_quarot_gptq`'s own docstring for exactly how the
+two compose) instead of independent round-to-nearest, needing real
+calibration activations only for that one step.
 
 **Scope note.** The real QuaRot rotates the *entire residual stream* by a
 single, shared rotation (fused into every adjacent weight matrix -- Q/K/V/O
@@ -86,15 +88,18 @@ rotations.
 
 from __future__ import annotations
 
-from typing import List, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import onnx
 import onnx.helper
 import onnx.numpy_helper
 
+from onnxsim import backend
 from onnxsim.adaround import _pack_int4
-from onnxsim.bias_correction import _all_names, _unique_name
+from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+from onnxsim.gptq import _gptq_quantize_columns
 from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
 from onnxsim.quip_sharp import _match_matmul_like, _random_orthogonal_matrix
 
@@ -299,6 +304,297 @@ def apply_quarot(
         safe_max_name = _new("Clip", [max_name, eps_name], "x_safe_max")
         x_scale = _new("Div", [safe_max_name, seven_name], "x_scale")
         x_scaled = _new("Div", [x_rotated, x_scale], "x_scaled")
+        x_rounded = _new("Round", [x_scaled], "x_rounded")
+        x_clipped = _new("Clip", [x_rounded, clip_min_name, clip_max_name], "x_clipped")
+        x_dequant = _new("Mul", [x_clipped, x_scale], "x_dequant")
+
+        w_dequant = _new(
+            "DequantizeLinear",
+            [codes_name, scale_name],
+            "w_dequant",
+            axis=0,
+            block_size=block_size,
+        )
+        core = _new("MatMul", [x_dequant, w_dequant], "core")
+
+        old_output = node.output[0]
+        if bias_name is not None:
+            final = onnx.helper.make_node(
+                "Add",
+                [core, bias_name],
+                [old_output],
+                name=_unique_name(f"{prefix}_bias_add_node", taken_names),
+            )
+        else:
+            final = onnx.helper.make_node(
+                "Identity",
+                [core],
+                [old_output],
+                name=_unique_name(f"{prefix}_identity_node", taken_names),
+            )
+        new_nodes.append(final)
+
+        node_idx = next(i for i, n_ in enumerate(graph.node) if n_ is node)
+        for offset, new_node in enumerate(new_nodes):
+            graph.node.insert(node_idx + offset, new_node)
+        del graph.node[node_idx + len(new_nodes)]
+
+    return out
+
+
+def apply_quarot_gptq(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    block_size: int = 32,
+    percdamp: float = 0.01,
+    proc_block_size: int = 128,
+    epsilon: float = 1e-12,
+    providers: Optional[Sequence[str]] = None,
+) -> onnx.ModelProto:
+    """Variant of :func:`apply_quarot` that quantizes the *rotated* weight
+    via :mod:`onnxsim.gptq`'s Hessian-based column algorithm (see that
+    module's own docstring for the algorithm itself) instead of plain
+    round-to-nearest -- the real QuaRot paper's own optional, tighter
+    weight quantizer that :func:`apply_quarot`'s own docstring flags as not
+    reproduced there.
+
+    Everything about the rotation and the activation is unchanged from
+    :func:`apply_quarot`: the same candidate matching, the same per-layer
+    random rotation ``U`` (this function reuses ``apply_quarot``'s own
+    rotation-derivation loop verbatim -- one ``numpy.random.Generator(seed)``
+    sequenced across every matched layer in graph node order -- so for a
+    given ``seed`` the two functions derive byte-identical rotations per
+    layer), and the same data-free, per-token round-to-nearest INT4
+    activation quantization at graph-run time. Only the weight-quantization
+    step differs, in three parts:
+
+    1. capture each candidate layer's real (pre-rotation) activation ``X``
+       from ``model`` using calibration data, exactly the pattern
+       :func:`onnxsim.gptq.apply_gptq` already uses
+       (:func:`onnxsim.bias_correction._add_probe_outputs` +
+       :func:`onnxsim.backend.run_model`, including its 2-D-only filtering
+       of what comes back);
+    2. rotate that activation by the same layer's own ``U``
+       (``X_rotated = X @ U``, mirroring the weight side's own
+       ``Wtilde = W @ U``) and compute GPTQ's Hessian in the *rotated*
+       space, ``H = X_rotated.T @ X_rotated`` -- the space
+       :func:`onnxsim.gptq._gptq_quantize_columns` actually minimizes
+       reconstruction error in, since it is ``Wtilde`` (not ``W``) being
+       quantized here;
+    3. quantize ``Wtilde`` via :func:`onnxsim.gptq._gptq_quantize_columns`
+       using that Hessian and the *same* per-``(output channel, block)``
+       scale :func:`onnxsim.omniquant._quantize_blockwise_int4_with_clip`
+       already computes for it in :func:`apply_quarot` (that call's own
+       round-to-nearest codes are discarded -- only its scale is reused,
+       since GPTQ's column algorithm takes an already-computed scale and
+       only changes which integer each element rounds to, never the scale
+       itself).
+
+    **Fallback for a layer with no usable calibration data.** A candidate
+    layer whose captured activation is empty (no calibration batch reached
+    it) or isn't a plain 2-D array, or whose feature dimension doesn't
+    match the weight's own ``K``, is left completely alone by this
+    function -- no rotation, no quantization -- rather than silently
+    falling back to plain round-to-nearest quantization under GPTQ's own
+    name (mirrors :func:`onnxsim.gptq.apply_gptq`'s own
+    ``if not acts: continue`` skip). Note this differs from
+    :func:`apply_quarot`, which never skips a layer for lack of data since
+    it needs none.
+
+    :param model: the original (unquantized) onnx ModelProto or file path
+    :param calibration_data: representative input batches to compute each
+            matched layer's rotated-space Hessian from. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``model``'s graph
+            inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            much more representative Hessian than random input).
+    :param num_samples: random batches to generate when
+            ``calibration_data`` is omitted
+    :param seed: seed for both the random rotation matrices (identical
+            derivation to :func:`apply_quarot`'s own ``seed``) and the
+            random calibration data (ignored for the latter if
+            ``calibration_data`` is supplied)
+    :param block_size: elements per weight quantization block along ``K``,
+            matching :func:`apply_quarot`'s own default
+    :param percdamp: Hessian damping factor, matching
+            :func:`onnxsim.gptq.apply_gptq`'s own parameter and default
+    :param proc_block_size: GPTQ's own column-processing block size (not
+            the quantization scale's own block size) -- see
+            :func:`onnxsim.gptq._gptq_quantize_columns`
+    :param epsilon: floor applied to a token's own max-abs activation value
+            before using it as a scale at graph-run time, matching
+            :func:`apply_quarot`'s own parameter
+    :param providers: onnxruntime execution providers to run ``model`` on
+            when capturing calibration activations
+    :returns: ``model`` with every matched layer that has usable
+            calibration data rotated and INT4-quantized (GPTQ for the
+            weight, data-free round-to-nearest for the activation, exactly
+            like :func:`apply_quarot`); a matched layer without usable
+            calibration data is left completely untouched. A model with no
+            matching layer, or an opset older than 21, is returned
+            unchanged (matching :func:`apply_quarot`).
+    """
+    if isinstance(model, str):
+        model = onnx.load(model, load_external_data=False)
+    if not _has_min_opset(model, 21):
+        return model
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_samples, seed=seed
+        )
+
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    initializer_map = {t.name: t for t in graph.initializer}
+    taken_names = _all_names(graph)
+
+    nodes = list(graph.node)
+    candidates = []
+    for node in nodes:
+        match = _match_matmul_like(node)
+        if match is None:
+            continue
+        x_name, w_name, bias_name, weight_transposed = match
+        w_init = initializer_map.get(w_name)
+        if (
+            w_init is None
+            or w_init.data_type != onnx.TensorProto.FLOAT
+            or len(w_init.dims) != 2
+        ):
+            continue
+        candidates.append((node, x_name, w_name, bias_name, weight_transposed))
+
+    if not candidates:
+        return out
+
+    rng = np.random.default_rng(seed)
+
+    # Pass 1: derive each eligible layer's rotation via the exact same
+    # loop apply_quarot uses (matching node order, matching k % block_size
+    # skip before drawing from rng) so the "same seed" yields the same U
+    # per layer in both functions.
+    rotated = []
+    for node, x_name, w_name, bias_name, weight_transposed in candidates:
+        w_init = initializer_map[w_name]
+        w = onnx.numpy_helper.to_array(w_init).astype(np.float64)
+        w_nk = w if weight_transposed else w.T  # [N, K], output channel first
+        n, k = w_nk.shape
+        if k % block_size != 0:
+            continue
+
+        u = _random_orthogonal_matrix(k, rng)  # [K, K]
+        rotated.append((node, x_name, w_name, bias_name, w_nk, n, k, u))
+
+    if not rotated:
+        return out
+
+    # Pass 2: capture every rotation-eligible layer's own (pre-rotation)
+    # activation from the *original* model -- same probe pattern as
+    # onnxsim.gptq.apply_gptq.
+    probe_names = [r[1] for r in rotated]  # x_name
+    probe_model = _add_probe_outputs(model, probe_names)
+    activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}
+    for batch in calibration_data:
+        result = backend.run_model(probe_model, batch, providers=providers)
+        for name in probe_names:
+            activations[name].append(np.asarray(result[name], dtype=np.float64))
+
+    for node, x_name, w_name, bias_name, w_nk, n, k, u in rotated:
+        acts = [a for a in activations[x_name] if a.ndim == 2]
+        if not acts:
+            continue  # no usable calibration activation -- leave untouched
+        x = np.concatenate(acts, axis=0)
+        if x.shape[1] != k:
+            continue  # activation's feature dim doesn't match K -- leave untouched
+
+        w_tilde_nk = w_nk @ u  # [N, K] -- exact before quantization
+        x_rotated = x @ u  # [S, K] -- same rotation, rotated-space Hessian
+        h = x_rotated.T @ x_rotated  # [K, K]
+
+        _, scale_blocks_nk = _quantize_blockwise_int4_with_clip(
+            w_tilde_nk, block_size, 1.0
+        )
+        codes_nk = _gptq_quantize_columns(
+            w_tilde_nk, scale_blocks_nk, block_size, h, percdamp, proc_block_size
+        )
+        codes_kn = codes_nk.T.astype(np.int64)  # [K, N], ready for a plain MatMul
+        scale_kn = scale_blocks_nk.T.astype(np.float32)  # [K/block_size, N]
+
+        prefix = f"{w_name}_quarot_gptq"
+        codes_name = _unique_name(f"{prefix}_codes", taken_names)
+        codes_tensor = onnx.TensorProto()
+        codes_tensor.name = codes_name
+        codes_tensor.data_type = onnx.TensorProto.INT4
+        codes_tensor.dims.extend([k, n])
+        codes_tensor.raw_data = _pack_int4(codes_kn)
+        graph.initializer.append(codes_tensor)
+
+        scale_name = _unique_name(f"{prefix}_scale", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(scale_kn, name=scale_name)
+        )
+        u_name = _unique_name(f"{prefix}_u", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(u.astype(np.float32), name=u_name)
+        )
+        eps_name = _unique_name(f"{prefix}_eps", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array(epsilon, dtype=np.float32), name=eps_name
+            )
+        )
+        seven_name = _unique_name(f"{prefix}_seven", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array(7.0, dtype=np.float32), name=seven_name
+            )
+        )
+        clip_min_name = _unique_name(f"{prefix}_clip_min", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array(-7.0, dtype=np.float32), name=clip_min_name
+            )
+        )
+        clip_max_name = _unique_name(f"{prefix}_clip_max", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(
+                np.array(7.0, dtype=np.float32), name=clip_max_name
+            )
+        )
+        axes_name = _unique_name(f"{prefix}_reduce_axes", taken_names)
+        graph.initializer.append(
+            onnx.numpy_helper.from_array(np.array([-1], dtype=np.int64), name=axes_name)
+        )
+
+        new_nodes: List[onnx.NodeProto] = []
+
+        def _new(op_type, inputs, out_suffix, **attrs):
+            out_name = _unique_name(f"{prefix}_{out_suffix}", taken_names)
+            n_ = onnx.helper.make_node(
+                op_type,
+                inputs,
+                [out_name],
+                name=_unique_name(f"{prefix}_{out_suffix}_node", taken_names),
+                **attrs,
+            )
+            new_nodes.append(n_)
+            return out_name
+
+        x_rotated_name = _new("MatMul", [x_name, u_name], "x_rotated")
+
+        # Data-free, per-token round-to-nearest INT4 activation
+        # quantization -- simulated via an immediate dequantize (kept in
+        # float32) rather than a true packed INT4 tensor, since X isn't
+        # constant: scale = max(reduce_max(abs(x_rotated), axis=-1), eps) / 7
+        abs_name = _new("Abs", [x_rotated_name], "x_abs")
+        max_name = _new("ReduceMax", [abs_name, axes_name], "x_max", keepdims=1)
+        safe_max_name = _new("Clip", [max_name, eps_name], "x_safe_max")
+        x_scale = _new("Div", [safe_max_name, seven_name], "x_scale")
+        x_scaled = _new("Div", [x_rotated_name, x_scale], "x_scaled")
         x_rounded = _new("Round", [x_scaled], "x_rounded")
         x_clipped = _new("Clip", [x_rounded, clip_min_name, clip_max_name], "x_clipped")
         x_dequant = _new("Mul", [x_clipped, x_scale], "x_dequant")

--- a/onnxsim/slim_llm.py
+++ b/onnxsim/slim_llm.py
@@ -73,7 +73,12 @@ import onnx.helper
 import onnx.numpy_helper
 
 from onnxsim import backend
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.gptq import _inverse_hessian_cholesky
 from onnxsim.quip_sharp import _match_matmul_like
@@ -213,8 +218,7 @@ def apply_slim_llm(
         result = backend.run_model(probe_model, batch, providers=providers)
         for name in probe_names:
             x = np.asarray(result[name], dtype=np.float64)
-            if x.ndim == 2:
-                activations[name].append(x)
+            activations[name].extend(_activation_rows([x]))
 
     target_bits_clamped = min(max(target_bits, float(low_bits)), float(high_bits))
     fraction_high = (target_bits_clamped - low_bits) / (high_bits - low_bits)
@@ -222,7 +226,7 @@ def apply_slim_llm(
     for node, x_name, w_name, bias_name, weight_transposed in candidates:
         acts = activations.get(x_name)
         if not acts:
-            continue  # no 2-D calibration activation observed; skip
+            continue  # no usable calibration activation observed; skip
 
         w_init = initializer_map[w_name]
         w = onnx.numpy_helper.to_array(w_init).astype(np.float64)

--- a/onnxsim/spinquant.py
+++ b/onnxsim/spinquant.py
@@ -78,7 +78,12 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
 from onnxsim.quip_sharp import _match_matmul_like
@@ -175,8 +180,7 @@ def apply_spinquant(
         result = backend.run_model(probe_model, batch, providers=providers)
         for name in probe_names:
             arr = np.asarray(result[name], dtype=np.float64)
-            if arr.ndim == 2:
-                activations[name].append(arr)
+            activations[name].extend(_activation_rows([arr]))
 
     for node, x_name, w_name, bias_name, weight_transposed in candidates:
         acts = activations.get(x_name, [])

--- a/onnxsim/spqr.py
+++ b/onnxsim/spqr.py
@@ -82,7 +82,12 @@ import onnx.numpy_helper
 
 from onnxsim import backend
 from onnxsim.adaround import _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.quip_sharp import _match_matmul_like
 
@@ -181,8 +186,7 @@ def quantize_weight_only_spqr(
         result = backend.run_model(probe_model, batch, providers=providers)
         for name in probe_names:
             arr = np.asarray(result[name], dtype=np.float64)
-            if arr.ndim == 2:
-                activations[name].append(arr)
+            activations[name].extend(_activation_rows([arr]))
 
     for node, x_name, w_name, bias_name, weight_transposed in candidates:
         acts = activations.get(x_name, [])

--- a/onnxsim/tesseraq.py
+++ b/onnxsim/tesseraq.py
@@ -87,7 +87,7 @@ from onnxsim.adaround import (
     _h_and_dhdv,
     _pack_int4,
 )
-from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
 
@@ -348,10 +348,9 @@ def apply_tesseraq(
     optimized_codes: Dict[str, np.ndarray] = {}
     optimized_scale: Dict[str, np.ndarray] = {}
     for c in candidates:
-        acts = activations[c.float_node.input[0]]
-        acts = [a for a in acts if a.ndim == 2]
+        acts = _activation_rows(activations[c.float_node.input[0]])
         if not acts:
-            continue  # not a plain 2-D activation (batched/broadcast MatMul); skip
+            continue  # no usable activation (no feature axis); skip
         x = np.concatenate(acts, axis=0)
 
         w = onnx.numpy_helper.to_array(c.w_float_init).astype(np.float64)

--- a/onnxsim/tesseraq.py
+++ b/onnxsim/tesseraq.py
@@ -333,7 +333,7 @@ def apply_tesseraq(
     if not candidates:
         return quantized_model
 
-    probe_names = [c.float_node.input[0] for c in candidates]
+    probe_names = sorted({c.float_node.input[0] for c in candidates})
     float_probe = _add_probe_outputs(float_model, probe_names)
 
     activations: Dict[str, List[np.ndarray]] = {name: [] for name in probe_names}

--- a/tests/test_adaround.py
+++ b/tests/test_adaround.py
@@ -243,3 +243,102 @@ def test_adaround_noop_when_no_int4_matmul_present():
         model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
     )
     assert result.SerializeToString() == model.SerializeToString()
+
+
+def _model_3d(K=64, N=16, seed=0):
+    # [batch, seq, K] -- the activation shape of essentially every real
+    # transformer, since ONNX MatMul broadcasts over leading dimensions.
+    rng = np.random.default_rng(seed)
+    return _model(
+        f"""
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(rng.standard_normal((K, N)).astype(np.float32) * 0.5, "W")],
+    )
+
+
+def _correlated_calibration_3d(K=64, batch=8, seq=16, rank=6, seed=1):
+    rng = np.random.default_rng(seed)
+    latent = rng.standard_normal((batch, seq, rank)).astype(np.float32)
+    projection = rng.standard_normal((rank, K)).astype(np.float32)
+    x = latent @ projection
+    x += rng.standard_normal((batch, seq, K)).astype(np.float32) * 0.05
+    return x.astype(np.float32)
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_adaround_handles_a_3d_transformer_shaped_activation(seed):
+    # A [batch, seq, K] activation used to be filtered out entirely (the
+    # capture kept only ndim == 2 arrays), so apply_adaround silently
+    # returned quantized_model unchanged on exactly the model shape it
+    # exists for. Flattening the leading dimensions is exact -- the layer's
+    # own reconstruction objective sums over the same rows either way.
+    float_model = _model_3d(K=64, N=16, seed=seed)
+    x = _correlated_calibration_3d(K=64, seed=seed + 100)
+    quant_model = onnxsim.quantize_weight_only_int4(float_model)
+
+    adaround_model = onnxsim.apply_adaround(
+        float_model, quant_model, calibration_data=[{"X": x}]
+    )
+    onnx.checker.check_model(adaround_model)
+    assert adaround_model.SerializeToString() != quant_model.SerializeToString(), (
+        "apply_adaround was a no-op on a 3-D activation"
+    )
+
+    (float_y,) = _run(float_model, {"X": x})
+    (rtn_y,) = _run(quant_model, {"X": x})
+    (ada_y,) = _run(adaround_model, {"X": x})
+    assert np.all(np.isfinite(ada_y))
+    # Correlated channels are the regime AdaRound's own per-layer objective
+    # exploits, so the improvement over plain round-to-nearest is large
+    # here (measured ~0.10 -> ~0.035 across seeds), not a marginal
+    # difference that could flip on another platform.
+    assert _rel_l2(float_y, ada_y) < 0.7 * _rel_l2(float_y, rtn_y)
+
+
+def test_adaround_flattening_matches_an_equivalent_2d_calibration():
+    # Flattening [batch, seq, K] -> [batch * seq, K] must be *exact*, not an
+    # approximation: feeding the same rows as a 2-D batch has to produce
+    # byte-identical INT4 codes.
+    K, N = 32, 8
+    weight = (np.random.default_rng(7).standard_normal((K, N)) * 0.5).astype(np.float32)
+    model_3d = _model(
+        f"""
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+    model_2d = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+    x3 = _correlated_calibration_3d(K=K, batch=4, seq=8, rank=4, seed=11)
+
+    out3 = onnxsim.apply_adaround(
+        model_3d,
+        onnxsim.quantize_weight_only_int4(model_3d),
+        calibration_data=[{"X": x3}],
+    )
+    out2 = onnxsim.apply_adaround(
+        model_2d,
+        onnxsim.quantize_weight_only_int4(model_2d),
+        calibration_data=[{"X": x3.reshape(-1, K)}],
+    )
+    codes3 = next(
+        t for t in out3.graph.initializer if t.data_type == onnx.TensorProto.INT4
+    )
+    codes2 = next(
+        t for t in out2.graph.initializer if t.data_type == onnx.TensorProto.INT4
+    )
+    assert codes3.raw_data == codes2.raw_data

--- a/tests/test_gptq.py
+++ b/tests/test_gptq.py
@@ -369,9 +369,7 @@ def test_gptq_flattening_matches_an_equivalent_2d_calibration():
     q3 = onnxsim.quantize_weight_only_int4(model_3d)
     q2 = onnxsim.quantize_weight_only_int4(model_2d)
     out3 = onnxsim.apply_gptq(model_3d, q3, calibration_data=[{"X": x3}])
-    out2 = onnxsim.apply_gptq(
-        model_2d, q2, calibration_data=[{"X": x3.reshape(-1, k)}]
-    )
+    out2 = onnxsim.apply_gptq(model_2d, q2, calibration_data=[{"X": x3.reshape(-1, k)}])
 
     w3 = next(t for t in out3.graph.initializer if t.data_type == onnx.TensorProto.INT4)
     w2 = next(t for t in out2.graph.initializer if t.data_type == onnx.TensorProto.INT4)

--- a/tests/test_gptq.py
+++ b/tests/test_gptq.py
@@ -252,3 +252,52 @@ def test_gptq_noop_when_no_int4_matmul_present():
         model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
     )
     assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_gptq_captures_a_shared_activation_only_once(monkeypatch):
+    # Q/K/V projections reading one shared LayerNorm output is the norm in a
+    # real transformer, and every calibration-driven pass in this repo probes
+    # each matched layer's activation by name. Collecting those names into a
+    # plain list (rather than a set) makes a shared tensor appear once per
+    # consuming layer, so the capture loop appends -- and later concatenates
+    # -- the same activation once per layer: N copies for N consumers, i.e.
+    # an N-times-larger Hessian to build and hold.
+    #
+    # The duplication is invisible in the *output* (H is scaled by a positive
+    # constant, and GPTQ's own column update depends only on the ratio
+    # hinv[i, j] / hinv[i, i], which that constant cancels out of), so only a
+    # structural check like this one catches a regression.
+    k, n = 32, 8
+    rng = np.random.default_rng(0)
+    model = _model(
+        f"""
+        g (float[batch,{k}] X) => (float[batch,{n}] Y1, float[batch,{n}] Y2)
+        {{
+          Y1 = MatMul(X, W1)
+          Y2 = MatMul(X, W2)
+        }}
+        """,
+        [
+            _f32(rng.standard_normal((k, n)) * 0.5, "W1"),
+            _f32(rng.standard_normal((k, n)) * 0.5, "W2"),
+        ],
+    )
+
+    seen = []
+    original = onnxsim.gptq._add_probe_outputs
+
+    def spy(m, names):
+        seen.append(list(names))
+        return original(m, names)
+
+    monkeypatch.setattr(onnxsim.gptq, "_add_probe_outputs", spy)
+    quant = onnxsim.quantize_weight_only_int4(model)
+    onnxsim.apply_gptq(
+        model,
+        quant,
+        calibration_data=[{"X": rng.standard_normal((16, k)).astype(np.float32)}],
+    )
+
+    assert seen, "apply_gptq did not probe any activation"
+    for names in seen:
+        assert len(names) == len(set(names)), f"duplicate probe names: {names}"

--- a/tests/test_gptq.py
+++ b/tests/test_gptq.py
@@ -301,3 +301,78 @@ def test_gptq_captures_a_shared_activation_only_once(monkeypatch):
     assert seen, "apply_gptq did not probe any activation"
     for names in seen:
         assert len(names) == len(set(names)), f"duplicate probe names: {names}"
+
+
+def _model_3d(k=64, n=16, seed=0):
+    # [batch, seq, K] -- the activation shape of essentially every real
+    # transformer, since ONNX MatMul broadcasts over leading dimensions.
+    rng = np.random.default_rng(seed)
+    return _model(
+        f"""
+        g (float[batch,seq,{k}] X) => (float[batch,seq,{n}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(rng.standard_normal((k, n)) * 0.5, "W")],
+    )
+
+
+def _correlated_calibration_3d(k=64, batch=8, seq=16, rank=6, seed=1):
+    rng = np.random.default_rng(seed)
+    latent = rng.standard_normal((batch, seq, rank)).astype(np.float32)
+    projection = rng.standard_normal((rank, k)).astype(np.float32)
+    x = latent @ projection
+    x += rng.standard_normal((batch, seq, k)).astype(np.float32) * 0.05
+    return x
+
+
+def test_gptq_handles_a_3d_transformer_shaped_activation():
+    # A [batch, seq, K] activation used to be filtered out entirely (the
+    # capture kept only ndim == 2 arrays), so apply_gptq silently returned
+    # quantized_model unchanged on exactly the model shape it exists for.
+    # Flattening the leading dimensions is exact -- the layer's own
+    # reconstruction objective sums over the same rows either way.
+    k, n = 64, 16
+    model = _model_3d(k=k, n=n, seed=0)
+    x = _correlated_calibration_3d(k=k, seed=1)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_weight_only_int4(model)
+    corrected = onnxsim.apply_gptq(model, quant, calibration_data=calibration_data)
+    onnx.checker.check_model(corrected)
+
+    assert corrected.SerializeToString() != quant.SerializeToString(), (
+        "apply_gptq was a no-op on a 3-D activation"
+    )
+
+    (float_y,) = _run(model, {"X": x})
+    (rtn_y,) = _run(quant, {"X": x})
+    (gptq_y,) = _run(corrected, {"X": x})
+    assert np.all(np.isfinite(gptq_y))
+    # Correlated channels are exactly the regime GPTQ's Hessian exploits, so
+    # the improvement over plain round-to-nearest is large here (measured
+    # ~0.11 -> ~0.02), not a marginal difference that could flip on another
+    # platform.
+    assert _rel_l2(float_y, gptq_y) < 0.5 * _rel_l2(float_y, rtn_y)
+
+
+def test_gptq_flattening_matches_an_equivalent_2d_calibration():
+    # Flattening [batch, seq, K] -> [batch * seq, K] must be *exact*, not an
+    # approximation: feeding the same rows as a 2-D batch has to produce
+    # byte-identical codes.
+    k, n = 32, 8
+    x3 = _correlated_calibration_3d(k=k, batch=4, seq=8, rank=4, seed=3)
+    model_3d = _model_3d(k=k, n=n, seed=2)
+    model_2d = _matmul_model(K=k, N=n, seed=2)
+
+    q3 = onnxsim.quantize_weight_only_int4(model_3d)
+    q2 = onnxsim.quantize_weight_only_int4(model_2d)
+    out3 = onnxsim.apply_gptq(model_3d, q3, calibration_data=[{"X": x3}])
+    out2 = onnxsim.apply_gptq(
+        model_2d, q2, calibration_data=[{"X": x3.reshape(-1, k)}]
+    )
+
+    w3 = next(t for t in out3.graph.initializer if t.data_type == onnx.TensorProto.INT4)
+    w2 = next(t for t in out2.graph.initializer if t.data_type == onnx.TensorProto.INT4)
+    assert w3.raw_data == w2.raw_data

--- a/tests/test_llm_fp4.py
+++ b/tests/test_llm_fp4.py
@@ -1,9 +1,14 @@
-"""Tests for ``onnxsim.quantize_weight_only_llm_fp4`` (LLM-FP4, see
+"""Tests for ``onnxsim.quantize_weight_only_llm_fp4`` and
+``onnxsim.apply_llm_fp4_activation_quantization`` (LLM-FP4, see
 ``onnxsim/llm_fp4.py``) -- block-wise quantization onto a searched
 sign/exponent/mantissa FP4 format (bit split searched per tensor) with a
 per-block *real-valued* scale (searched jointly, standing in for the
 paper's own "pre-shifted exponent bias"), represented in the ONNX graph via
-ordinary Gather/Reshape/Mul (no contrib op, no opset-21 features).
+ordinary Gather/Reshape/Mul (no contrib op, no opset-21 features), plus a
+per-token, data-free activation quantizer that completes W4A4 for layers
+already weight-quantized this way (a different granularity than the
+paper's own per-tensor-via-migration design -- see
+``apply_llm_fp4_activation_quantization``'s own docstring).
 
 Per this repo's own platform-numerics lesson (onnxruntime's MatMul kernel
 reduction order is not bit-exact across CPU architectures), value
@@ -341,3 +346,178 @@ def test_llm_fp4_restricting_formats_only_uses_requested_ones():
     assert "llm_fp4_codebook_e3m0" in names
     assert "llm_fp4_codebook_e1m2" not in names
     assert "llm_fp4_codebook_e2m1" not in names
+
+
+# --- apply_llm_fp4_activation_quantization -----------------------------
+#
+# A per-token, data-free activation-quantization pass that completes W4A4
+# for layers already weight-quantized by quantize_weight_only_llm_fp4 --
+# see that function's own docstring for exactly how this differs from the
+# paper's own per-tensor-via-migration design. Needs opset >= 18
+# (ReduceMax's axes-as-input form), so these models parse at opset 18
+# rather than the file's usual default of 13.
+
+
+def _matmul_model_opset18(K=64, N=16, weight=None, seed=0):
+    if weight is None:
+        rng = np.random.default_rng(seed)
+        weight = rng.standard_normal((K, N)).astype(np.float32) * 0.5
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        initializer=[_f32(weight, "W")],
+        opset=18,
+    )
+
+
+def test_llm_fp4_activation_quant_output_stays_close_to_float():
+    rng = np.random.default_rng(20)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model_opset18(weight=weight)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    qa = onnxsim.apply_llm_fp4_activation_quantization(q)
+    onnx.checker.check_model(qa)
+
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (qa_y,) = _run(qa, {"X": x})
+    assert np.all(np.isfinite(qa_y))
+    # Loose bound picked from a real run: this weight/input pair measured
+    # ~0.15 relative L2 error for the full W4A4 round-trip (vs. ~0.09 for
+    # weight-only FP4) -- both bit widths are lossy, so this is a sanity
+    # bound against a badly broken construction, not a tight accuracy claim.
+    assert _rel_l2(float_y, qa_y) < 0.4
+
+
+def test_llm_fp4_activation_quant_actually_changes_output():
+    # Proves the pass actually ran (inserted a real, non-identity
+    # quantize/dequantize round-trip) rather than silently no-op'ing.
+    rng = np.random.default_rng(21)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model_opset18(weight=weight)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    qa = onnxsim.apply_llm_fp4_activation_quantization(q)
+
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    (wonly_y,) = _run(q, {"X": x})
+    (qa_y,) = _run(qa, {"X": x})
+    # Measured ~0.10 relative L2 difference between weight-only and W4A4 on
+    # this model/input -- a generous margin well clear of floating-point
+    # noise, not a rounding-boundary tie.
+    assert _rel_l2(wonly_y, qa_y) > 0.02
+
+
+def test_llm_fp4_activation_quant_skips_plain_float_model():
+    # No quantize_weight_only_llm_fp4 pass has run at all: nothing in this
+    # model matches the exact weight-dequant pattern this function looks
+    # for, so it must come back byte-identical.
+    model = _matmul_model_opset18(seed=22)
+    out = onnxsim.apply_llm_fp4_activation_quantization(model)
+    assert out.SerializeToString() == model.SerializeToString()
+
+
+def test_llm_fp4_activation_quant_skips_differently_quantized_layer():
+    # A layer dequantized via a *different* pattern (a bare DequantizeLinear,
+    # as onnxsim.quantize_weight_only_int4 produces) is not
+    # quantize_weight_only_llm_fp4's own Gather/Reshape/Mul/Cast chain, so
+    # it must be left completely untouched -- this pass never runs the
+    # weight-side quantization itself and must not mistake one dequant
+    # scheme for another.
+    k, n = 64, 16
+    wq = onnx.TensorProto()
+    wq.name = "Wq"
+    wq.data_type = onnx.TensorProto.INT4
+    wq.dims.extend([k, n])
+    wq.raw_data = b"\x00" * (k * n // 2)
+    ws = _f32(np.ones((k // 32, n), dtype=np.float32), "Ws")
+
+    model = _model(
+        f"""
+        g (float[batch,{k}] X) => (float[batch,{n}] Y)
+        {{
+          Wdq = DequantizeLinear<axis = 0, block_size = 32>(Wq, Ws)
+          Y = MatMul(X, Wdq)
+        }}
+        """,
+        initializer=[wq, ws],
+        opset=21,
+    )
+    out = onnxsim.apply_llm_fp4_activation_quantization(model)
+    assert out.SerializeToString() == model.SerializeToString()
+
+
+def test_llm_fp4_activation_quant_uses_each_layers_own_codebook():
+    # Two weights chosen so the format search picks two different formats
+    # (mirrors test_llm_fp4_format_search_beats_a_forced_single_format's own
+    # adversarial-weight construction for the wide-range tensor); confirms
+    # the activation-quantization pass recovers and uses *each layer's own*
+    # codebook, not some other layer's.
+    k = 64
+    rng = np.random.default_rng(23)
+    exponents = rng.integers(-6, 7, size=(k, 16))
+    w_wide = (2.0**exponents).astype(np.float32) * rng.choice(
+        [-1.0, 1.0], size=(k, 16)
+    ).astype(np.float32)  # favors e3m0: wide dynamic range, coarse mantissa
+
+    rng2 = np.random.default_rng(24)
+    w_narrow = (rng2.standard_normal((k, 8)) * 0.3).astype(np.float32)
+
+    model = _model(
+        f"""
+        g (float[batch,{k}] X) => (float[batch,16] Y, float[batch,8] Z)
+        {{
+          Y = MatMul(X, W1)
+          Z = MatMul(X, W2)
+        }}
+        """,
+        initializer=[_f32(w_wide, "W1"), _f32(w_narrow, "W2")],
+        opset=18,
+    )
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+
+    def _codebook_name_used_by(model, w_name):
+        gather = next(
+            n
+            for n in model.graph.node
+            if n.op_type == "Gather" and n.input[1] == f"{w_name}_llmfp4_codes_i64"
+        )
+        return gather.input[0]
+
+    cb1_name = _codebook_name_used_by(q, "W1")
+    cb2_name = _codebook_name_used_by(q, "W2")
+    # The two adversarial weights must actually land on two different
+    # formats for this test to be meaningful.
+    assert cb1_name != cb2_name
+
+    qa = onnxsim.apply_llm_fp4_activation_quantization(q)
+    onnx.checker.check_model(qa)
+
+    # Each layer's own inserted nearest-codebook-lookup ("Sub" against the
+    # codebook) must reference that same layer's own codebook initializer.
+    subs = {n.name: n.input[1] for n in qa.graph.node if n.op_type == "Sub"}
+    w1_sub = next(name for name in subs if name.startswith("W1_llmfp4_dq_llmfp4act"))
+    w2_sub = next(name for name in subs if name.startswith("W2_llmfp4_dq_llmfp4act"))
+    assert subs[w1_sub] == cb1_name
+    assert subs[w2_sub] == cb2_name
+
+    # And the per-token scale's own denominator (that layer's codebook max
+    # magnitude) must match each codebook's real max, not a swapped one.
+    cb1 = onnx.numpy_helper.to_array(
+        next(t for t in qa.graph.initializer if t.name == cb1_name)
+    )
+    cb2 = onnx.numpy_helper.to_array(
+        next(t for t in qa.graph.initializer if t.name == cb2_name)
+    )
+    maxabs1 = onnx.numpy_helper.to_array(
+        next(t for t in qa.graph.initializer if t.name == f"{cb1_name}_maxabs")
+    )
+    maxabs2 = onnx.numpy_helper.to_array(
+        next(t for t in qa.graph.initializer if t.name == f"{cb2_name}_maxabs")
+    )
+    assert np.isclose(float(maxabs1), float(np.abs(cb1).max()))
+    assert np.isclose(float(maxabs2), float(np.abs(cb2).max()))
+    assert not np.isclose(float(maxabs1), float(maxabs2))

--- a/tests/test_llm_fp4.py
+++ b/tests/test_llm_fp4.py
@@ -1,14 +1,16 @@
-"""Tests for ``onnxsim.quantize_weight_only_llm_fp4`` and
-``onnxsim.apply_llm_fp4_activation_quantization`` (LLM-FP4, see
+"""Tests for ``onnxsim.quantize_weight_only_llm_fp4``,
+``onnxsim.apply_llm_fp4_activation_quantization`` and
+``onnxsim.apply_llm_fp4_activation_quantization_per_tensor`` (LLM-FP4, see
 ``onnxsim/llm_fp4.py``) -- block-wise quantization onto a searched
 sign/exponent/mantissa FP4 format (bit split searched per tensor) with a
 per-block *real-valued* scale (searched jointly, standing in for the
 paper's own "pre-shifted exponent bias"), represented in the ONNX graph via
-ordinary Gather/Reshape/Mul (no contrib op, no opset-21 features), plus a
-per-token, data-free activation quantizer that completes W4A4 for layers
-already weight-quantized this way (a different granularity than the
-paper's own per-tensor-via-migration design -- see
-``apply_llm_fp4_activation_quantization``'s own docstring).
+ordinary Gather/Reshape/Mul (no contrib op, no opset-21 features), plus the
+module's two activation-side passes completing W4A4 for layers already
+weight-quantized this way: a per-token, data-free one (a different
+granularity than the paper's own design) and a calibrated per-tensor one
+(the paper's own quantizer, whose per-channel outlier-migration half is the
+caller's job -- ``apply_smoothquant``/``apply_outlier_suppression`` first).
 
 Per this repo's own platform-numerics lesson (onnxruntime's MatMul kernel
 reduction order is not bit-exact across CPU architectures), value
@@ -521,3 +523,275 @@ def test_llm_fp4_activation_quant_uses_each_layers_own_codebook():
     assert np.isclose(float(maxabs1), float(np.abs(cb1).max()))
     assert np.isclose(float(maxabs2), float(np.abs(cb2).max()))
     assert not np.isclose(float(maxabs1), float(maxabs2))
+
+
+# --- apply_llm_fp4_activation_quantization_per_tensor -------------------
+#
+# The *calibrated per-tensor* activation quantizer: the paper's own
+# activation-side quantizer (its per-channel outlier-migration half is the
+# caller's job -- run apply_smoothquant/apply_outlier_suppression first).
+# One real-valued scale per activation tensor, fit offline from calibration
+# data by the same clip-ratio-vs-MSE grid search the weight side uses, and
+# emitted as a constant initializer -- so the inserted subgraph carries no
+# runtime range reduction at all, unlike the per-token pass above.
+#
+# Every numeric bound below was picked from a real measured run (see the
+# comment on each) with generous margin, per this repo's own lesson about
+# razor-thin single-seed inequalities.
+
+
+def _act_scale_initializers(model):
+    return [
+        t for t in model.graph.initializer if t.name.endswith("_llmfp4act_pt_scale")
+    ]
+
+
+def test_llm_fp4_per_tensor_activation_quant_output_stays_close_to_float():
+    rng = np.random.default_rng(20)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model_opset18(weight=weight)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    qa = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(q)
+    onnx.checker.check_model(qa)
+
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (qa_y,) = _run(qa, {"X": x})
+    assert np.all(np.isfinite(qa_y))
+    # Measured across six independent weight/input seeds: 0.137 -- 0.172
+    # relative L2 for the full W4A4 round-trip (vs. 0.074 -- 0.094 for
+    # weight-only FP4, and 0.125 -- 0.146 for the per-token pass on the
+    # same models). 0.4 is a generous sanity bound against a badly broken
+    # construction, not a tight accuracy claim.
+    assert _rel_l2(float_y, qa_y) < 0.4
+
+
+def test_llm_fp4_per_tensor_activation_quant_actually_changes_output():
+    # Proves the pass really ran (inserted a non-identity quantize/
+    # dequantize round-trip) rather than silently no-op'ing.
+    rng = np.random.default_rng(21)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model_opset18(weight=weight)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    qa = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(q)
+
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    (wonly_y,) = _run(q, {"X": x})
+    (qa_y,) = _run(qa, {"X": x})
+    # Measured 0.108 -- 0.146 relative L2 difference from weight-only
+    # across six seeds -- a generous margin above floating-point noise,
+    # not a rounding-boundary tie.
+    assert _rel_l2(wonly_y, qa_y) > 0.02
+
+
+def test_llm_fp4_per_tensor_activation_quant_emits_no_runtime_scale_and_fewer_nodes():
+    # The concrete structural difference between the two activation passes:
+    # a compile-time-constant scale means no Abs/ReduceMax/Max range
+    # reduction at graph-run time, so strictly fewer nodes than the
+    # per-token pass on the same model. That is the practical point of the
+    # per-tensor design.
+    rng = np.random.default_rng(25)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model_opset18(weight=weight)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    per_token = onnxsim.apply_llm_fp4_activation_quantization(q)
+    per_tensor = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(q)
+
+    op_types = [n.op_type for n in per_tensor.graph.node]
+    assert "ReduceMax" not in op_types
+    assert "Max" not in op_types
+    # The only Abs is the codebook-distance one (shared with the per-token
+    # pass); the per-token pass has a second Abs feeding its ReduceMax.
+    assert op_types.count("Abs") == 1
+    assert [n.op_type for n in per_token.graph.node].count("Abs") == 2
+
+    # 7 inserted nodes per layer (Div, Unsqueeze, Sub, Abs, ArgMin, Gather,
+    # Mul) vs. the per-token pass's 11 (those plus Abs/ReduceMax/Max and a
+    # second Div to derive the scale).
+    assert len(per_tensor.graph.node) - len(q.graph.node) == 7
+    assert len(per_token.graph.node) - len(q.graph.node) == 11
+    assert len(per_tensor.graph.node) < len(per_token.graph.node)
+
+
+def test_llm_fp4_per_tensor_activation_scale_is_a_constant_initializer():
+    rng = np.random.default_rng(26)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model_opset18(weight=weight)
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+    qa = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(q)
+
+    scales = _act_scale_initializers(qa)
+    assert len(scales) == 1
+    (scale_init,) = scales
+    assert scale_init.data_type == onnx.TensorProto.FLOAT
+    value = onnx.numpy_helper.to_array(scale_init)
+    assert value.size == 1  # scalar (0-d here) or 1-element
+    assert np.isfinite(float(value)) and float(value) > 0.0
+
+    # And it really is what the graph divides/multiplies by -- not a stray
+    # unused initializer next to a runtime-computed scale.
+    div = next(n for n in qa.graph.node if n.op_type == "Div")
+    mul = next(
+        n for n in qa.graph.node if n.op_type == "Mul" and n.input[1] == scale_init.name
+    )
+    assert div.input[1] == scale_init.name
+    assert mul.input[1] == scale_init.name
+
+
+def test_llm_fp4_per_tensor_activation_quant_works_at_opset_13():
+    # Unlike the per-token pass (which needs opset 18 for ReduceMax's
+    # axes-as-input form), this pass emits only Unsqueeze (axes-as-input:
+    # opset 13) plus ArgMin/Gather/Sub/Abs/Div/Mul, all older -- so opset
+    # 13 is enough, and the per-token pass declines the very same model.
+    rng = np.random.default_rng(27)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model(weight=weight)  # opset 13
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+
+    qa = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(q)
+    onnx.checker.check_model(qa)
+    assert len(qa.graph.node) > len(q.graph.node)
+
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    (qa_y,) = _run(qa, {"X": x})
+    assert np.all(np.isfinite(qa_y))
+
+    per_token = onnxsim.apply_llm_fp4_activation_quantization(q)
+    assert per_token.SerializeToString() == q.SerializeToString()
+
+
+def test_llm_fp4_per_tensor_activation_quant_skips_plain_float_model():
+    # No quantize_weight_only_llm_fp4 pass has run at all: nothing matches
+    # the exact weight-dequant pattern this function looks for, so it must
+    # come back byte-identical (and must not even run calibration).
+    model = _matmul_model_opset18(seed=28)
+    out = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(model)
+    assert out.SerializeToString() == model.SerializeToString()
+
+
+def test_llm_fp4_per_tensor_activation_quant_skips_differently_quantized_layer():
+    # A layer dequantized via a *different* scheme (a bare DequantizeLinear,
+    # as onnxsim.quantize_weight_only_int4 produces) is not
+    # quantize_weight_only_llm_fp4's own Gather/Reshape/Mul/Cast chain, so
+    # it must be left completely untouched -- this pass never runs the
+    # weight-side quantization itself and must not mistake one dequant
+    # scheme for another.
+    k, n = 64, 16
+    wq = onnx.TensorProto()
+    wq.name = "Wq"
+    wq.data_type = onnx.TensorProto.INT4
+    wq.dims.extend([k, n])
+    wq.raw_data = b"\x00" * (k * n // 2)
+    ws = _f32(np.ones((k // 32, n), dtype=np.float32), "Ws")
+
+    model = _model(
+        f"""
+        g (float[batch,{k}] X) => (float[batch,{n}] Y)
+        {{
+          Wdq = DequantizeLinear<axis = 0, block_size = 32>(Wq, Ws)
+          Y = MatMul(X, Wdq)
+        }}
+        """,
+        initializer=[wq, ws],
+        opset=21,
+    )
+    out = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(model)
+    assert out.SerializeToString() == model.SerializeToString()
+
+
+def test_llm_fp4_per_tensor_activation_quant_uses_each_layers_own_codebook():
+    # Two weights chosen so the format search picks two different formats
+    # (mirrors test_llm_fp4_activation_quant_uses_each_layers_own_codebook
+    # above); confirms each layer's inserted quantizer recovers and uses
+    # *that layer's own* codebook, not the other layer's, and fits its own
+    # separate scale.
+    k = 64
+    rng = np.random.default_rng(23)
+    exponents = rng.integers(-6, 7, size=(k, 16))
+    w_wide = (2.0**exponents).astype(np.float32) * rng.choice(
+        [-1.0, 1.0], size=(k, 16)
+    ).astype(np.float32)  # favors e3m0: wide dynamic range, coarse mantissa
+
+    rng2 = np.random.default_rng(24)
+    w_narrow = (rng2.standard_normal((k, 8)) * 0.3).astype(np.float32)
+
+    model = _model(
+        f"""
+        g (float[batch,{k}] X) => (float[batch,16] Y, float[batch,8] Z)
+        {{
+          Y = MatMul(X, W1)
+          Z = MatMul(X, W2)
+        }}
+        """,
+        initializer=[_f32(w_wide, "W1"), _f32(w_narrow, "W2")],
+        opset=18,
+    )
+    q = onnxsim.quantize_weight_only_llm_fp4(model, block_size=32)
+
+    def _codebook_name_used_by(model, w_name):
+        gather = next(
+            n
+            for n in model.graph.node
+            if n.op_type == "Gather" and n.input[1] == f"{w_name}_llmfp4_codes_i64"
+        )
+        return gather.input[0]
+
+    cb1_name = _codebook_name_used_by(q, "W1")
+    cb2_name = _codebook_name_used_by(q, "W2")
+    # The two adversarial weights must actually land on two different
+    # formats for this test to be meaningful.
+    assert cb1_name != cb2_name
+
+    qa = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(q)
+    onnx.checker.check_model(qa)
+
+    # Both layers read the same graph input X, so both inserted quantizers
+    # must exist, and each one's nearest-codebook lookup ("Sub" against the
+    # codebook) must reference its own layer's codebook -- the two together
+    # must cover both codebooks, not the same one twice.
+    subs = [n for n in qa.graph.node if n.op_type == "Sub"]
+    assert len(subs) == 2
+    assert {n.input[1] for n in subs} == {cb1_name, cb2_name}
+
+    # Two separately fit scales, one per layer: the two codebooks have
+    # different max magnitudes, so the same activation yields different
+    # scales.
+    scales = [float(onnx.numpy_helper.to_array(t)) for t in _act_scale_initializers(qa)]
+    assert len(scales) == 2
+    assert not np.isclose(scales[0], scales[1])
+
+    # Each MatMul must consume its own layer's dequantized activation, and
+    # the two must be different tensors.
+    matmuls = [n for n in qa.graph.node if n.op_type == "MatMul"]
+    assert len({n.input[0] for n in matmuls}) == 2
+
+
+def test_llm_fp4_per_tensor_activation_quant_composes_with_smoothquant():
+    # The paper's actual pipeline, and exactly the three-call sequence
+    # apply_llm_fp4_activation_quantization_per_tensor's own docstring tells
+    # callers to use: migrate the per-channel activation outliers first,
+    # then weight-quantize, then per-tensor activation-quantize. A smoke
+    # test that the composition really works end-to-end.
+    rng = np.random.default_rng(29)
+    weight = rng.standard_normal((64, 16)).astype(np.float32) * 0.5
+    model = _matmul_model_opset18(weight=weight)
+
+    migrated = onnxsim.apply_smoothquant(model)
+    weight_q = onnxsim.quantize_weight_only_llm_fp4(migrated, block_size=32)
+    w4a4 = onnxsim.apply_llm_fp4_activation_quantization_per_tensor(weight_q)
+    onnx.checker.check_model(w4a4)
+
+    # The migration's own Mul is still there, and the activation quantizer
+    # was inserted on top of it (not instead of it).
+    assert any(n.op_type == "ArgMin" for n in w4a4.graph.node)
+    assert len(_act_scale_initializers(w4a4)) == 1
+
+    x = rng.standard_normal((8, 64)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (w4a4_y,) = _run(w4a4, {"X": x})
+    assert np.all(np.isfinite(w4a4_y))
+    # Measured ~0.144 relative L2 for this sequence -- essentially the same
+    # as the un-migrated W4A4 run above (SmoothQuant has little to migrate
+    # on a synthetic Gaussian activation with no per-channel outliers).
+    # Same generous 0.4 sanity bound.
+    assert _rel_l2(float_y, w4a4_y) < 0.4

--- a/tests/test_omniquant.py
+++ b/tests/test_omniquant.py
@@ -223,3 +223,97 @@ def test_omniquant_noop_when_no_int4_matmul_present():
         model, model, calibration_data=[{"X": np.zeros((4, 4), dtype=np.float32)}]
     )
     assert result.SerializeToString() == model.SerializeToString()
+
+
+def _matmul_model_3d(K=64, N=16, seed=0):
+    # [batch, seq, K] -- the activation shape of essentially every real
+    # transformer, since ONNX MatMul broadcasts over leading dimensions.
+    rng = np.random.default_rng(seed)
+    return _model(
+        f"""
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(rng.standard_normal((K, N)).astype(np.float32) * 0.5, "W")],
+    )
+
+
+def _outlier_weight_calibration_3d(K=64, batch=8, seq=16, outlier_dims=(3, 7), seed=1):
+    # The 3-D counterpart of _outlier_weight_calibration: a nonzero
+    # per-channel mean (LET's shift should help) plus a couple of
+    # much-larger-magnitude channels (LET's scale and LWC's clipping should
+    # both help).
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((batch, seq, K)).astype(np.float32) + 2.0
+    for c in outlier_dims:
+        x[:, :, c] *= 20.0
+    return x
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_omniquant_handles_a_3d_transformer_shaped_activation(seed):
+    # A [batch, seq, K] activation used to be filtered out entirely (the
+    # capture kept only ndim == 2 arrays), so apply_omniquant silently
+    # returned quantized_model unchanged on exactly the model shape it
+    # exists for. Flattening the leading dimensions is exact -- LWC's and
+    # LET's own per-channel statistics sum over the same rows either way.
+    model = _matmul_model_3d(K=64, N=16, seed=seed)
+    x = _outlier_weight_calibration_3d(K=64, seed=seed + 400)
+    quant = onnxsim.quantize_weight_only_int4(model)
+
+    oq_model = onnxsim.apply_omniquant(model, quant, calibration_data=[{"X": x}])
+    onnx.checker.check_model(oq_model)
+    assert oq_model.SerializeToString() != quant.SerializeToString(), (
+        "apply_omniquant was a no-op on a 3-D activation"
+    )
+
+    (float_y,) = _run(model, {"X": x})
+    (rtn_y,) = _run(quant, {"X": x})
+    (oq_y,) = _run(oq_model, {"X": x})
+    assert np.all(np.isfinite(oq_y))
+    # Shifted, outlier-heavy channels are exactly what LET/LWC exist for,
+    # so the improvement over plain round-to-nearest is large here
+    # (measured ~0.12 -> ~0.035 across seeds), not a marginal difference
+    # that could flip on another platform.
+    assert _rel_l2(float_y, oq_y) < 0.7 * _rel_l2(float_y, rtn_y)
+
+
+def test_omniquant_flattening_matches_an_equivalent_2d_calibration():
+    # Flattening [batch, seq, K] -> [batch * seq, K] must be *exact*, not an
+    # approximation: feeding the same rows as a 2-D batch has to produce a
+    # byte-identical set of rewritten initializers (codes, scales, and
+    # LET's own shift/scale constants alike).
+    K, N = 32, 8
+    weight = (np.random.default_rng(5).standard_normal((K, N)) * 0.5).astype(np.float32)
+    model_3d = _model(
+        f"""
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+    model_2d = _matmul_model(K=K, N=N, weight=weight)
+    x3 = _outlier_weight_calibration_3d(K=K, batch=4, seq=8, outlier_dims=(2,), seed=6)
+
+    out3 = onnxsim.apply_omniquant(
+        model_3d,
+        onnxsim.quantize_weight_only_int4(model_3d),
+        calibration_data=[{"X": x3}],
+    )
+    out2 = onnxsim.apply_omniquant(
+        model_2d,
+        onnxsim.quantize_weight_only_int4(model_2d),
+        calibration_data=[{"X": x3.reshape(-1, K)}],
+    )
+    assert _initializer_bytes(out3) == _initializer_bytes(out2)
+
+
+def _initializer_bytes(model):
+    return sorted(
+        (t.name, onnx.numpy_helper.to_array(t).tobytes())
+        for t in model.graph.initializer
+    )

--- a/tests/test_owq.py
+++ b/tests/test_owq.py
@@ -270,3 +270,112 @@ def test_owq_noop_when_outlier_fraction_rounds_to_zero():
         model, quant, calibration_data=calibration_data, outlier_fraction=0.001
     )
     assert owq_model.SerializeToString() == quant.SerializeToString()
+
+
+def _matmul_model_3d_with_outlier_column(K=64, N=16, outlier_col=3, seed=0):
+    # _matmul_model_with_outlier_column's [batch, seq, K] counterpart --
+    # the activation shape of essentially every real transformer, since
+    # ONNX MatMul broadcasts over leading dimensions.
+    rng = np.random.default_rng(seed)
+    weight = rng.standard_normal((K, N)).astype(np.float32) * 0.1
+    weight[outlier_col, :] = rng.standard_normal(N).astype(np.float32) * 20.0
+    return _model(
+        f"""
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+
+
+def _calibration_3d(K=64, batch=6, seq=12, seed=1):
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((batch, seq, K)).astype(np.float32)
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_owq_handles_a_3d_transformer_shaped_activation(seed):
+    # A [batch, seq, K] activation used to be filtered out entirely (the
+    # capture kept only ndim == 2 arrays), so apply_owq silently returned
+    # quantized_model unchanged on exactly the model shape it exists for.
+    # Flattening the leading dimensions is exact -- the Hessian X^T X sums
+    # over the same rows either way.
+    model = _matmul_model_3d_with_outlier_column(K=64, N=16, outlier_col=3, seed=seed)
+    x = _calibration_3d(K=64, seed=seed + 300)
+    quant = onnxsim.quantize_weight_only_int4(model)
+
+    owq_model = onnxsim.apply_owq(model, quant, calibration_data=[{"X": x}])
+    onnx.checker.check_model(owq_model)
+    assert owq_model.SerializeToString() != quant.SerializeToString(), (
+        "apply_owq was a no-op on a 3-D activation"
+    )
+    # The rescued column is spliced back in via a Gather-fed correction
+    # term, exactly as on a 2-D activation.
+    assert any(n.op_type == "Gather" for n in owq_model.graph.node)
+
+    (float_y,) = _run(model, {"X": x})
+    (rtn_y,) = _run(quant, {"X": x})
+    (owq_y,) = _run(owq_model, {"X": x})
+    assert np.all(np.isfinite(owq_y))
+    # OWQ rescues a single column out of 64 here, so its reconstruction
+    # gain is real but small (measured ~3-4% across seeds). Assert only
+    # that the correction did not make things *worse* -- the exactness of
+    # what it wrote is checked deterministically below and by
+    # test_owq_correction_initializer_exactly_cancels_int4_error.
+    assert _rel_l2(float_y, owq_y) <= 1.05 * _rel_l2(float_y, rtn_y)
+
+
+def test_owq_flattening_matches_an_equivalent_2d_calibration():
+    # Flattening [batch, seq, K] -> [batch * seq, K] must be *exact*, not an
+    # approximation: feeding the same rows as a 2-D batch has to produce a
+    # byte-identical set of rewritten initializers (the rescued column
+    # indices and the delta_w correction alike).
+    K, N = 32, 8
+    rng = np.random.default_rng(4)
+    weight = (rng.standard_normal((K, N)) * 0.1).astype(np.float32)
+    weight[3, :] = (rng.standard_normal(N) * 20.0).astype(np.float32)
+    model_3d = _model(
+        f"""
+        g (float[batch,seq,{K}] X) => (float[batch,seq,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+    model_2d = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+    x3 = _calibration_3d(K=K, batch=4, seq=8, seed=5)
+
+    # K=32 with the default outlier_fraction would round to zero rescued
+    # columns and make this vacuous, so ask for a few explicitly.
+    out3 = onnxsim.apply_owq(
+        model_3d,
+        onnxsim.quantize_weight_only_int4(model_3d),
+        calibration_data=[{"X": x3}],
+        outlier_fraction=0.1,
+    )
+    out2 = onnxsim.apply_owq(
+        model_2d,
+        onnxsim.quantize_weight_only_int4(model_2d),
+        calibration_data=[{"X": x3.reshape(-1, K)}],
+        outlier_fraction=0.1,
+    )
+    assert any(n.op_type == "Gather" for n in out2.graph.node)
+    assert _initializer_bytes(out3) == _initializer_bytes(out2)
+
+
+def _initializer_bytes(model):
+    return sorted(
+        (t.name, onnx.numpy_helper.to_array(t).tobytes())
+        for t in model.graph.initializer
+    )

--- a/tests/test_quarot.py
+++ b/tests/test_quarot.py
@@ -1,7 +1,11 @@
-"""Tests for ``onnxsim.apply_quarot`` -- see ``onnxsim/quarot.py`` for the
-technique (random-rotation preprocessing, reused from
-``onnxsim.quip_sharp``, plus INT4 round-to-nearest quantization of *both*
-the weight and the activation -- no calibration data needed).
+"""Tests for ``onnxsim.apply_quarot``/``onnxsim.apply_quarot_gptq`` -- see
+``onnxsim/quarot.py`` for the technique (random-rotation preprocessing,
+reused from ``onnxsim.quip_sharp``, plus INT4 quantization of *both* the
+weight and the activation). ``apply_quarot`` needs no calibration data
+(plain round-to-nearest for the weight); ``apply_quarot_gptq`` is the same
+scheme but with the weight quantized via ``onnxsim.gptq``'s Hessian-based
+column algorithm, using real calibration activations captured in the
+*rotated* space.
 """
 
 import numpy as np
@@ -60,6 +64,18 @@ def _rel_l2(a, b):
     a = np.asarray(a, dtype=np.float64).ravel()
     b = np.asarray(b, dtype=np.float64).ravel()
     return np.linalg.norm(a - b) / max(np.linalg.norm(a), 1e-6)
+
+
+def _full_rank_calibration(K, num_samples=96, seed=1):
+    # A plain full-rank Gaussian, not a low-rank-plus-noise signal: keeps
+    # GPTQ's own Hessian (H = X^T X) well-conditioned, matching
+    # tests/test_gptaq.py's own ``_full_rank_calibration`` (see that
+    # module's docstring for why: a low-rank calibration signal makes the
+    # shared Cholesky factorization sensitive to which BLAS/LAPACK backend
+    # a given platform uses, risking a cross-platform tie in a
+    # margin-based comparison).
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((num_samples, K)).astype(np.float32)
 
 
 def test_quarot_output_stays_close_to_float_via_onnxruntime():
@@ -159,4 +175,173 @@ def test_quarot_noop_when_no_matmul_present():
 def test_quarot_declines_below_opset21():
     model = _matmul_model(K=32, N=8, opset=13)
     result = onnxsim.apply_quarot(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+# ---------------------------------------------------------------------------
+# apply_quarot_gptq
+# ---------------------------------------------------------------------------
+
+
+def test_quarot_gptq_rotation_matches_plain_quarot_for_same_seed():
+    # For a given seed, apply_quarot_gptq must derive the exact same
+    # per-layer rotation U as apply_quarot (it reuses that function's own
+    # rotation-derivation loop unchanged) -- checked byte-for-byte here.
+    model = _matmul_model(K=16, N=4, seed=3)
+    x = _full_rank_calibration(K=16, num_samples=32, seed=9)
+    calibration_data = [{"X": x}]
+
+    q_rtn = onnxsim.apply_quarot(model, block_size=4, seed=4)
+    q_gptq = onnxsim.apply_quarot_gptq(
+        model, calibration_data=calibration_data, block_size=4, seed=4
+    )
+
+    u_rtn = next(t for t in q_rtn.graph.initializer if t.name.endswith("_quarot_u"))
+    u_gptq = next(
+        t for t in q_gptq.graph.initializer if t.name.endswith("_quarot_gptq_u")
+    )
+    assert u_rtn.raw_data == u_gptq.raw_data or np.array_equal(
+        onnx.numpy_helper.to_array(u_rtn), onnx.numpy_helper.to_array(u_gptq)
+    )
+
+
+def test_quarot_gptq_output_stays_close_to_float_via_onnxruntime():
+    model = _matmul_model(K=64, N=16, seed=0)
+    x = _full_rank_calibration(K=64, num_samples=96, seed=100)
+    calibration_data = [{"X": x}]
+
+    q = onnxsim.apply_quarot_gptq(
+        model, calibration_data=calibration_data, block_size=16, seed=1
+    )
+    onnx.checker.check_model(q)
+
+    op_types = [n.op_type for n in q.graph.node]
+    assert op_types.count("MatMul") == 2  # X rotation, core
+    assert "DequantizeLinear" in op_types
+    assert "ReduceMax" in op_types  # data-free per-token activation scale
+
+    (float_y,) = _run(model, {"X": x})
+    (q_y,) = _run(q, {"X": x})
+    assert np.all(np.isfinite(q_y))
+    assert _rel_l2(float_y, q_y) < 0.5
+
+
+def test_quarot_gptq_beats_plain_round_to_nearest_on_aggregate():
+    # GPTQ's whole point is a tighter reconstruction error than
+    # independent round-to-nearest on the same rotated weight/activation
+    # pair. Empirically (see this session's verification harness) the
+    # per-seed margin is real but modest (~5-10% relative L2, GPTQ always
+    # at least as good, never worse, across 20 independent seeds tried
+    # while writing this test) -- thin enough that trusting a single fixed
+    # seed risks a cross-platform tie (the same concern
+    # tests/test_gptaq.py's own comparison test flags and works around).
+    # Aggregate the squared reconstruction error across several
+    # independent weight/rotation/calibration seeds instead of trusting
+    # one comparison.
+    total_sq_rtn = 0.0
+    total_sq_gptq = 0.0
+    for seed in range(5):
+        model = _matmul_model(K=64, N=16, seed=seed)
+        x = _full_rank_calibration(K=64, num_samples=96, seed=seed + 100)
+        calibration_data = [{"X": x}]
+
+        q_rtn = onnxsim.apply_quarot(model, block_size=16, seed=seed + 1)
+        q_gptq = onnxsim.apply_quarot_gptq(
+            model, calibration_data=calibration_data, block_size=16, seed=seed + 1
+        )
+        onnx.checker.check_model(q_rtn)
+        onnx.checker.check_model(q_gptq)
+
+        (float_y,) = _run(model, {"X": x})
+        (rtn_y,) = _run(q_rtn, {"X": x})
+        (gptq_y,) = _run(q_gptq, {"X": x})
+        assert np.all(np.isfinite(gptq_y))
+
+        float_y64 = float_y.astype(np.float64)
+        total_sq_rtn += float(np.sum((float_y64 - rtn_y) ** 2))
+        total_sq_gptq += float(np.sum((float_y64 - gptq_y) ** 2))
+
+    # A comfortable, empirically-verified margin (aggregate GPTQ error
+    # comes in around 90-95% of aggregate RTN error across these seeds).
+    assert total_sq_gptq < 0.98 * total_sq_rtn
+
+
+def test_quarot_gptq_skips_layer_with_no_calibration_data():
+    model = _matmul_model(K=32, N=8, seed=0)
+    result = onnxsim.apply_quarot_gptq(model, calibration_data=[], block_size=8)
+    # No calibration batch ever reached the candidate layer's own probe,
+    # so it must be left completely untouched -- not silently quantized
+    # via plain round-to-nearest under GPTQ's own name.
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_quarot_gptq_skips_layer_with_mismatched_activation_shape(monkeypatch):
+    # A captured activation whose feature dimension doesn't match the
+    # layer's own K must be skipped (mirrors onnxsim.gptq.apply_gptq's own
+    # shape-mismatch skip) rather than used anyway.
+    model = _matmul_model(K=32, N=8, seed=0)
+
+    def fake_run_model(probe_model, batch, providers=None):
+        # Feature dim 16 != K=32.
+        return {"X": np.zeros((4, 16), dtype=np.float32)}
+
+    monkeypatch.setattr(onnxsim.quarot.backend, "run_model", fake_run_model)
+    result = onnxsim.apply_quarot_gptq(
+        model,
+        calibration_data=[{"X": np.zeros((1, 32), dtype=np.float32)}],
+        block_size=8,
+    )
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_quarot_gptq_skips_layer_with_non_2d_activation(monkeypatch):
+    model = _matmul_model(K=32, N=8, seed=0)
+
+    def fake_run_model(probe_model, batch, providers=None):
+        return {"X": np.zeros((4, 32, 2), dtype=np.float32)}  # 3-D, not 2-D
+
+    monkeypatch.setattr(onnxsim.quarot.backend, "run_model", fake_run_model)
+    result = onnxsim.apply_quarot_gptq(
+        model,
+        calibration_data=[{"X": np.zeros((1, 32), dtype=np.float32)}],
+        block_size=8,
+    )
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_quarot_gptq_declines_when_k_not_divisible_by_block_size():
+    model = _matmul_model(K=20, N=4, seed=7)  # 20 is not a multiple of 8
+    q = onnxsim.apply_quarot_gptq(model, block_size=8)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_quarot_gptq_declines_non_constant_weight():
+    model = _model(
+        """
+        g (float[4,32] X, float[32,4] W) => (float[4,4] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
+    q = onnxsim.apply_quarot_gptq(model)
+    assert q.SerializeToString() == model.SerializeToString()
+
+
+def test_quarot_gptq_noop_when_no_matmul_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    result = onnxsim.apply_quarot_gptq(model)
+    assert result.SerializeToString() == model.SerializeToString()
+
+
+def test_quarot_gptq_declines_below_opset21():
+    model = _matmul_model(K=32, N=8, opset=13)
+    result = onnxsim.apply_quarot_gptq(model)
     assert result.SerializeToString() == model.SerializeToString()

--- a/tests/test_quarot.py
+++ b/tests/test_quarot.py
@@ -345,3 +345,342 @@ def test_quarot_gptq_declines_below_opset21():
     model = _matmul_model(K=32, N=8, opset=13)
     result = onnxsim.apply_quarot_gptq(model)
     assert result.SerializeToString() == model.SerializeToString()
+
+
+# --- apply_quarot_fused ------------------------------------------------
+# The same rotation, folded into the producing layer's weight so it costs
+# nothing at inference. See onnxsim/quarot.py's own docstring.
+
+
+def _u_initializers(model):
+    return [t.name for t in model.graph.initializer if t.name.endswith("_quarot_u")]
+
+
+def _two_layer_model(K=32, M=32, N=8, seed=0):
+    rng = np.random.default_rng(seed)
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          T = MatMul(X, W1)
+          Y = MatMul(T, W2)
+        }}
+        """,
+        initializer=[
+            _f32(rng.standard_normal((K, M)) * 0.5, "W1"),
+            _f32(rng.standard_normal((M, N)) * 0.5, "W2"),
+        ],
+    )
+
+
+def _three_layer_model(K=32, M=32, P=32, N=8, seed=0):
+    rng = np.random.default_rng(seed)
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          A = MatMul(X, W1)
+          B = MatMul(A, W2)
+          Y = MatMul(B, W3)
+        }}
+        """,
+        initializer=[
+            _f32(rng.standard_normal((K, M)) * 0.5, "W1"),
+            _f32(rng.standard_normal((M, P)) * 0.5, "W2"),
+            _f32(rng.standard_normal((P, N)) * 0.5, "W3"),
+        ],
+    )
+
+
+def test_quarot_fused_emits_no_rotation_node_for_the_fused_layer():
+    model = _two_layer_model()
+    fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=1)
+    onnx.checker.check_model(fused)
+
+    # Both layers are quantized, but only the first -- whose activation is
+    # the graph input X -- still needs a runtime MatMul(X, U). The second
+    # layer's rotation is folded into W1, so it has no U at all.
+    assert _u_initializers(fused) == ["W1_quarot_u"]
+    names = {t.name for t in fused.graph.initializer}
+    assert "W2_quarot_codes" in names  # ...but it is still quantized
+
+
+def test_quarot_fused_has_strictly_fewer_nodes_than_apply_quarot():
+    model = _two_layer_model()
+    plain = onnxsim.apply_quarot(model, block_size=8, seed=1)
+    fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=1)
+    # Exactly the one fused layer's MatMul(X, U) is gone.
+    assert len(fused.graph.node) == len(plain.graph.node) - 1
+    plain_ops = [n.op_type for n in plain.graph.node]
+    fused_ops = [n.op_type for n in fused.graph.node]
+    assert fused_ops.count("MatMul") == plain_ops.count("MatMul") - 1
+    assert len(_u_initializers(fused)) == len(_u_initializers(plain)) - 1
+
+
+def test_quarot_fused_is_about_as_accurate_as_apply_quarot():
+    # The fold is exact algebra, so the only lossy steps are the same two
+    # INT4 roundings apply_quarot already does -- but the rotation now
+    # happens inside a different float matmul, so the two are not
+    # bit-identical. Aggregate across seeds rather than betting on one.
+    plain_errors = []
+    fused_errors = []
+    for s in range(6):
+        model = _two_layer_model(seed=s)
+        plain = onnxsim.apply_quarot(model, block_size=8, seed=s + 1)
+        fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=s + 1)
+        x = np.random.default_rng(500 + s).standard_normal((16, 32)).astype(np.float32)
+        (float_y,) = _run(model, {"X": x})
+        (plain_y,) = _run(plain, {"X": x})
+        (fused_y,) = _run(fused, {"X": x})
+        assert np.all(np.isfinite(fused_y))
+        plain_errors.append(_rel_l2(float_y, plain_y))
+        fused_errors.append(_rel_l2(float_y, fused_y))
+
+    # Verified from real runs: both land around 0.17 mean, 0.23 max here.
+    assert np.mean(fused_errors) < 0.4
+    # Generous slack -- a layout/axis bug in the fold shows up as a
+    # several-times-worse error, not as a few percent.
+    assert np.mean(fused_errors) < 1.5 * np.mean(plain_errors) + 0.05
+
+
+def test_quarot_fused_chained_three_layers_round_trips():
+    # A -> B -> C: the middle layer is both a fused producer (its output
+    # dim carries C's rotation) and a quantized consumer (its reduction
+    # dim carries its own). Both rotations must be applied while the
+    # weight is still float; getting either axis wrong wrecks the numbers,
+    # not the shapes, so this has to be a real numeric check.
+    plain_errors = []
+    fused_errors = []
+    for s in range(6):
+        model = _three_layer_model(seed=s)
+        plain = onnxsim.apply_quarot(model, block_size=8, seed=s + 1)
+        fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=s + 1)
+        onnx.checker.check_model(fused)
+        # Only the first layer, fed by the graph input, keeps a runtime U.
+        assert _u_initializers(fused) == ["W1_quarot_u"]
+        assert len(fused.graph.node) == len(plain.graph.node) - 2
+
+        x = np.random.default_rng(700 + s).standard_normal((16, 32)).astype(np.float32)
+        (float_y,) = _run(model, {"X": x})
+        (plain_y,) = _run(plain, {"X": x})
+        (fused_y,) = _run(fused, {"X": x})
+        assert np.all(np.isfinite(fused_y))
+        plain_errors.append(_rel_l2(float_y, plain_y))
+        fused_errors.append(_rel_l2(float_y, fused_y))
+
+    # Verified from real runs: both land around 0.23 mean, 0.28 max here.
+    assert np.mean(fused_errors) < 0.5
+    assert np.mean(fused_errors) < 1.5 * np.mean(plain_errors) + 0.05
+
+
+def test_quarot_fused_gemm_producer_folds_the_bias_too():
+    # b_P' = b_P @ U, on the bias's output-channel axis. Left unrotated,
+    # the layer would emit T @ U + b_P instead of (T + b_P) @ U, which is
+    # visibly wrong rather than slightly noisy.
+    rng = np.random.default_rng(21)
+    K, M, N = 32, 32, 8
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          T = Gemm<transB=1>(X, W1, B1)
+          Y = Gemm(T, W2, B2)
+        }}
+        """,
+        initializer=[
+            _f32(rng.standard_normal((M, K)) * 0.5, "W1"),
+            _f32(rng.standard_normal((M,)) * 0.5, "B1"),
+            _f32(rng.standard_normal((M, N)) * 0.5, "W2"),
+            _f32(rng.standard_normal((N,)) * 0.1, "B2"),
+        ],
+    )
+    fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=2)
+    onnx.checker.check_model(fused)
+    assert _u_initializers(fused) == ["W1_quarot_u"]
+    assert "B1_quarot_folded" in {t.name for t in fused.graph.initializer}
+
+    x = rng.standard_normal((16, K)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (fused_y,) = _run(fused, {"X": x})
+    assert _rel_l2(float_y, fused_y) < 0.5
+
+
+def test_quarot_fused_folds_into_a_producer_it_does_not_quantize():
+    # The producer's own K=20 is not divisible by block_size 8, so it is
+    # left in float -- but its weight is still constant, so the consumer's
+    # rotation folds into it exactly and its rotated float weight is
+    # simply written back under a fresh name.
+    rng = np.random.default_rng(22)
+    model = _model(
+        """
+        g (float[batch,20] X) => (float[batch,8] Y)
+        {
+          T = MatMul(X, W1)
+          Y = MatMul(T, W2)
+        }
+        """,
+        initializer=[
+            _f32(rng.standard_normal((20, 32)) * 0.5, "W1"),
+            _f32(rng.standard_normal((32, 8)) * 0.5, "W2"),
+        ],
+    )
+    fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=2)
+    onnx.checker.check_model(fused)
+    assert _u_initializers(fused) == []
+    assert "W1_quarot_folded" in {t.name for t in fused.graph.initializer}
+
+    x = rng.standard_normal((16, 20)).astype(np.float32)
+    (float_y,) = _run(model, {"X": x})
+    (fused_y,) = _run(fused, {"X": x})
+    assert _rel_l2(float_y, fused_y) < 0.5
+
+
+def test_quarot_fused_declines_when_activation_has_two_consumers():
+    # Rotating T for one consumer would corrupt the other, so both layers
+    # fall back to apply_quarot's explicit runtime rotation -- which is
+    # exactly what apply_quarot itself produces here, byte for byte.
+    rng = np.random.default_rng(23)
+    K, M, N = 32, 32, 8
+    model = _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          T = MatMul(X, W1)
+          Y1 = MatMul(T, W2)
+          Y2 = MatMul(T, W3)
+          Y = Add(Y1, Y2)
+        }}
+        """,
+        initializer=[
+            _f32(rng.standard_normal((K, M)) * 0.5, "W1"),
+            _f32(rng.standard_normal((M, N)) * 0.5, "W2"),
+            _f32(rng.standard_normal((M, N)) * 0.5, "W3"),
+        ],
+    )
+    plain = onnxsim.apply_quarot(model, block_size=8, seed=3)
+    fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=3)
+    assert len(_u_initializers(fused)) == 3
+    assert fused.SerializeToString() == plain.SerializeToString()
+
+
+def test_quarot_fused_declines_when_producer_output_is_a_graph_output():
+    # T must keep its unrotated value for whoever reads it.
+    rng = np.random.default_rng(24)
+    model = _model(
+        """
+        g (float[batch,32] X) => (float[batch,32] T, float[batch,8] Y)
+        {
+          T = MatMul(X, W1)
+          Y = MatMul(T, W2)
+        }
+        """,
+        initializer=[
+            _f32(rng.standard_normal((32, 32)) * 0.5, "W1"),
+            _f32(rng.standard_normal((32, 8)) * 0.5, "W2"),
+        ],
+    )
+    plain = onnxsim.apply_quarot(model, block_size=8, seed=3)
+    fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=3)
+    assert len(_u_initializers(fused)) == 2
+    assert fused.SerializeToString() == plain.SerializeToString()
+
+
+def test_quarot_fused_declines_non_constant_producer_weight():
+    # Nothing to fold into: W1 is a graph input, not an initializer.
+    rng = np.random.default_rng(25)
+    model = _model(
+        """
+        g (float[batch,32] X, float[32,32] W1) => (float[batch,8] Y)
+        {
+          T = MatMul(X, W1)
+          Y = MatMul(T, W2)
+        }
+        """,
+        initializer=[_f32(rng.standard_normal((32, 8)) * 0.5, "W2")],
+    )
+    plain = onnxsim.apply_quarot(model, block_size=8, seed=3)
+    fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=3)
+    assert _u_initializers(fused) == ["W2_quarot_u"]
+    assert fused.SerializeToString() == plain.SerializeToString()
+
+
+def test_quarot_fused_declines_broadcast_gemm_bias():
+    # A scalar Gemm bias has no output-channel axis for b @ U to act on.
+    rng = np.random.default_rng(26)
+    model = _model(
+        """
+        g (float[batch,32] X) => (float[batch,8] Y)
+        {
+          T = Gemm(X, W1, B1)
+          Y = MatMul(T, W2)
+        }
+        """,
+        initializer=[
+            _f32(rng.standard_normal((32, 32)) * 0.5, "W1"),
+            _f32(np.array(0.25, dtype=np.float32), "B1"),
+            _f32(rng.standard_normal((32, 8)) * 0.5, "W2"),
+        ],
+    )
+    plain = onnxsim.apply_quarot(model, block_size=8, seed=3)
+    fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=3)
+    assert len(_u_initializers(fused)) == 2
+    assert fused.SerializeToString() == plain.SerializeToString()
+
+
+def test_quarot_fused_leaves_a_shared_producer_weight_intact():
+    # W1 feeds two nodes; only the one whose output is fused gets the
+    # rotated copy, under a fresh name. The other must stay exact.
+    rng = np.random.default_rng(27)
+    model = _model(
+        """
+        g (float[batch,20] X) => (float[batch,8] Y, float[batch,32] Z)
+        {
+          T = MatMul(X, W1)
+          Z = MatMul(X, W1)
+          Y = MatMul(T, W2)
+        }
+        """,
+        initializer=[
+            _f32(rng.standard_normal((20, 32)) * 0.5, "W1"),
+            _f32(rng.standard_normal((32, 8)) * 0.5, "W2"),
+        ],
+    )
+    fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=3)
+    onnx.checker.check_model(fused)
+    x = rng.standard_normal((16, 20)).astype(np.float32)
+    float_y, float_z = _run(model, {"X": x})
+    fused_y, fused_z = _run(fused, {"X": x})
+    assert np.allclose(float_z, fused_z, atol=1e-5)
+    assert _rel_l2(float_y, fused_y) < 0.5
+
+
+def test_quarot_fused_matches_apply_quarot_when_nothing_is_fusable():
+    model = _matmul_model(K=32, N=8, seed=8)
+    plain = onnxsim.apply_quarot(model, block_size=8, seed=9)
+    fused = onnxsim.apply_quarot_fused(model, block_size=8, seed=9)
+    assert fused.SerializeToString() == plain.SerializeToString()
+
+
+def test_quarot_fused_declines_when_k_not_divisible_by_block_size():
+    model = _matmul_model(K=20, N=4, seed=10)
+    fused = onnxsim.apply_quarot_fused(model, block_size=8)
+    assert fused.SerializeToString() == model.SerializeToString()
+
+
+def test_quarot_fused_noop_when_no_matmul_present():
+    model = _model(
+        """
+        g (float[4,4] X) => (float[4,4] Y)
+        {
+          Y = Relu(X)
+        }
+        """
+    )
+    fused = onnxsim.apply_quarot_fused(model)
+    assert fused.SerializeToString() == model.SerializeToString()
+
+
+def test_quarot_fused_declines_below_opset21():
+    model = _matmul_model(K=32, N=8, opset=13)
+    fused = onnxsim.apply_quarot_fused(model)
+    assert fused.SerializeToString() == model.SerializeToString()


### PR DESCRIPTION
Three strands: a significant bug fix, two feature gaps the repo's own docs flagged as future work, and the NNCF benchmark those docs asked for (which is what surfaced the bug).

## The bug: 26 calibration-driven passes did nothing on real transformers

Every calibration-driven PTQ pass captured each matched layer's activation and kept only arrays with `ndim == 2`. But a MatMul/Gemm activation is `[..., K]`: 2-D for a plain MLP, and `[batch, seq, hidden]` for essentially every real transformer, since ONNX MatMul broadcasts over leading dimensions.

So on the models these techniques exist for, `apply_gptq`, `apply_awq`, `apply_adaround`, `apply_owq` and 22 others **returned the input model completely unchanged, with no diagnostic** — the pass looked like it ran and did nothing.

Measured on a `[batch, seq, K]` MatMul with correlated calibration data:

| pass | before | after |
|---|---|---|
| GPTQ | 0.11005 (untouched RTN) | 0.02425 |
| AdaRound | ~0.10 | ~0.035 |
| OmniQuant | ~0.12 | ~0.035 |

Collapsing the leading dimensions is **exact**, not an approximation: a layer's reconstruction objective `||W X^T - Ŵ X^T||²` sums over the same rows however the leading dimensions group them. Tests assert this directly — a `[batch, seq, K]` calibration and the same rows reshaped to `[batch*seq, K]` produce byte-identical rewritten initializers.

All 26 were verified no-op-before / active-after by running each module's real entry point. Two were not mechanical and were handled on their own terms rather than substituted blindly:

- **brecq** pairs a block's input with that block's own output; it now keeps the pair only when row counts agree, so a block that doesn't preserve its token axis is declined rather than silently misaligning samples.
- **qronos** subtracts two separately-captured tensors; it now requires their flattened row counts to match, which its old pair of independent guards never checked.

Deliberately **not** included: a separate `ndim != 2` family (`smoothquant`, `llm_int8`, `rptq`, `duquant`, and ~6 others) spells the same restriction differently, but several *reduce over* the row axis for per-channel statistics rather than solving against it. Each needs its own analysis, so they are left for a follow-up rather than changed blind.

## Other fixes

- **Duplicate activation capture (18 modules).** Probe names were collected into a list, so a tensor shared by several layers — Q/K/V reading one LayerNorm output, the norm in any transformer — was captured and concatenated once *per consuming layer*, building an N× larger Hessian. Output is unaffected (H is scaled by a positive constant, which cancels out of GPTQ's `hinv[i,j]/hinv[i,i]` ratio), which is why it went unnoticed; a structural regression test covers it, verified to fail before the fix and pass after.
- **Unbounded allocation** in the per-tensor FP4 scale fit: it fed every concatenated calibration sample into a routine that materializes a `size × 16` float64 tensor per candidate clip ratio. Now a bounded deterministic subsample, with `max_abs` still exact over all data.
- Two stale docstrings, including one still claiming W4A4 was out of scope after the passes implementing it landed.

## Features (both flagged as future work in this repo's own docs)

- **`apply_quarot_fused`** — folds each layer's rotation into the producing layer's weight (`W_P' = W_P @ U`, `b_P' = b_P @ U`), so the rotation costs zero runtime ops instead of an explicit `MatMul(X, U)` per layer. Exact algebra, so accuracy matches `apply_quarot`; only the cost goes away. Handles the chained `A→B→C` case (rotations on different axes compose, applied in float before quantization). Non-fusable edges fall back to the explicit rotation.
- **`apply_llm_fp4_activation_quantization_per_tensor`** — the LLM-FP4 paper's own calibrated per-tensor activation quantizer (grid-searched real-valued scale, emitted as a constant, no runtime `ReduceMax`), composing with `apply_smoothquant`/`apply_outlier_suppression` for the paper's full per-channel-migration pipeline. Complements the existing per-token data-free pass.

## Benchmark (`docs/nncf-comparison-future-work.md` item 3)

`bench/nncf_comparison.py` plus measured results in `bench/RESULTS_nncf_comparison.md`, run against NNCF 3.3.0. At matched settings (`all_layers=True`, `group_size=32`, both at 6.40× compression): **onnxsim+GPTQ 0.1571, NNCF best 0.1698, onnxsim RTN 0.1953**.

Two corrections were needed before those numbers meant anything, and both are findings in their own right — the first is what led to the 3-D bug above:

1. onnxsim quantized **1 of 4 layers** in the first run, because its INT4 pass silently declines a MatMul whose activation element type it can't read, and a hand-built graph has no `value_info` for intermediate tensors.
2. onnxsim+GPTQ measured **0.2384 — worse than plain RTN** — because the calibration set had 64 rows for a `K=256` Hessian. Sized above `K` the same configuration becomes the best result in the table. Undersized calibration data inverts the conclusion.

A third finding, verified by decoding both tools' initializers: **onnxsim emits INT4 codes in `[-7, 7]` while NNCF uses `[-8, 7]`**, making onnxsim's step ~12.5% coarser at byte-identical size — which accounts for the plain-RTN gap. Recorded as a measured trade-off rather than a bug to fix blindly, since a symmetric grid keeps `-x` representable whenever `x` is and other passes rely on that.

## Verification

Full suite green at **3457 passed, 198 skipped** against latest master, run with onnxsim's C++ extension actually built (not stubbed). `ruff format`/`ruff check` clean; `mypy` unchanged at its 26 pre-existing errors (all guarded-`None` narrowing and onnx stub gaps — checked, not real).

Known follow-up left undone deliberately: `apply_quarot_gptq` still duplicates the emission block that `_emit_quarot_layer` now shares with the other two entry points. Unifying them needs an optional-precomputed-codes parameter, and a careless version would silently swap GPTQ's codes for RTN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bXu6wmjxZVj66UcGxvdFU

---
_Generated by [Claude Code](https://claude.ai/code/session_011bXu6wmjxZVj66UcGxvdFU)_