### PR TITLE
mcode: correction -- the segment table's word counts are load-bearing, the rest is not

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3158,21 +3158,41 @@ Admitting them takes the config segments' non-zero bytes from 97.4% to
 segments stay at ~46% under the same rule). `_tokenize_mcode` takes
 these as `odd_tags`.
 
-**Confirmed on the AX650N: the segment table is a loader manifest the
-runtime validates field by field.** Patching one field of the decode
-subgraph's tail tables and re-running with valid inputs, every variant
-faulted with `0x8030070C` on every run (3 of 3 each, baseline
-bit-identical 3 of 3): the op segment's type word `0x8801 -> 0xe801`;
-its word count `f2 + 1`; its remaining count `f3 + 1`; table 0's total
-`f3 + 1`; a 6-field table's byte size `f5 - 64`; the same table's
-packed word `f4 + 1`; and table 0's own `f2 + 1`. Two of them (the type
-word's first run and the total-count patch) first hung the runtime for
-about two minutes -- `axcl_run_model` in uninterruptible sleep and
-`axcl-smi` blocked behind it -- before the fault surfaced, so a wrong
-segment table is the one patch class found so far that can stall the
-device rather than fail fast. Treat the table as load-bearing: an
-emitter must write the word counts, the countdown, the packed
-`f3 << 8 | 1` and the byte sizes exactly, not as metadata.
+**Confirmed on the AX650N: the segment table is a loader manifest --
+but only its word counts are load-bearing, and the first version of
+this paragraph got that wrong.** The first series of tail-table patches
+(type word, word count, remaining count, total, byte size, packed word,
+each on its own) reported a `0x8030070C` fault for *every* variant, 3 of
+3 each. That table was measured after the first variant -- the type
+word `0x8801 -> 0xe801` -- had already stalled the runtime for about two
+minutes, and after the series the driver's heartbeat thread stayed
+blocked until a reboot; the faults were the degraded device, not
+validation. Redone on the healthy device, one variant at a time with an
+`axcl-smi` health check and a baseline control run after each
+(baseline bit-identical throughout):
+
+| patch (decode subgraph tail tables) | result |
+|---|---|
+| a 6-field table's byte size `f5 - 64` | runs, outputs **identical** |
+| the same table's packed word `f4 + 1` | runs, outputs **identical** |
+| op segment word count `f2 + 1` | runs, outputs **identical** |
+| op segment remaining count `f3 + 1` | runs, outputs **identical** |
+| table 0 word count `f2 + 1` | **`Loading model failed`** -- rejected at load, no fault, device unharmed |
+| table 0 total `f3 + 1` | **`Loading model failed`** -- same |
+| op segment word count `f2 - 1` | **fault `0x8030070C`** at run, device unharmed |
+| table 0 word count `f2 - 1` | **fault `0x8030070C`** at run, device unharmed |
+| op segment type word `0x8801 -> 0xe801` | not repeated: the one patch that wedged the runtime |
+
+So the loader reads the word counts (`f2`) and table 0's total (`f3`) to
+lay the segments out: a count that overshoots the blob is rejected at
+load, a count shorter than its segment lets the run read a truncated
+program and fault, and a mid-table count one word too long merely reads
+8 bytes of padding. The remaining count, the packed `f3 << 8 | 1` and the
+byte size are compiler bookkeeping the runtime does not check. An
+emitter must get the word counts and the total exactly right; the rest
+it can mirror without consequence. The one caution stands: a bad *type
+word* is the patch class that stalls the device rather than failing
+fast, and it is the one to avoid.
 
 **`llm_build` emits one instruction stream for all 30 layers.** Every
 per-layer file's two mcodes are byte-identical to layer 0's from the

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -3388,3 +3388,83 @@ def test_resnet18d_a1_is_a_tag_and_bit6_tags_take_odd_registers(tmp_path):
     before = nonzero_residue(blob)
     after = nonzero_residue(blob, tags=_ALL_TAGS | {0xA1}, odd_tags={0xC1, 0xE1})
     assert after <= 0.85 * before, (before, after)
+
+
+def test_llm_build_segment_table_is_validated_on_device(tmp_path):
+    """Confirmed real on the AX650N (see the README's "the segment table is
+    a loader manifest -- but only its word counts are load-bearing"
+    paragraph), on a fresh `llm_build` of SmolLM2-135M and a healthy
+    device: the layer-0 decode subgraph runs deterministically with valid
+    inputs; table 0's word count + 1 is rejected at load ("Loading model
+    failed", no fault); the op segment's word count - 1 faults every run;
+    and the op segment's remaining count + 1 runs with outputs identical
+    to baseline. The type-word patch is deliberately not exercised -- it
+    is the one that stalled the runtime. Skips without a device or the
+    cached checkpoint.
+    """
+    import shutil
+
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+    ckpt = _cached_hf_checkpoint("HuggingFaceTB/SmolLM2-135M")
+    if ckpt is None:
+        pytest.skip("HuggingFaceTB/SmolLM2-135M is not in the local HuggingFace cache")
+    work = tmp_path / "work"
+    work.mkdir()
+    shutil.copytree(ckpt, work / "SmolLM2-135M", symlinks=False)
+    result = pulsar2_docker.llm_build(str(work), "SmolLM2-135M", "output", parallel=8)
+    assert result.success, getattr(result, "error", None)
+    layer = str(work / "output" / "llama_p512_l0_together.axmodel")
+
+    model = onnx.load(layer)
+    inputs = _llm_layer_inputs(model)
+    neu0 = next(n for n in model.graph.node if n.op_type == "neu mode")
+    info = json.loads(
+        next(a for a in neu0.attribute if a.name == "npu_graph_info").s.decode()
+    )
+    key = info["dotneus"][0]["neu_key"]
+    mcode = bytes(next(i for i in model.graph.initializer if i.name == key).raw_data)
+    vec, tables = _tail_tables(mcode)
+
+    def field_offset(k, f):
+        p = vec + 4 + 4 * k
+        tpos = p + struct.unpack_from("<I", mcode, p)[0]
+        vt = tpos - struct.unpack_from("<i", mcode, tpos)[0]
+        fo = struct.unpack_from("<H", mcode, vt + 4 + 2 * f)[0]
+        assert fo, (k, f)
+        return tpos + fo
+
+    k_ops = next(k for k, t in enumerate(tables) if t[0] == 0x8801)
+
+    def patched(name, k, f, value):
+        b = bytearray(mcode)
+        struct.pack_into("<I", b, field_offset(k, f), value)
+        m2 = onnx.ModelProto()
+        m2.CopyFrom(model)
+        next(i for i in m2.graph.initializer if i.name == key).raw_data = bytes(b)
+        path = str(tmp_path / f"{name}.axmodel")
+        onnx.save(m2, path)
+        return path
+
+    base = [o for o in _run_llm_layer(layer, inputs, 3) if o != "fault"]
+    assert len(base) >= 2 and len(set(base)) == 1, base
+    baseline = base[0]
+
+    load = pulsar2_docker.run_on_device_with_inputs(
+        patched("t0_f2_plus1", 0, 2, tables[0][2] + 1), inputs, repeat=1, warmup=1
+    )
+    assert not load.outputs and load.error and "Loading model" in load.error, load.error
+
+    short = _run_llm_layer(
+        patched("ops_f2_minus1", k_ops, 2, tables[k_ops][2] - 1), inputs, 2
+    )
+    assert short == ["fault", "fault"], short
+
+    same = [
+        o
+        for o in _run_llm_layer(
+            patched("ops_f3_plus1", k_ops, 3, tables[k_ops][3] + 1), inputs, 3
+        )
+        if o != "fault"
+    ]
+    assert len(same) >= 2 and all(o == baseline for o in same), same


### PR DESCRIPTION
Corrects the "segment table is validated field by field" paragraph that landed in #1201, and lands the matching device test.

**What was wrong.** The first tail-table patch series reported a `0x8030070C` fault for every variant. It was measured after the first variant (the op segment's type word) had already stalled the runtime for ~2 minutes, and the driver's heartbeat thread never recovered until a reboot -- the faults were the degraded device, not validation.

**Redone on a healthy device**, one variant at a time with an `axcl-smi` health check and a baseline control run after each (baseline bit-identical throughout):

| patch (decode subgraph tail tables) | result |
|---|---|
| byte size `f5 - 64`, packed word `f4 + 1`, op segment word count `f2 + 1`, remaining count `f3 + 1` | run, outputs **identical** |
| table 0 word count `f2 + 1`, table 0 total `f3 + 1` | **`Loading model failed`** at load, no fault, device unharmed |
| op segment word count `f2 - 1`, table 0 word count `f2 - 1` | **fault `0x8030070C`** at run, device unharmed |
| op segment type word | not repeated: the one patch that wedged the runtime |

So the loader reads the word counts and table 0's total to lay the segments out (overshoot rejected at load, a short count lets the run read a truncated program and fault, one word too long mid-table just reads padding); the remaining count, the packed `f3 << 8 | 1` and the byte size are compiler bookkeeping the runtime does not check.

The device test asserts the load rejection, the short-count fault and the identical outputs, and deliberately avoids the type word. Passed on the real AX650N after the driver fixes in #1204, with the card healthy afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jz5D7t8hBZezBTNtF5LEJJ
