### PR TITLE
Make rich an optional dependency

### DIFF
--- a/.github/workflows/x2paddle-regression.yml
+++ b/.github/workflows/x2paddle-regression.yml
@@ -110,7 +110,8 @@ jobs:
           # X2Paddle 1.6.0 targets onnx<1.16 (onnx.mapping) and opset <= 15.
           # six and requests are undeclared x2paddle runtime deps that its
           # conversion path pulls in (x2paddle/core/program.py imports six and,
-          # via x2paddle.utils, requests); rich is an onnxsim runtime dep. All
+          # via x2paddle.utils, requests); rich is an optional onnxsim dep, kept
+          # here so the regression run exercises onnxsim's rich output path. All
           # are installed explicitly because the onnxsim wheel below goes in with
           # --no-deps. onnxslim is the comparison arm.
           python -m pip install "paddlepaddle>=2.5" "x2paddle==1.6.0" "onnx<1.16" \

--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ For more advanced features, try the following command for help message
 onnxsim -h
 ```
 
+`onnx` is the only required dependency. Everything else is an extra, installed
+only if you want it -- among them `rich`, which is used purely to colour and box
+the terminal reports (the original-vs-simplified table, the memory plan, the
+graph diff, CLI warnings). Without it those print as plain-text ASCII tables and
+the simplified models are byte-for-byte the same:
+
+```
+pip3 install "onnxsim[rich]"
+```
+
 ### Node.js version
 
 The same WebAssembly build backing the web version above is also published as

--- a/onnxsim/_onnx_compat.py
+++ b/onnxsim/_onnx_compat.py
@@ -1,0 +1,23 @@
+"""Compatibility shims for ONNX features that older ``onnx`` releases lack.
+
+onnxsim's own pipeline targets a current ``onnx``, but the package still has to
+*import* against an older one: downstream integrations pin old versions and
+install onnxsim next to them (X2Paddle 1.6.0 needs ``onnx.mapping``, removed in
+onnx 1.16, so its regression harness installs ``onnx<1.16``). A module-level
+``onnx.TensorProto.UINT4`` turns that into an ``AttributeError`` at
+``import onnxsim``, long before any 4-bit code could run.
+
+The tensor element type numbers are fixed by the ONNX spec and never reused, so
+the fallbacks below are the real wire values rather than sentinels: a model that
+does carry a 4-bit initializer is still recognised by dtype even when the
+installed ``onnx`` has no name for it. Only *creating* such tensors needs the
+newer onnx, and that fails where it is attempted instead of at import time.
+"""
+
+import onnx
+
+__all__ = ["INT4", "UINT4"]
+
+# Added in onnx 1.16 (opset 21).
+UINT4 = getattr(onnx.TensorProto, "UINT4", 21)
+INT4 = getattr(onnx.TensorProto, "INT4", 22)

--- a/onnxsim/_rich_compat.py
+++ b/onnxsim/_rich_compat.py
@@ -1,0 +1,207 @@
+"""``rich``-optional console output.
+
+onnxsim uses ``rich`` for exactly three things -- its ``print``, its ``Table``
+and its ``Text`` -- and only ever to make terminal reports (the
+original-vs-simplified table, the memory plan, the graph diff, the weight
+quantization error table, CLI warnings) look nicer. None of it affects the
+models onnxsim produces, so ``rich`` is an *optional* dependency
+(``pip install onnxsim[rich]``) rather than something every install has to
+carry.
+
+Modules that print should import ``print``/``Table``/``Text`` from here instead
+of from ``rich``. When ``rich`` is installed these names *are* rich's own; when
+it is not, they are the plain-text stand-ins below, which cover the small API
+surface onnxsim actually uses:
+
+- ``print(*objects)`` -- writes to stdout, rendering the stand-in ``Table`` and
+  ``Text`` objects and stripping rich console markup (``[bold]...[/bold]``)
+  from plain strings so tags never leak into the output.
+- ``Table(title=...)`` with ``add_column``/``add_row`` -- rendered as an ASCII
+  grid (deliberately ASCII: without rich there is no terminal detection to tell
+  us whether box-drawing characters are safe to emit).
+- ``Text(text, style=...)`` -- keeps the text, drops the style.
+
+The stand-ins are intentionally not a rich re-implementation: no styling, no
+wrapping, no width detection. They exist so that output stays readable, not so
+that it stays identical.
+"""
+
+from __future__ import annotations
+
+import builtins
+import re
+from typing import IO, Any, List, Optional
+
+__all__ = ["HAS_RICH", "Table", "Text", "print"]
+
+
+# --------------------------------------------------------------------------- #
+# Markup stripping
+# --------------------------------------------------------------------------- #
+# Rich console markup is `[style]text[/style]`. Stripping every bracketed word
+# would mangle ordinary output (tensor shapes, file paths, Python reprs), so a
+# tag is only removed when *every* word in it names a style -- an attribute
+# below, or a color (optionally `bright_`-prefixed and/or numbered, as in
+# `green1`), a `#rrggbb` triplet, or `color(N)`.
+_STYLE_ATTRS = frozenset(
+    {
+        "b",
+        "blink",
+        "blink2",
+        "bold",
+        "c",
+        "conceal",
+        "d",
+        "default",
+        "dim",
+        "encircle",
+        "frame",
+        "i",
+        "italic",
+        "none",
+        "not",
+        "o",
+        "on",
+        "overline",
+        "r",
+        "reverse",
+        "s",
+        "strike",
+        "u",
+        "underline",
+        "underline2",
+        "uu",
+    }
+)
+_COLOR_RE = re.compile(
+    r"(?:bright_)?"
+    r"(?:black|red|green|yellow|blue|magenta|cyan|white|grey|gray|purple)\d*$"
+    r"|#[0-9a-fA-F]{6}$"
+    r"|color\(\d+\)$"
+)
+_TAG_RE = re.compile(r"\[/?([a-zA-Z#()_ \d]*)\]")
+
+
+def _is_style(word: str) -> bool:
+    return word in _STYLE_ATTRS or _COLOR_RE.match(word) is not None
+
+
+def _strip_markup(text: str) -> str:
+    """Remove rich console markup tags from ``text``, leaving everything that
+    is not a style tag (``[1, 2]``, ``C:\\[tmp]``, ...) untouched."""
+
+    def replace(match: "re.Match[str]") -> str:
+        words = match.group(1).split()
+        # `[/]` (a bare close-all tag) has no words; `[]` is not markup.
+        if not words:
+            return "" if match.group(0) == "[/]" else match.group(0)
+        return "" if all(_is_style(w) for w in words) else match.group(0)
+
+    return _TAG_RE.sub(replace, text)
+
+
+# --------------------------------------------------------------------------- #
+# Plain-text stand-ins
+# --------------------------------------------------------------------------- #
+class _PlainText:
+    """Stand-in for ``rich.text.Text``: carries the text, ignores the style."""
+
+    def __init__(self, text: str = "", style: Any = "", **kwargs: Any) -> None:
+        self.plain = str(text)
+        self.style = style
+
+    def append(self, text: Any, style: Any = None) -> "_PlainText":
+        self.plain += _plain(text)
+        return self
+
+    def __len__(self) -> int:
+        return len(self.plain)
+
+    def __str__(self) -> str:
+        return self.plain
+
+    def __repr__(self) -> str:
+        return f"Text({self.plain!r})"
+
+
+def _plain(obj: Any) -> str:
+    """Render one printable object as plain text."""
+    if isinstance(obj, _PlainText):
+        return obj.plain
+    if isinstance(obj, str):
+        return _strip_markup(obj)
+    return str(obj)
+
+
+class _PlainTable:
+    """Stand-in for ``rich.table.Table``: an ASCII grid with an optional title.
+
+    Only the ``add_column``/``add_row`` subset onnxsim uses is supported; every
+    other rich ``Table`` keyword (styling, box, padding, ...) is accepted and
+    ignored so callers do not have to branch on whether rich is installed.
+    """
+
+    def __init__(self, *headers: Any, title: Optional[Any] = None, **kwargs: Any):
+        self.title = None if title is None else _plain(title)
+        self.columns: List[str] = [_plain(h) for h in headers]
+        self.rows: List[List[str]] = []
+
+    def add_column(self, header: Any = "", **kwargs: Any) -> None:
+        self.columns.append(_plain(header))
+
+    def add_row(self, *cells: Any, **kwargs: Any) -> None:
+        self.rows.append([_plain(c) for c in cells])
+
+    def _widths(self) -> List[int]:
+        width = max([len(self.columns)] + [len(r) for r in self.rows] + [0])
+        widths = [0] * width
+        for row in [self.columns] + self.rows:
+            for i, cell in enumerate(row):
+                widths[i] = max(widths[i], len(cell))
+        return widths
+
+    def __str__(self) -> str:
+        widths = self._widths()
+        if not widths:
+            return self.title or ""
+
+        def line(row: List[str]) -> str:
+            cells = row + [""] * (len(widths) - len(row))
+            return "| " + " | ".join(c.ljust(w) for c, w in zip(cells, widths)) + " |"
+
+        border = "+" + "+".join("-" * (w + 2) for w in widths) + "+"
+        lines = [border, line(self.columns), border]
+        lines.extend(line(row) for row in self.rows)
+        lines.append(border)
+        if self.title is not None:
+            lines.insert(0, self.title.center(len(border)).rstrip())
+        return "\n".join(lines)
+
+
+def _plain_print(
+    *objects: Any,
+    sep: str = " ",
+    end: str = "\n",
+    file: Optional[IO[str]] = None,
+    flush: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Stand-in for ``rich.print``: ``builtins.print`` plus markup stripping and
+    rendering of the stand-in ``Table``/``Text`` objects."""
+    builtins.print(
+        *(_plain(o) for o in objects), sep=sep, end=end, file=file, flush=flush
+    )
+
+
+try:
+    from rich import print as print  # noqa: F401
+    from rich.table import Table as Table  # noqa: F401
+    from rich.text import Text as Text  # noqa: F401
+
+    HAS_RICH = True
+except ImportError:  # rich is optional; fall back to the stand-ins above.
+    print = _plain_print  # type: ignore[assignment]
+    Table = _PlainTable  # type: ignore[assignment, misc]
+    Text = _PlainText  # type: ignore[assignment, misc]
+
+    HAS_RICH = False

--- a/onnxsim/d2quant.py
+++ b/onnxsim/d2quant.py
@@ -67,12 +67,10 @@ import onnx.helper
 import onnx.numpy_helper
 
 from onnxsim import backend
+from onnxsim._onnx_compat import INT4 as _INT4
 from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.smoothquant import _match_matmul_like
-
-_INT4 = onnx.TensorProto.INT4
-
 
 # ---------------------------------------------------------------------------
 # Dual-Scale Quantizer (DSQ)

--- a/onnxsim/hqq.py
+++ b/onnxsim/hqq.py
@@ -61,9 +61,8 @@ import onnx
 import onnx.helper
 import onnx.numpy_helper
 
+from onnxsim._onnx_compat import UINT4 as _UINT4
 from onnxsim.bias_correction import _all_names, _unique_name
-
-_UINT4 = onnx.TensorProto.UINT4
 
 
 def _match_matmul_like(node: onnx.NodeProto):

--- a/onnxsim/memory_planning.py
+++ b/onnxsim/memory_planning.py
@@ -3,10 +3,8 @@ import dataclasses
 from typing import Dict, List, Tuple
 
 import onnx
-from rich import print
-from rich.table import Table
-from rich.text import Text
 
+from onnxsim._rich_compat import Table, Text, print
 from onnxsim.model_info import (
     METADATA_PREFIX,
     ModelInfo,

--- a/onnxsim/model_info.py
+++ b/onnxsim/model_info.py
@@ -20,9 +20,8 @@ import numpy as np
 import onnx
 from onnx import defs, helper, numpy_helper, shape_inference
 from onnx.external_data_helper import ExternalDataInfo, uses_external_data
-from rich import print
-from rich.table import Table
-from rich.text import Text
+
+from onnxsim._rich_compat import Table, Text, print
 
 try:
     import sympy

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -24,12 +24,11 @@ import onnx.helper  # type: ignore
 import onnx.numpy_helper  # type: ignore
 import onnx.shape_inference  # type: ignore
 from google.protobuf.message import EncodeError
-from rich import print
-from rich.text import Text
 
 import onnxsim.onnxsim_cpp2py_export as C
 
 from . import backend, model_checking, model_info, profile_merge, version
+from ._rich_compat import Text, print
 from .calibration import Tensors, generate_random_calibration_data
 from .pruning import EmbeddingPruningResult, _ImportanceNorm
 

--- a/onnxsim/pruning.py
+++ b/onnxsim/pruning.py
@@ -1448,6 +1448,8 @@ import onnx.numpy_helper
 import onnx.shape_inference
 
 from onnxsim import backend
+from onnxsim._onnx_compat import INT4 as _INT4
+from onnxsim._onnx_compat import UINT4 as _UINT4
 from onnxsim.bias_correction import _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.gptq import _inverse_hessian_cholesky
@@ -46186,8 +46188,8 @@ def _match_embed_layer_norm_producer(
 #     matching or slicing correctness.
 _GATHER_BLOCK_QUANTIZED_DOMAIN = "com.microsoft"
 _GATHER_BLOCK_QUANTIZED_DATA_TYPES = {
-    onnx.TensorProto.UINT4,
-    onnx.TensorProto.INT4,
+    _UINT4,
+    _INT4,
     onnx.TensorProto.UINT8,
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"
 requires-python = ">=3.11"
 dependencies = [
     "onnx",
-    "rich",
 ]
 authors = [
     {name = "ONNX Simplifier Authors", email = "daquexian566@gmail.com"},
@@ -29,6 +28,12 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+# rich is used only to pretty-print terminal reports (the original-vs-simplified
+# table, the memory plan, the graph diff, CLI warnings). Without it those fall
+# back to plain-text tables via onnxsim._rich_compat; nothing about the produced
+# model changes. The 12.1.0 exclusion matches requirements.txt's long-standing
+# pin of that known-bad release.
+rich = ["rich != 12.1.0"]
 # onnxruntime is preferred for constant folding and correctness checking.
 # When it is not installed, onnxsim falls back to onnx's reference evaluator.
 onnxruntime = ["onnxruntime >= 1.6.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ onnxoptimizer >= 0.2.5
 # when it is not installed. See https://github.com/onnxsim/onnxsim/issues/441
 onnxruntime >= 1.6.0
 protobuf >= 3.7.0
+# rich is optional too; onnxsim._rich_compat falls back to plain-text tables
+# when it is not installed. Kept here so development/CI exercises the rich path.
 rich != 12.1.0

--- a/scripts/cross/assemble_wheel.py
+++ b/scripts/cross/assemble_wheel.py
@@ -71,9 +71,10 @@ Classifier: Topic :: Scientific/Engineering
 Classifier: Topic :: Software Development
 Requires-Python: >=3.11
 Requires-Dist: onnx
-Requires-Dist: rich
 Provides-Extra: onnxruntime
 Requires-Dist: onnxruntime >=1.6.0 ; extra == 'onnxruntime'
+Provides-Extra: rich
+Requires-Dist: rich !=12.1.0 ; extra == 'rich'
 Description-Content-Type: text/markdown
 
 Simplify your ONNX model. See https://github.com/onnxsim/onnxsim for details.

--- a/scripts/cross/bootstrap_s390x_rootfs.sh
+++ b/scripts/cross/bootstrap_s390x_rootfs.sh
@@ -97,8 +97,9 @@ if [[ -f /root/.ccr/ca-bundle.crt ]]; then
   cp /root/.ccr/ca-bundle.crt "${SYSROOT}/root/.ccr/"
 fi
 
-# rich is a runtime dependency of onnxsim and pure Python, so the host's pip can
-# drop it straight in.
+# rich is an optional dependency of onnxsim (without it the reports fall back to
+# plain-text tables) and pure Python, so the host's pip can drop it straight in
+# and the rootfs exercises the rich path.
 python3 -m pip install --quiet --target="${SYSROOT}/usr/lib/python3/dist-packages" rich
 
 # ml_dtypes is a C extension the vendored onnx needs and has no s390x wheel, so

--- a/scripts/cross/run_s390x_tests.sh
+++ b/scripts/cross/run_s390x_tests.sh
@@ -105,9 +105,12 @@ print(sys.byteorder, \"endian | python\", sys.version.split()[0],
 # module not copied into the chroot" reason as the four vendor-compat tests
 # above. test_axera_conv_matmul_coverage.py (pulsar2_backend),
 # test_axera_conv_matmul_coverage_hardware.py, test_axera_neu_format_arith_ops.py,
-# test_pulsar2_hf_to_axmodel.py, test_axera_op_coverage_hardware.py and
-# test_axera_quantonnx.py (all: pulsar2_docker) are the same scripts/axera/
-# vendor-module gap. test_tflite_export_torchvision.py imports
+# test_pulsar2_hf_to_axmodel.py, test_axera_op_coverage_hardware.py,
+# test_axera_quantonnx.py and test_axera_mcode_structure.py (all: pulsar2_docker)
+# are the same scripts/axera/ vendor-module gap. Unlike the tests that guard a
+# missing dependency with pytest.importorskip (a skip), an unguarded import like
+# these is a *collection error*, which aborts the whole run -- so a new test in
+# this family has to be added here. test_tflite_export_torchvision.py imports
 # torch directly at module scope, the same "no s390x build" reason as
 # test_torch_export_integration.py/test_timm.py/test_yolo.py/test_gan.py above.
 #
@@ -160,6 +163,7 @@ chroot "${SYSROOT}" /bin/sh -c "cd /work && GITHUB_STEP_SUMMARY=${CHROOT_SUMMARY
   --ignore=tests/test_pulsar2_hf_to_axmodel.py \
   --ignore=tests/test_axera_op_coverage_hardware.py \
   --ignore=tests/test_axera_quantonnx.py \
+  --ignore=tests/test_axera_mcode_structure.py \
   --ignore=tests/test_tflite_export_torchvision.py \
   --deselect tests/test_fusion_patterns.py::test_fuse_conv_bn_into_conv \
   --deselect tests/test_fusion_patterns.py::test_fuse_convtranspose_bn \

--- a/scripts/pyodide_demo/index.html
+++ b/scripts/pyodide_demo/index.html
@@ -308,6 +308,8 @@
   const ONNXSIM_PURE_PY_FILES = [
     "__init__.py",
     "__main__.py",
+    // The rich-optional print/Table/Text shim model_info.py imports.
+    "_rich_compat.py",
     "accuracy.py",
     "backend.py",
     "calibration.py",
@@ -359,7 +361,8 @@
 
   // Installs the real onnx PyPI package via micropip (works now that this
   // page's Pyodide version shares onnx's wheel's ABI epoch -- see the
-  // top-of-file comment), plus rich (a pure-Python onnxsim dependency), then
+  // top-of-file comment), plus rich (a pure-Python optional onnxsim dependency
+  // -- without it the reports fall back to plain-text tables), then
   // drops onnxsim's own pure-Python files into site-packages next to the
   // already-loaded onnxsim_cpp2py_export extension. Idempotent: safe to call
   // before every "full pipeline" run, only does real work once.

--- a/scripts/pyodide_wheel_smoke_test.mjs
+++ b/scripts/pyodide_wheel_smoke_test.mjs
@@ -63,7 +63,7 @@ async function main() {
   // `import onnxsim` needs both, not just onnxsim.simplify(). deps=False was
   // tried first and failed on exactly that ("ModuleNotFoundError: No module
   // named 'numpy'"), confirming this isn't optional. Letting micropip
-  // resolve the wheel's own declared dependencies (onnx, rich, and onnx's
+  // resolve the wheel's own declared dependencies (onnx and onnx's
   // own transitive numpy/protobuf/ml_dtypes) is also a better test than
   // skipping it: it validates the wheel's METADATA declares them correctly,
   // not just that the extension itself loads.

--- a/tests/test_onnx_compat.py
+++ b/tests/test_onnx_compat.py
@@ -1,0 +1,75 @@
+"""Tests for ``onnxsim._onnx_compat`` -- importing against an older ``onnx``.
+
+Downstream integrations pin old onnx versions and install onnxsim beside them
+(X2Paddle 1.6.0 needs ``onnx.mapping``, removed in onnx 1.16, so its regression
+harness installs ``onnx<1.16``). ``onnx.TensorProto.UINT4``/``INT4`` arrived in
+onnx 1.16, so touching them while a module is being imported breaks
+``import onnxsim`` outright on such an install -- long before any 4-bit code
+could run. ``_onnx_compat`` holds the guarded lookups; these tests check the
+fallback values are right and that no module goes back to the direct attribute.
+"""
+
+import ast
+import pathlib
+
+import onnx
+import pytest
+
+from onnxsim import _onnx_compat, model_info
+
+# Element types onnxsim references that older supported onnx releases lack:
+# UINT4/INT4 came in onnx 1.16, FLOAT4E2M1 and FLOAT8E8M0 later still.
+NEW_TENSOR_DTYPES = {"UINT4", "INT4", "FLOAT4E2M1", "FLOAT8E8M0"}
+
+
+def test_fallbacks_match_the_installed_onnx():
+    assert _onnx_compat.UINT4 == onnx.TensorProto.UINT4
+    assert _onnx_compat.INT4 == onnx.TensorProto.INT4
+
+
+def test_fallbacks_are_the_spec_wire_values():
+    # The fallbacks are hard-coded numbers, valid only because the ONNX spec
+    # fixes them; if onnx ever renumbered, these would silently mismatch.
+    assert (onnx.TensorProto.UINT4, onnx.TensorProto.INT4) == (21, 22)
+
+
+def _module_level_nodes(tree):
+    """Yield every node evaluated at import time: module-level statements and
+    class bodies, plus the parts of a function definition (decorators,
+    annotations, argument defaults) that run when the ``def`` is executed -- but
+    not function bodies, which run only when called."""
+
+    def walk(node):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for part in [
+                    *child.decorator_list,
+                    *(child.args.defaults or []),
+                    *[d for d in (child.args.kw_defaults or []) if d is not None],
+                    *([child.returns] if child.returns else []),
+                ]:
+                    yield from ast.walk(part)
+            else:
+                yield child
+                yield from walk(child)
+
+    yield from walk(tree)
+
+
+@pytest.mark.parametrize(
+    "path",
+    sorted(pathlib.Path(model_info.__file__).parent.glob("*.py")),
+    ids=lambda p: p.name,
+)
+def test_new_tensor_dtypes_are_not_touched_at_import_time(path):
+    if path.name == "_onnx_compat.py":
+        return  # the one module allowed to look them up (it guards the lookup)
+    offenders = [
+        f"{path.name}:{node.lineno} {ast.unparse(node)}"
+        for node in _module_level_nodes(ast.parse(path.read_text()))
+        if isinstance(node, ast.Attribute) and node.attr in NEW_TENSOR_DTYPES
+    ]
+    assert offenders == [], (
+        "these run at import and break `import onnxsim` on an older onnx; "
+        "take the value from onnxsim._onnx_compat instead: " + ", ".join(offenders)
+    )

--- a/tests/test_rich_optional.py
+++ b/tests/test_rich_optional.py
@@ -1,0 +1,253 @@
+"""Tests for ``onnxsim._rich_compat`` -- the shim that makes ``rich`` optional.
+
+``rich`` is only ever used to pretty-print terminal reports, so it lives in the
+``onnxsim[rich]`` extra and the printing modules import ``print``/``Table``/
+``Text`` from the shim instead of from ``rich`` directly. These tests cover both
+halves of that: the plain-text stand-ins render something readable and
+markup-free, and no module goes around the shim (which would reintroduce a hard
+``rich`` dependency without anyone noticing).
+
+The "rich is not installed" case is simulated -- the shim's fallback classes are
+exercised directly, and the import-time branch is re-executed as a throwaway
+module with ``rich`` made unimportable -- so the tests report the same result
+whether or not ``rich`` happens to be installed.
+"""
+
+import builtins
+import contextlib
+import importlib.util
+import pathlib
+import re
+import sys
+
+import onnx.parser as parser
+import pytest
+
+from onnxsim import _rich_compat, memory_planning, model_info, onnx_simplifier
+from onnxsim._rich_compat import _plain_print, _PlainTable, _PlainText, _strip_markup
+
+
+@contextlib.contextmanager
+def _rich_unimportable(monkeypatch):
+    """Make ``import rich`` (and any submodule) raise ImportError."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "rich" or name.startswith("rich."):
+            raise ImportError("simulated: rich is not installed")
+        return real_import(name, *args, **kwargs)
+
+    for name in [n for n in sys.modules if n == "rich" or n.startswith("rich.")]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    yield
+
+
+def _load_shim_without_rich(monkeypatch):
+    # A throwaway copy of the module, so the canonical onnxsim._rich_compat (and
+    # the names model_info/memory_planning/onnx_simplifier already imported from
+    # it) is left untouched.
+    spec = importlib.util.spec_from_file_location(
+        "_rich_compat_no_rich", _rich_compat.__file__
+    )
+    module = importlib.util.module_from_spec(spec)
+    with _rich_unimportable(monkeypatch):
+        spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------- #
+# The shim is the only door to rich
+# --------------------------------------------------------------------------- #
+def test_printing_modules_import_from_the_shim():
+    for module in (model_info, memory_planning):
+        assert module.print is _rich_compat.print
+        assert module.Table is _rich_compat.Table
+        assert module.Text is _rich_compat.Text
+    assert onnx_simplifier.print is _rich_compat.print
+    assert onnx_simplifier.Text is _rich_compat.Text
+
+
+def test_no_module_imports_rich_directly():
+    # rich must stay optional: everything goes through _rich_compat, which is
+    # the one module allowed to import it.
+    package = pathlib.Path(model_info.__file__).parent
+    offenders = [
+        path.name
+        for path in sorted(package.glob("*.py"))
+        if path.name != "_rich_compat.py"
+        and re.search(r"^\s*(from|import) rich\b", path.read_text(), re.MULTILINE)
+    ]
+    assert offenders == []
+
+
+# --------------------------------------------------------------------------- #
+# The import-time fallback branch
+# --------------------------------------------------------------------------- #
+def test_shim_falls_back_when_rich_is_missing(monkeypatch, capsys):
+    module = _load_shim_without_rich(monkeypatch)
+    assert module.HAS_RICH is False
+    assert module.print is module._plain_print
+    assert module.Table is module._PlainTable
+    assert module.Text is module._PlainText
+    # The fallback names are usable exactly like rich's.
+    table = module.Table(title="t")
+    table.add_column("col")
+    table.add_row(module.Text("value", style="bold green1"))
+    module.print(table)
+    assert "value" in capsys.readouterr().out
+
+
+def test_shim_reports_rich_when_importable():
+    rich = pytest.importorskip("rich")
+    assert _rich_compat.HAS_RICH is True
+    assert _rich_compat.print is rich.print
+
+
+# --------------------------------------------------------------------------- #
+# Markup stripping
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("[bold]Nodes removed (2):[/bold]", "Nodes removed (2):"),
+        ("[bold magenta]too large[/bold magenta]", "too large"),
+        ("[dim]... and 3 more[/dim]", "... and 3 more"),
+        ("[bold green1]4.0 MiB[/bold green1]", "4.0 MiB"),
+        ("[#ff00aa]x[/#ff00aa] [color(3)]y[/color(3)]", "x y"),
+        ("[not bold]x[/]", "x"),
+        # Not markup: ordinary bracketed output must survive untouched.
+        ("shape [1, 3, 224, 224]", "shape [1, 3, 224, 224]"),
+        ("path C:\\models[v2]\\a.onnx", "path C:\\models[v2]\\a.onnx"),
+        ("node [id0] removed", "node [id0] removed"),
+        ("empty []", "empty []"),
+    ],
+)
+def test_strip_markup(text, expected):
+    assert _strip_markup(text) == expected
+
+
+# --------------------------------------------------------------------------- #
+# The plain-text stand-ins
+# --------------------------------------------------------------------------- #
+def test_plain_text_keeps_text_and_drops_style():
+    text = _PlainText("hello", style="bold red")
+    assert str(text) == "hello"
+    assert text.plain == "hello"
+    assert len(text) == 5
+    text.append(_PlainText(" world"))
+    assert str(text) == "hello world"
+
+
+def test_plain_table_renders_an_ascii_grid():
+    table = _PlainTable(title="Activation Memory Plan")
+    table.add_column("Tensor")
+    table.add_column("Offset")
+    table.add_row("input", "0")
+    table.add_row("a_much_longer_name", _PlainText("1.2 MiB", style="dim"))
+    lines = str(table).splitlines()
+
+    assert lines[0].strip() == "Activation Memory Plan"
+    assert lines[1].startswith("+") and lines[1].endswith("+")
+    assert [c.strip() for c in lines[2].strip("|").split("|")] == ["Tensor", "Offset"]
+    assert [c.strip() for c in lines[4].strip("|").split("|")] == ["input", "0"]
+    # Every row is padded to the same width, so the grid lines up.
+    assert len({len(line) for line in lines[1:]}) == 1
+    # Styles are dropped, not rendered as markup or escape codes.
+    assert "1.2 MiB" in lines[5]
+    assert "\x1b[" not in str(table)
+
+
+def test_plain_table_without_title_or_rows():
+    table = _PlainTable()
+    table.add_column("only")
+    assert str(table).splitlines() == ["+------+", "| only |", "+------+", "+------+"]
+
+
+def test_plain_table_tolerates_short_and_long_rows():
+    table = _PlainTable()
+    table.add_column("a")
+    table.add_column("b")
+    table.add_row("1")
+    table.add_row("2", "3", "4")
+    rendered = str(table)
+    for cell in ("1", "2", "3", "4"):
+        assert cell in rendered
+
+
+def test_plain_print_strips_markup_and_renders_objects(capsys):
+    table = _PlainTable()
+    table.add_column("col")
+    table.add_row("v")
+    _plain_print("[bold]title[/bold]", _PlainText("t", style="dim"), sep=" | ")
+    _plain_print(table)
+    _plain_print()
+    out = capsys.readouterr().out
+    assert out.splitlines()[0] == "title | t"
+    assert "| v" in out
+    assert "[bold]" not in out
+
+
+# --------------------------------------------------------------------------- #
+# The real report functions, with the stand-ins in place of rich
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def no_rich(monkeypatch):
+    """Point the printing modules at the plain-text stand-ins, i.e. run them as
+    they would run in an install without ``rich``."""
+    for module in (model_info, memory_planning, onnx_simplifier):
+        monkeypatch.setattr(module, "print", _plain_print, raising=False)
+        monkeypatch.setattr(module, "Text", _PlainText, raising=False)
+        monkeypatch.setattr(module, "Table", _PlainTable, raising=False)
+
+
+def _model():
+    return parser.parse_model(
+        """
+        <ir_version: 10, opset_import: ["": 23]>
+        g (float[1,4] x) => (float[1,4] y)
+        {
+          [id0] mid = Identity(x)
+          [relu0] y = Relu(mid)
+        }
+        """
+    )
+
+
+def _simplified():
+    return parser.parse_model(
+        """
+        <ir_version: 10, opset_import: ["": 23]>
+        g (float[1,4] x) => (float[1,4] y)
+        {
+          [relu0] y = Relu(x)
+        }
+        """
+    )
+
+
+def test_print_simplifying_info_without_rich(no_rich, capsys):
+    model_info.print_simplifying_info(_model(), _simplified())
+    out = capsys.readouterr().out
+    assert "Model Size" in out
+    assert "Original Model" in out
+    assert "Simplified Model" in out
+    assert "[bold" not in out
+
+
+def test_print_graph_diff_without_rich(no_rich, capsys):
+    model_info.print_graph_diff(_model(), _simplified())
+    out = capsys.readouterr().out
+    assert "Nodes removed" in out
+    assert "id0" in out
+    # The section headings are markup in the rich path; they must not leak.
+    assert "[bold]" not in out and "[/bold]" not in out
+
+
+def test_print_memory_plan_without_rich(no_rich, capsys):
+    plan = memory_planning.plan_activation_memory(_model())
+    memory_planning.print_memory_plan(plan)
+    out = capsys.readouterr().out
+    assert "Activation Memory Plan" in out
+    assert "Arena:" in out
+    assert "[dim]" not in out


### PR DESCRIPTION
rich was a hard runtime dependency but is used for exactly three things --
its print, Table and Text -- and only ever to make terminal reports look
nicer (the original-vs-simplified table, the memory plan, the graph diff,
the weight quantization error table, CLI warnings). None of it affects the
models onnxsim produces, so every install had to carry it for cosmetics.

Add onnxsim/_rich_compat.py, which re-exports rich's print/Table/Text when
rich is importable and otherwise provides plain-text stand-ins covering the
small API surface onnxsim uses: an ASCII grid Table, a Text that keeps the
text and drops the style, and a print that renders those and strips rich
console markup ([bold]...[/bold]) so tags never leak into the output. Only
style tags are stripped, so ordinary bracketed output (shapes, paths, node
names) survives untouched. model_info, memory_planning and onnx_simplifier
now import the three names from the shim instead of from rich.

rich moves from [project] dependencies to a `rich` extra
(pip install "onnxsim[rich]"), keeping requirements.txt's != 12.1.0 pin;
the cross-built Windows wheel's hand-written METADATA follows. It stays in
requirements.txt and in the s390x rootfs / x2paddle CI environments so
development and those runs keep exercising the rich path.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014ckzABfiVJN3bDppEgW8DZ