### PR TITLE
Recognize LinearAttentionGate-fed decay/beta pass-through in C++ port

### DIFF
--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -35772,12 +35772,13 @@ def apply_attention_head_pruning(
     function body, not at module scope) to avoid a circular import:
     ``onnxsim.onnx_simplifier`` already imports from this module
     (:class:`EmbeddingPruningResult`), so importing it back at module load
-    time here would deadlock the import machinery. One pre-existing,
-    pre-approved narrowing: a ``com.microsoft::LinearAttentionGate``-fed
-    decay/beta producer (see this module's own
-    :func:`_match_linear_attention_gate`/:class:`_LinearAttentionGatePassThrough`)
-    is not yet recognized by the C++ port, which cleanly declines the whole
-    match instead of mis-slicing it -- see ``tests/test_pruning.py``'s own
+    time here would deadlock the import machinery. The C++ port also
+    recognizes a ``com.microsoft::LinearAttentionGate``-fed decay/beta
+    producer (see this module's own
+    :func:`_match_linear_attention_gate`/:class:`_LinearAttentionGatePassThrough`,
+    and ``structured_pruning_entry.cpp``'s own ``MatchLinearAttentionGate``/
+    ``LinearAttentionGatePassThrough``), verified full parity -- see
+    ``tests/test_pruning.py``'s own
     ``test_linear_attention_pruning_gate_fed_decay_and_beta_matches_oracle``/
     ``test_linear_attention_pruning_gate_fed_decay_only_slices_wa_and_gate_weights``.
     """
@@ -35931,8 +35932,9 @@ def apply_attention_head_wanda_pruning(
     ``ApplyAttentionHeadWandaPruning``), forwarding every argument unchanged.
     Imported lazily (inside the function body, not at module scope) to avoid
     a circular import, same reasoning as :func:`apply_attention_head_pruning`'s
-    own alias. Shares that same function's one pre-existing, pre-approved
-    ``com.microsoft::LinearAttentionGate`` narrowing (see its own docstring).
+    own alias. Also shares that same function's
+    ``com.microsoft::LinearAttentionGate``-fed decay/beta recognition (see
+    its own docstring).
     """
     from onnxsim.onnx_simplifier import apply_attention_head_wanda_pruning_cpp
 

--- a/onnxsim/structured_pruning_entry.cpp
+++ b/onnxsim/structured_pruning_entry.cpp
@@ -5770,6 +5770,39 @@ struct QkNormRopePassThrough {
   std::optional<std::string> output_reshape_shape;
 };
 
+// A `com.microsoft::LinearAttentionGate` node recognized, by
+// MatchLinearAttentionGate, as a safe pass-through producer for a matched
+// `LinearAttention` chain's own dynamic `decay`/`beta` inputs -- mirrors
+// pruning.py's own `_LinearAttentionGatePassThrough` dataclass exactly (see
+// that class's own docstring for the full empirical schema findings: `decay
+// = decay_scale * Softplus(a + dt_bias)`, `beta = Sigmoid(b)`, `dt_bias`/
+// `decay_scale` each a real per-KV-head `(kv_num_heads,)` float constant).
+// `dt_bias`/`decay_scale` (this node's own inputs 1/2) are sliced directly,
+// axis 0, by the chain's own `keep_groups`. `a`/`b` (this node's own inputs
+// 0/3 -- `a` always present/resolved, since `decay` is this op's own
+// required output; `b` only present/resolved when `beta` is also wired to
+// the matched chain's own `LinearAttention` node) need no slicing of their
+// own: each is itself a plain MatMul/vanilla-Gemm activation, exactly
+// `kv_num_heads`-wide, so narrowing that producer's own output columns by
+// the identical `keep_groups` -- recorded here as `a_weight`/`a_bias`/
+// `a_weight_transposed` (always set) and `b_weight`/`b_bias`/
+// `b_weight_transposed` (set only when `b` needs narrowing too) -- narrows
+// `a`/`b` themselves "for free", the same way slicing Q's/K's/V's own
+// producer weight already narrows their own activation with no separate
+// step. `b_weight` stays `nullopt` whenever `beta` isn't wired to the
+// matched chain at all.
+struct LinearAttentionGatePassThrough {
+  onnx::NodeProto* node = nullptr;
+  std::string dt_bias;
+  std::string decay_scale;
+  std::string a_weight;
+  std::optional<std::string> a_bias;
+  bool a_weight_transposed = false;
+  std::optional<std::string> b_weight;
+  std::optional<std::string> b_bias;
+  bool b_weight_transposed = false;
+};
+
 struct AttnChain {
   AttnChainKind kind;
   onnx::NodeProto* node;
@@ -5827,6 +5860,15 @@ struct AttnChain {
   // from the `Split` with no hop in between.
   std::optional<QkNormRopePassThrough> q_norm_rope;
   std::optional<QkNormRopePassThrough> k_norm_rope;
+  // Set only for a matched `LinearAttention` node whose own `decay`/`beta`
+  // inputs (indices 4/5) are fed by a recognized
+  // `com.microsoft::LinearAttentionGate` node -- mirrors pruning.py's own
+  // `_GQAChain.linear_attention_gate` field exactly (see
+  // MatchLinearAttentionGate/LinearAttentionGatePassThrough for what's
+  // matched and sliced at apply time). `nullopt` (the default) for every
+  // other matched op, and for a `LinearAttention` chain whose `decay`/`beta`
+  // are absent or genuine constants.
+  std::optional<LinearAttentionGatePassThrough> linear_attention_gate;
   // Shared:
   std::vector<AttnChainOp> chain_ops;
   onnx::NodeProto* consumer_node = nullptr;
@@ -6379,17 +6421,16 @@ std::optional<HeadCountsMatch> MatchPagedAttentionProducer(
 // a size-1 broadcast -- don't need `head_size` to tell apart, unlike
 // `decay`'s own).
 //
-// Still deliberately narrower than pruning.py's own matcher in one respect:
-// a *dynamic* `decay`/`beta` still declines the whole match here outright,
-// rather than being deferred to a `com.microsoft::LinearAttentionGate`
-// pass-through check the way pruning.py's own `_find_linear_attention_
-// chains` (via `_match_linear_attention_gate`) does -- that dynamic
-// producer-recognition machinery is not ported here (see this file's own
-// "Attention-head pruning" section comment, the `LinearAttention` bullet,
-// for the documented scope boundary this narrowing keeps). `decay`'s own
-// exact-shape check (which needs `head_size`, not known yet here) is
-// deferred to `FindLinearAttentionChains`, mirroring pruning.py's own
-// identical deferral to `_find_linear_attention_chains`.
+// A *dynamic* `decay`/`beta` (index 4/5) is no longer declined right here --
+// mirrors pruning.py's own `_match_linear_attention_producer` exactly: it
+// might be the one recognized `com.microsoft::LinearAttentionGate`
+// pass-through shape, checked later, once the graph-wide consumer/producer
+// maps are available, by `FindLinearAttentionChains` (via
+// `MatchLinearAttentionGate`) -- see that function's own comment for the
+// full reasoning either way. `decay`'s own exact-shape check (which needs
+// `head_size`, not known yet here) is likewise deferred to
+// `FindLinearAttentionChains`, mirroring pruning.py's own identical
+// deferral to `_find_linear_attention_chains`.
 // `value_info_by_name` accepted (see MatchPagedAttentionProducer's own
 // comment) but ignored: this op has no attention_bias/attn_mask-equivalent
 // input on its own schema either.
@@ -6443,10 +6484,12 @@ std::optional<HeadCountsMatch> MatchLinearAttentionProducer(
     }
     auto it = init_map.find(node.input(idx));
     if (it == init_map.end()) {
-      // Dynamic decay/beta -- unlike pruning.py's own deferred
-      // LinearAttentionGate-pass-through check (not ported here, see this
-      // function's own comment above), declined outright.
-      return std::nullopt;
+      // Dynamic decay/beta -- no longer declined right here: might be the
+      // one recognized `LinearAttentionGate` pass-through shape, checked
+      // later, once graph-wide consumer/producer maps are available, by
+      // `FindLinearAttentionChains` (via `MatchLinearAttentionGate`) -- see
+      // this function's own comment for the full reasoning either way.
+      continue;
     }
     if (!IsSupportedFloatDtype(it->second->data_type()) ||
         it->second->dims_size() != 3) {
@@ -6466,6 +6509,170 @@ std::optional<HeadCountsMatch> MatchLinearAttentionProducer(
   }
 
   return HeadCountsMatch{q_num_heads, kv_num_heads};
+}
+
+// Recognizes exactly one dynamic-producer shape for a matched
+// `LinearAttention` `node`'s own `decay`/`beta` inputs (indices 4/5, each
+// already confirmed non-constant by the caller -- see
+// MatchLinearAttentionProducer's own comment for why a dynamic `decay`/
+// `beta` is no longer declined right there, deferred here instead, where the
+// graph-wide consumer/producer maps this needs are available): both fed,
+// directly and exclusively, by the SAME `com.microsoft::LinearAttentionGate`
+// node's own `decay` (output 0) and, when `beta` is also connected, `beta`
+// (output 1) outputs -- this op's own documented companion: `decay =
+// decay_scale * Softplus(a + dt_bias)`, `beta = Sigmoid(b)` (`b` "Required
+// when the beta output is requested"), `dt_bias`/`decay_scale` "per-head
+// float32 vectors of length H" (`H` == `kv_num_heads`). Mirrors pruning.py's
+// own `_match_linear_attention_gate` exactly -- see that function's own
+// comment for why this is deliberately the ONLY dynamic `decay`/`beta`
+// producer shape ever recognized; anything else (a bare graph input, any
+// other node, a gate whose own `a`/`b` don't resolve to a plain
+// constant-weight producer) still declines the whole match.
+//
+// Every edge crossed -- `node`'s own `decay`/`beta` input(s), and the gate
+// node's own `a`/`b` input(s) -- is required to have exactly one consumer
+// and not be a graph output (the same "no other consumer along the way" bar
+// WalkBackThroughQkNormRope already holds its own crossed hops to). `a`'s
+// (always) and `b`'s (only when `beta` is connected) own producer must
+// independently resolve via MatchProducerAnyFloat (a plain MatMul/
+// vanilla-Gemm with a constant 2-D float weight -- the same matcher
+// FindSeparateQkvChains itself uses for Q/K/V) to a `kv_num_heads`-wide
+// output -- exactly the schema's own `(B, T, H)` shape -- so
+// ApplyOneGqaChain can narrow it the same "slice the producer weight's own
+// output columns by `keep_groups`" way Q's/K's/V's own producer weight
+// already gets narrowed. Anything not matching this exact shape declines
+// outright (returns `nullopt`) rather than guessed at.
+std::optional<LinearAttentionGatePassThrough> MatchLinearAttentionGate(
+    const onnx::NodeProto& node, int64_t kv_num_heads, const InitMap& init_map,
+    const ConsumerMap& consumers_of,
+    const std::unordered_set<std::string>& graph_outputs,
+    const std::unordered_map<std::string, onnx::NodeProto*>& node_by_output) {
+  auto is_internal = [&](const std::string& n) {
+    return ConsumerCount(consumers_of, n) == 1 && !graph_outputs.count(n);
+  };
+
+  const std::string decay_name =
+      node.input_size() > 4 ? node.input(4) : std::string();
+  const std::string beta_name =
+      node.input_size() > 5 ? node.input(5) : std::string();
+  const bool dyn_decay = !decay_name.empty() && !init_map.count(decay_name);
+  const bool dyn_beta = !beta_name.empty() && !init_map.count(beta_name);
+  if (!dyn_decay && !dyn_beta) {
+    return std::nullopt;  // nothing dynamic here -- not this function's own
+                          // case
+  }
+
+  std::vector<std::string> dyn_names;
+  if (dyn_decay) {
+    dyn_names.push_back(decay_name);
+  }
+  if (dyn_beta) {
+    dyn_names.push_back(beta_name);
+  }
+
+  auto git = node_by_output.find(dyn_names[0]);
+  if (git == node_by_output.end()) {
+    return std::nullopt;
+  }
+  onnx::NodeProto* gate_node = git->second;
+  for (const auto& n : dyn_names) {
+    auto it = node_by_output.find(n);
+    if (it == node_by_output.end() || it->second != gate_node) {
+      return std::nullopt;  // both dynamic inputs must be this SAME gate
+                            // node's own outputs
+    }
+  }
+  if (gate_node->domain() != kComMicrosoftDomain ||
+      gate_node->op_type() != "LinearAttentionGate") {
+    return std::nullopt;
+  }
+  if (dyn_decay &&
+      (gate_node->output_size() < 1 || gate_node->output(0).empty() ||
+       gate_node->output(0) != decay_name)) {
+    return std::nullopt;
+  }
+  if (dyn_beta &&
+      (gate_node->output_size() < 2 || gate_node->output(1).empty() ||
+       gate_node->output(1) != beta_name)) {
+    return std::nullopt;
+  }
+  for (const auto& n : dyn_names) {
+    if (!is_internal(n)) {
+      return std::nullopt;
+    }
+  }
+
+  if (gate_node->input_size() < 3 || gate_node->input(0).empty() ||
+      gate_node->input(1).empty() || gate_node->input(2).empty()) {
+    return std::nullopt;
+  }
+  const std::string a_name = gate_node->input(0);
+  const std::string dt_bias_name = gate_node->input(1);
+  const std::string decay_scale_name = gate_node->input(2);
+
+  auto dt_bias_it = init_map.find(dt_bias_name);
+  auto decay_scale_it = init_map.find(decay_scale_name);
+  if (dt_bias_it == init_map.end() || decay_scale_it == init_map.end()) {
+    return std::nullopt;
+  }
+  for (const onnx::TensorProto* init :
+       {dt_bias_it->second, decay_scale_it->second}) {
+    if (!IsSupportedFloatDtype(init->data_type()) || init->dims_size() != 1 ||
+        init->dims(0) != kv_num_heads) {
+      return std::nullopt;
+    }
+  }
+
+  if (!is_internal(a_name)) {
+    return std::nullopt;
+  }
+  auto a_prod_it = node_by_output.find(a_name);
+  if (a_prod_it == node_by_output.end()) {
+    return std::nullopt;
+  }
+  auto a_info = MatchProducerAnyFloat(*a_prod_it->second, init_map);
+  if (!a_info || a_info->n_channels != kv_num_heads) {
+    return std::nullopt;
+  }
+
+  std::optional<std::string> b_weight, b_bias;
+  bool b_weight_transposed = false;
+  if (dyn_beta) {
+    if (gate_node->input_size() < 4 || gate_node->input(3).empty()) {
+      return std::nullopt;
+    }
+    const std::string b_name = gate_node->input(3);
+    if (!is_internal(b_name)) {
+      return std::nullopt;
+    }
+    auto b_prod_it = node_by_output.find(b_name);
+    if (b_prod_it == node_by_output.end()) {
+      return std::nullopt;
+    }
+    auto b_info = MatchProducerAnyFloat(*b_prod_it->second, init_map);
+    if (!b_info || b_info->n_channels != kv_num_heads) {
+      return std::nullopt;
+    }
+    if (b_info->weight == a_info->weight) {
+      return std::nullopt;  // degenerate -- can't independently slice a
+                            // shared producer
+    }
+    b_weight = b_info->weight;
+    b_weight_transposed = b_info->weight_transposed;
+    b_bias = b_info->bias;
+  }
+
+  LinearAttentionGatePassThrough result;
+  result.node = gate_node;
+  result.dt_bias = dt_bias_name;
+  result.decay_scale = decay_scale_name;
+  result.a_weight = a_info->weight;
+  result.a_bias = a_info->bias;
+  result.a_weight_transposed = a_info->weight_transposed;
+  result.b_weight = b_weight;
+  result.b_bias = b_bias;
+  result.b_weight_transposed = b_weight_transposed;
+  return result;
 }
 
 // If `node` is a com.microsoft::SparseAttention node this pass can safely
@@ -7717,14 +7924,25 @@ std::vector<AttnChain> FindPagedAttentionChains(onnx::GraphProto* graph) {
 // attribute is named `q_num_heads` (same as the plain ai.onnx `Attention`
 // op's own), no combined bias input.
 //
-// Performs the one deferred check MatchLinearAttentionProducer itself
-// cannot: a connected constant `decay` (index 4) must be exactly one of its
-// own two documented shapes -- `(*, *, kv_num_heads)` (DeltaNet/RetNet,
-// per-head scalar decay) or `(*, *, kv_num_heads * head_size)` (GLA/RWKV-6,
-// per-key-dimension decay) -- anything else declines the whole chain here,
-// mirroring pruning.py's own `_find_linear_attention_chains` exactly
-// (`head_size`, Q's/K's own shared per-head width, is resolved only here,
-// by FindSeparateQkvChains itself, not yet known at match time).
+// Performs the two deferred checks MatchLinearAttentionProducer itself
+// cannot:
+//
+// - A connected constant `decay` (index 4) must be exactly one of its own
+//   two documented shapes -- `(*, *, kv_num_heads)` (DeltaNet/RetNet,
+//   per-head scalar decay) or `(*, *, kv_num_heads * head_size)` (GLA/RWKV-6,
+//   per-key-dimension decay) -- anything else declines the whole chain here,
+//   mirroring pruning.py's own `_find_linear_attention_chains` exactly
+//   (`head_size`, Q's/K's own shared per-head width, is resolved only here,
+//   by FindSeparateQkvChains itself, not yet known at match time).
+// - A connected *dynamic* `decay`/`beta` (deferred here, since it might be
+//   the one recognized `com.microsoft::LinearAttentionGate` pass-through
+//   shape) is resolved via MatchLinearAttentionGate, which needs the
+//   graph-wide consumer/producer maps MatchLinearAttentionProducer itself is
+//   never given -- a chain whose dynamic `decay`/`beta` doesn't resolve this
+//   way is dropped here (the same "unmatched topology" outcome as any other
+//   declined chain), one that does has its own `.linear_attention_gate` set,
+//   for ApplyOneGqaChain to slice at apply time. Mirrors pruning.py's own
+//   identical `_find_linear_attention_chains` logic exactly.
 std::vector<AttnChain> FindLinearAttentionChains(onnx::GraphProto* graph) {
   std::vector<AttnChain> chains =
       FindSeparateQkvChains(graph, MatchLinearAttentionProducer, "q_num_heads");
@@ -7732,11 +7950,52 @@ std::vector<AttnChain> FindLinearAttentionChains(onnx::GraphProto* graph) {
   for (const auto& t : graph->initializer()) {
     init_map[t.name()] = &t;
   }
+  ConsumerMap consumers_of = ConsumersOf(graph);
+  std::unordered_set<std::string> graph_outputs;
+  for (const auto& o : graph->output()) {
+    graph_outputs.insert(o.name());
+  }
+  std::unordered_map<std::string, onnx::NodeProto*> node_by_output;
+  for (int i = 0; i < graph->node_size(); ++i) {
+    onnx::NodeProto* node = graph->mutable_node(i);
+    for (const auto& out : node->output()) {
+      node_by_output[out] = node;
+    }
+  }
+
   std::vector<AttnChain> out;
   out.reserve(chains.size());
   for (auto& chain : chains) {
-    if (chain.node->input_size() > 4 && !chain.node->input(4).empty()) {
-      auto it = init_map.find(chain.node->input(4));
+    const std::string decay_name =
+        chain.node->input_size() > 4 ? chain.node->input(4) : std::string();
+    const std::string beta_name =
+        chain.node->input_size() > 5 ? chain.node->input(5) : std::string();
+    const bool decay_dynamic =
+        !decay_name.empty() && !init_map.count(decay_name);
+    const bool beta_dynamic = !beta_name.empty() && !init_map.count(beta_name);
+
+    std::optional<LinearAttentionGatePassThrough> gate;
+    if (decay_dynamic || beta_dynamic) {
+      gate =
+          MatchLinearAttentionGate(*chain.node, chain.kv_num_heads, init_map,
+                                   consumers_of, graph_outputs, node_by_output);
+      if (!gate) {
+        continue;  // dynamic decay/beta not the recognized
+                   // LinearAttentionGate shape -- declined
+      }
+      if (gate->a_weight == chain.q_weight ||
+          gate->a_weight == chain.k_weight ||
+          gate->a_weight == chain.v_weight ||
+          (gate->b_weight && (*gate->b_weight == chain.q_weight ||
+                              *gate->b_weight == chain.k_weight ||
+                              *gate->b_weight == chain.v_weight))) {
+        continue;  // degenerate -- can't independently slice a shared
+                   // producer
+      }
+    }
+
+    if (!decay_name.empty() && !decay_dynamic) {
+      auto it = init_map.find(decay_name);
       if (it != init_map.end() && it->second->dims_size() > 0) {
         const int64_t last = it->second->dims(it->second->dims_size() - 1);
         if (last != chain.kv_num_heads &&
@@ -7745,6 +8004,8 @@ std::vector<AttnChain> FindLinearAttentionChains(onnx::GraphProto* graph) {
         }
       }
     }
+
+    chain.linear_attention_gate = std::move(gate);
     out.push_back(std::move(chain));
   }
   return out;
@@ -8502,13 +8763,7 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
   // (GLA/RWKV-6, per-key-dimension); and `beta` (rank-3) along its own last
   // axis by `keep_groups`, only when genuinely `kv_num_heads`-wide (a size-1
   // broadcast needs no slicing at all, the same "PER_TENSOR broadcast, left
-  // alone" reasoning as k_scale/v_scale above). A
-  // `com.microsoft::LinearAttentionGate`-fed dynamic `decay`/`beta`
-  // pass-through (pruning.py's own further upgrade, ranked/sliced through
-  // `chain.linear_attention_gate` there) is NOT ported here --
-  // MatchLinearAttentionProducer already declines that shape outright (see
-  // that function's own comment for the documented scope boundary), so it
-  // never reaches this branch.
+  // alone" reasoning as k_scale/v_scale above).
   const bool is_linear_attention = chain.node->domain().empty() &&
                                    chain.node->op_type() == "LinearAttention";
   if (is_linear_attention) {
@@ -8537,6 +8792,36 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
         const int64_t last_axis = it->second->dims_size() - 1;
         if (it->second->dims(last_axis) == h) {
           SliceAxisGeneric(it->second, keep_groups, last_axis);
+        }
+      }
+    }
+
+    // A recognized `com.microsoft::LinearAttentionGate` pass-through (see
+    // MatchLinearAttentionGate/LinearAttentionGatePassThrough): `dt_bias`/
+    // `decay_scale` (both real `(kv_num_heads,)` constants) are sliced
+    // directly, axis 0 -- the one genuinely new per-tensor edit this feature
+    // adds. `a`'s (always) and `b`'s (only when `beta` was also wired to
+    // this chain) own producer weight -- resolved, at match time, to a
+    // plain MatMul/vanilla-Gemm output exactly `kv_num_heads` columns wide
+    // -- is sliced the identical `keep_groups` way Q's/K's/V's own producer
+    // weight already is a few lines above, narrowing `a`/`b` themselves with
+    // no separate step (see LinearAttentionGatePassThrough's own comment for
+    // why). Mirrors pruning.py's own `_apply_one_gqa_chain` handling of
+    // `chain.linear_attention_gate` exactly.
+    if (chain.linear_attention_gate) {
+      const LinearAttentionGatePassThrough& gate = *chain.linear_attention_gate;
+      SliceAxisGeneric(init_map.at(gate.dt_bias), keep_groups, 0);
+      SliceAxisGeneric(init_map.at(gate.decay_scale), keep_groups, 0);
+      SliceAxisGeneric(init_map.at(gate.a_weight), keep_groups,
+                       gate.a_weight_transposed ? 0 : 1);
+      if (gate.a_bias) {
+        SliceAxisGeneric(init_map.at(*gate.a_bias), keep_groups, 0);
+      }
+      if (gate.b_weight) {
+        SliceAxisGeneric(init_map.at(*gate.b_weight), keep_groups,
+                         gate.b_weight_transposed ? 0 : 1);
+        if (gate.b_bias) {
+          SliceAxisGeneric(init_map.at(*gate.b_bias), keep_groups, 0);
         }
       }
     }
@@ -8723,6 +9008,23 @@ std::optional<AppliedAttn> ApplyOneGqaChain(
       out.stale.insert(extra);
     }
   }
+  // A recognized `LinearAttentionGate` pass-through node is a distinct node
+  // from `chain.node` (already covered by `out.stale` above), so its own
+  // `decay`/`beta` outputs need marking stale here too, and `a`'s/`b`'s own
+  // (now narrower) producer weight needs the same touched-producer
+  // bookkeeping every other producer weight in this chain already gets --
+  // mirrors pruning.py's own `_apply_one_gqa_chain` identical addition to
+  // its returned producer-name/stale sets exactly.
+  if (chain.linear_attention_gate) {
+    const LinearAttentionGatePassThrough& gate = *chain.linear_attention_gate;
+    for (const auto& gate_out : gate.node->output()) {
+      out.stale.insert(gate_out);
+    }
+    out.producer_weights.insert(gate.a_weight);
+    if (gate.b_weight) {
+      out.producer_weights.insert(*gate.b_weight);
+    }
+  }
   return out;
 }
 
@@ -8766,6 +9068,17 @@ void ApplyAttentionChains(
             ? std::unordered_set<std::string>{chain.q_weight, chain.k_weight,
                                               chain.v_weight}
             : std::unordered_set<std::string>{chain.weight};
+    if (chain.kind == AttnChainKind::kGqaLike && chain.linear_attention_gate) {
+      // Mirrors ApplyOneGqaChain's own identical addition to its returned
+      // producer-name set -- checked here too so a `LinearAttentionGate`'s
+      // own `a`/`b` producer weight shared with an earlier chain is skipped
+      // up front, the same as Q's/K's/V's own already are. Mirrors
+      // pruning.py's own `_apply_attention_chains` identical check exactly.
+      producer_names.insert(chain.linear_attention_gate->a_weight);
+      if (chain.linear_attention_gate->b_weight) {
+        producer_names.insert(*chain.linear_attention_gate->b_weight);
+      }
+    }
 
     bool conflict = consumer_touched.count(chain.consumer_weight) != 0;
     for (const auto& w : producer_names) {

--- a/tests/test_attention_head_pruning_cpp.py
+++ b/tests/test_attention_head_pruning_cpp.py
@@ -13913,13 +13913,12 @@ def test_cpp_paged_attention_pruning_constant_per_channel_kv_scale_sliced_matche
 # `_match_linear_attention_producer`/`_apply_one_gqa_chain` exactly for the
 # "linear"/"delta"/"gated" update_rule shapes -- rather than a blanket
 # decline of the whole match whenever any of the three is connected at all.
-# Still narrower than pruning.py's own matcher in one respect: a *dynamic*
-# `decay`/`beta` still declines the whole match here outright rather than
-# being deferred to a recognized `com.microsoft::LinearAttentionGate`
-# pass-through the way pruning.py's own `_find_linear_attention_chains`
-# (via `_match_linear_attention_gate`) does -- see
-# MatchLinearAttentionProducer's own comment for the documented scope
-# boundary this narrowing keeps.
+# A *dynamic* `decay`/`beta` fed by a recognized `com.microsoft::
+# LinearAttentionGate` node is also now recognized as a safe pass-through --
+# mirroring pruning.py's own `_find_linear_attention_chains`/
+# `_match_linear_attention_gate` exactly (see MatchLinearAttentionGate/
+# LinearAttentionGatePassThrough in structured_pruning_entry.cpp) -- anything
+# else dynamic still declines the whole match outright.
 
 
 def _linear_attention_model(
@@ -14051,12 +14050,14 @@ def test_cpp_linear_attention_pruning_gated_mode_constant_decay_is_sliced_matche
     # not a whole-match decline -- mirrors pruning.py's own
     # `_match_linear_attention_producer`/`_apply_one_gqa_chain` exactly
     # (MatchLinearAttentionProducer/ApplyOneGqaChain's own `is_linear_
-    # attention` branch, see either's own comment). Only a genuinely
-    # DYNAMIC decay/beta still declines the whole match outright in this
-    # port (the LinearAttentionGate-fed pass-through pruning.py's own
-    # further upgrade recognizes is not ported here) -- see
-    # test_cpp_linear_attention_pruning_dynamic_decay_is_declined_matches_python
-    # below for that still-narrower scope boundary's own cpp-parity coverage.
+    # attention` branch, see either's own comment). A dynamic decay/beta fed
+    # by anything OTHER than a recognized `com.microsoft::
+    # LinearAttentionGate` node still declines the whole match outright --
+    # see test_cpp_linear_attention_pruning_dynamic_decay_is_declined_matches_python
+    # below for that scope boundary's own cpp-parity coverage, and
+    # test_cpp_linear_attention_pruning_gate_fed_decay_and_beta_matches_python
+    # further below for the recognized `LinearAttentionGate` pass-through
+    # itself.
     model, cfg = _linear_attention_model(
         Hq=4, Hkv=4, D=4, K=16, seed=63, decay=np.zeros((1, 3, 4), dtype=np.float32)
     )
@@ -14160,11 +14161,11 @@ def test_cpp_linear_attention_pruning_gated_mode_gla_decay_matches_python():
 
 
 def test_cpp_linear_attention_pruning_dynamic_decay_is_declined_matches_python():
-    # A `decay` fed by anything other than a constant initializer still
-    # declines the whole match outright in this port -- the
-    # LinearAttentionGate-fed pass-through pruning.py's own further upgrade
-    # recognizes is not ported here (see MatchLinearAttentionProducer's own
-    # comment). Mirrors tests/test_pruning.py's own
+    # A `decay` fed by anything other than a constant initializer OR a
+    # recognized `com.microsoft::LinearAttentionGate` node (here, a bare
+    # graph input) still declines the whole match outright -- see
+    # MatchLinearAttentionGate's own comment for the documented scope
+    # boundary. Mirrors tests/test_pruning.py's own
     # test_linear_attention_pruning_dynamic_decay_is_declined, called
     # through the C++ port instead.
     Hq, Hkv, D, K = 4, 2, 4, 16
@@ -14204,6 +14205,208 @@ def test_cpp_linear_attention_pruning_dynamic_decay_is_declined_matches_python()
     onnx.checker.check_model(pruned_cpp)
     assert pruned_cpp.SerializeToString() == model.SerializeToString()  # untouched
     assert pruned_cpp.SerializeToString() == pruned_py.SerializeToString()
+
+
+def test_cpp_linear_attention_pruning_dynamic_decay_from_non_gate_node_still_declines():
+    # Same math as `LinearAttentionGate` (`decay_scale * Softplus(a +
+    # dt_bias)`) but decomposed into plain ops instead of the single
+    # recognized `com.microsoft::LinearAttentionGate` node -- still declines:
+    # MatchLinearAttentionGate recognizes exactly one op shape, not a
+    # general "any dynamic decay computed from a per-head constant is fine"
+    # relaxation. Mirrors tests/test_pruning.py's own
+    # test_linear_attention_pruning_dynamic_decay_from_non_gate_node_still_declines,
+    # called through the C++ port instead.
+    Hq, Hkv, D, K = 4, 2, 4, 16
+    body = f"""
+        g (float[1,3,{K}] X) => (float[1,3,{K}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          a = MatMul(X, Wa)
+          ap = Add(a, DtBias)
+          sp = Softplus(ap)
+          decay = Mul(sp, DecayScale)
+          attn_out, ps = LinearAttention<q_num_heads={Hq}, kv_num_heads={Hkv}, update_rule="gated">(q, k, v, , decay)
+          Y = MatMul(attn_out, Wo)
+        }}
+        """
+    rng = np.random.default_rng(14)
+    wq = rng.standard_normal((K, Hq * D)).astype(np.float32) * 0.3
+    wk = rng.standard_normal((K, Hkv * D)).astype(np.float32) * 0.3
+    wv = rng.standard_normal((K, Hkv * D)).astype(np.float32) * 0.3
+    wo = rng.standard_normal((Hq * D, K)).astype(np.float32) * 0.3
+    wa = rng.standard_normal((K, Hkv)).astype(np.float32) * 0.3
+    dt_bias = rng.standard_normal((Hkv,)).astype(np.float32)
+    decay_scale = -np.abs(rng.standard_normal((Hkv,))).astype(np.float32)
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 27]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            _f32(wq, "Wq"),
+            _f32(wk, "Wk"),
+            _f32(wv, "Wv"),
+            _f32(wo, "Wo"),
+            _f32(wa, "Wa"),
+            _f32(dt_bias, "DtBias"),
+            _f32(decay_scale, "DecayScale"),
+        ]
+    )
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+    assert pruned.SerializeToString() == model.SerializeToString()  # untouched
+
+
+# --- com.microsoft::LinearAttentionGate-fed dynamic decay/beta pass-through -
+#
+# `LinearAttention`'s own `decay`/`beta` inputs (indices 4/5), when fed by a
+# genuine `com.microsoft::LinearAttentionGate` node, are recognized as a safe
+# pass-through: `dt_bias`/`decay_scale` (real `(kv_num_heads,)` constants,
+# this node's own inputs 1/2) are sliced directly, axis 0, and `a`'s/`b`'s
+# (inputs 0/3) own producer weight is sliced the identical `keep_groups` way
+# Q's/K's/V's own is -- see MatchLinearAttentionGate/
+# LinearAttentionGatePassThrough in structured_pruning_entry.cpp, and
+# tests/test_pruning.py's own identical section comment for the full
+# reasoning (including why `LinearAttentionGate` itself has no CPU kernel in
+# this environment's onnxruntime, so these tests check shapes/values
+# directly against the oracle `keep_groups` rather than running the
+# gate-bearing model end to end).
+
+
+def _linear_attention_gate_model(Hkv=4, K=16, seed=0, decay_only=False):
+    """The exact `com.microsoft::LinearAttentionGate`-fed `gated_delta`
+    topology tests/test_pruning.py's own `_linear_attention_gate_model`
+    builds: `q`/`k`/`v` each `MatMul(X, W*)`, `a`/`b_in` each `MatMul(X,
+    Wa/Wb)` (also `Hkv`-wide -- per-head scalar `a`/`b`, this op's own
+    documented shape), gated into `decay`/`beta` by the gate node, consumed
+    by `LinearAttention<update_rule="gated_delta">`. `Hq == Hkv` (a plain,
+    non-GQA shape, `group_size == 1`). `decay_only=True` omits `b_in`/`beta`
+    entirely (the `"gated"`-mode shape, `beta` never requested), exercising
+    `LinearAttentionGatePassThrough`'s own `b_weight` staying unset.
+    """
+    rng = np.random.default_rng(seed)
+    D = 4
+    N = Hkv * D
+    wq = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    wk = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    wv = rng.standard_normal((K, N)).astype(np.float32) * 0.3
+    wo = rng.standard_normal((N, K)).astype(np.float32) * 0.3
+    wa = rng.standard_normal((K, Hkv)).astype(np.float32) * 0.3
+    dt_bias = rng.standard_normal((Hkv,)).astype(np.float32)
+    decay_scale = -np.abs(rng.standard_normal((Hkv,))).astype(np.float32)
+    cfg = dict(
+        Hq=Hkv,
+        Hkv=Hkv,
+        D=D,
+        K=K,
+        wq=wq,
+        wk=wk,
+        wv=wv,
+        wo=wo,
+        wa=wa,
+        dt_bias=dt_bias,
+        decay_scale=decay_scale,
+    )
+    initializer = [
+        _f32(wq, "Wq"),
+        _f32(wk, "Wk"),
+        _f32(wv, "Wv"),
+        _f32(wo, "Wo"),
+        _f32(wa, "Wa"),
+        _f32(dt_bias, "DtBias"),
+        _f32(decay_scale, "DecayScale"),
+    ]
+    if decay_only:
+        gate_line = "decay = com.microsoft.LinearAttentionGate(a, DtBias, DecayScale)"
+        la_args = "q, k, v, , decay"
+        update_rule = "gated"
+    else:
+        wb = rng.standard_normal((K, Hkv)).astype(np.float32) * 0.3
+        cfg["wb"] = wb
+        initializer.append(_f32(wb, "Wb"))
+        gate_line = (
+            "decay, beta = com.microsoft.LinearAttentionGate"
+            "(a, DtBias, DecayScale, b_in)"
+        )
+        la_args = "q, k, v, , decay, beta"
+        update_rule = "gated_delta"
+    b_line = "" if decay_only else "b_in = MatMul(X, Wb)"
+
+    body = f"""
+        <
+          ir_version: 10,
+          opset_import: ["" : 27, "com.microsoft" : 1]
+        >
+        g (float[1,3,{K}] X) => (float[1,3,{K}] Y)
+        {{
+          q = MatMul(X, Wq)
+          k = MatMul(X, Wk)
+          v = MatMul(X, Wv)
+          a = MatMul(X, Wa)
+          {b_line}
+          {gate_line}
+          attn_out, ps = LinearAttention<q_num_heads={Hkv}, kv_num_heads={Hkv}, update_rule="{update_rule}">({la_args})
+          Y = MatMul(attn_out, Wo)
+        }}
+        """
+    model = parser.parse_model(body)
+    model.graph.initializer.extend(initializer)
+    return model, cfg
+
+
+def test_cpp_linear_attention_pruning_gate_fed_decay_and_beta_matches_python():
+    model, cfg = _linear_attention_gate_model(Hkv=4, K=16, seed=10)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _linear_attention_node(pruned)
+    q_num_heads, kv_num_heads = _linear_attention_attrs(node)
+    assert kv_num_heads == 2
+    assert q_num_heads == 2  # group_size == 1 for this plain (non-GQA) shape
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["Hq"], cfg["Hkv"], cfg["D"], 2
+    )
+    q_idx = _head_idx(keep_groups, cfg["D"])
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["DtBias"], cfg["dt_bias"][keep_groups])
+    np.testing.assert_array_equal(inits["DecayScale"], cfg["decay_scale"][keep_groups])
+    np.testing.assert_array_equal(inits["Wa"], cfg["wa"][:, keep_groups])
+    np.testing.assert_array_equal(inits["Wb"], cfg["wb"][:, keep_groups])
+    np.testing.assert_array_equal(inits["Wq"], cfg["wq"][:, q_idx])
+    np.testing.assert_array_equal(inits["Wk"], cfg["wk"][:, q_idx])
+    np.testing.assert_array_equal(inits["Wv"], cfg["wv"][:, q_idx])
+    np.testing.assert_array_equal(inits["Wo"], cfg["wo"][q_idx, :])
+
+
+def test_cpp_linear_attention_pruning_gate_fed_decay_only_matches_python():
+    # `"gated"` mode: `beta` never requested, so the gate node has no `b`
+    # input/`beta` output at all.
+    model, cfg = _linear_attention_gate_model(Hkv=4, K=16, seed=13, decay_only=True)
+    pruned = onnxsim.apply_attention_head_pruning_cpp(model, sparsity=0.5)
+    onnx.checker.check_model(pruned)
+
+    node = _linear_attention_node(pruned)
+    q_num_heads, kv_num_heads = _linear_attention_attrs(node)
+    assert kv_num_heads == 2
+    assert q_num_heads == 2
+
+    keep_groups = _oracle_keep_groups(
+        cfg["wq"], cfg["wk"], cfg["wv"], cfg["Hq"], cfg["Hkv"], cfg["D"], 2
+    )
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert "Wb" not in inits
+    np.testing.assert_array_equal(inits["DtBias"], cfg["dt_bias"][keep_groups])
+    np.testing.assert_array_equal(inits["DecayScale"], cfg["decay_scale"][keep_groups])
+    np.testing.assert_array_equal(inits["Wa"], cfg["wa"][:, keep_groups])
 
 
 # --- com.microsoft::SparseAttention ------------------------------------------

--- a/tests/test_attention_head_wanda_pruning_cpp.py
+++ b/tests/test_attention_head_wanda_pruning_cpp.py
@@ -52,18 +52,18 @@ own docstring for the exact narrower-than-pruning.py scope each still
 carries.
 
 ``onnxsim.apply_attention_head_wanda_pruning`` (the pure-Python name) is now
-itself a thin alias for this port (full parity verified -- see pruning.py's
-own "Attention-head pruning" section comment), exactly like
+itself a thin alias for this port (full parity verified, including the
+``com.microsoft::LinearAttentionGate``-fed decay/beta pass-through -- see
+pruning.py's own "Attention-head pruning" section comment), exactly like
 ``apply_attention_head_pruning``/``apply_wanda_pruning`` before it -- see
-``test_attention_head_pruning_cpp.py``'s own docstring for the one
-pre-existing, pre-approved narrowing (``com.microsoft::LinearAttentionGate``)
-that survives the alias. Every test below that used to call BOTH entry
-points and compare their live outputs would be tautological (literally the
-same code path twice) if left as-is -- those now instead compare the C++
-port's output against a golden fixture (`_GOLDEN`, base64-encoded serialized
-``ModelProto`` bytes) captured from the real pure-Python implementation
-*before* its own mutating body was replaced by the alias, mirroring
-``test_wanda_pruning_cpp.py``'s own established convention.
+``test_attention_head_pruning_cpp.py``'s own docstring. Every test below
+that used to call BOTH entry points and compare their live outputs would be
+tautological (literally the same code path twice) if left as-is -- those now
+instead compare the C++ port's output against a golden fixture (`_GOLDEN`,
+base64-encoded serialized ``ModelProto`` bytes) captured from the real
+pure-Python implementation *before* its own mutating body was replaced by
+the alias, mirroring ``test_wanda_pruning_cpp.py``'s own established
+convention.
 """
 
 import base64

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -45839,20 +45839,17 @@ def _linear_attention_gate_model(Hkv=4, K=16, seed=0, decay_only=False):
 
 
 def test_linear_attention_pruning_gate_fed_decay_and_beta_matches_oracle():
-    # Documented, pre-approved narrowing versus the pure-Python reference
-    # this test used to exercise directly: `apply_attention_head_pruning`
-    # is now a thin alias for the verified-full-parity C++ port
-    # (`apply_attention_head_pruning_cpp`), which does not (yet) recognize
+    # `apply_attention_head_pruning` is a thin alias for the C++ port
+    # (`apply_attention_head_pruning_cpp`), which now recognizes
     # `com.microsoft.LinearAttentionGate` as a decay/beta pass-through the
-    # way pruning.py's own from-scratch `_walk_back_through_linear_attention_gate`
-    # does -- a real, SAFE-DIRECTION scope gap: the C++ port cleanly declines
-    # the whole match (leaving every tensor/attribute completely untouched)
-    # rather than slicing `Wq`/`Wk`/`Wv`/`Wo` while leaving the gate's own
-    # `DtBias`/`DecayScale`/`Wa`/`Wb` at their original (now head-count-
-    # mismatched) width, exactly the same "declines rather than mis-slices"
-    # category as e.g.
-    # `test_gqa_pruning_qk_norm_weight_wrong_shape_is_declined` above. Out of
-    # scope to close here -- see this module's own C++-port-aliasing notes.
+    # same way pruning.py's own from-scratch `_match_linear_attention_gate`
+    # does -- see MatchLinearAttentionGate/LinearAttentionGatePassThrough in
+    # onnxsim/structured_pruning_entry.cpp for the ported mechanics. This
+    # test independently confirms, via the numeric oracle described in this
+    # module's own "LinearAttentionGate-fed dynamic decay/beta pass-through"
+    # section comment, that the pruned model's own sliced `Wa`/`Wb`/
+    # `DtBias`/`DecayScale` are mathematically equivalent to "compute at full
+    # width, then keep only the surviving heads' own output".
     model, cfg = _linear_attention_gate_model(Hkv=4, K=16, seed=10)
     pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned)
@@ -45860,58 +45857,135 @@ def test_linear_attention_pruning_gate_fed_decay_and_beta_matches_oracle():
     node = _linear_attention_node(pruned)
     q_attr = next(a.i for a in node.attribute if a.name == "q_num_heads")
     kv_attr = next(a.i for a in node.attribute if a.name == "kv_num_heads")
-    assert (q_attr, kv_attr) == (cfg["Hq"], cfg["Hkv"])  # left untouched
+    assert kv_attr == 2
+    assert q_attr == 2  # group_size == 1 for this plain (non-GQA) shape
 
-    inits_before = {
-        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
+    keep_groups = _linear_attention_keep_groups(
+        dict(
+            Hq=cfg["Hq"],
+            Hkv=cfg["Hkv"],
+            Dk=cfg["D"],
+            Dv=cfg["D"],
+            wq=cfg["wq"],
+            wk=cfg["wk"],
+            wv=cfg["wv"],
+        ),
+        sparsity=0.5,
+    )
+
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    np.testing.assert_array_equal(inits["DtBias"], cfg["dt_bias"][keep_groups])
+    np.testing.assert_array_equal(inits["DecayScale"], cfg["decay_scale"][keep_groups])
+    np.testing.assert_array_equal(inits["Wa"], cfg["wa"][:, keep_groups])
+    np.testing.assert_array_equal(inits["Wb"], cfg["wb"][:, keep_groups])
+
+    rng = np.random.default_rng(99)
+    x = rng.standard_normal((1, 3, cfg["K"])).astype(np.float32)
+    D = cfg["D"]
+    q_idx = np.concatenate([np.arange(h * D, (h + 1) * D) for h in keep_groups])
+
+    # Oracle: compute the gate's own formula at FULL width from the
+    # original weights, then slice its own output by `keep_groups`.
+    a_full = x @ cfg["wa"]
+    b_full = x @ cfg["wb"]
+    decay_full = cfg["decay_scale"] * _softplus(a_full + cfg["dt_bias"])
+    beta_full = _sigmoid(b_full)
+    oracle, _ = _linear_attention_model(
+        Hq=len(keep_groups),
+        Hkv=len(keep_groups),
+        Dk=D,
+        Dv=D,
+        K=cfg["K"],
+        update_rule="gated_delta",
+        decay=decay_full[:, :, keep_groups],
+        beta=beta_full[:, :, keep_groups],
+    )
+    oracle_vals = {
+        "Wq": cfg["wq"][:, q_idx],
+        "Wk": cfg["wk"][:, q_idx],
+        "Wv": cfg["wv"][:, q_idx],
+        "Wo": cfg["wo"][q_idx, :],
+        "Decay": decay_full[:, :, keep_groups],
+        "Beta": beta_full[:, :, keep_groups],
     }
-    inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
+    for init in oracle.graph.initializer:
+        init.CopyFrom(
+            onnx.numpy_helper.from_array(
+                np.ascontiguousarray(oracle_vals[init.name]), init.name
+            )
+        )
+    onnx.checker.check_model(oracle)
+
+    # Materialized pruned model: compute the identical formula, but from the
+    # PRUNED model's own already-sliced `Wa`/`Wb`/`DtBias`/`DecayScale`.
+    a_pruned = x @ inits["Wa"]
+    b_pruned = x @ inits["Wb"]
+    decay_pruned = inits["DecayScale"] * _softplus(a_pruned + inits["DtBias"])
+    beta_pruned = _sigmoid(b_pruned)
+    materialized, _ = _linear_attention_model(
+        Hq=len(keep_groups),
+        Hkv=len(keep_groups),
+        Dk=D,
+        Dv=D,
+        K=cfg["K"],
+        update_rule="gated_delta",
+        decay=decay_pruned,
+        beta=beta_pruned,
+    )
+    mat_vals = {
+        "Wq": inits["Wq"],
+        "Wk": inits["Wk"],
+        "Wv": inits["Wv"],
+        "Wo": inits["Wo"],
+        "Decay": decay_pruned,
+        "Beta": beta_pruned,
     }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+    for init in materialized.graph.initializer:
+        init.CopyFrom(
+            onnx.numpy_helper.from_array(
+                np.ascontiguousarray(mat_vals[init.name]), init.name
+            )
+        )
+    onnx.checker.check_model(materialized)
+
+    y_oracle = _run27(oracle, {"X": x})[0]
+    y_pruned_materialized = _run27(materialized, {"X": x})[0]
+    np.testing.assert_array_equal(y_pruned_materialized, y_oracle)
 
 
 def test_linear_attention_pruning_gate_fed_decay_only_slices_wa_and_gate_weights():
     # `"gated"` mode: `beta` never requested, so the gate node has no `b`
-    # input/`beta` output at all. Same documented, pre-approved
-    # `LinearAttentionGate` narrowing as
-    # `test_linear_attention_pruning_gate_fed_decay_and_beta_matches_oracle`
-    # above -- the C++ port this function is now a thin alias for declines
-    # the whole match cleanly rather than mis-slicing.
+    # input/`beta` output at all -- exercises MatchLinearAttentionGate's own
+    # `b_weight` (`std::optional`) staying unset (nothing to slice for a `b`
+    # that was never connected).
     model, cfg = _linear_attention_gate_model(Hkv=4, K=16, seed=13, decay_only=True)
     pruned = onnxsim.apply_attention_head_pruning(model, sparsity=0.5)
     onnx.checker.check_model(pruned)
 
-    node = _linear_attention_node(pruned)
-    q_attr = next(a.i for a in node.attribute if a.name == "q_num_heads")
-    kv_attr = next(a.i for a in node.attribute if a.name == "kv_num_heads")
-    assert (q_attr, kv_attr) == (cfg["Hq"], cfg["Hkv"])  # left untouched
-
-    inits_before = {
-        t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer
-    }
-    inits_after = {
-        t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer
-    }
-    for name in inits_before:
-        np.testing.assert_array_equal(inits_before[name], inits_after[name])
+    keep_groups = _linear_attention_keep_groups(
+        dict(
+            Hq=cfg["Hq"],
+            Hkv=cfg["Hkv"],
+            Dk=cfg["D"],
+            Dv=cfg["D"],
+            wq=cfg["wq"],
+            wk=cfg["wk"],
+            wv=cfg["wv"],
+        ),
+        sparsity=0.5,
+    )
+    inits = {t.name: onnx.numpy_helper.to_array(t) for t in pruned.graph.initializer}
+    assert "Wb" not in inits
+    np.testing.assert_array_equal(inits["DtBias"], cfg["dt_bias"][keep_groups])
+    np.testing.assert_array_equal(inits["DecayScale"], cfg["decay_scale"][keep_groups])
+    np.testing.assert_array_equal(inits["Wa"], cfg["wa"][:, keep_groups])
 
 
 def test_linear_attention_pruning_constant_decay_beta_prunes_same_shapes_as_gate_fed():
-    # Regression guard, ORIGINALLY: a genuine *constant* decay/beta (the
-    # shape this pass already supported before this fix) must keep pruning
-    # to the exact same shapes as the new gate-fed path, given the identical
-    # Wq/Wk/Wv/Wo (and therefore the identical importance ranking/
-    # `keep_groups`). Now a documented divergence, same pre-approved
-    # `LinearAttentionGate` narrowing as
-    # `test_linear_attention_pruning_gate_fed_decay_and_beta_matches_oracle`
-    # above: `apply_attention_head_pruning` is a thin alias for the C++ port,
-    # which prunes the genuine-constant-decay/beta path exactly as before
-    # (still verified full parity -- see
-    # `test_linear_attention_pruning_gated_mode_slices_gla_decay_matches_oracle`)
-    # but cleanly declines the gate-fed one, so the two paths' own shapes now
-    # genuinely differ instead of matching.
+    # Regression guard: a genuine *constant* decay/beta (the shape this pass
+    # already supported before this fix) must keep pruning to the exact same
+    # shapes as the gate-fed path, given the identical Wq/Wk/Wv/Wo (and
+    # therefore the identical importance ranking/`keep_groups`).
     gate_model, cfg = _linear_attention_gate_model(Hkv=4, K=16, seed=12)
 
     const_decay = np.broadcast_to(
@@ -45938,24 +46012,17 @@ def test_linear_attention_pruning_constant_decay_beta_prunes_same_shapes_as_gate
     onnx.checker.check_model(pruned_gate)
     onnx.checker.check_model(pruned_const)
 
-    # Gate-fed: declined, left at its original width (Hkv=4).
     dims_gate = _initializer_dims(pruned_gate)
-    for name in ("Wq", "Wk", "Wv", "Wo"):
-        assert dims_gate[name] == _initializer_dims(gate_model)[name]
-
-    # Constant decay/beta: genuinely pruned down to kv_num_heads=2 groups.
     dims_const = _initializer_dims(pruned_const)
-    assert dims_const["Wk"] != dims_gate["Wk"]
+    for name in ("Wq", "Wk", "Wv", "Wo"):
+        assert dims_gate[name] == dims_const[name]
 
     node_gate = _linear_attention_node(pruned_gate)
     node_const = _linear_attention_node(pruned_const)
-    assert (
-        next(a.i for a in node_gate.attribute if a.name == "kv_num_heads") == cfg["Hkv"]
-    )  # untouched
-    assert (
-        next(a.i for a in node_const.attribute if a.name == "kv_num_heads")
-        == cfg["Hkv"] // 2
-    )  # actually pruned
+    for attr_name in ("q_num_heads", "kv_num_heads"):
+        assert next(a.i for a in node_gate.attribute if a.name == attr_name) == next(
+            a.i for a in node_const.attribute if a.name == attr_name
+        )
 
 
 def test_linear_attention_pruning_dynamic_decay_from_non_gate_node_still_declines():


### PR DESCRIPTION
## Summary

Closes the last remaining gap between `apply_attention_head_pruning`/`apply_attention_head_wanda_pruning` (now aliased to their C++ ports, see #1195) and their C++ implementations — the `LinearAttentionGate` dynamic pass-through, previously a documented, deliberately-deferred narrowing.

### The pattern

Found in `onnxsim/pruning.py`'s `_match_linear_attention_gate`/`_LinearAttentionGatePassThrough`: when `LinearAttention`'s `decay`/`beta` inputs (indices 4/5) are dynamic (not constants), pruning.py doesn't just decline the match — it checks whether both are fed directly and exclusively by the same `com.microsoft::LinearAttentionGate` node's `decay`/`beta` outputs (that op's own documented formula: `decay = decay_scale * Softplus(a + dt_bias)`, `beta = Sigmoid(b)`). If so:
- `dt_bias`/`decay_scale` (the gate's own real `(kv_num_heads,)` constants) are sliced directly on axis 0 by `keep_groups`.
- `a`'s (always) and `b`'s (only if `beta` is wired) own producer — required to independently resolve to a plain MatMul/vanilla-Gemm with a constant 2-D weight exactly `kv_num_heads` columns wide — is sliced the same way Q/K/V's own producer weights are.
- Every crossed edge must have exactly one consumer and not be a graph output (same bar as the decomposed-GQA family's `_walk_back_through_qk_norm_rope`'s crossed hops); anything else declines cleanly.

### What's added

`LinearAttentionGatePassThrough` struct, `AttnChain::linear_attention_gate` field, `MatchLinearAttentionGate` (mirroring `_match_linear_attention_gate` exactly, reusing existing `MatchProducerAnyFloat`/`ConsumersOf`/`ConsumerCount`/`IsSupportedFloatDtype` helpers), wired into `FindLinearAttentionChains` when `decay`/`beta` is dynamic. `ApplyOneGqaChain`'s `is_linear_attention` branch now slices `dt_bias`/`decay_scale`/`a`'s/`b`'s producer weight via the existing `SliceAxisGeneric`, with both `AppliedAttn`/`ApplyAttentionChains`'s conflict-tracking extended to include the gate's producer weights.

Restored `tests/test_pruning.py`'s three affected tests to their genuine pruning/oracle-match assertions (they had been rewritten in a prior round to assert the old safe-decline behavior — this reverses that, now that the gap is closed). Added new dedicated coverage in `tests/test_attention_head_pruning_cpp.py` using `onnx.parser.parse_model`.

## Verification

- Full parity verified by reading `_match_linear_attention_gate`, `_LinearAttentionGatePassThrough`, and the `is_linear_attention` apply-time code in pruning.py end-to-end, porting each check/slice 1:1 — not just docstrings.
- `pip install -e . -v`: clean build, zero errors/redefinitions.
- Full suite (`CI=1 pytest tests/ -q --ignore=tests/test_timm.py`): **3623 passed, 0 failed, 175 skipped**.
- `clang-format`/`ruff format`/`ruff check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4t6ntCm72RfFf64W9GYB1)_