### PR TITLE
QAT design note, plus its first two stages: ONNX step graphs and provider-picked calibration

### DIFF
--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Run WebNN helper unit test
         working-directory: scripts/convertmodel
         run: npm run test:webnn
+      - name: Run browser-calibration unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:quantize-cal
       - name: Run library-versions unit test
         working-directory: scripts/convertmodel
         run: npm run test:versions

--- a/docs/nncf-comparison-future-work.md
+++ b/docs/nncf-comparison-future-work.md
@@ -102,6 +102,11 @@ on that decision, not as independent work.
   would mean maintaining a second, fundamentally different code path rather
   than adding another pass, which is a much bigger scope change than anything
   else in this list. Not pursued unless there's a specific driving use case.
+  `docs/qat.md` revisits this on a narrower reading -- label-free, block-wise
+  distillation against the float model, which needs no task loss and no
+  labelled dataset -- and sketches how its training step could run on WebGPU
+  or an NPU through the existing execution-provider boundary. Task-loss QAT,
+  the thing this bullet is about, stays out of scope there too.
 - **OpenVINO IR export/interop.** onnxsim targets ONNX Runtime; adding an
   OpenVINO IR export path duplicates what NNCF already does well and doesn't
   play to onnxsim's ONNX/ORT-centric strength.

--- a/docs/qat.md
+++ b/docs/qat.md
@@ -1,0 +1,205 @@
+# Delivering QAT in onnxsim: a design note
+
+**Status: design note, not an implementation.** It answers "how *could* we
+deliver quantization-aware training as an onnxsim feature, and can the
+training math run on WebGPU or an NPU?" and records the shape of the work so
+the question doesn't have to be re-derived. `docs/nncf-comparison-future-work.md`
+currently lists QAT as out of scope ("QAT needs a training loop with a
+framework-native model"); this note revisits that on the narrower reading
+below, and leaves the broader one (task loss, labels, epochs) exactly as
+out of scope as it was.
+
+## The thing to notice first: most of QAT is already here
+
+onnxsim does not have "no training". It has, today, six passes that are
+gradient descent with a straight-through estimator, hand-derived, in plain
+numpy:
+
+| Module | What it optimizes by SGD/Adam | Objective |
+| --- | --- | --- |
+| `adaround.py` | per-element floor/ceil relaxation (rectified sigmoid) | one layer's output MSE |
+| `adaquant.py` | rounding **+ activation scale/zero-point** (STE, LSQ-style) | one layer's output MSE |
+| `brecq.py` | rounding, backpropagated through a **multi-layer block** | the block's final output MSE |
+| `flexround.py` | a multiplicative rounding reparametrization | layer output MSE |
+| `autoround.py` | rounding + clip ratio, LSQ-style scale gradient | layer output MSE |
+| `omniquant.py` | learnable clip ratio | layer output MSE |
+
+What separates these from QAT is not the machinery, it is four axes:
+
+1. **What is free.** They optimize *which integer a weight rounds to* (and
+   sometimes the scale). QAT lets the underlying float weight itself move.
+2. **Scope.** One layer, or one hand-identified block (`brecq.py`'s
+   `block_input_name`/`block_output_name`). QAT trains the whole model.
+3. **Objective.** Local reconstruction against the float model's own
+   activations. QAT uses a task loss on labelled data.
+4. **Budget.** Hundreds of Adam steps on a handful of calibration batches,
+   on CPU, in numpy. QAT is orders of magnitude more compute.
+
+Axes 1-2 and 4 are engineering. Axis 3 is the architectural one: a task loss
+means labels, a dataset API, a metric, and a training-loop lifecycle onnxsim
+has never had. So split the feature there.
+
+## Three deliverables, only two of which we should build
+
+### A. QAT interop (graph-only, no training)
+
+Consume and produce QAT artifacts without running any training:
+
+- **Ingest.** A model exported from PyTorch/TF QAT arrives as a QDQ graph
+  whose scales and zero-points were *learned*. Today's calibration-based
+  entry points (`calibration.py`'s `calibrate` / `quantize_static`) would
+  re-derive them from min/max observation and throw the learned values away.
+  A `keep_existing_qdq_scales` path — detect QDQ pairs already present,
+  canonicalize them, and let the rest of the pipeline (folding, QDQ→QOperator,
+  `passes/`) run without re-calibrating — is pure graph rewriting and fits
+  onnxsim's architecture exactly.
+- **Egress.** Emit a fake-quant (QDQ) model whose scale/zero-point
+  initializers are marked as the tensors an external trainer should make
+  learnable, so a user can round-trip: onnxsim picks the scheme and the
+  per-layer bit widths (`mixed_precision.py`, `precision_estimator.py`), the
+  user trains in their framework, onnxsim re-imports the trained scales via
+  the ingest path.
+
+This is the cheapest real QAT value we can ship and it costs no new paradigm.
+
+### B. Graph-native QAT = block-wise, label-free fine-tuning
+
+The honest name for what onnxsim can do itself: **knowledge-distillation QAT**.
+The float model is the teacher; the quantized model is the student; the loss
+is reconstruction against the teacher's own activations — exactly the
+objective `brecq.py` already optimizes, extended along axes 1, 2 and 4:
+
+- weights themselves free (fp32 master weights, fake-quantized in the
+  forward with an STE), not only their rounding bit;
+- learnable step size for weights *and* activations (LSQ / LSQ+ / PACT) —
+  `adaquant.py` already does this for activation scale/zero-point, so the
+  gradients exist in-tree;
+- block discovery that walks through normalization/activation nodes instead
+  of `brecq.py`'s strict linear-chain restriction, then a sliding window over
+  blocks, ending with an optional end-to-end pass on the whole graph;
+- real data via `calibration.load_huggingface_calibration_data`, many epochs
+  over it rather than one probe capture.
+
+No labels, no task loss, no metric API — the teacher supplies the target.
+That keeps the lifecycle onnxsim already has (model in, model out) and still
+delivers the thing users actually want from QAT: recovering accuracy that
+PTQ cannot, especially at 4 bits and below with activation quantization.
+
+### C. Task-loss QAT
+
+Out of scope, unchanged. If it is ever wanted, the seam is a caller-supplied
+callback returning dL/d(model output) per batch — B's machinery would then
+carry it — but the dataset/label/metric surface is a different project.
+
+## Making it run on WebGPU and NPUs
+
+The constraint that shapes the implementation: **the training step must be
+expressible as an ordinary ONNX inference graph.**
+
+That is achievable precisely *because* this codebase hand-derives its
+gradients instead of using autodiff. A hand-derived backward pass is just
+dataflow — `MatMul`, `Transpose`, `Mul`, `Sub`, `ReduceSum`, `Sigmoid`,
+`Clip`, `Where`, `Sqrt` — with no autograd tape and no `Gradient` op. So one
+Adam step over one block can be emitted as a single **step graph**:
+
+```
+inputs :  X (activations), Y* (teacher output), W, s, zp, m, v, t, lr
+outputs:  W', s', zp', m', v', loss
+```
+
+a pure function, optimizer state carried in and out as tensors. Run it N
+times and you have trained a block — using nothing but an inference runtime.
+
+Every accelerator this project already reaches then comes for free, through
+boundaries that exist today:
+
+- **Python.** `backend.run_model(..., providers=[...])` (`onnxsim/backend.py`)
+  already takes an ordered execution-provider list and already validates it.
+  CUDA, DirectML, and the NPU-class EPs each vendor harness in `scripts/`
+  already exercises — QNN (`scripts/qualcomm`), Core ML/ANE (`scripts/apple`),
+  OpenVINO (`scripts/intel`), MIGraphX (`scripts/amd`), Axera pulsar2
+  (`scripts/axera`) — take the same step graph unmodified.
+- **Browser.** The WASM build already delegates model evaluation to
+  onnxruntime-web through `JsModelExecutor` (`docs/wasm_ort_web.md`), and
+  `scripts/convertmodel/ort_executor.mjs`'s `makeOrtRunner(ort, { providers })`
+  already selects `webgpu`, `webnn-gpu` or `webnn-npu` with a `wasm` fallback
+  (`docs/webnn.md`). A step graph is just another model to run there.
+
+So the accelerator story is not a second backend to write; it is the existing
+`ModelExecutor`/`providers` boundary, applied to a graph we already know how
+to build. Three things it does *not* give for free:
+
+- **Readback dominates if ignored.** A naive loop copies every parameter and
+  every Adam moment host↔device per step. Parameters must stay resident:
+  `IOBinding` on the Python side, and on the web side onnxruntime-web's
+  GPU-buffer tensors with `preferredOutputLocation: "gpu-buffer"` (ORT-web
+  ≥1.17; the converter page is on 1.27), feeding each step's outputs straight
+  back in as the next step's inputs. Only the loss comes back to the host.
+- **NPUs are inference silicon, and it shows.** WebNN, QNN, Core ML and the
+  Axera path compile a *fixed* graph, prefer fp16/int8, and often reject
+  fp32 accumulation or dynamic shapes. Adam in fp16 is not stable. The
+  realistic split is therefore: **NPU runs the forward passes** — the frozen
+  teacher, and the student forward, which is where the FLOPs are, static
+  shape, fp16-friendly — while **the gradient and optimizer step runs on
+  WebGPU or CPU** with fp32 master weights. That is ordinary mixed-precision
+  training practice, and it means "QAT on an NPU" should be advertised as
+  NPU-accelerated, not NPU-resident.
+- **Determinism goes away.** GPU/NPU reductions reassociate;
+  `tests/test_constant_fold_determinism.py`'s standard cannot hold for a
+  trained result. CI stays on CPU with exact assertions; accelerator paths
+  get tolerance-based tests and stay opt-in.
+
+Rejected alternatives, recorded so they aren't re-proposed: **ORT on-device
+training artifacts** (authoring them needs PyTorch, and the training EP
+coverage is far narrower than the inference EPs — it would *lose* WebGPU and
+NPU reach, not gain it); **a torch dependency** (violates this project's
+no-framework rule and reaches neither WebGPU nor an NPU from the wheel);
+**hand-written WGSL kernels** (re-implements what onnxruntime-web's WebGPU EP
+already does, and would serve the browser only).
+
+## Staging
+
+Each stage is independently shippable and independently useful.
+
+0. **Provider plumbing.** `apply_adaround`/`apply_adaquant`/`apply_brecq`
+   already accept `providers=`, but only for the teacher's activation capture
+   — the optimization itself is CPU numpy. Meanwhile
+   `scripts/convertmodel/quantize_calibration.mjs` hard-codes
+   `executionProviders: ["wasm"]` and ignores the page's own EP dropdown.
+   Fixing that one line puts browser calibration on WebGPU/WebNN today, and
+   is the smallest end-to-end proof that the accelerator path works.
+1. **`qat_graph.py`: the step-graph builder/runner.** Emit forward + backward
+   + Adam as one ONNX model; run it through `backend` with `providers=`.
+   Prove it by porting one existing pass (`adaround.py` is the smallest) onto
+   it and showing bit-comparable CPU results plus a working non-CPU provider.
+   This is the load-bearing piece; everything else is application.
+2. **`qat.py` / `apply_qat()`.** Free weights + LSQ/LSQ+ scales + block-wise
+   teacher distillation over `load_huggingface_calibration_data`, a
+   `QuantizationConfig` flag to reach it from `quantize()`, a doc, and tests
+   in the established style (parser-built models, a *measured* improvement
+   over RTN/AdaRound on a scenario engineered to make them differ, scoped as
+   honestly as `brecq.py` scopes its own).
+3. **Browser QAT panel.** A "fine-tune" panel in the converter page: data
+   from `hf_datasets.mjs`, execution from `ort_executor.mjs` on WebGPU, a
+   loss curve, and `quantize_metrics.mjs` for the before/after. Client-side
+   QAT with no server is something none of the comparable tools offer.
+4. **QAT interop (A).** Ingest externally-trained QDQ scales; emit the
+   fake-quant model for external trainers.
+
+## Costs and risks
+
+- **Op coverage.** The backward graph's ops must all be implemented by the
+  target EP. On WebGPU that is very likely; on WebNN/NPU it is exactly why
+  the forward/backward split above exists. Needs measuring per EP before any
+  claim is made in the README.
+- **A second code path.** This is the objection `nncf-comparison-future-work.md`
+  raises, and it is real — mitigated by the fact that stage 1's step-graph
+  builder *replaces* numpy inner loops in existing passes rather than sitting
+  beside them, and speeds them up on the way.
+- **No new dependency.** Nothing above adds a runtime dependency: onnxruntime
+  stays optional, onnxruntime-web is already on the converter page, numpy is
+  already there.
+- **Expectation management.** Label-free distillation QAT is not
+  paper-QAT accuracy. It should be documented as what it is — the strongest
+  thing reachable without labels — the same way `brecq.py`'s docstring refuses
+  to claim its paper's reported numbers.

--- a/docs/qat.md
+++ b/docs/qat.md
@@ -1,9 +1,11 @@
 # Delivering QAT in onnxsim: a design note
 
-**Status: design note, not an implementation.** It answers "how *could* we
-deliver quantization-aware training as an onnxsim feature, and can the
-training math run on WebGPU or an NPU?" and records the shape of the work so
-the question doesn't have to be re-derived. `docs/nncf-comparison-future-work.md`
+**Status: design note, with its first two stages implemented.**
+`onnxsim/qat_graph.py` and the converter page's calibration-provider picker
+have landed (see "Staging" below); `apply_qat()` itself has not. This note
+answers "how *could* we deliver quantization-aware training as an onnxsim
+feature, and can the training math run on WebGPU or an NPU?" and records the
+shape of the work so the question doesn't have to be re-derived. `docs/nncf-comparison-future-work.md`
 currently lists QAT as out of scope ("QAT needs a training loop with a
 framework-native model"); this note revisits that on the narrower reading
 below, and leaves the broader one (task loss, labels, epochs) exactly as
@@ -161,19 +163,30 @@ already does, and would serve the browser only).
 
 Each stage is independently shippable and independently useful.
 
-0. **Provider plumbing.** `apply_adaround`/`apply_adaquant`/`apply_brecq`
-   already accept `providers=`, but only for the teacher's activation capture
-   — the optimization itself is CPU numpy. Meanwhile
-   `scripts/convertmodel/quantize_calibration.mjs` hard-codes
-   `executionProviders: ["wasm"]` and ignores the page's own EP dropdown.
-   Fixing that one line puts browser calibration on WebGPU/WebNN today, and
-   is the smallest end-to-end proof that the accelerator path works.
-1. **`qat_graph.py`: the step-graph builder/runner.** Emit forward + backward
-   + Adam as one ONNX model; run it through `backend` with `providers=`.
-   Prove it by porting one existing pass (`adaround.py` is the smallest) onto
-   it and showing bit-comparable CPU results plus a working non-CPU provider.
-   This is the load-bearing piece; everything else is application.
-2. **`qat.py` / `apply_qat()`.** Free weights + LSQ/LSQ+ scales + block-wise
+0. **Provider plumbing -- done.** The converter page's browser-side
+   calibration (`scripts/convertmodel/quantize_calibration.mjs`) used to
+   hard-code `executionProviders: ["wasm"]`; it now takes the providers the
+   Quantize panel's own **calibration execution provider** picker selects
+   (`providersForEp` from `webnn.mjs`, so every accelerated choice keeps its
+   WASM fallback), and asks for onnxruntime-web's "all" bundle when a WebNN
+   device is chosen. WASM stays the default: an accelerated provider can
+   compute in a different precision, which moves the observed min/max, so
+   calibrating on one is opt-in. Unit-tested browser-free in
+   `scripts/convertmodel/test/quantize_calibration.test.mjs`.
+1. **`qat_graph.py`: the step-graph builder/runner -- done.** `GraphBuilder`
+   assembles a hand-derived gradient as ONNX nodes, `adam_update` appends one
+   Adam step, `make_step_graph` wraps the result into a pure
+   `(constants, state, per-step scalars) -> (next state, loss)` function, and
+   `run_step_graph` runs it N times through a single `onnxsim.backend.Runner`
+   -- one session for the whole loop, on whichever `providers=` the caller
+   names. `onnxsim.adaround` is the first caller ported onto it:
+   `apply_adaround(..., step_providers=[...])` runs the optimization as a step
+   graph instead of in host numpy. `tests/test_qat_graph.py` checks that it
+   agrees with the numpy loop it replaces (>95% of elements pick the identical
+   floor/ceil decision; the rest is float32-vs-float64 boundary rounding, and
+   the reconstruction error lands within 10%) and that both step graphs stay
+   inside an operator allowlist the accelerator backends actually implement.
+2. **`qat.py` / `apply_qat()`** (next). Free weights + LSQ/LSQ+ scales + block-wise
    teacher distillation over `load_huggingface_calibration_data`, a
    `QuantizationConfig` flag to reach it from `quantize()`, a doc, and tests
    in the established style (parser-built models, a *measured* improvement
@@ -185,6 +198,36 @@ Each stage is independently shippable and independently useful.
    QAT with no server is something none of the comparable tools offer.
 4. **QAT interop (A).** Ingest externally-trained QDQ scales; emit the
    fake-quant model for external trainers.
+
+## Using what has landed
+
+```python
+import onnxsim
+
+# The optimization loop itself now runs as an ONNX step graph on these
+# providers rather than in host numpy. `providers=` (unchanged) still selects
+# where the float model's calibration activations are captured.
+tuned = onnxsim.apply_adaround(
+    float_model,
+    quantized_model,
+    calibration_data=batches,
+    providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    step_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+)
+```
+
+Omitting `step_providers` keeps the existing float64 numpy loop, which is what
+CI runs: it is exact and reproducible, and a non-CPU provider is neither. In
+the browser, the Quantize panel's **calibration execution provider** picker
+does the equivalent for calibration's own forward passes (WebGPU, or WebNN's
+GPU/NPU device types).
+
+To put a *new* algorithm on a step graph: build its gradient with
+`qat_graph.GraphBuilder`, close the loop with `qat_graph.adam_update` and
+`make_step_graph`, and run it with `run_step_graph`.
+`adaround._build_rounding_step_graph` is the worked example, and it is short
+for the reason this whole approach works -- a hand-derived gradient is just
+arithmetic.
 
 ## Costs and risks
 

--- a/onnxsim/adaround.py
+++ b/onnxsim/adaround.py
@@ -41,6 +41,7 @@ from real activations" style.
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Union
 
@@ -48,7 +49,7 @@ import numpy as np
 import onnx
 import onnx.numpy_helper
 
-from onnxsim import backend
+from onnxsim import backend, qat_graph
 from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
@@ -162,6 +163,23 @@ def _h_and_dhdv(v: np.ndarray) -> "tuple[np.ndarray, np.ndarray]":
     return h, dh_dv
 
 
+def _init_relaxation(
+    w_nk: np.ndarray, scale_nk: np.ndarray
+) -> "tuple[np.ndarray, np.ndarray]":
+    """The rectified-sigmoid relaxation's starting point ``v`` and each
+    element's own quantization bin ``floor(w / scale)``, shared by both
+    optimization paths (numpy and :mod:`onnxsim.qat_graph`)."""
+    ratio = w_nk / scale_nk
+    floor_base = np.floor(ratio)
+    frac = np.clip(ratio - floor_base, 1e-4, 1.0 - 1e-4)
+    # Inverse of h(v) at v's initial point: start each element's relaxation
+    # at round-to-nearest's own choice (h == frac puts the soft weight
+    # exactly at the un-rounded ratio, the least-biased starting point).
+    sig0 = (frac - _GAMMA) / (_ZETA - _GAMMA)
+    sig0 = np.clip(sig0, 1e-4, 1.0 - 1e-4)
+    return np.log(sig0 / (1.0 - sig0)), floor_base
+
+
 def _optimize_rounding(
     w_nk: np.ndarray,
     scale_nk: np.ndarray,
@@ -183,15 +201,7 @@ def _optimize_rounding(
     """
     y_float = x @ w_nk.T  # [num_samples, N]
 
-    ratio = w_nk / scale_nk
-    floor_base = np.floor(ratio)
-    frac = np.clip(ratio - floor_base, 1e-4, 1.0 - 1e-4)
-    # Inverse of h(v) at v's initial point: start each element's relaxation
-    # at round-to-nearest's own choice (h == frac puts the soft weight
-    # exactly at the un-rounded ratio, the least-biased starting point).
-    sig0 = (frac - _GAMMA) / (_ZETA - _GAMMA)
-    sig0 = np.clip(sig0, 1e-4, 1.0 - 1e-4)
-    v = np.log(sig0 / (1.0 - sig0))
+    v, floor_base = _init_relaxation(w_nk, scale_nk)
 
     m = np.zeros_like(v)
     v2 = np.zeros_like(v)
@@ -229,8 +239,157 @@ def _optimize_rounding(
         v_hat = v2 / (1.0 - adam_beta2 ** (t + 1))
         v = v - learning_rate * m_hat / (np.sqrt(v_hat) + adam_eps)
 
+    return _rounding_codes(v, floor_base, n_min, n_max)
+
+
+def _rounding_codes(
+    v: np.ndarray, floor_base: np.ndarray, n_min: float, n_max: float
+) -> np.ndarray:
+    """The hard (floor/ceil) decision each element's relaxation ``v`` has
+    settled on, as integer codes -- the last line of both the numpy and the
+    step-graph optimization paths."""
     h_final, _ = _h_and_dhdv(v)
     return np.clip(floor_base + np.round(h_final), n_min, n_max)
+
+
+def _build_rounding_step_graph(
+    num_rows: int, n: int, k: int, n_min: float, n_max: float
+) -> qat_graph.StepGraph:
+    """One Adam step of :func:`_optimize_rounding`, as an ONNX graph.
+
+    Node for node the same computation the numpy loop performs -- the same
+    rectified-sigmoid relaxation, the same straight-through masks, the same
+    annealed regularizer, the same Adam -- expressed so it can run on an
+    execution provider instead of on the host. See :mod:`onnxsim.qat_graph`
+    for why a hand-derived gradient can be written this way at all, and
+    ``docs/qat.md`` for what it is for.
+
+    Shapes are baked in at build time (``x`` is ``[num_rows, k]``, the weight
+    ``[n, k]``): the accelerator backends this exists for -- WebNN, and the
+    NPU execution providers -- compile a graph once and want static shapes,
+    and a step graph is rebuilt per layer anyway.
+    """
+    b = qat_graph.GraphBuilder()
+
+    x, y_float, floor_base, scale = "x", "y_float", "floor_base", "scale"
+    v, m, vv = "v", "m", "vv"
+
+    # h(v), the rectified sigmoid, and its derivative -- _h_and_dhdv's own
+    # two lines, with the "is this element still inside the clip" test as a
+    # float 0/1 mask rather than a Where.
+    s = b.sigmoid(v)
+    raw = b.add(b.mul(s, b.const(_ZETA - _GAMMA)), b.const(_GAMMA))
+    h = b.clip(raw, 0.0, 1.0)
+    active = b.mul(b.greater_mask(raw, 0.0), b.less_mask(raw, 1.0))
+    ds = b.mul(s, b.sub(b.const(1.0), s))
+    dh_dv = b.mul(active, b.mul(ds, b.const(_ZETA - _GAMMA)))
+
+    # The soft weight this relaxation currently implies, and the layer's own
+    # reconstruction error against the float model's activations.
+    raw2 = b.add(floor_base, h)
+    w_hat = b.mul(b.clip(raw2, n_min, n_max), scale)
+    active_w = b.mul(b.greater_mask(raw2, n_min), b.less_mask(raw2, n_max))
+    y_hat = b.matmul(x, b.transpose(w_hat))  # [num_rows, n]
+    diff = b.sub(y_hat, y_float)
+    dl_dy = b.mul(diff, b.const(2.0 / (num_rows * n)))
+    dl_dw_hat = b.matmul(b.transpose(dl_dy), x)  # [n, k]
+    dl_dh = b.mul(dl_dw_hat, b.mul(active_w, scale))
+    grad = b.mul(dl_dh, dh_dv)
+
+    # The rounding regularizer, pulling each relaxation toward a hard 0/1.
+    # `reg_scale` is the caller's reg_param, or 0 during the warm start --
+    # a scalar fed per step, so the warm start needs no second graph.
+    u = b.sub(b.mul(b.const(2.0), h), b.const(1.0))
+    sign_u = b.op("Sign", [u])
+    abs_u = b.op("Abs", [u])
+    pow_u = b.op("Pow", [abs_u, b.sub("beta", b.const(1.0))])
+    dreg_dh = b.mul(
+        b.mul(b.mul(b.const(-2.0), "reg_scale"), "beta"), b.mul(sign_u, pow_u)
+    )
+    grad = b.add(grad, b.mul(dreg_dh, dh_dv))
+
+    v_next, m_next, vv_next = qat_graph.adam_update(
+        b, v, grad, m, vv, "lr", "m_correction", "v_correction"
+    )
+    loss = b.mean_square(diff)
+
+    return qat_graph.make_step_graph(
+        b,
+        constants={
+            x: [num_rows, k],
+            y_float: [num_rows, n],
+            floor_base: [n, k],
+            scale: [n, k],
+        },
+        state={v: ([n, k], v_next), m: ([n, k], m_next), vv: ([n, k], vv_next)},
+        scalars=["lr", "reg_scale", "beta", "m_correction", "v_correction"],
+        loss=loss,
+        name="onnxsim_adaround_step",
+    )
+
+
+def _optimize_rounding_on_graph(
+    w_nk: np.ndarray,
+    scale_nk: np.ndarray,
+    x: np.ndarray,
+    n_min: float,
+    n_max: float,
+    num_iterations: int,
+    learning_rate: float,
+    reg_param: float,
+    warm_start: float,
+    beta_range: "tuple[float, float]",
+    providers: Optional[Sequence[str]],
+) -> np.ndarray:
+    """:func:`_optimize_rounding`, run through :mod:`onnxsim.qat_graph`
+    instead of in host numpy, on ``providers``.
+
+    Same result, up to the float32 the step graph computes in (the numpy loop
+    uses float64, which is not something a GPU/NPU execution provider offers).
+    """
+    v0, floor_base = _init_relaxation(w_nk, scale_nk)
+    step = _build_rounding_step_graph(
+        x.shape[0], w_nk.shape[0], w_nk.shape[1], n_min, n_max
+    )
+
+    warm_start_iters = int(num_iterations * warm_start)
+    beta_start, beta_end = beta_range
+
+    def scalars(t: int) -> Dict[str, float]:
+        values = {"lr": learning_rate}
+        if t >= warm_start_iters:
+            progress = (t - warm_start_iters) / max(
+                1, num_iterations - warm_start_iters - 1
+            )
+            values["reg_scale"] = reg_param
+            values["beta"] = beta_start + (beta_end - beta_start) * progress
+        else:
+            # The regularizer is switched off by its own weight rather than by
+            # a second graph. `beta` still needs a value Pow can evaluate --
+            # 1.0 makes the (zero-weighted) term |u|^0, finite everywhere.
+            values["reg_scale"] = 0.0
+            values["beta"] = 1.0
+        values.update(qat_graph.adam_bias_corrections(t))
+        return values
+
+    final = qat_graph.run_step_graph(
+        step,
+        constants={
+            "x": x,
+            "y_float": x @ w_nk.T,
+            "floor_base": floor_base,
+            "scale": scale_nk,
+        },
+        state={
+            "v": v0,
+            "m": np.zeros_like(v0),
+            "vv": np.zeros_like(v0),
+        },
+        num_steps=num_iterations,
+        scalars=scalars,
+        providers=providers,
+    )
+    return _rounding_codes(final["v"].astype(np.float64), floor_base, n_min, n_max)
 
 
 def _pack_int4(codes: np.ndarray) -> bytes:
@@ -259,6 +418,7 @@ def apply_adaround(
     warm_start: float = 0.2,
     beta_range: "tuple[float, float]" = (20.0, 2.0),
     providers: Optional[Sequence[str]] = None,
+    step_providers: Optional[Sequence[str]] = None,
 ) -> onnx.ModelProto:
     """Optimizes AdaRound-style adaptive rounding for every
     ``quantize_weight_only_int4``-quantized MatMul/Gemm layer present (by
@@ -301,6 +461,14 @@ def apply_adaround(
             ``warm_start``
     :param providers: onnxruntime execution providers to run ``float_model``
             on when capturing calibration activations
+    :param step_providers: onnxruntime execution providers to run the *Adam
+            optimization itself* on, as an ONNX step graph
+            (:mod:`onnxsim.qat_graph`) rather than in host numpy -- the way to
+            reach a GPU, an NPU execution provider, or (in the WASM build)
+            WebGPU with this loop. ``None``, the default, keeps the in-process
+            float64 numpy loop, which is exact and deterministic; a step graph
+            computes in float32, so its result agrees closely rather than
+            bit-exactly. See ``docs/qat.md``.
     :returns: ``quantized_model`` with every matched layer's INT4 weight
             initializer rewritten to its AdaRound-optimized codes (same
             shape, dtype, and scale -- only which integer each element
@@ -351,7 +519,14 @@ def apply_adaround(
             continue  # activation's feature dim doesn't match K; skip
         scale_nk = np.repeat(scale_blocks, c.block_size, axis=1)[:, : w_nk.shape[1]]
 
-        codes_nk = _optimize_rounding(
+        optimize = (
+            _optimize_rounding
+            if step_providers is None
+            else functools.partial(
+                _optimize_rounding_on_graph, providers=step_providers
+            )
+        )
+        codes_nk = optimize(
             w_nk,
             scale_nk,
             x,

--- a/onnxsim/backend.py
+++ b/onnxsim/backend.py
@@ -373,3 +373,81 @@ def run_model(
             deterministic,
         )
     return _run_with_reference(model, inputs, output_names, custom_lib, providers)
+
+
+class Runner:
+    """A model prepared once and run many times.
+
+    :func:`run_model` creates a fresh session per call, which is right for
+    constant folding (every fold group is a different throwaway sub-model) and
+    wrong for an optimization loop, where the *same* small graph is run
+    hundreds of times with different tensor values -- there, session creation
+    would dominate and ``enable_mem_pattern``'s cross-run buffer planning,
+    disabled in :func:`run_model` because it can never pay for itself in a
+    single ``Run()``, is exactly what should be on.
+
+    This is the Python counterpart of the converter page's own
+    ``makeOrtRunner`` (``scripts/convertmodel/ort_executor.mjs``): bind a model
+    and an execution-provider list once, then call it per step. See
+    :mod:`onnxsim.qat_graph` for the loop it exists for.
+    """
+
+    def __init__(
+        self,
+        model: Union[str, bytes, onnx.ModelProto],
+        output_names: Optional[Sequence[str]] = None,
+        providers: Optional[Sequence[Provider]] = None,
+    ) -> None:
+        self._providers = providers
+        if _HAS_ONNXRUNTIME:
+            if providers is None:
+                providers = DEFAULT_PROVIDERS
+            validate_providers(providers)
+            sess_options = rt.SessionOptions()
+            sess_options.graph_optimization_level = rt.GraphOptimizationLevel(0)
+            sess_options.log_severity_level = 3
+            if isinstance(model, onnx.ModelProto):
+                model = model.SerializeToString()
+            self._sess: Any = rt.InferenceSession(
+                model, sess_options=sess_options, providers=list(providers)
+            )
+            self._output_names = list(
+                output_names
+                if output_names is not None
+                else [o.name for o in self._sess.get_outputs()]
+            )
+            self._run_options = rt.RunOptions()
+            self._run_options.log_severity_level = 3
+            self._graph = None
+        else:
+            validate_providers(providers)
+            from onnx.reference import ReferenceEvaluator
+
+            if isinstance(model, str):
+                model = onnx.load(model)
+            elif isinstance(model, bytes):
+                model = onnx.load_from_string(model)
+            self._sess = ReferenceEvaluator(model)
+            self._output_names = list(
+                output_names
+                if output_names is not None
+                else list(self._sess.output_names)
+            )
+            self._graph = None if _has_subgraphs(model.graph) else model.graph
+
+    @property
+    def output_names(self) -> List[str]:
+        return list(self._output_names)
+
+    def __call__(self, inputs: Dict[str, np.ndarray]) -> "OrderedDict[str, np.ndarray]":
+        if _HAS_ONNXRUNTIME:
+            outputs = self._sess.run(
+                self._output_names, inputs, run_options=self._run_options
+            )
+        elif self._graph is not None:
+            outputs = _run_reference_pruned(
+                self._sess, self._graph, self._output_names, inputs
+            )
+        else:
+            outputs = cast(List[np.ndarray], self._sess.run(self._output_names, inputs))
+        return OrderedDict(zip(self._output_names, outputs))

--- a/onnxsim/qat_graph.py
+++ b/onnxsim/qat_graph.py
@@ -1,0 +1,323 @@
+"""One optimizer step, expressed as an ONNX graph, so it can run wherever an
+ONNX model can run -- CPU, CUDA, an NPU execution provider, or WebGPU in a
+browser -- instead of only in host numpy.
+
+Six passes in this repo (:mod:`onnxsim.adaround`, :mod:`onnxsim.adaquant`,
+:mod:`onnxsim.brecq`, :mod:`onnxsim.flexround`, :mod:`onnxsim.autoround`,
+:mod:`onnxsim.omniquant`) already optimize a quantization parameter by Adam
+with hand-derived, straight-through gradients. Every one of them runs that
+loop in host numpy: their ``providers=`` argument reaches only the *capture*
+of calibration activations from the float model, never the optimization
+itself. That is the whole gap this module closes, and the reason it can be
+closed cheaply is the "hand-derived" part:
+
+    **A hand-derived backward pass is ordinary dataflow.** There is no tape,
+    no autograd framework, and no ``Gradient`` operator involved -- just
+    ``MatMul``/``Mul``/``Sub``/``Sigmoid``/``Clip``/``Sqrt`` over tensors. So
+    it is expressible as a plain ONNX *inference* graph, and any runtime that
+    can do inference can therefore train these parameters.
+
+A **step graph** is that expression: a pure function
+
+.. code-block:: text
+
+    (fixed constants, mutable state, per-step scalars) -> (next state, loss)
+
+with the optimizer's own state (Adam's two moments) carried in and out as
+tensors rather than held in Python. Running it ``N`` times, feeding each
+call's state outputs back in as the next call's state inputs
+(:func:`run_step_graph`), *is* the optimization loop -- and it happens
+wherever the execution provider says.
+
+**What this buys, concretely.** :class:`onnxsim.backend.Runner` binds the
+graph and a provider list once, so the same builder reaches
+``CUDAExecutionProvider`` or an NPU EP (QNN, Core ML, OpenVINO -- see the
+harnesses under ``scripts/``) from Python, and in the browser the WASM
+build's model-executor trampoline (``docs/wasm_ort_web.md``) hands the same
+graph to onnxruntime-web, whose provider list already offers ``webgpu`` and
+WebNN's ``gpu``/``npu`` device types (``docs/webnn.md``).
+
+**What it does not buy, and the honest limits.**
+
+- *Feeds are re-sent every step.* The calibration activations are re-fed on every
+  call, so on a non-CPU provider the loop currently pays a host-to-device copy
+  per step. Keeping tensors device-resident (``IOBinding`` in Python, ORT-web
+  GPU-buffer tensors in the browser) is the follow-up; the graph shape here --
+  state in, state out -- is exactly what that needs.
+- *Precision.* Step graphs are built in float32, not the float64 the numpy
+  loops use: fp64 is what accelerators do not have. Results therefore agree
+  with the numpy path closely rather than bit-exactly.
+- *Determinism.* A non-CPU provider reassociates reductions, so a trained
+  result is not reproducible the way ``tests/test_constant_fold_determinism.py``
+  requires of folding. CPU stays the default everywhere in-tree.
+
+See ``docs/qat.md`` for how this fits the larger QAT picture.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import onnx
+
+from onnxsim import backend
+
+# Same opset/IR pairing every other graph builder in this package uses (see
+# onnxsim/gguf_reconstruct.py): opset 17 with the IR version opset 17 actually
+# requires, rather than whatever the installed onnx's newest opset needs.
+_OPSET = 17
+_IR_VERSION = 8
+
+# Adam's own standard hyper-parameters, matching the hand-rolled loops in
+# adaround.py/adaquant.py/brecq.py exactly so a ported loop keeps its
+# behaviour.
+ADAM_BETA1 = 0.9
+ADAM_BETA2 = 0.999
+ADAM_EPS = 1e-8
+
+
+class GraphBuilder:
+    """Accumulates nodes and initializers with unique names.
+
+    Exists so a hand-derived gradient reads like the expression it is --
+    ``g = b.mul(b.sub(y_hat, y), two_over_n)`` -- rather than like a pile of
+    ``onnx.helper.make_node`` calls with hand-managed intermediate names.
+    """
+
+    def __init__(self, prefix: str = "") -> None:
+        self.nodes: List[onnx.NodeProto] = []
+        self.initializer: List[onnx.TensorProto] = []
+        self._prefix = prefix
+        self._counter = 0
+
+    def name(self, hint: str = "t") -> str:
+        self._counter += 1
+        return f"{self._prefix}{hint}_{self._counter}"
+
+    def const(self, value, hint: str = "c") -> str:
+        """A float32 initializer holding ``value`` (scalar or array)."""
+        array = np.asarray(value, dtype=np.float32)
+        name = self.name(hint)
+        self.initializer.append(onnx.numpy_helper.from_array(array, name))
+        return name
+
+    def op(self, op_type: str, inputs: Sequence[str], hint: str = "", **attrs) -> str:
+        out = self.name(hint or op_type.lower())
+        self.nodes.append(onnx.helper.make_node(op_type, list(inputs), [out], **attrs))
+        return out
+
+    # The handful of operators the hand-derived gradients below actually use.
+    # Deliberately kept to ops with broad execution-provider coverage: no
+    # boolean logic ops (a mask is a float 0/1 from Cast(Greater), multiplied
+    # in) and no Where, both of which are patchier on the WebNN/NPU backends
+    # than plain arithmetic is.
+    def add(self, a: str, b: str) -> str:
+        return self.op("Add", [a, b])
+
+    def sub(self, a: str, b: str) -> str:
+        return self.op("Sub", [a, b])
+
+    def mul(self, a: str, b: str) -> str:
+        return self.op("Mul", [a, b])
+
+    def div(self, a: str, b: str) -> str:
+        return self.op("Div", [a, b])
+
+    def matmul(self, a: str, b: str) -> str:
+        return self.op("MatMul", [a, b])
+
+    def transpose(self, a: str, perm: Optional[Sequence[int]] = None) -> str:
+        if perm is None:
+            return self.op("Transpose", [a])
+        return self.op("Transpose", [a], perm=list(perm))
+
+    def sqrt(self, a: str) -> str:
+        return self.op("Sqrt", [a])
+
+    def sigmoid(self, a: str) -> str:
+        return self.op("Sigmoid", [a])
+
+    def clip(self, a: str, low: float, high: float) -> str:
+        return self.op("Clip", [a, self.const(low), self.const(high)])
+
+    def greater_mask(self, a: str, threshold: float) -> str:
+        """``(a > threshold)`` as a float32 0/1 tensor."""
+        gt = self.op("Greater", [a, self.const(threshold)])
+        return self.op("Cast", [gt], to=onnx.TensorProto.FLOAT)
+
+    def less_mask(self, a: str, threshold: float) -> str:
+        """``(a < threshold)`` as a float32 0/1 tensor."""
+        lt = self.op("Less", [a, self.const(threshold)])
+        return self.op("Cast", [lt], to=onnx.TensorProto.FLOAT)
+
+    def mean_square(self, a: str) -> str:
+        """``mean(a * a)`` as a scalar, for a reported loss."""
+        sq = self.mul(a, a)
+        return self.op("ReduceMean", [sq], keepdims=0)
+
+
+def adam_update(
+    b: GraphBuilder,
+    param: str,
+    grad: str,
+    m: str,
+    v: str,
+    lr: str,
+    m_correction: str,
+    v_correction: str,
+    eps: float = ADAM_EPS,
+) -> Tuple[str, str, str]:
+    """Appends one Adam step to ``b`` and returns ``(param', m', v')``.
+
+    ``m_correction``/``v_correction`` are the bias-correction *factors*
+    ``1 / (1 - beta**t)``, passed in as scalars rather than derived from a step
+    counter inside the graph: they are two host-side floats per step, so
+    computing them outside costs nothing and keeps the graph free of the state
+    that a ``Pow`` over a step counter would need.
+    """
+    beta1 = b.const(ADAM_BETA1)
+    beta2 = b.const(ADAM_BETA2)
+    one_minus_beta1 = b.const(1.0 - ADAM_BETA1)
+    one_minus_beta2 = b.const(1.0 - ADAM_BETA2)
+
+    m_next = b.add(b.mul(beta1, m), b.mul(one_minus_beta1, grad))
+    v_next = b.add(b.mul(beta2, v), b.mul(one_minus_beta2, b.mul(grad, grad)))
+    m_hat = b.mul(m_next, m_correction)
+    v_hat = b.mul(v_next, v_correction)
+    step = b.div(b.mul(lr, m_hat), b.add(b.sqrt(v_hat), b.const(eps)))
+    param_next = b.sub(param, step)
+    return param_next, m_next, v_next
+
+
+@dataclass
+class StepGraph:
+    """A pure function performing one optimizer step.
+
+    :param model: the graph itself. Its inputs are the fixed constants, the
+            mutable state, and any per-step scalars; its outputs are the next
+            state (and optionally a loss).
+    :param state: ``{input name: output name}`` -- which output carries the
+            next value of which input. :func:`run_step_graph` uses exactly this
+            to close the loop.
+    :param loss_name: an output holding a scalar loss, recorded per step when
+            the caller asks for it. Optional: nothing in the loop needs it, it
+            is for diagnostics.
+    """
+
+    model: onnx.ModelProto
+    state: Dict[str, str]
+    loss_name: Optional[str] = None
+
+
+def make_step_graph(
+    b: GraphBuilder,
+    constants: Dict[str, Sequence[int]],
+    state: Dict[str, Tuple[Sequence[int], str]],
+    scalars: Sequence[str] = (),
+    loss: Optional[str] = None,
+    name: str = "onnxsim_step",
+) -> StepGraph:
+    """Wraps ``b``'s accumulated nodes into a :class:`StepGraph`.
+
+    :param constants: ``{input name: shape}`` for the tensors that do not
+            change across steps (calibration activations, the reconstruction
+            target, a frozen scale, ...)
+    :param state: ``{input name: (shape, output name)}`` for the tensors the
+            step updates -- the parameter being optimized and the optimizer's
+            own moments
+    :param scalars: names of scalar (rank-0) per-step inputs, e.g. a learning
+            rate or an annealed regularization weight
+    :param loss: an optional scalar output name to expose as the loss
+    """
+    inputs = [
+        onnx.helper.make_tensor_value_info(n, onnx.TensorProto.FLOAT, list(shape))
+        for n, shape in constants.items()
+    ]
+    inputs += [
+        onnx.helper.make_tensor_value_info(n, onnx.TensorProto.FLOAT, list(shape))
+        for n, (shape, _) in state.items()
+    ]
+    inputs += [
+        onnx.helper.make_tensor_value_info(n, onnx.TensorProto.FLOAT, [])
+        for n in scalars
+    ]
+    outputs = [
+        onnx.helper.make_tensor_value_info(out, onnx.TensorProto.FLOAT, list(shape))
+        for _, (shape, out) in state.items()
+    ]
+    if loss is not None:
+        outputs.append(
+            onnx.helper.make_tensor_value_info(loss, onnx.TensorProto.FLOAT, [])
+        )
+    graph = onnx.helper.make_graph(
+        b.nodes, name, inputs, outputs, initializer=b.initializer
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", _OPSET)]
+    )
+    model.ir_version = _IR_VERSION
+    return StepGraph(
+        model=model,
+        state={n: out for n, (_, out) in state.items()},
+        loss_name=loss,
+    )
+
+
+def run_step_graph(
+    step: StepGraph,
+    constants: Dict[str, np.ndarray],
+    state: Dict[str, np.ndarray],
+    num_steps: int,
+    scalars: Optional[Callable[[int], Dict[str, float]]] = None,
+    providers: Optional[Sequence[backend.Provider]] = None,
+    losses: Optional[List[float]] = None,
+) -> Dict[str, np.ndarray]:
+    """Runs ``step`` ``num_steps`` times, threading its state through, and
+    returns the final state.
+
+    The session (and its execution providers) is created once for the whole
+    loop, not once per step -- see :class:`onnxsim.backend.Runner`.
+
+    :param constants: values for the step graph's constant inputs
+    :param state: initial values for its state inputs
+    :param num_steps: iterations to run
+    :param scalars: called with the step index, returning that step's scalar
+            inputs (learning rate, annealed regularization weight, Adam's bias
+            corrections, ...). Adam's bias corrections are the reason this is a
+            callback rather than a fixed dict: they change every step.
+    :param providers: onnxruntime execution providers, in priority order, to
+            run the step on. ``None`` means CPU.
+    :param losses: when given, the step graph's loss output is appended to it
+            once per step. Reading it back costs a scalar transfer per step.
+    """
+    fetch = list(step.state.values())
+    if losses is not None and step.loss_name is not None:
+        fetch.append(step.loss_name)
+    runner = backend.Runner(step.model, output_names=fetch, providers=providers)
+
+    fixed = {k: np.asarray(v, dtype=np.float32) for k, v in constants.items()}
+    current = {k: np.asarray(v, dtype=np.float32) for k, v in state.items()}
+    for t in range(num_steps):
+        feeds = dict(fixed)
+        feeds.update(current)
+        if scalars is not None:
+            feeds.update(
+                {k: np.asarray(v, dtype=np.float32) for k, v in scalars(t).items()}
+            )
+        out = runner(feeds)
+        current = {name: out[output] for name, output in step.state.items()}
+        if losses is not None and step.loss_name is not None:
+            losses.append(float(out[step.loss_name]))
+    return current
+
+
+def adam_bias_corrections(t: int) -> Dict[str, float]:
+    """Adam's two bias-correction factors at (0-based) step ``t``, named the
+    way :func:`adam_update`'s callers wire them: ``{"m_correction": ...,
+    "v_correction": ...}``."""
+    return {
+        "m_correction": 1.0 / (1.0 - ADAM_BETA1 ** (t + 1)),
+        "v_correction": 1.0 / (1.0 - ADAM_BETA2 ** (t + 1)),
+    }

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -410,6 +410,15 @@ agraph (float[N] X) =&gt; (float[N] Y) {
             <br/>
             <label for="quantize-samples">calibration samples (Static / QOperator only)</label>
             <input type="number" id="quantize-samples" value="8" min="1" max="64" step="1" style="width: 4em;">
+            <label for="quantize-ep">calibration execution provider</label>
+            <select id="quantize-ep"
+                    title="Which execution provider runs calibration's forward passes (Static / QOperator only). WASM is the default; the accelerated choices fall back to WASM when the device or an operator is unsupported, and can observe slightly different ranges because they may compute in a different precision.">
+                <option value="wasm">WASM</option>
+                <option value="webgpu">WebGPU (fallback to WASM)</option>
+                <option value="webnn-gpu">WebNN · GPU (fallback to WASM)</option>
+                <option value="webnn-npu">WebNN · NPU (fallback to WASM)</option>
+                <option value="webnn-cpu">WebNN · CPU (fallback to WASM)</option>
+            </select>
             <br/>
             <input type="checkbox" id="quantize-metrics-toggle" checked>
             <label for="quantize-metrics-toggle" title="After quantizing, run the float and quantized models on the same random input through onnxruntime-web and report the size change plus how far the outputs drifted -- relative L2 error and SQNR, the same aggregate-error metric onnxsim's own test suite checks.">

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -28,7 +28,8 @@
     "test:sample": "node test/sample_inputs.test.mjs",
     "test:classify": "node test/classify_output.test.mjs",
     "test:quantize-risk": "node test/quantize_risk_estimate.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:node-reduction && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:hftoken && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:ortlog && npm run test:cdn && npm run test:fill && npm run test:tokenize && npm run test:hfdata && npm run test:sample && npm run test:classify && npm run test:quantize-risk && npm run test:inference && npm run test:compare",
+    "test:quantize-cal": "node test/quantize_calibration.test.mjs",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:node-reduction && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:hftoken && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:ortlog && npm run test:cdn && npm run test:fill && npm run test:tokenize && npm run test:hfdata && npm run test:sample && npm run test:classify && npm run test:quantize-risk && npm run test:quantize-cal && npm run test:inference && npm run test:compare",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/quantize_calibration.mjs
+++ b/scripts/convertmodel/quantize_calibration.mjs
@@ -13,6 +13,16 @@
 // onnx.ValueInfoProto(name=name) -- and onnxruntime-web (already loaded on
 // this page for the "Run inference" panel) actually executes the augmented
 // model to observe them.
+//
+// Those forward passes are the expensive part of calibration (numSamples full
+// runs of the model), so they are not pinned to WASM: the caller passes the
+// execution providers the Quantize panel's own EP picker selected, the same
+// providersForEp() list the inference panel uses (webnn.mjs), which always
+// ends in "wasm" so an unavailable WebGPU/WebNN device just falls back. WASM
+// stays the default -- an accelerated provider can compute in a different
+// precision (fp16 on a WebNN NPU device), which moves the observed min/max a
+// little, so choosing one is opt-in rather than something calibration does
+// behind the user's back.
 
 import { loadOrt, makeDummyInputs } from "./inference_browser.mjs";
 
@@ -23,7 +33,16 @@ import { loadOrt, makeDummyInputs } from "./inference_browser.mjs";
 // zero-sized dim, is dropped), and `flat` is a plain array of
 // [min0, max0, min1, max1, ...] in the same order -- exactly the shape
 // runtime.onnxsim_quantize_static / _quantize_qoperator expect.
-export async function calibrateRanges(runtime, modelBuf, tensorNames, numSamples = 8, log = () => {}) {
+// `options` carries the execution-provider choice ({ providers, needWebnn } as
+// returned by providersForEp) and, for tests, injectable onnxruntime-web
+// entry points.
+export async function calibrateRanges(runtime, modelBuf, tensorNames, numSamples = 8, log = () => {}, options = {}) {
+  const {
+    providers = ["wasm"],
+    needWebnn = false,
+    ortLoader = loadOrt,
+    makeInputs = makeDummyInputs,
+  } = options;
   if (!tensorNames || tensorNames.length === 0) {
     return { names: [], flat: [] };
   }
@@ -35,9 +54,11 @@ export async function calibrateRanges(runtime, modelBuf, tensorNames, numSamples
   // next wasm call, and onnxruntime-web needs its own stable copy anyway.
   const augmentedBytes = new Uint8Array(augmented).slice();
 
-  const ort = await loadOrt();
+  // The WebNN providers only exist in onnxruntime-web's "all" bundle, the
+  // same variant split the inference panel makes.
+  const ort = await ortLoader(needWebnn ? "all" : "default");
   const sess = await ort.InferenceSession.create(augmentedBytes, {
-    executionProviders: ["wasm"],
+    executionProviders: providers,
   });
   const wanted = new Set(tensorNames);
   const ranges = new Map();
@@ -47,7 +68,7 @@ export async function calibrateRanges(runtime, modelBuf, tensorNames, numSamples
     // "zeros"/"sample": a fixed input would collapse every tensor's observed
     // range to a single point, and "sample" would need network fetches this
     // background calibration step shouldn't depend on.
-    const feeds = await makeDummyInputs(ort, sess, 1, "random", null, null, log);
+    const feeds = await makeInputs(ort, sess, 1, "random", null, null, log);
     const outputs = await sess.run(feeds);
     for (const name of sess.outputNames) {
       if (!wanted.has(name)) continue;

--- a/scripts/convertmodel/quantize_ui.mjs
+++ b/scripts/convertmodel/quantize_ui.mjs
@@ -29,6 +29,7 @@
 import { downloadBytes } from "./download.mjs";
 import { resolveOriginalModelBytes } from "./inference_browser.mjs";
 import { calibrateRanges } from "./quantize_calibration.mjs";
+import { providersForEp, isWebnnEp } from "./webnn.mjs";
 import { computeQuantizationQuality, renderQuantizationQuality } from "./quantize_metrics.mjs";
 
 // Resolves the model to quantize per the "Quantize input" radio: the raw
@@ -87,6 +88,7 @@ function initQuantizePanel() {
   const statusEl = document.getElementById("quantize-status");
   const dlBtn = document.getElementById("quantize-download");
   const samplesEl = document.getElementById("quantize-samples");
+  const epEl = document.getElementById("quantize-ep");
   const metricsToggleEl = document.getElementById("quantize-metrics-toggle");
   const metricsEl = document.getElementById("quantize-metrics");
 
@@ -140,8 +142,20 @@ function initQuantizePanel() {
           return;
         }
         const numSamples = Math.max(1, parseInt((samplesEl && samplesEl.value) || "8", 10) || 8);
-        setStatus(`calibrating ${names.length} tensor(s) over ${numSamples} random sample(s)…`);
-        const { names: calNames, flat } = await calibrateRanges(runtime, modelBuf, names, numSamples, setStatus);
+        // Calibration's own forward passes are the one part of quantizing that
+        // actually runs the model, so they honour this panel's own execution
+        // provider picker (WASM by default; every accelerated choice falls
+        // back to WASM -- see webnn.mjs / quantize_calibration.mjs).
+        const epValue = epEl ? epEl.value : "wasm";
+        const { providers, needWebnn } = providersForEp(epValue);
+        if (isWebnnEp(epValue)) {
+          setStatus("WebNN is experimental; calibration falls back to WASM if the device or an operator is unsupported.");
+        }
+        setStatus(`calibrating ${names.length} tensor(s) over ${numSamples} random sample(s) on ${epValue}…`);
+        const { names: calNames, flat } = await calibrateRanges(runtime, modelBuf, names, numSamples, setStatus, {
+          providers,
+          needWebnn,
+        });
         if (calNames.length === 0) {
           setStatus("calibration produced no ranges (the model may have no runnable inputs).");
           return;

--- a/scripts/convertmodel/test/quantize_calibration.test.mjs
+++ b/scripts/convertmodel/test/quantize_calibration.test.mjs
@@ -1,0 +1,155 @@
+// Unit test for the converter page's browser-side calibration
+// (quantize_calibration.mjs). No DOM and no real onnxruntime-web: calibrateRanges
+// takes injectable ORT entry points (`ortLoader`, `makeInputs`) for exactly this,
+// so the range accumulation and the execution-provider plumbing -- the Quantize
+// panel's EP picker reaching the session that actually runs the model -- are
+// testable under Node.
+//
+// Usage:
+//   node test/quantize_calibration.test.mjs
+
+import assert from "node:assert/strict";
+import { providersForEp } from "../webnn.mjs";
+
+// quantize_calibration.mjs pulls onnxruntime-web's loader from
+// inference_browser.mjs, which wires the inference panel at import time. A
+// getElementById that finds nothing makes that wiring bail out immediately
+// (`if (!btn) return`), the same globalThis stub versions.test.mjs uses; the
+// import has to follow the stub, hence the dynamic import.
+globalThis.document = { getElementById: () => null, querySelector: () => null };
+globalThis.window = { addEventListener: () => {} };
+const { calibrateRanges } = await import("../quantize_calibration.mjs");
+
+let passed = 0;
+async function check(name, fn) {
+  await fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+// A runtime whose onnxsim_add_graph_outputs just records what it was asked for
+// and hands back some bytes (the real one returns the augmented model).
+function fakeRuntime(calls = []) {
+  return {
+    calls,
+    onnxsim_add_graph_outputs(modelBuf, names) {
+      calls.push({ modelBuf, names: [...names] });
+      return new Uint8Array([1, 2, 3]).buffer;
+    },
+  };
+}
+
+// `samples` is one {tensor: values} object per run; the session reports every
+// tensor named across them as an output, the way an augmented model would.
+function fakeOrt(samples, seen = {}) {
+  const outputNames = [...new Set(samples.flatMap((s) => Object.keys(s)))];
+  let i = 0;
+  return {
+    seen,
+    InferenceSession: {
+      async create(bytes, options) {
+        seen.bytes = bytes;
+        seen.options = options;
+        return {
+          outputNames,
+          inputMetadata: [],
+          async run() {
+            const sample = samples[Math.min(i, samples.length - 1)];
+            i += 1;
+            return Object.fromEntries(
+              Object.entries(sample).map(([k, v]) => [k, { data: v }]),
+            );
+          },
+        };
+      },
+    },
+  };
+}
+
+function options(ort, extra = {}) {
+  return {
+    ortLoader: async (variant) => {
+      ort.seen.variant = variant;
+      return ort;
+    },
+    makeInputs: async () => ({}),
+    ...extra,
+  };
+}
+
+// Nothing to calibrate: no session is created at all (loading onnxruntime-web
+// for an empty tensor list would be a pointless multi-megabyte fetch).
+await check("no candidate tensors short-circuits", async () => {
+  const runtime = fakeRuntime();
+  const ort = fakeOrt([]);
+  const result = await calibrateRanges(runtime, new ArrayBuffer(0), [], 4, () => {}, options(ort));
+  assert.deepEqual(result, { names: [], flat: [] });
+  assert.equal(ort.seen.options, undefined);
+  assert.equal(runtime.calls.length, 0);
+});
+
+// Each tensor's range is the min/max across every sample, and `flat` is
+// [min, max, ...] in the returned `names` order -- the shape
+// runtime.onnxsim_quantize_static expects.
+await check("ranges accumulate across samples", async () => {
+  const ort = fakeOrt([
+    { a: [0, 1, 2], b: [-5, 5] },
+    { a: [-3, 7], b: [-1, 1] },
+  ]);
+  const { names, flat } = await calibrateRanges(
+    fakeRuntime(), new ArrayBuffer(0), ["a", "b"], 2, () => {}, options(ort),
+  );
+  assert.deepEqual(names, ["a", "b"]);
+  assert.deepEqual(flat, [-3, 7, -5, 5]);
+});
+
+// A tensor that never produced data (e.g. a zero-sized dim) is dropped rather
+// than reported with an empty/infinite range.
+await check("tensors with no data are dropped", async () => {
+  const ort = fakeOrt([{ a: [1, 2], empty: [] }]);
+  const { names, flat } = await calibrateRanges(
+    fakeRuntime(), new ArrayBuffer(0), ["a", "empty"], 1, () => {}, options(ort),
+  );
+  assert.deepEqual(names, ["a"]);
+  assert.deepEqual(flat, [1, 2]);
+});
+
+// Only the requested tensors are observed, even though an augmented model's
+// session also reports the model's own original outputs.
+await check("outputs outside the requested set are ignored", async () => {
+  const ort = fakeOrt([{ a: [1, 2], Y: [100, 200] }]);
+  const { names, flat } = await calibrateRanges(
+    fakeRuntime(), new ArrayBuffer(0), ["a"], 1, () => {}, options(ort),
+  );
+  assert.deepEqual(names, ["a"]);
+  assert.deepEqual(flat, [1, 2]);
+});
+
+// The panel's EP choice reaches the session, and the WebNN choices ask for the
+// onnxruntime-web bundle that actually carries the WebNN backend.
+await check("execution providers and bundle variant are forwarded", async () => {
+  for (const ep of ["wasm", "webgpu", "webnn-npu"]) {
+    const { providers, needWebnn } = providersForEp(ep);
+    const ort = fakeOrt([{ a: [1, 2] }]);
+    await calibrateRanges(
+      fakeRuntime(), new ArrayBuffer(0), ["a"], 1, () => {},
+      options(ort, { providers, needWebnn }),
+    );
+    assert.deepEqual(ort.seen.options.executionProviders, providers);
+    assert.equal(ort.seen.variant, needWebnn ? "all" : "default");
+    // Every accelerated choice keeps a WASM fallback, so an unavailable
+    // device degrades instead of failing the whole quantization.
+    assert.equal(providers[providers.length - 1], "wasm");
+  }
+});
+
+// Default (no options): WASM only, and the default bundle -- calibrating on an
+// accelerator stays opt-in.
+await check("defaults to WASM", async () => {
+  const ort = fakeOrt([{ a: [1, 2] }]);
+  await calibrateRanges(fakeRuntime(), new ArrayBuffer(0), ["a"], 1, () => {}, options(ort));
+  assert.deepEqual(ort.seen.options.executionProviders, ["wasm"]);
+  assert.equal(ort.seen.variant, "default");
+});
+
+console.log(`\nquantize_calibration: ${passed} checks passed`);

--- a/tests/test_qat_graph.py
+++ b/tests/test_qat_graph.py
@@ -1,0 +1,294 @@
+"""Tests for ``onnxsim.qat_graph`` -- one optimizer step expressed as an ONNX
+graph, so an optimization loop that used to be host numpy can run on any
+execution provider (a GPU, an NPU EP, or WebGPU in the WASM build). See
+``onnxsim/qat_graph.py`` and ``docs/qat.md``.
+
+Two things are worth testing about that claim, and both are here: that the
+graph really does optimize (it agrees with the numpy Adam loop it replaces,
+on the generic machinery *and* on the first real caller,
+``onnxsim.adaround``), and that it stays inside an operator set the
+accelerator backends actually implement -- a step graph that reached for a
+convenient op no NPU execution provider supports would pass every numerical
+test here and still be useless for what it exists for.
+"""
+
+import numpy as np
+import onnx
+import pytest
+
+import onnxsim
+from onnxsim import adaround, qat_graph
+
+ort = pytest.importorskip("onnxruntime")
+
+# Operators a step graph may use. Everything here is a plain arithmetic,
+# comparison or reduction op with broad coverage across onnxruntime's
+# execution providers (including onnxruntime-web's WebGPU backend and the
+# WebNN/NPU ones). Ops deliberately kept out: control flow, boolean logic,
+# Where, anything that would make a graph runnable only on the CPU.
+_ALLOWED_OPS = {
+    "Abs",
+    "Add",
+    "Cast",
+    "Clip",
+    "Div",
+    "Greater",
+    "Less",
+    "MatMul",
+    "Mul",
+    "Pow",
+    "ReduceMean",
+    "Sigmoid",
+    "Sign",
+    "Sqrt",
+    "Sub",
+    "Transpose",
+}
+
+
+def _linear_fit_step_graph(rows, k, n):
+    """A step graph fitting ``y = x @ W.T`` by Adam -- the smallest useful
+    exercise of the builder, the Adam nodes and the state plumbing."""
+    b = qat_graph.GraphBuilder()
+    y_hat = b.matmul("x", b.transpose("w"))
+    diff = b.sub(y_hat, "y")
+    grad = b.mul(b.matmul(b.transpose(diff), "x"), b.const(2.0 / (rows * n)))
+    w_next, m_next, v_next = qat_graph.adam_update(
+        b, "w", grad, "m", "vv", "lr", "m_correction", "v_correction"
+    )
+    return qat_graph.make_step_graph(
+        b,
+        constants={"x": [rows, k], "y": [rows, n]},
+        state={
+            "w": ([n, k], w_next),
+            "m": ([n, k], m_next),
+            "vv": ([n, k], v_next),
+        },
+        scalars=["lr", "m_correction", "v_correction"],
+        loss=b.mean_square(diff),
+    )
+
+
+def _numpy_adam_linear_fit(x, y, num_steps, lr=0.1):
+    """The same fit, as the hand-rolled numpy Adam loop this repo's
+    reconstruction passes all use."""
+    rows, k = x.shape
+    n = y.shape[1]
+    w = np.zeros((n, k))
+    m = np.zeros_like(w)
+    v = np.zeros_like(w)
+    for t in range(num_steps):
+        grad = 2.0 * ((x @ w.T - y).T @ x) / (rows * n)
+        m = qat_graph.ADAM_BETA1 * m + (1.0 - qat_graph.ADAM_BETA1) * grad
+        v = qat_graph.ADAM_BETA2 * v + (1.0 - qat_graph.ADAM_BETA2) * grad * grad
+        m_hat = m / (1.0 - qat_graph.ADAM_BETA1 ** (t + 1))
+        v_hat = v / (1.0 - qat_graph.ADAM_BETA2 ** (t + 1))
+        w = w - lr * m_hat / (np.sqrt(v_hat) + qat_graph.ADAM_EPS)
+    return w
+
+
+def _run_linear_fit(step, x, y, num_steps, lr=0.1, losses=None, providers=None):
+    # w, and Adam's two moments, all share the parameter's [n, k] shape.
+    zeros = np.zeros((y.shape[1], x.shape[1]))
+    return qat_graph.run_step_graph(
+        step,
+        constants={"x": x, "y": y},
+        state={"w": zeros, "m": zeros, "vv": zeros},
+        num_steps=num_steps,
+        scalars=lambda t: dict(lr=lr, **qat_graph.adam_bias_corrections(t)),
+        providers=providers,
+        losses=losses,
+    )
+
+
+def test_step_graph_adam_matches_the_numpy_loop_it_replaces():
+    rng = np.random.default_rng(3)
+    rows, k, n = 32, 5, 3
+    x = rng.standard_normal((rows, k))
+    w_true = rng.standard_normal((n, k))
+    y = x @ w_true.T
+
+    step = _linear_fit_step_graph(rows, k, n)
+    final = _run_linear_fit(step, x, y, num_steps=400)
+    reference = _numpy_adam_linear_fit(x, y, num_steps=400)
+
+    # Both recover the generating weight; the step graph computes in float32
+    # (what accelerators have) against the loop's float64, so they agree to
+    # float32 precision rather than exactly.
+    assert np.abs(final["w"] - w_true).max() < 1e-5
+    assert np.abs(final["w"] - reference).max() < 1e-5
+
+
+def test_step_graph_reports_a_decreasing_loss():
+    rng = np.random.default_rng(4)
+    rows, k, n = 24, 4, 2
+    x = rng.standard_normal((rows, k))
+    y = x @ rng.standard_normal((n, k)).T
+
+    losses = []
+    step = _linear_fit_step_graph(rows, k, n)
+    _run_linear_fit(step, x, y, num_steps=200, losses=losses)
+
+    assert len(losses) == 200
+    assert losses[-1] < losses[0] * 1e-3
+
+
+def test_step_graph_is_a_pure_function_of_its_state():
+    """Running N steps and then M more is the same as running N + M: nothing
+    is carried between calls except the state the graph declares."""
+    rng = np.random.default_rng(5)
+    rows, k, n = 16, 4, 3
+    x = rng.standard_normal((rows, k))
+    y = x @ rng.standard_normal((n, k)).T
+    step = _linear_fit_step_graph(rows, k, n)
+
+    straight = _run_linear_fit(step, x, y, num_steps=60)
+    part = _run_linear_fit(step, x, y, num_steps=25)
+    resumed = qat_graph.run_step_graph(
+        step,
+        constants={"x": x, "y": y},
+        state=part,
+        num_steps=35,
+        scalars=lambda t: dict(lr=0.1, **qat_graph.adam_bias_corrections(t + 25)),
+    )
+    for name in ("w", "m", "vv"):
+        np.testing.assert_allclose(straight[name], resumed[name], rtol=0, atol=1e-6)
+
+
+def test_step_graph_is_a_valid_model_and_declares_its_state():
+    step = _linear_fit_step_graph(8, 3, 2)
+    onnx.checker.check_model(step.model)
+
+    input_names = {i.name for i in step.model.graph.input}
+    output_names = {o.name for o in step.model.graph.output}
+    assert set(step.state) <= input_names
+    assert set(step.state.values()) <= output_names
+    assert step.loss_name in output_names
+
+
+@pytest.mark.parametrize(
+    "step",
+    [
+        _linear_fit_step_graph(8, 3, 2),
+        adaround._build_rounding_step_graph(8, 3, 4, -7.0, 7.0),
+    ],
+    ids=["linear_fit", "adaround"],
+)
+def test_step_graphs_stay_within_broadly_supported_ops(step):
+    used = {node.op_type for node in step.model.graph.node}
+    assert used <= _ALLOWED_OPS, f"unsupported ops in step graph: {used - _ALLOWED_OPS}"
+
+
+def _rounding_case(seed, rows=40, n=8, k=32):
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((rows, k))
+    w = rng.standard_normal((n, k)) * 0.5
+    scale = np.repeat(np.abs(w).max(axis=1, keepdims=True) / 7.0, k, axis=1)
+    return x, w, scale
+
+
+def _reconstruction_error(x, w, scale, codes):
+    return float(np.linalg.norm(x @ w.T - x @ (codes * scale).T))
+
+
+def test_adaround_step_graph_agrees_with_the_numpy_loop():
+    """The step-graph path is the same optimization as ``_optimize_rounding``,
+    not merely another one that also happens to help: the two pick the same
+    floor/ceil decision for all but a handful of elements (the ones whose
+    relaxation lands near the 0.5 boundary, where float32 and float64 can
+    round apart) and land on the same reconstruction error."""
+    kwargs = dict(
+        n_min=-7.0,
+        n_max=7.0,
+        num_iterations=200,
+        learning_rate=0.1,
+        reg_param=0.01,
+        warm_start=0.2,
+        beta_range=(20.0, 2.0),
+    )
+    for seed in range(3):
+        x, w, scale = _rounding_case(seed)
+        numpy_codes = adaround._optimize_rounding(w, scale, x, **kwargs)
+        graph_codes = adaround._optimize_rounding_on_graph(
+            w, scale, x, providers=None, **kwargs
+        )
+        assert (numpy_codes == graph_codes).mean() > 0.95
+
+        rtn = np.clip(np.round(w / scale), -7.0, 7.0)
+        rtn_err = _reconstruction_error(x, w, scale, rtn)
+        numpy_err = _reconstruction_error(x, w, scale, numpy_codes)
+        graph_err = _reconstruction_error(x, w, scale, graph_codes)
+        assert graph_err < rtn_err
+        assert graph_err == pytest.approx(numpy_err, rel=0.1)
+
+
+def test_apply_adaround_on_a_step_graph_beats_round_to_nearest():
+    """End to end through the public API: ``step_providers`` moves the
+    optimization onto an execution provider and the result is still an
+    AdaRound-improved model."""
+    rng = np.random.default_rng(11)
+    k, n, batch = 64, 16, 32
+    weight = rng.standard_normal((k, n)).astype(np.float32) * 0.5
+    float_model = onnx.parser.parse_model(
+        f"""
+        <ir_version: 10, opset_import: ["": 21]>
+        g (float[{batch},{k}] X) => (float[{batch},{n}] Y) {{
+          Y = MatMul(X, W)
+        }}
+        """
+    )
+    float_model.graph.initializer.append(onnx.numpy_helper.from_array(weight, "W"))
+    quant_model = onnxsim.quantize_weight_only_int4(float_model)
+
+    x = rng.standard_normal((batch, k)).astype(np.float32)
+    tuned = onnxsim.apply_adaround(
+        float_model,
+        quant_model,
+        calibration_data=[{"X": x}],
+        num_iterations=200,
+        step_providers=["CPUExecutionProvider"],
+    )
+    onnx.checker.check_model(tuned)
+
+    def run(model):
+        sess = ort.InferenceSession(
+            model.SerializeToString(), providers=["CPUExecutionProvider"]
+        )
+        return sess.run(None, {"X": x})[0].astype(np.float64)
+
+    reference = run(float_model)
+    rtn_err = np.linalg.norm(reference - run(quant_model))
+    tuned_err = np.linalg.norm(reference - run(tuned))
+    assert tuned_err < rtn_err
+
+
+def test_apply_adaround_step_providers_are_validated():
+    """An execution provider the installed onnxruntime does not have fails
+    loudly rather than silently running on the CPU -- backend.validate_providers'
+    own contract, inherited by the step-graph path."""
+    rng = np.random.default_rng(12)
+    k, n, batch = 32, 8, 8
+    float_model = onnx.parser.parse_model(
+        f"""
+        <ir_version: 10, opset_import: ["": 21]>
+        g (float[{batch},{k}] X) => (float[{batch},{n}] Y) {{
+          Y = MatMul(X, W)
+        }}
+        """
+    )
+    float_model.graph.initializer.append(
+        onnx.numpy_helper.from_array(
+            (rng.standard_normal((k, n)) * 0.5).astype(np.float32), "W"
+        )
+    )
+    quant_model = onnxsim.quantize_weight_only_int4(float_model)
+    with pytest.raises(ValueError, match="not available"):
+        onnxsim.apply_adaround(
+            float_model,
+            quant_model,
+            calibration_data=[
+                {"X": rng.standard_normal((batch, k)).astype(np.float32)}
+            ],
+            num_iterations=5,
+            step_providers=["NoSuchExecutionProvider"],
+        )


### PR DESCRIPTION
Add a design note on how quantization-aware training (QAT) could be delivered as an onnxsim feature — with the constraint that the training math be able to run on WebGPU or an NPU — and implement its first two stages.

## Summary

`docs/qat.md` revisits the "out of scope" QAT decision in `nncf-comparison-future-work.md`. Task-loss QAT (labels, datasets, a training lifecycle) stays out of scope; the note proposes a narrower, label-free alternative — **knowledge-distillation QAT**, fine-tuning the quantized model against the float model's own activations.

The lever that makes WebGPU/NPU execution possible: onnxsim hand-derives its gradients rather than taping them, so a backward pass here is ordinary dataflow (`MatMul`/`Mul`/`Sub`/`Sigmoid`/`Clip`/`Sqrt`, no autograd and no `Gradient` op) and one optimizer step is expressible as a plain ONNX **inference** graph. Any runtime that can do inference can therefore train these parameters, through boundaries that already exist: `backend`'s `providers=` in Python, and the WASM build's onnxruntime-web trampoline (`webgpu`, WebNN `gpu`/`npu`) in the browser.

Stages 0 and 1 of the note's plan are implemented here; `apply_qat()` itself (stage 2) is not.

## Key Changes

- **`docs/qat.md` (new).** Six existing passes (adaround, adaquant, brecq, flexround, autoround, omniquant) are already STE gradient descent — QAT differs along four axes, not as a new paradigm. Three deliverables: (A) QAT interop for externally-trained QDQ scales, (B) graph-native distillation QAT, (C) task-loss QAT (out of scope). Plus the WebGPU/NPU execution story with its honest limits (per-step readback, NPUs being inference silicon, loss of determinism), rejected alternatives, and a four-stage plan.
- **`onnxsim/qat_graph.py` (new) — stage 1.** `GraphBuilder` assembles a hand-derived gradient as ONNX nodes; `adam_update` appends one Adam step; `make_step_graph` wraps the result into a pure `(constants, state, per-step scalars) -> (next state, loss)` function with Adam's moments carried in and out as tensors; `run_step_graph` iterates it.
- **`onnxsim/backend.py`: `Runner`.** Binds a model and its execution providers once for a whole loop, with `enable_mem_pattern` left on — `run_model` creates a session per call, which is right for constant folding and ruinous for a 300-step optimization. The Python counterpart of the converter page's own `makeOrtRunner`.
- **`onnxsim/adaround.py`: the first caller ported.** `apply_adaround(..., step_providers=[...])` runs the optimization as a step graph on those providers. Omitting it keeps the float64 numpy loop as the default: it is exact and deterministic, and a non-CPU provider is neither.
- **Converter page — stage 0.** Browser calibration hard-coded `executionProviders: ["wasm"]`; it now honours a new **calibration execution provider** picker (`providersForEp`, so every accelerated choice keeps its WASM fallback) and loads onnxruntime-web's "all" bundle for WebNN. WASM stays the default, since an accelerated provider can compute in a different precision and move the observed min/max.

## Tests

- `tests/test_qat_graph.py` (9 tests): the generic machinery against an equivalent numpy Adam loop; the ported AdaRound path against the loop it replaces (>95% of elements pick the identical floor/ceil decision, reconstruction error within 10% — the rest is float32-vs-float64 boundary rounding); and both step graphs pinned to an operator allowlist, since a step graph reaching for an op no WebGPU/NPU backend implements would pass every numerical test and still be useless.
- `scripts/convertmodel/test/quantize_calibration.test.mjs` (6 checks): range accumulation and provider plumbing, browser-free under Node via injectable ORT entry points. Wired into `npm run test:all` and the convertmodel CI job.
- Existing `test_adaround.py` / `test_backend.py` / `test_brecq.py` / `test_adaquant.py` / `test_foem.py` still pass; `ruff check`, `ruff format` and `mypy` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC