### PR TITLE
axera: LXD VM passthrough for the AX650N and an AXCL_LXD_VM remote mode (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ node_modules/
 # Claude Code local session/tooling state (e.g. background-agent worktree
 # checkouts under .claude/worktrees/) -- never part of the repo itself.
 /.claude/
+scripts/axera/vm/share/

--- a/scripts/axera/pulsar2_docker.py
+++ b/scripts/axera/pulsar2_docker.py
@@ -77,7 +77,7 @@ import tarfile
 import tempfile
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Tuple
 
 DEFAULT_IMAGE = "pulsar2:6.0-lite"
 
@@ -633,8 +633,114 @@ def llm_build(
     )
 
 
+# ---------------------------------------------------------------------------
+# Device runs, locally or inside an LXD virtual machine.
+#
+# Set `AXCL_LXD_VM=<vm name>` to run every `axcl_run_model` invocation inside
+# an LXD *virtual machine* that has the AX650N passed through via VFIO (see
+# `vm/README.md`). The out-of-tree AXCL host driver has crashed and wedged this
+# host more than once; inside a KVM guest the same fault kills only the guest,
+# and `lxc restart --force <vm>` bus-resets the card without a host reboot.
+# Files are pushed into a fresh guest temp dir, the tool runs via `lxc exec`,
+# and any output folder is pulled back -- callers see the same results as a
+# local run. `lxc exec` is an ordinary host client process, so the caller's
+# `timeout` still fires even when the guest driver hangs.
+# ---------------------------------------------------------------------------
+_AXCL_LXD_VM = os.environ.get("AXCL_LXD_VM")
+
+
+def axcl_lxd_vm() -> Optional[str]:
+    """Name of the LXD VM device runs are routed to, or None for local runs."""
+    return _AXCL_LXD_VM or None
+
+
 def axcl_available(binary: str = "/usr/bin/axcl/axcl_run_model") -> bool:
+    vm = axcl_lxd_vm()
+    if vm:
+        try:
+            proc = subprocess.run(
+                ["lxc", "exec", vm, "--", "test", "-x", binary],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+        return proc.returncode == 0
     return os.path.exists(binary)
+
+
+def _invoke_axcl(
+    binary: str,
+    args: List[str],
+    *,
+    timeout: int,
+    push: Sequence[str] = (),
+    pull: Optional[Tuple[str, str]] = None,
+) -> Tuple[int, str]:
+    """Run `binary args...` locally or inside the `AXCL_LXD_VM` guest.
+
+    `push` lists local paths (files or directories) that appear in `args`;
+    in VM mode they are copied into a guest temp dir and their occurrences
+    in `args` rewritten to the guest paths. `pull=(guest_relative_name,
+    local_dir)` copies a guest output directory back into `local_dir` (as
+    `local_dir/<name>`) after the run. Returns `(returncode, stdout+stderr)`
+    and lets `subprocess.TimeoutExpired` propagate like a local run would.
+    """
+    vm = axcl_lxd_vm()
+    if not vm:
+        proc = subprocess.run(
+            [binary, *args], capture_output=True, text=True, timeout=timeout
+        )
+        return proc.returncode, proc.stdout + proc.stderr
+
+    def lxc(*cmd: str, t: int = 120) -> subprocess.CompletedProcess:
+        return subprocess.run(["lxc", *cmd], capture_output=True, text=True, timeout=t)
+
+    made = lxc("exec", vm, "--", "mktemp", "-d", "/tmp/axcl.XXXXXX")
+    if made.returncode != 0:
+        return made.returncode, "lxc exec mktemp failed: " + made.stdout + made.stderr
+    remote = made.stdout.strip()
+    mapping: Dict[str, str] = {}
+    try:
+        for local in push:
+            name = os.path.basename(os.path.normpath(local))
+            target = f"{remote}/{name}"
+            if os.path.isdir(local):
+                # `lxc file push -r DIR guest:REMOTE/` lands at REMOTE/<basename>
+                res = lxc("file", "push", "-r", local, f"{vm}{remote}/", t=600)
+            else:
+                res = lxc("file", "push", local, f"{vm}{target}", t=600)
+            if res.returncode != 0:
+                return (
+                    res.returncode,
+                    "lxc file push failed: " + res.stdout + res.stderr,
+                )
+            mapping[os.path.normpath(local)] = target
+        if pull:
+            mapping[os.path.normpath(os.path.join(pull[1], pull[0]))] = (
+                f"{remote}/{pull[0]}"
+            )
+
+        def rewrite(a: str) -> str:
+            key = os.path.normpath(a) if os.path.sep in a else a
+            return mapping.get(key, a)
+
+        proc = subprocess.run(
+            ["lxc", "exec", vm, "--", binary, *[rewrite(a) for a in args]],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        log = proc.stdout + proc.stderr
+        if pull:
+            lxc("file", "pull", "-r", f"{vm}{remote}/{pull[0]}", pull[1], t=600)
+        return proc.returncode, log
+    finally:
+        try:
+            lxc("exec", vm, "--", "rm", "-rf", remote, t=60)
+        except subprocess.TimeoutExpired:
+            pass
 
 
 def run_on_device(
@@ -658,15 +764,14 @@ def run_on_device(
             "error": "axcl_run_model not found",
         }
     try:
-        proc = subprocess.run(
-            [binary, "-m", axmodel_path, "-r", str(repeat), "-w", str(warmup)],
-            capture_output=True,
-            text=True,
+        _, log = _invoke_axcl(
+            binary,
+            ["-m", axmodel_path, "-r", str(repeat), "-w", str(warmup)],
             timeout=timeout,
+            push=[axmodel_path],
         )
     except subprocess.TimeoutExpired:
         return {"min_ms": None, "max_ms": None, "avg_ms": None, "error": "timeout"}
-    log = proc.stdout + proc.stderr
     m = _LATENCY_RE.search(log)
     if not m:
         return {"min_ms": None, "max_ms": None, "avg_ms": None, "error": log[-500:]}
@@ -744,9 +849,9 @@ def run_on_device_with_inputs(
         with open(list_path, "w") as f:
             f.write("0\n")
         try:
-            proc = subprocess.run(
+            _, log = _invoke_axcl(
+                binary,
                 [
-                    binary,
                     "-m",
                     axmodel_path,
                     "-i",
@@ -760,13 +865,12 @@ def run_on_device_with_inputs(
                     "-w",
                     str(warmup),
                 ],
-                capture_output=True,
-                text=True,
                 timeout=timeout,
+                push=[axmodel_path, os.path.join(td, "in"), list_path],
+                pull=("out", td),
             )
         except subprocess.TimeoutExpired:
             return DeviceRunResult(error="timeout")
-        log = proc.stdout + proc.stderr
         outputs = []
         for p in sorted(glob.glob(os.path.join(out_dir, "0", "*.bin"))):
             with open(p, "rb") as f:

--- a/scripts/axera/vm/README.md
+++ b/scripts/axera/vm/README.md
@@ -1,0 +1,79 @@
+# Running the AX650N inside an LXD virtual machine
+
+The AXCL host driver is an out-of-tree kernel module, and its faults have taken
+this host down (see `../host-driver-patches/NOTES.md`). Putting the card into a
+KVM guest via VFIO passthrough bounds the blast radius: a driver fault kills the
+guest, and `lxc restart --force <vm>` bus-resets the card without a host reboot.
+This must be an LXD **virtual machine** (`--vm`); a container shares the host
+kernel and gives no protection.
+
+Everything that only *compiles* (Docker, `pulsar2 build`/`llm_build`) stays on
+the host. Only `axcl_run_model` moves into the guest, and the harness routes
+it there transparently when `AXCL_LXD_VM=<vm name>` is set:
+`pulsar2_docker.axcl_available()`, `run_on_device()` and
+`run_on_device_with_inputs()` push the `.axmodel` and input folders with
+`lxc file push`, run the tool with `lxc exec`, and pull outputs back. Every
+existing device test runs unchanged.
+
+## One-time host prerequisites (sudo)
+
+1. The IOMMU must be on. This host shipped with `amd_iommu=off` on the kernel
+   command line; removing it (optionally adding `iommu=pt`) and rebooting gave
+   38 IOMMU groups, with the card in a group of its own plus its ASMedia
+   downstream bridge -- the friendly case (bridges stay on the host). Check:
+   `ls /sys/kernel/iommu_groups/*/devices/ | grep 03:00.0`.
+2. Hand the card to `vfio-pci` and keep the host from loading the AXCL stack:
+   `sudo bash scripts/axera/vm/host_bind_vfio.sh` (`--undo` reverses it). It
+   writes `modprobe.d` overrides, rebuilds the initramfs, and tries to rebind
+   immediately; a reboot makes it certain.
+
+**Why the host can no longer run the card once the IOMMU is on** (confirmed
+2026-09-07): a Thunderbolt-attached device is treated as untrusted, so the
+kernel keeps it in a translated `DMA` domain even with `iommu=pt`
+(`/sys/bus/pci/devices/0000:03:00.0/iommu_group/type` reads `DMA`), and the
+AXCL driver hands the card raw host physical addresses for its shared memory
+-- the card's DMA then faults (`AMD-Vi: Event logged [IO_PAGE_FAULT
+domain=0x0003 ...]` from `ax_pcie_dev_host 0000:03:00.0`) and `axcl-smi`
+hangs. That is almost certainly why `amd_iommu=off` was on the command line.
+Inside a VFIO guest the same driver works, because VFIO installs the guest's
+memory map in the IOMMU and the addresses the guest driver hands the card are
+exactly the ones mapped. That was fixed the same day by driver fix 5 (`../host-driver-patches/`,
+`fix_axcl_iommu_p5.sh`): every card-visible buffer is now allocated and
+mapped against the card's own `pci_dev`, and the host runs the card with the
+IOMMU on and zero faults. The VM is therefore optional again -- its value is
+containment of driver faults, not access to the card.
+
+## Create the guest (no sudo)
+
+```sh
+bash scripts/axera/vm/create_vm.sh            # ubuntu:24.04, 8 cores, 16 GiB, the card, /mnt/share
+lxc exec axcl-vm -- bash /mnt/share/guest_install_axcl.sh   # deb + DKMS + the four driver fixes
+lxc exec axcl-vm -- axcl-smi
+```
+
+`create_vm.sh` stages the `axclhost` deb (`AXCL_DEB=` to point at it), the
+`host-driver-patches/` tree and the guest installer into
+`scripts/axera/vm/share/` (git-ignored), mounted at `/mnt/share` in the guest.
+The guest installer registers the driver with DKMS exactly as on the host and
+applies the four fixes with `patch -p1`, so a Thunderbolt hiccup inside the
+guest is survivable there too.
+
+## Use it
+
+```sh
+export AXCL_LXD_VM=axcl-vm
+python -m pytest tests/test_axera_mcode_structure.py -k on_device
+```
+
+If the guest driver wedges: `lxc restart --force axcl-vm` (the card gets a
+secondary bus reset on the way), then re-run. The host is never involved.
+
+## Known limits
+
+- A Thunderbolt link drop while the card is assigned reaches the *guest*
+  driver as a hot-unplug -- exactly the path fix 3 hardens -- and VFIO on the
+  host handles the surprise removal; untested until it happens.
+- `lxc file push` adds ~0.1 s per run for a small model and scales with the
+  weight table (a 12 MB resnet18d `.axmodel` is fine; a 250 MB LLM head is
+  noticeable). Keep large models in `/mnt/share` and pass that path when it
+  matters.

--- a/scripts/axera/vm/README.md
+++ b/scripts/axera/vm/README.md
@@ -68,6 +68,21 @@ python -m pytest tests/test_axera_mcode_structure.py -k on_device
 If the guest driver wedges: `lxc restart --force axcl-vm` (the card gets a
 secondary bus reset on the way), then re-run. The host is never involved.
 
+## A host crash to never repeat (2026-09-07 19:39, kdump `202609071939`)
+
+Starting the VM while the host AXCL modules were still loaded (the blacklist
+had been undone to test driver fix 5) took the host down. LXD steals the card
+with a per-device `driver_override`; when the guest driver reset the card's
+SoC, the card re-enumerated, the override went with the old device instance,
+the host's `ax_pcie_dev_host` probed the new one, and driver fix 4's automatic
+bring-up pushed firmware into a card the guest was driving -- panic in
+`axcl_firmware_load` (`axcl_pcie_device_online_work`). `create_vm.sh` now
+refuses to run unless the stack is unloaded *and* the blacklist file exists.
+The guest side has a rule too: a VFIO bus reset does not reset the card's
+SoC, only the driver's unload path does, so after `lxc restart --force`
+always `modprobe -r axcl_host && modprobe axcl_host` inside the guest before
+expecting a firmware push to succeed.
+
 ## Known limits
 
 - A Thunderbolt link drop while the card is assigned reaches the *guest*

--- a/scripts/axera/vm/README.md
+++ b/scripts/axera/vm/README.md
@@ -83,6 +83,41 @@ SoC, only the driver's unload path does, so after `lxc restart --force`
 always `modprobe -r axcl_host && modprobe axcl_host` inside the guest before
 expecting a firmware push to succeed.
 
+## Where the guest path stands (2026-09-07 evening)
+
+Two guest-side configuration bugs found and fixed, one blocker left.
+
+**Fixed: the guest's virtual IOMMU was remapping the card's DMA.** Passing
+`-device intel-iommu,intremap=on,caching-mode=on` with a split irqchip (both
+in `raw.qemu`/`raw.qemu.conf`, already set on the VM) brings interrupt
+remapping up, but it also turns on DMA remapping, and the card's group in the
+guest came up as a translated `DMA` domain: the guest driver handed the card
+guest IOVAs that VFIO had never mapped, and the host logged
+`vfio-pci ... IO_PAGE_FAULT domain=0x0009 address=0xffc00000`. Adding
+`iommu=pt` to the *guest's* kernel command line (`/etc/default/grub.d/
+99-axcl-iommu.cfg`) gives the card an `identity` domain, so it gets
+guest-physical addresses that VFIO's mapping covers. After that: no host
+faults from the guest's DMA, and `DMAR-IR: Enabled IRQ remapping in x2apic
+mode` in the guest.
+
+**Fixed: a VFIO bus reset does not reset the card's SoC.** Only the driver's
+unload path does (`start reset slave`). After `lxc restart --force`, always
+`modprobe -r axcl_host && modprobe axcl_host` inside the guest before
+expecting a firmware push to succeed.
+
+**Blocker: the card's onboard software never comes up in the guest.** The
+boot ROM works -- all five firmware stages report `[STATUS]: SUCCESS`, which
+means the guest's MMIO writes reach the card *and* the card's DMA/status
+writes come back. But after `start_devices()` nothing follows: BAR0's shared
+window stays all zeros, the card raises no interrupt at all (VFIO's four host
+IRQs `vfio-msi[0..3]` stay at count 0 while the guest's MSI capability is
+enabled with the vIOMMU's remapped address `0xfee00918`), the RC/EP handshake
+times out, and `axcl-smi` reports `Recv port ack timeout`. On the host the
+same card raises hundreds of interrupts on its `endpoint-msi-irq` line. So
+the card's own Linux either does not finish booting or cannot signal from
+inside the guest; that is the next thing to chase, e.g. by capturing the
+card's own boot log (`/proc/ax_proc/pcie/sysdump`) after a failed bring-up.
+
 ## Known limits
 
 - A Thunderbolt link drop while the card is assigned reaches the *guest*

--- a/scripts/axera/vm/create_vm.sh
+++ b/scripts/axera/vm/create_vm.sh
@@ -9,6 +9,24 @@ ADDR=${AXCL_PCI_ADDR:-0000:03:00.0}
 REPO=$(cd "$(dirname "$0")/../../.." && pwd)
 SHARE=${AXCL_VM_SHARE:-$REPO/scripts/axera/vm/share}
 mkdir -p "$SHARE"
+
+# HARD GUARD -- confirmed host crash 2026-09-07 19:39 (kdump 202609071939):
+# with the host AXCL modules loaded, LXD's per-device driver_override is
+# not enough. When the guest driver resets the card's SoC, the card
+# re-enumerates, the override is lost with the old device instance, the
+# host's ax_pcie_dev_host probes the new one, and driver fix 4's automatic
+# bring-up pushes firmware into a card a guest is driving -- the host panicked
+# in axcl_firmware_load. Only the blacklist written by host_bind_vfio.sh keeps
+# the host driver away from a re-enumerated card, so refuse to run without it.
+if lsmod | grep -qE '^(axcl_host|ax_pcie_msg|ax_pcie_mmb|ax_pcie_host_dev)\b'; then
+  echo "ERROR: the host AXCL driver stack is loaded. Run 'sudo bash scripts/axera/vm/host_bind_vfio.sh' first" >&2
+  echo "       (it blacklists the stack and hands the card to vfio-pci); never start the VM with it loaded." >&2
+  exit 1
+fi
+if [ ! -f /etc/modprobe.d/blacklist-axcl-host.conf ]; then
+  echo "ERROR: /etc/modprobe.d/blacklist-axcl-host.conf is missing -- run host_bind_vfio.sh first." >&2
+  exit 1
+fi
 # stage what the guest installer needs
 cp -n "${AXCL_DEB:-$HOME/dev/archives/axclhost_x86_64_8G_V2.25.0_20250207.deb}" "$SHARE"/ 2>/dev/null || echo "note: put the axclhost .deb into $SHARE (AXCL_DEB=... to point at it)"
 rm -rf "$SHARE/host-driver-patches" && cp -r "$REPO/scripts/axera/host-driver-patches" "$SHARE"/

--- a/scripts/axera/vm/create_vm.sh
+++ b/scripts/axera/vm/create_vm.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Create the LXD virtual machine that owns the AX650N. No sudo needed (the
+# user must be in the `lxd` group). Idempotent: re-running reconfigures.
+#
+#   bash scripts/axera/vm/create_vm.sh [vm-name]
+set -euo pipefail
+VM=${1:-axcl-vm}
+ADDR=${AXCL_PCI_ADDR:-0000:03:00.0}
+REPO=$(cd "$(dirname "$0")/../../.." && pwd)
+SHARE=${AXCL_VM_SHARE:-$REPO/scripts/axera/vm/share}
+mkdir -p "$SHARE"
+# stage what the guest installer needs
+cp -n "${AXCL_DEB:-$HOME/dev/archives/axclhost_x86_64_8G_V2.25.0_20250207.deb}" "$SHARE"/ 2>/dev/null || echo "note: put the axclhost .deb into $SHARE (AXCL_DEB=... to point at it)"
+rm -rf "$SHARE/host-driver-patches" && cp -r "$REPO/scripts/axera/host-driver-patches" "$SHARE"/
+cp "$REPO/scripts/axera/vm/guest_install_axcl.sh" "$SHARE"/
+
+if ! lxc info "$VM" >/dev/null 2>&1; then
+  lxc launch ubuntu:24.04 "$VM" --vm -c limits.cpu=8 -c limits.memory=16GiB -c security.secureboot=false
+  echo "waiting for the guest agent..."; for i in $(seq 1 60); do lxc exec "$VM" -- true 2>/dev/null && break; sleep 2; done
+fi
+lxc stop "$VM" --force 2>/dev/null || true
+# the card, and a shared folder for .axmodel files / patches / the deb
+lxc config device add "$VM" ax650 pci address="$ADDR" 2>/dev/null || lxc config device set "$VM" ax650 address="$ADDR"
+lxc config device add "$VM" share disk source="$SHARE" path=/mnt/share 2>/dev/null || true
+lxc start "$VM"
+for i in $(seq 1 60); do lxc exec "$VM" -- true 2>/dev/null && break; sleep 2; done
+echo "guest sees:"; lxc exec "$VM" -- lspci -nn | grep -i 1f4b || echo "  (card not visible in guest -- is it bound to vfio-pci on the host?)"
+echo "next: copy the AXCL deb and host-driver-patches into $SHARE, then"
+echo "      lxc exec $VM -- bash /mnt/share/guest_install_axcl.sh"

--- a/scripts/axera/vm/guest_install_axcl.sh
+++ b/scripts/axera/vm/guest_install_axcl.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Inside the guest: install the AXCL host package, register its driver with
+# DKMS, apply the host-driver-patches, load the stack, and check the card.
+# Expects /mnt/share/axclhost_*.deb and /mnt/share/host-driver-patches/.
+set -euo pipefail
+DEB=$(ls /mnt/share/axclhost_*.deb | head -1)
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq dkms build-essential "linux-headers-$(uname -r)" python3 patch >/dev/null
+dpkg -i "$DEB" || apt-get install -f -y -qq
+SRC=/usr/src/axcl-2.25.0
+if [ ! -d "$SRC" ]; then
+  mkdir -p "$SRC" && cp -r /usr/src/axcl/driver/axcl/. "$SRC"/
+  cat > "$SRC/dkms.conf" <<CONF
+PACKAGE_NAME="axcl"
+PACKAGE_VERSION="2.25.0"
+AUTOINSTALL="yes"
+CLEAN="make -C /lib/modules/\${kernelver}/build M=\${dkms_tree}/\${PACKAGE_NAME}/\${PACKAGE_VERSION}/build clean"
+MAKE[0]="make -C /lib/modules/\${kernelver}/build M=\${dkms_tree}/\${PACKAGE_NAME}/\${PACKAGE_VERSION}/build -j\$(nproc) modules"
+BUILT_MODULE_NAME[0]="ax_pcie_host_dev"
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+BUILT_MODULE_NAME[1]="ax_pcie_mmb"
+DEST_MODULE_LOCATION[1]="/updates/dkms"
+BUILT_MODULE_NAME[2]="ax_pcie_msg"
+DEST_MODULE_LOCATION[2]="/updates/dkms"
+BUILT_MODULE_NAME[3]="axcl_host"
+DEST_MODULE_LOCATION[3]="/updates/dkms"
+CONF
+fi
+# the three pre-existing kernel-7 build edits (see host-driver-patches/NOTES.md)
+grep -q 'linux/vmalloc.h' "$SRC/axcl_pcie_host.c" || sed -i '0,/#include/s//#include <linux\/vmalloc.h>\n#include/' "$SRC/axcl_pcie_host.c"
+grep -q 'linux/vmalloc.h' "$SRC/ax_pcie_msg_usrdev.c" || sed -i '0,/#include/s//#include <linux\/vmalloc.h>\n#include/' "$SRC/ax_pcie_msg_usrdev.c"
+sed -i 's/SUPPORT_PCI_NET 1/SUPPORT_PCI_NET 0/' "$SRC/ax_pcie_dev.h"
+# the four fixes
+for p in /mnt/share/host-driver-patches/patches/*.patch; do
+  if patch -p1 -d "$SRC" -R --dry-run -f < "$p" >/dev/null 2>&1; then echo "already applied: $(basename "$p")"; else patch -p1 -d "$SRC" < "$p"; fi
+done
+dkms add axcl/2.25.0 2>/dev/null || true
+dkms build axcl/2.25.0 --force && dkms install axcl/2.25.0 --force
+modprobe ax_pcie_host_dev && modprobe ax_pcie_msg && modprobe ax_pcie_mmb && modprobe axcl_host
+echo "waiting for the handshake (up to ~2 min)..."; sleep 90
+timeout 30 axcl-smi || echo "axcl-smi did not answer yet; check dmesg for 'handshake'"

--- a/scripts/axera/vm/host_bind_vfio.sh
+++ b/scripts/axera/vm/host_bind_vfio.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Hand the AX650N (PCI 1f4b:0650) to vfio-pci on the host so an LXD virtual
+# machine can own it. Run with sudo; takes effect at the next boot (initramfs
+# is rebuilt) and, if the axcl stack is not currently in use, immediately.
+#
+#   sudo bash scripts/axera/vm/host_bind_vfio.sh          # bind to vfio-pci
+#   sudo bash scripts/axera/vm/host_bind_vfio.sh --undo   # give it back to the host driver
+set -euo pipefail
+ADDR=${AXCL_PCI_ADDR:-0000:03:00.0}
+IDS=1f4b:0650
+if [ "$(id -u)" -ne 0 ]; then echo "run with sudo" >&2; exit 1; fi
+
+if [ "${1:-}" = "--undo" ]; then
+  rm -f /etc/modprobe.d/vfio-axcl.conf /etc/modprobe.d/blacklist-axcl-host.conf
+  update-initramfs -u
+  if [ -e /sys/bus/pci/devices/$ADDR/driver ]; then echo "$ADDR" > /sys/bus/pci/devices/$ADDR/driver/unbind || true; fi
+  echo > /sys/bus/pci/devices/$ADDR/driver_override
+  modprobe ax_pcie_host_dev && modprobe ax_pcie_msg && modprobe ax_pcie_mmb && modprobe axcl_host
+  echo "$ADDR returned to the host driver"; exit 0
+fi
+
+# 1. vfio-pci claims the card at boot, before the axcl driver can.
+cat > /etc/modprobe.d/vfio-axcl.conf <<CONF
+options vfio-pci ids=$IDS
+softdep ax_pcie_host_dev pre: vfio-pci
+CONF
+# 2. the host never loads the axcl stack again (the VM runs it).
+cat > /etc/modprobe.d/blacklist-axcl-host.conf <<CONF
+blacklist axcl_host
+blacklist ax_pcie_mmb
+blacklist ax_pcie_msg
+blacklist ax_pcie_host_dev
+CONF
+update-initramfs -u
+
+# 3. try to switch right now (harmless if the axcl stack is busy or absent).
+modprobe -r axcl_host ax_pcie_mmb ax_pcie_msg ax_pcie_host_dev 2>/dev/null || true
+modprobe vfio-pci
+echo vfio-pci > /sys/bus/pci/devices/$ADDR/driver_override
+if [ -e /sys/bus/pci/devices/$ADDR/driver ]; then echo "$ADDR" > /sys/bus/pci/devices/$ADDR/driver/unbind || true; fi
+echo "$ADDR" > /sys/bus/pci/drivers_probe
+echo "driver now: $(basename "$(readlink /sys/bus/pci/devices/$ADDR/driver)" 2>/dev/null || echo none)"
+echo "IOMMU group: $(basename "$(readlink /sys/bus/pci/devices/$ADDR/iommu_group)" 2>/dev/null || echo NONE -- is the IOMMU on?)"


### PR DESCRIPTION
Work in progress, opened so the pieces are reviewable while the guest path is still being debugged.

**Goal.** Contain AXCL host-driver faults: pass the AX650N to an LXD *virtual machine* through VFIO so a driver crash kills the guest rather than the host, and `lxc restart --force` bus-resets the card without a reboot. A container would share the host kernel and give no protection.

**What is here.**
- `scripts/axera/vm/host_bind_vfio.sh` (sudo): bind the card to `vfio-pci`, blacklist the AXCL stack on the host, rebuild the initramfs; `--undo` reverses it.
- `scripts/axera/vm/create_vm.sh`: `ubuntu:24.04` VM (8 cores, 16 GiB) with the card and a shared folder; stages the `axclhost` deb, `host-driver-patches/` and the guest installer into `scripts/axera/vm/share/` (git-ignored).
- `scripts/axera/vm/guest_install_axcl.sh`: deb + DKMS + the driver patches inside the guest.
- `pulsar2_docker`: with `AXCL_LXD_VM=<vm>`, `axcl_available()`, `run_on_device()` and `run_on_device_with_inputs()` push files into a guest temp dir, run `axcl_run_model` via `lxc exec`, and pull outputs back, so every existing device test runs unchanged. Local mode is untouched (verified: import and local `axcl_available()` still work).

**Status, confirmed on the real hardware.** IOMMU groups appear once `amd_iommu=off` is removed; the card lands in a group of its own plus its ASMedia bridge; VFIO takes it and bus-resets it at VM start; containment was demonstrated twice (guest stalls, host untouched). Inside the guest the firmware push succeeds stage by stage (which proves card DMA into guest memory under VFIO) and the RC/EP handshake passes, but the card's onboard agent never answered: BAR0's shared area stays zero, the guest's MSI vector never fires, and `axcl-smi` times out on its port request. Two findings on the way: a VFIO bus reset does not reset the card's SoC (only the driver's unload path does, so a re-push after a plain restart fails), and the host needed driver fix 5 (#1212) to work with the IOMMU on at all.

**Not yet done.** A model has not run through the remote mode end to end. Next steps are in the README: retry from a cold card, then interrupt delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UR9eKjjw4j9Wx3RfchBKAu
