### PR TITLE
Handle GridSample's pre-opset-20 mode names in both rewrites

### DIFF
--- a/onnxsim/passes/rewrite_gridsample_to_gather.h
+++ b/onnxsim/passes/rewrite_gridsample_to_gather.h
@@ -31,10 +31,14 @@
 //    tensor type for `X` (dequantizing to float internally and requantizing
 //    at the end for integer types); this pass does not attempt that and
 //    leaves such nodes alone.
-//  - Only `mode` (default `"linear"`) `"linear"` or `"nearest"`; `"cubic"` is
-//    left alone. Also leaves alone the pre-opset-20 `"bilinear"`/`"bicubic"`
-//    spelling of the same modes -- purely a naming difference (the sampling
-//    algorithm is identical), out of scope here rather than a semantic gap.
+//  - Only `mode` `"linear"` or `"nearest"`; `"cubic"` is left alone.
+//    GridSample-20 renamed two of the three modes -- opset 16-19 spell them
+//    `"bilinear"`/`"nearest"`/`"bicubic"` (default `"bilinear"`), opset 20+
+//    `"linear"`/`"nearest"`/`"cubic"` (default `"linear"`) -- with no change
+//    to the sampling algorithm, so both spellings of each mode are accepted
+//    and normalized to the opset-20 name before anything else looks at it.
+//    (Whichever spelling a node uses, the emitted subgraph is the same:
+//    `GridSample` disappears, so there is no spelling to preserve.)
 //  - All three `padding_mode` values (`"zeros"` default, `"border"`,
 //    `"reflection"`) and both `align_corners` values (0 default, 1) are
 //    handled.
@@ -428,6 +432,24 @@ struct GridSampleToGatherBuilder {
   }
 };
 
+// Reads `mode` off a `GridSample` node in the opset-20 spelling, whichever
+// spelling the node itself uses. GridSample-20 renamed "bilinear" -> "linear"
+// and "bicubic" -> "cubic" (and its default with them) without touching the
+// sampling algorithm, so an opset-16..19 node means exactly what the
+// same-named opset-20 one does. An absent attribute is "linear" under either
+// spelling, so the default needs no opset check of its own.
+inline std::string GetNormalizedGridSampleMode(Node* node) {
+  const std::string mode =
+      GetValueFromAttrWithDefault<std::string>(node, kmode, "linear");
+  if (mode == "bilinear") {
+    return "linear";
+  }
+  if (mode == "bicubic") {
+    return "cubic";
+  }
+  return mode;
+}
+
 struct RewriteGridSampleToGather final : public PredicateBasedPass {
   explicit RewriteGridSampleToGather()
       : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
@@ -467,8 +489,7 @@ struct RewriteGridSampleToGather final : public PredicateBasedPass {
     if (X->elemType() != TensorProto_DataType_FLOAT) {
       return false;
     }
-    const std::string mode =
-        GetValueFromAttrWithDefault<std::string>(node, kmode, "linear");
+    const std::string mode = GetNormalizedGridSampleMode(node);
     if (mode != "linear" && mode != "nearest") {
       return false;
     }
@@ -491,8 +512,7 @@ struct RewriteGridSampleToGather final : public PredicateBasedPass {
 
     Value* X = node->input(0);
     Value* grid = node->input(1);
-    const std::string mode =
-        GetValueFromAttrWithDefault<std::string>(node, kmode, "linear");
+    const std::string mode = GetNormalizedGridSampleMode(node);
     const std::string padding_mode = GetValueFromAttrWithDefault<std::string>(
         node, Symbol("padding_mode"), "zeros");
     const bool align_corners =

--- a/onnxsim/passes/rewrite_msdeformattn_to_gridsample.h
+++ b/onnxsim/passes/rewrite_msdeformattn_to_gridsample.h
@@ -150,7 +150,9 @@
 //       output position 1, instead of `num_queries`).
 //    c. `level_sampled = GridSample(value_reshaped_l, level_grid_reshaped,
 //       mode="linear", padding_mode="zeros", align_corners=0)` -> `(bs*M, D,
-//       num_queries, P)`. This is exactly mmcv's own `F.grid_sample(...,
+//       num_queries, P)`. (`mode` is spelled `"bilinear"`, GridSample-16's
+//       name for the same mode, on a graph whose opset is below 20 -- see
+//       `GridSampleOp`.) This is exactly mmcv's own `F.grid_sample(...,
 //       mode='bilinear', padding_mode='zeros', align_corners=False)` call --
 //       emitted as a real `GridSample` node rather than decomposed further
 //       (that is `rewrite_gridsample_to_gather`'s job; the two passes
@@ -360,11 +362,22 @@ struct MSDeformAttnToGridSampleBuilder {
     return outs;
   }
 
+  // GridSample-20 renamed two of the three interpolation modes: the linear
+  // one is "bilinear" in opset 16-19 and "linear" from opset 20 on. The
+  // sampling algorithm behind both names is identical, but the attribute is
+  // validated against the opset the model actually imports -- onnxruntime
+  // rejects "linear" on a GridSample-16 node ('mode "linear" not supported,
+  // expect bilinear, nearest or bicubic') just as it rejects "bilinear" on a
+  // GridSample-20 one -- so emit the spelling this graph's opset expects. A
+  // graph carrying no ai.onnx opset import at all (getOpsetVersion() == 0,
+  // which this pass's predicate also lets through) gets the current spelling.
   Value* GridSampleOp(Value* X, Value* grid) {
+    const int opset = PredicateBasedPass::getOpsetVersion(graph);
+    const char* mode = (opset != 0 && opset < 20) ? "bilinear" : "linear";
     Node* n = graph.create(Symbol("GridSample"), 1);
     n->addInput(X);
     n->addInput(grid);
-    n->s_(kmode, "linear");
+    n->s_(kmode, mode);
     n->s_(Symbol("padding_mode"), "zeros");
     n->i_(Symbol("align_corners"), int64_t(0));
     n->insertBefore(anchor);

--- a/tests/test_bev_models_torch_e2e.py
+++ b/tests/test_bev_models_torch_e2e.py
@@ -115,13 +115,15 @@ def _export_and_simplify(model, inputs, input_names, output_names):
             model,
             inputs,
             buf,
-            # >= 20, not just the >= 16 rewrite_msdeformattn_to_gridsample.h's
-            # header comment asks for: that pass hardcodes GridSample's
-            # mode="linear" (opset 20's renamed enum value), which is not a
-            # legal value under GridSample-16's schema (needs "bilinear")
-            # even though the pass's own predicate only checks opset >= 16 --
-            # discovered empirically running this file against onnxruntime,
-            # not from the header comment alone.
+            # 20 (not just the >= 16 rewrite_msdeformattn_to_gridsample.h's
+            # header comment asks for) simply because it is the current opset
+            # for the ops these models use. The pass emits GridSample's `mode`
+            # in the spelling the graph's opset expects -- "linear" from opset
+            # 20 on, "bilinear" (the same mode's pre-20 name, and the only one
+            # GridSample-16's schema accepts) below it -- so a 16..19 export
+            # loads in onnxruntime just as well; that spelling is covered
+            # directly by tests/test_msdeformattn_to_gridsample.py's
+            # test_gridsample_mode_spelling_follows_opset.
             opset_version=20,
             dynamo=False,
             input_names=input_names,

--- a/tests/test_gridsample_to_gather.py
+++ b/tests/test_gridsample_to_gather.py
@@ -16,12 +16,24 @@ idiom, which this mirrors.
 """
 
 import collections
+import importlib.util
 
 import numpy as np
 import pytest
 from onnx import parser
 
 import onnxsim
+
+# The onnx reference evaluator implements only GridSample-20's spelling of the
+# interpolation modes ("linear"/"nearest"/"cubic") and raises outright on the
+# opset-16..19 "bilinear"/"bicubic" spelling of the same modes. onnxsim's
+# equivalence check has to run the *original* (unrewritten) GridSample node, so
+# the pre-opset-20 tests below need onnxruntime, which implements both
+# spellings -- each one only on the opset range that uses it.
+requires_ort = pytest.mark.skipif(
+    importlib.util.find_spec("onnxruntime") is None,
+    reason="running a pre-opset-20 GridSample node needs onnxruntime",
+)
 
 
 def _model(
@@ -34,6 +46,10 @@ def _model(
     opset=20,
     ir_version=10,
 ):
+    # ``mode=None`` omits the attribute entirely, exercising the schema
+    # default ("bilinear" before opset 20, "linear" from 20 on -- the same
+    # mode either way).
+    mode_attr = "" if mode is None else f'mode="{mode}", '
     body = f"""
     <
       ir_version: {ir_version},
@@ -41,7 +57,7 @@ def _model(
     >
     agraph (float{x_shape} X, float{grid_shape} grid) => (float{out_shape} Y)
     {{
-      Y = GridSample <mode="{mode}", padding_mode="{padding_mode}", align_corners={align_corners}> (X, grid)
+      Y = GridSample <{mode_attr}padding_mode="{padding_mode}", align_corners={align_corners}> (X, grid)
     }}
     """
     return parser.parse_model(body)
@@ -67,6 +83,22 @@ def _simplify_and_check(model, input_data, check_n=1):
     assert "GridSample" not in op_types, op_types
     assert "GatherND" in op_types, op_types
     return sim_model, op_types
+
+
+def _simplify_expect_declined(model):
+    """Simplifies with the pass opted in and asserts it left the node alone.
+
+    No equivalence check (``check_n=0``): nothing about the graph changed, and
+    the modes this is used for ("cubic"/"bicubic") are exactly the ones the
+    pass declines to decompose.
+    """
+    sim_model, _ = onnxsim.simplify(
+        model,
+        extra_optimizers=["rewrite_gridsample_to_gather"],
+    )
+    op_types = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert op_types == collections.Counter({"GridSample": 1}), op_types
+    return sim_model
 
 
 # --------------------------------------------------------------------------- #
@@ -188,3 +220,94 @@ def test_dynamic_input_shape_reflection_nearest():
         align_corners=1,
     )
     _simplify_and_check(model, {"X": X, "grid": grid})
+
+
+# --------------------------------------------------------------------------- #
+# Pre-opset-20 mode spelling. GridSample-20 renamed two of the three
+# interpolation modes -- "bilinear" -> "linear" and "bicubic" -> "cubic" (the
+# schema default with them) -- without changing what they compute, so an
+# opset-16..19 model spells the very same mode differently. The pass must
+# recognize both spellings; a node it would decompose at opset 20 must not
+# survive untouched merely for having been exported at opset 16.
+# --------------------------------------------------------------------------- #
+
+
+@requires_ort
+@pytest.mark.parametrize("opset", [16, 19])
+@pytest.mark.parametrize("padding_mode", ["zeros", "border", "reflection"])
+def test_bilinear_pre_opset_20(opset, padding_mode):
+    rng = np.random.RandomState(4)
+    X = rng.randn(2, 3, 5, 7).astype(np.float32)
+    grid = _rand_grid(rng, (2, 4, 6, 2))
+
+    model = _model(
+        "[2,3,5,7]",
+        "[2,4,6,2]",
+        "[2,3,4,6]",
+        mode="bilinear",
+        padding_mode=padding_mode,
+        align_corners=0,
+        opset=opset,
+    )
+    _simplify_and_check(model, {"X": X, "grid": grid})
+
+
+@requires_ort
+@pytest.mark.parametrize("opset", [16, 19])
+def test_nearest_pre_opset_20(opset):
+    # "nearest" is spelled the same in both opset ranges -- covered here to
+    # pin that the added spelling handling did not disturb it.
+    rng = np.random.RandomState(5)
+    X = rng.randn(1, 2, 6, 8).astype(np.float32)
+    grid = _rand_grid(rng, (1, 3, 5, 2))
+
+    model = _model(
+        "[1,2,6,8]",
+        "[1,3,5,2]",
+        "[1,2,3,5]",
+        mode="nearest",
+        padding_mode="reflection",
+        align_corners=1,
+        opset=opset,
+    )
+    _simplify_and_check(model, {"X": X, "grid": grid})
+
+
+@pytest.mark.parametrize("opset", [16, 20])
+def test_default_mode(opset):
+    # No `mode` attribute at all: the schema default is "bilinear" before
+    # opset 20 and "linear" from 20 on -- the same mode under both names, so
+    # the pass must decompose it either way.
+    rng = np.random.RandomState(6)
+    X = rng.randn(2, 3, 5, 7).astype(np.float32)
+    grid = _rand_grid(rng, (2, 4, 6, 2))
+
+    model = _model(
+        "[2,3,5,7]",
+        "[2,4,6,2]",
+        "[2,3,4,6]",
+        mode=None,
+        padding_mode="zeros",
+        align_corners=0,
+        opset=opset,
+    )
+    _simplify_and_check(model, {"X": X, "grid": grid})
+
+
+@pytest.mark.parametrize(
+    "opset,mode", [(16, "bicubic"), (20, "cubic")], ids=["bicubic-16", "cubic-20"]
+)
+def test_declines_cubic(opset, mode):
+    # The cubic mode is out of scope for this rewrite under either of its
+    # names -- recognizing the pre-opset-20 spelling must not turn "bicubic"
+    # into something the pass thinks it can decompose.
+    model = _model(
+        "[2,3,5,7]",
+        "[2,4,6,2]",
+        "[2,3,4,6]",
+        mode=mode,
+        padding_mode="zeros",
+        align_corners=0,
+        opset=opset,
+    )
+    _simplify_expect_declined(model)

--- a/tests/test_msdeformattn_to_gridsample.py
+++ b/tests/test_msdeformattn_to_gridsample.py
@@ -42,6 +42,7 @@ CLAUDE.md's convention for this repo's tests.
 
 import collections
 import contextlib
+import importlib.util
 
 import numpy as np
 import onnx
@@ -53,9 +54,16 @@ import onnxsim
 
 OP_TYPE = "MMCVMultiScaleDeformableAttention"
 
+# Only onnxruntime validates GridSample's `mode` against the opset the model
+# imports (the onnx reference evaluator accepts just the opset-20 spelling
+# whatever the opset), so it is what the pre-opset-20 spelling test below
+# checks the emitted graph against -- when it is installed.
+_HAS_ORT = importlib.util.find_spec("onnxruntime") is not None
+
 # A single reusable GridSample model/evaluator (mode="linear",
 # padding_mode="zeros", align_corners=0 -- exactly what the rewrite itself
-# emits per level, and exactly mmcv's own
+# emits per level on an opset-20 graph, "bilinear" being the same mode's name
+# on a pre-20 one, and exactly mmcv's own
 # ``F.grid_sample(..., mode='bilinear', padding_mode='zeros',
 # align_corners=False)`` call) used as the bilinear-sampling primitive for
 # the NumPy reference below, instead of a second hand-rolled implementation.
@@ -463,3 +471,64 @@ def test_declines_unknown_num_levels():
         op_types = collections.Counter(n.op_type for n in sim_model.graph.node)
         assert OP_TYPE in op_types, op_types
         assert "GridSample" not in op_types, op_types
+
+
+# --------------------------------------------------------------------------- #
+# GridSample's `mode` attribute follows the graph's opset. GridSample-20
+# renamed "bilinear" -> "linear" (and "bicubic" -> "cubic") without changing
+# what either computes, but runtimes validate the attribute against the opset
+# the model actually imports: onnxruntime rejects "linear" on a GridSample-16
+# node ('mode "linear" not supported, expect bilinear, nearest or bicubic')
+# just as it rejects "bilinear" on a GridSample-20 one. This pass accepts any
+# opset >= 16, so it must emit the spelling that opset uses.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "opset,expected_mode", [(16, "bilinear"), (19, "bilinear"), (20, "linear")]
+)
+def test_gridsample_mode_spelling_follows_opset(opset, expected_mode):
+    rng = np.random.RandomState(7)
+    spatial_shapes = [(6, 6), (3, 4)]
+    bs, M, D, P = 1, 2, 4, 3
+    num_keys = sum(h * w for h, w in spatial_shapes)
+    num_queries = 4
+
+    with _msda_schema(""):
+        model = _model(bs, num_keys, num_queries, M, D, spatial_shapes, P, opset=opset)
+        value, ss, lsi, loc, attn = _rand_inputs(
+            rng, bs, num_keys, num_queries, M, D, spatial_shapes, P
+        )
+        feeds = {
+            "value": value,
+            "spatial_shapes": ss,
+            "level_start_index": lsi,
+            "sampling_locations": loc,
+            "attention_weights": attn,
+        }
+        sim_model, _ = onnxsim.simplify(
+            model, extra_optimizers=["rewrite_msdeformattn_to_gridsample"]
+        )
+
+    op_types = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert OP_TYPE not in op_types, op_types
+    gs_nodes = [n for n in sim_model.graph.node if n.op_type == "GridSample"]
+    assert len(gs_nodes) == len(spatial_shapes), op_types
+    modes = {
+        attr.s.decode() for n in gs_nodes for attr in n.attribute if attr.name == "mode"
+    }
+    assert modes == {expected_mode}
+
+    if not _HAS_ORT:
+        return
+    # The spelling only matters because a runtime enforces it -- so actually
+    # load and run the rewritten graph under onnxruntime, which is what would
+    # reject the other spelling at this opset.
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(
+        sim_model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    actual = sess.run(None, feeds)[0]
+    expected = multi_scale_deformable_attn_reference(value, ss, loc, attn)
+    np.testing.assert_allclose(actual, expected, rtol=1e-4, atol=1e-5)


### PR DESCRIPTION
GridSample-20 renamed two of the three interpolation modes -- "bilinear"
-> "linear" and "bicubic" -> "cubic", the schema default with them --
without changing what either computes. Opset 16-19 models (what most
exporters still emit) therefore spell the same modes differently, and
runtimes enforce the spelling per opset: onnxruntime rejects "linear" on
a GridSample-16 node ('mode "linear" not supported, expect bilinear,
nearest or bicubic') just as it rejects "bilinear" on a GridSample-20
one. Both onnxsim passes that touch GridSample knew only the opset-20
names:

- rewrite_gridsample_to_gather declined any node spelled "bilinear",
  so it silently did nothing on 16-19 models -- the exact models that
  need the decomposition, since the pass exists for backends with no
  GridSample kernel. It now normalizes the mode to the opset-20 name
  before matching, and still declines the cubic mode under both names.

- rewrite_msdeformattn_to_gridsample hardcoded mode="linear" while its
  predicate accepts any opset >= 16, producing a model onnxruntime
  refuses to load below opset 20. It now emits the spelling the graph's
  opset uses.

Tests cover both spellings (and the absent-attribute default) at opsets
16/19/20 for the decomposition, the emitted spelling plus an actual
onnxruntime run of the rewritten graph for the MSDeformAttn rewrite, and
that cubic/bicubic stays declined.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ba6kQU5QkCbSw3Z6vtfTxE