### PR TITLE
Add io_dtype parameter for fp16 model interface

### DIFF
--- a/.github/workflows/coreml-integration.yml
+++ b/.github/workflows/coreml-integration.yml
@@ -272,6 +272,7 @@ jobs:
             quantize_weights: none
             matmul_to_conv: "false"
             min_deployment_target: iOS18
+            io_dtype: fp32
           - model_id: Qwen/Qwen2.5-1.5B-Instruct
             slug: qwen2.5-1.5b
             max_context_length: 512
@@ -279,6 +280,7 @@ jobs:
             quantize_weights: none
             matmul_to_conv: "false"
             min_deployment_target: ""
+            io_dtype: fp32
           # Same model/dtype as the first entry, weight-only int8 quantized --
           # see scripts/apple/README.md's "Theoretical ceiling" section for why
           # this is expected to raise decode tok/s (roughly halves DRAM bytes
@@ -292,6 +294,7 @@ jobs:
             quantize_weights: int8
             matmul_to_conv: "false"
             min_deployment_target: ""
+            io_dtype: fp32
           # Same model/dtype as the first entry, --matmul-to-conv enabled --
           # unlike the int8 entry above, this targets compute (not bandwidth):
           # the M4 ANE's native matmul path measures well below its conv1x1
@@ -309,6 +312,7 @@ jobs:
             quantize_weights: none
             matmul_to_conv: "true"
             min_deployment_target: iOS18
+            io_dtype: fp32
           # Both flags together -- measured worse than either alone: 2.26
           # tok/s vs. 3.61 baseline, 4.64 int8-only, 3.04 conv-only (see the
           # README's "matmul-to-conv1x1" section). Not the neutral
@@ -323,6 +327,39 @@ jobs:
             quantize_weights: int8
             matmul_to_conv: "true"
             min_deployment_target: ""
+            io_dtype: fp32
+          # Same model/dtype as the first entry with an fp16 *model interface*
+          # -- neither a bandwidth lever on the weights nor a change to which
+          # ops run, but the removal of the fp32<->fp16 conversion Core ML
+          # otherwise does at the model boundary on every call. This pipeline
+          # pays that twice per decode step over the whole KV cache (in as
+          # past_key_values_*, out as present_*), the largest thing crossing
+          # the boundary; see the README's "fp16 model interface" section.
+          # Runs decode parity too: it should be unchanged from the baseline
+          # (the computation was already fp16 -- only whether the caller gets
+          # that value or an upcast copy of it differs), so a parity *drop*
+          # here would mean something other than the interface moved.
+          - model_id: HuggingFaceTB/SmolLM2-135M-Instruct
+            slug: smollm2-135m-io16
+            max_context_length: 512
+            dtype: fp32
+            quantize_weights: none
+            matmul_to_conv: "false"
+            min_deployment_target: ""
+            io_dtype: fp16
+          # int8 weights + fp16 interface: the two levers that measured (int8)
+          # or are expected (fp16 I/O) to help, together. Checked explicitly
+          # rather than assumed to compose -- the int8 + matmul-to-conv entry
+          # above is precisely the case where two independently-scoped flags
+          # did not compose neutrally.
+          - model_id: HuggingFaceTB/SmolLM2-135M-Instruct
+            slug: smollm2-135m-int8-io16
+            max_context_length: 512
+            dtype: fp32
+            quantize_weights: int8
+            matmul_to_conv: "false"
+            min_deployment_target: ""
+            io_dtype: fp16
           # Few-billion-parameter tier -- DeviceMark's own leaderboard weight
           # class (https://devicemark.github.io/, roughly 1-4B), and the
           # entries prepare_benchmark_models.py's BENCHMARK_MODELS already
@@ -344,6 +381,7 @@ jobs:
             quantize_weights: none
             matmul_to_conv: "false"
             min_deployment_target: ""
+            io_dtype: fp32
           - model_id: meta-llama/Llama-3.2-1B-Instruct
             slug: llama-3.2-1b
             max_context_length: 512
@@ -351,6 +389,7 @@ jobs:
             quantize_weights: none
             matmul_to_conv: "false"
             min_deployment_target: ""
+            io_dtype: fp32
           - model_id: meta-llama/Llama-3.2-3B-Instruct
             slug: llama-3.2-3b
             max_context_length: 512
@@ -358,6 +397,7 @@ jobs:
             quantize_weights: none
             matmul_to_conv: "false"
             min_deployment_target: ""
+            io_dtype: fp32
           - model_id: Qwen/Qwen2.5-3B-Instruct
             slug: qwen2.5-3b
             max_context_length: 512
@@ -365,6 +405,7 @@ jobs:
             quantize_weights: none
             matmul_to_conv: "false"
             min_deployment_target: ""
+            io_dtype: fp32
           - model_id: microsoft/Phi-3.5-mini-instruct
             slug: phi-3.5-mini
             max_context_length: 512
@@ -372,6 +413,7 @@ jobs:
             quantize_weights: none
             matmul_to_conv: "false"
             min_deployment_target: ""
+            io_dtype: fp32
     env:
       # Read-only secret; only meta-llama/Llama-3.2-*-Instruct entries above
       # need it (gated -- see prepare_benchmark_models.py's module
@@ -402,6 +444,7 @@ jobs:
             --max-context-length ${{ matrix.max_context_length }} \
             --quantize-weights ${{ matrix.quantize_weights }} \
             ${{ matrix.matmul_to_conv == 'true' && '--matmul-to-conv' || '' }} \
+            --io-dtype ${{ matrix.io_dtype }} \
             ${{ matrix.min_deployment_target != '' && format('--minimum-deployment-target {0}', matrix.min_deployment_target) || '' }} \
             --output ${{ matrix.slug }}.mlpackage
       - name: Run the decode benchmark through the real Core ML runtime

--- a/README.md
+++ b/README.md
@@ -423,8 +423,21 @@ onnxsim.export_coreml(model_simp, "model.mlpackage")
 `export_coreml` accepts a few keyword arguments: `convert_to` (`"mlprogram"`,
 the default, or the legacy `"neuralnetwork"`), `compute_units` (which devices
 the model may run on, e.g. `"CPU_ONLY"`), `compute_precision`,
-`minimum_deployment_target` (e.g. `"iOS16"`), and `skip_model_load` (see
-above). See `onnxsim/coreml_export.py` for the full signature.
+`minimum_deployment_target` (e.g. `"iOS16"`), `io_dtype` (see below), and
+`skip_model_load` (see above). See `onnxsim/coreml_export.py` for the full
+signature.
+
+`io_dtype="fp16"` (CLI: `--coreml-io-dtype fp16`) declares the model's float
+inputs and outputs float16 instead of float32. An ML Program already computes
+in float16, so the float32 default only buys a conversion in each direction on
+every call, over twice the bytes — with no accuracy difference, since a float32
+output is just an upcast of the float16 value Core ML computed either way. It's
+worth most where the same large float tensors cross the boundary repeatedly, as
+a transformer decoder's KV cache does on every generated token. Requires
+`convert_to="mlprogram"` and raises the deployment target to iOS16/macOS13 when
+one isn't given. See
+[`scripts/apple/README.md`](scripts/apple/README.md)'s "fp16 model interface"
+section.
 
 ## Exporting to TensorFlow Lite
 

--- a/onnxsim/coreml_export.py
+++ b/onnxsim/coreml_export.py
@@ -132,6 +132,7 @@ def _make_input_spec(
     range_dims: Dict[str, Any],
     RangeDim,
     TensorType,
+    io_dtype: Optional[str] = None,
 ):
     """Build this input's MIL ``TensorSpec`` and, if it has a dynamic dim, the
     matching coremltools ``TensorType`` (for ``ct.convert(inputs=...)``; ``None``
@@ -175,6 +176,11 @@ def _make_input_spec(
         ct_shape.append(rd)
         has_dynamic = True
     dtype = _onnx_elem_type_to_mil(tt.elem_type, types)
+    if io_dtype == "fp16" and dtype == types.fp32:
+        # Declare the *model boundary* as fp16 (see convert_to_coreml's `io_dtype`).
+        # Only float inputs move: an int/bool input has no fp16 equivalent, and
+        # Core ML would reject one anyway.
+        dtype = types.fp16
     spec = mb.TensorSpec(shape=tuple(mil_shape), dtype=dtype)
     ct_input = (
         TensorType(name=value_info.name, shape=tuple(ct_shape)) if has_dynamic else None
@@ -269,6 +275,14 @@ class _Lowerer:
         if suffix:
             base = f"{base}_{suffix}"
         return f"{base}__{self._counter}"
+
+    def fresh_io_name(self, base: str, suffix: str) -> str:
+        """A unique name for a cast inserted at the graph's I/O boundary, where
+        there is no ONNX node to derive one from (see ``convert_to_coreml``'s
+        ``io_dtype``). Shares ``_counter`` with ``fresh_name``/``make_const`` so a
+        graph tensor literally named ``x_from_fp16__1`` still can't collide."""
+        self._counter += 1
+        return f"{base}_{suffix}__{self._counter}"
 
     def lower_node(self, node: onnx.NodeProto) -> None:
         handler = _OP_HANDLERS.get(node.op_type)
@@ -1187,6 +1201,7 @@ def _build_mil_program(
     dynamic_shapes: Optional[Dict[str, Tuple[int, int, int]]] = None,
     matmul_to_conv: bool = False,
     opset_version: Optional[Any] = None,
+    io_dtype: Optional[str] = None,
 ):
     graph = model.graph
     initializer_names = {t.name for t in graph.initializer}
@@ -1201,18 +1216,34 @@ def _build_mil_program(
     range_dims: Dict[str, Any] = {}
     input_specs = {}
     flexible_inputs = []
+    graph_dtypes: Dict[str, Any] = {}
     for inp in graph.input:
         if inp.name in initializer_names:
             continue
         spec, ct_input = _make_input_spec(
-            inp, mb, types, dynamic_shapes, range_dims, RangeDim, TensorType
+            inp, mb, types, dynamic_shapes, range_dims, RangeDim, TensorType, io_dtype
         )
         input_specs[inp.name] = spec
+        graph_dtypes[inp.name] = _onnx_elem_type_to_mil(
+            inp.type.tensor_type.elem_type, types
+        )
         if ct_input is not None:
             flexible_inputs.append(ct_input)
 
     with Function(input_specs, opset_version=opset_version) as func:
         for name, var in func.inputs.items():
+            if var.dtype != graph_dtypes[name]:
+                # `io_dtype="fp16"` declared this input fp16 where the ONNX graph
+                # says fp32. Cast straight back at the boundary so every op below
+                # is lowered against exactly the dtype it would see without the
+                # flag -- the graph body stays byte-identical, only the model's
+                # declared input type changes. coremltools' own fp16
+                # compute-precision pass folds the round trip away.
+                var = mb.cast(
+                    x=var,
+                    dtype=types.builtin_to_string(graph_dtypes[name]),
+                    name=lowerer.fresh_io_name(name, "from_fp16"),
+                )
             lowerer.bind(name, var)
         for init in graph.initializer:
             lowerer.bind(
@@ -1220,9 +1251,15 @@ def _build_mil_program(
             )
         for node in graph.node:
             lowerer.lower_node(node)
-        outputs = [
-            mb.identity(x=lowerer.get(out.name), name=out.name) for out in graph.output
-        ]
+        outputs = []
+        for out in graph.output:
+            var = lowerer.get(out.name)
+            if io_dtype == "fp16" and var.dtype == types.fp32:
+                # Terminal cast: the Core ML model's declared output dtype is the
+                # dtype of the op that produces it.
+                outputs.append(mb.cast(x=var, dtype="fp16", name=out.name))
+            else:
+                outputs.append(mb.identity(x=var, name=out.name))
         func.set_outputs(outputs)
 
     prog = Program()
@@ -1251,6 +1288,38 @@ def _resolve_deployment_target(ct, target: Union[str, Any]):
     return target
 
 
+def _resolve_io_dtype(ct, io_dtype: Optional[str], convert_to: str, resolved_target):
+    """Validate ``io_dtype`` and return ``(normalized, resolved_target)``.
+
+    ``normalized`` is ``"fp16"`` or ``None`` ("leave the boundary alone"), and
+    ``resolved_target`` is bumped to iOS16/macOS13 when fp16 I/O is requested
+    without an explicit target -- that is the first Core ML version whose
+    ``MLMultiArray`` model interface can be declared float16 at all.
+    """
+    if io_dtype is None or io_dtype == "fp32":
+        return None, resolved_target
+    if io_dtype != "fp16":
+        raise RuntimeError(
+            f"Unknown io_dtype {io_dtype!r}; valid values: 'fp32' (the default, "
+            "float model inputs/outputs declared float32) or 'fp16'."
+        )
+    if convert_to != "mlprogram":
+        raise RuntimeError(
+            "io_dtype='fp16' requires convert_to='mlprogram'; the legacy "
+            "'neuralnetwork' format has no float16 model interface."
+        )
+    floor = ct.target.iOS16
+    if resolved_target is None:
+        return "fp16", floor
+    if int(resolved_target) < int(floor):
+        raise RuntimeError(
+            f"io_dtype='fp16' needs minimum_deployment_target iOS16/macOS13 or "
+            f"newer (got {resolved_target.name}); float16 model inputs/outputs "
+            "did not exist before then."
+        )
+    return "fp16", resolved_target
+
+
 def convert_to_coreml(
     model: onnx.ModelProto,
     *,
@@ -1261,6 +1330,7 @@ def convert_to_coreml(
     skip_model_load: bool = True,
     dynamic_shapes: Optional[Dict[str, Tuple[int, int, int]]] = None,
     matmul_to_conv: bool = False,
+    io_dtype: Optional[str] = None,
 ):
     """Convert an ONNX model to an in-memory Core ML model.
 
@@ -1315,6 +1385,28 @@ def convert_to_coreml(
         Any ``MatMul`` that doesn't match that exact shape (a non-constant or
         non-2-D weight, or ``x`` of any rank other than 3) is left on the
         ``matmul`` path unchanged.
+    io_dtype:
+        Dtype of the *model interface* -- the float inputs and outputs Core ML
+        exposes to a caller. ``None``/``"fp32"`` (the default) leaves them
+        float32, coremltools' own default; ``"fp16"`` declares every float input
+        and output float16 instead.
+
+        An ML Program already computes in float16 by default, so a float32
+        interface makes Core ML convert every float input down to fp16 on the way
+        in and every float output back up on the way out, moving twice the bytes
+        across the boundary in the process. Declaring the boundary fp16 skips
+        both conversions; the ANE reverse-engineering work this follows measures
+        direct fp16 I/O at roughly 37% faster than fp32 I/O on the same buffers
+        (`maderix/ANE <https://github.com/maderix/ANE>`_, "How It Works" step 3).
+        It costs no accuracy relative to the default either: the computation was
+        already fp16 either way, so a float32 output is an upcast fp16 value.
+
+        Worth most on a graph that hands the same large float tensors back and
+        forth every call -- a decoder's KV cache, which arrives as
+        ``past_key_values_*`` inputs and leaves as ``present_*`` outputs on every
+        single decode step. Integer and bool inputs are unaffected (Core ML has
+        no fp16 form for them). Requires ``convert_to="mlprogram"`` and raises
+        ``minimum_deployment_target`` to iOS16/macOS13 when one isn't given.
 
     Returns
     -------
@@ -1346,6 +1438,9 @@ def convert_to_coreml(
         if minimum_deployment_target is not None
         else None
     )
+    io_dtype, resolved_target = _resolve_io_dtype(
+        ct, io_dtype, convert_to, resolved_target
+    )
 
     prog, flexible_inputs = _build_mil_program(
         model,
@@ -1358,6 +1453,7 @@ def convert_to_coreml(
         dynamic_shapes,
         matmul_to_conv,
         opset_version=resolved_target,
+        io_dtype=io_dtype,
     )
 
     kwargs: Dict[str, Any] = {}

--- a/onnxsim/onnx_simplifier.py
+++ b/onnxsim/onnx_simplifier.py
@@ -4473,6 +4473,15 @@ def main():
         help="Which compute devices the --emit-coreml model may run on. Default: ALL.",
     )
     parser.add_argument(
+        "--coreml-io-dtype",
+        choices=["fp32", "fp16"],
+        default="fp32",
+        help="Dtype of the --emit-coreml model's float inputs and outputs. 'fp16' "
+        "matches the precision an ML Program already computes in, so Core ML stops "
+        "converting every float tensor at the model boundary on each call (needs "
+        "--coreml-format mlprogram and iOS16/macOS13 or newer). Default: fp32.",
+    )
+    parser.add_argument(
         "--coreml-minimum-deployment-target",
         default=None,
         metavar="TARGET",
@@ -5394,6 +5403,7 @@ def main():
                 convert_to=args.coreml_format,
                 compute_units=args.coreml_compute_units,
                 minimum_deployment_target=args.coreml_minimum_deployment_target,
+                io_dtype=args.coreml_io_dtype,
             )
         except RuntimeError as e:
             print(Text(str(e), style="bold red"))

--- a/scripts/apple/README.md
+++ b/scripts/apple/README.md
@@ -359,6 +359,115 @@ quantized, rather than the two costs just adding. Reinforces the same
 conclusion from the solo measurement above: `--matmul-to-conv` isn't worth
 enabling for this pipeline's shapes, combined with int8 or otherwise.
 
+### fp16 model interface (`--io-dtype fp16`)
+
+Where `--quantize-weights` cuts the bytes read from DRAM *inside* the model and
+`--matmul-to-conv` changes which op runs, this flag touches neither: it changes
+the dtype of the model's **interface** -- the float tensors a caller hands in
+and gets back -- from float32 to float16.
+
+The reason it's worth a flag: an ML Program already computes in float16
+(coremltools' `compute_precision` default), but coremltools declares the
+model's inputs and outputs float32 unless told otherwise. That mismatch is not
+free. It shows up directly in the emitted program -- exporting a two-op graph
+and reading back the ops Core ML actually stores (`const` instances, which just
+carry other ops' arguments, elided):
+
+| `io_dtype` | ops in the ML Program |
+| --- | --- |
+| `fp32` (default) | `cast`, `relu`, `sqrt`, `cast` |
+| `fp16` | `relu`, `sqrt` |
+
+Those two `cast`s are the boundary conversion, and they run on every single
+`predict()` call: float32 down to float16 on the way in, float16 back up to
+float32 on the way out, with twice the bytes crossing the boundary in each
+direction. This pipeline is close to the worst case for that. The KV cache
+crosses the boundary **twice per decode step** -- in as `past_key_values_*`,
+out as `present_*` -- it is by far the largest thing moving (far larger than
+the single token's activations that step actually computes), and it grows with
+every token generated. `--io-dtype fp16` deletes both conversions.
+
+The finding this follows is from the same M4 ANE reverse-engineering work as
+the "Theoretical ceiling" section above -- its companion repository
+[`maderix/ANE`](https://github.com/maderix/ANE), which drives the ANE directly
+through the private `_ANEClient`/`_ANECompiler` APIs rather than through Core
+ML. Passing tensors as fp16 in its IOSurface I/O path measures **~37% faster
+than fp32** over the same buffers ("How It Works", step 3). That number is from
+a different stack (raw IOSurface I/O, no Core ML framework in between), so
+treat it as the reason to expect the effect, not as a prediction of this
+pipeline's speedup -- `coreml-integration.yml`'s `benchmark-decode-macos`
+matrix has an `io_dtype: fp16` entry (same model as the unquantized baseline,
+decode parity included) to measure what it's actually worth here.
+
+```bash
+python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \
+    --max-context-length 512 --io-dtype fp16 --output smollm2-io16.mlpackage
+```
+
+Unlike the other two flags, this one is **not** a precision or structural
+trade-off. `--quantize-weights` changes stored values; `--matmul-to-conv`
+changes which ops run. This changes neither: the computation was float16 on
+both sides of the flag, so an fp32 output was only ever an upcast copy of the
+fp16 value Core ML had already computed. What changes is whether the caller is
+handed that value directly.
+
+Notes:
+
+- Only **float** inputs and outputs move. Integer inputs (`input_ids`,
+  `attention_mask`, `position_ids`) are untouched -- Core ML has no float16
+  form for them.
+- Needs `--format mlprogram` (the default; the legacy `neuralnetwork` format
+  has no float16 interface) and iOS16/macOS13 or newer. `onnxsim.export_coreml`
+  raises the deployment target to iOS16 itself when one isn't given, and
+  rejects an explicitly *lower* one rather than emitting a model Core ML would
+  refuse to load.
+- The graph body is lowered exactly as it is without the flag: each fp16 input
+  is cast straight back to the dtype the ONNX graph declares before any node is
+  translated, so no op sees a different dtype than it otherwise would, and
+  coremltools' own fp16 compute-precision pass folds the round trip away (the
+  table above is that folding, observed).
+- `run_llm_decode_benchmark.py`, `check_decode_parity.py` and
+  `lm_eval_coreml_adapter.py` all read their feed dtypes off the model's own
+  spec (`_DATATYPE_TO_NUMPY`), so they run against either interface with no
+  changes.
+
+#### What else came from `maderix/ANE`, and why not (yet)
+
+That repository documents several other ANE findings. Two are worth recording
+as deliberately *not* taken here, so the next person doesn't have to re-derive
+the reasoning:
+
+- **INT8 W8A8 (int8 weights *and* activations)** -- measured there at
+  **1.85-1.88x** fp16 throughput (35.1 vs 18.6 TOPS on 128x conv 512ch), via
+  MIL `quantize`/`dequantize` between tiles so activations stay int8 in L2
+  SRAM. Core ML's own equivalent is
+  `coremltools.optimize.coreml.linear_quantize_activations`, which needs a
+  calibration pass over real data. It is a **compute** lever, and the
+  "Theoretical ceiling" section above works out that single-token decode at
+  these model sizes is bandwidth-bound with compute already down in the noise
+  -- so it would be aimed at the side of the ceiling that isn't binding.
+  Interesting for *prefill* (whole-prompt, genuinely compute-bound), which this
+  suite doesn't currently optimize for; not for the decode tok/s number
+  `run_llm_decode_benchmark.py` reports.
+- **Channel-first `[1,C,1,S]` layout throughout** -- that project eliminates
+  transposes by keeping *its whole CPU-side pipeline* in the ANE's native
+  IOSurface layout, not by transposing around each op. Notably, that is the
+  opposite of what `--matmul-to-conv` does here: it wraps every projection in a
+  transpose/conv/transpose, and measured *slower* (see above). Doing this
+  properly means a layout-propagation pass over the whole graph that inserts
+  transposes only where the layout genuinely has to change -- a real
+  translator-level project, not a flag, and one that should only be started
+  once there's a measurement showing the transposes (rather than something
+  else) are what cost `--matmul-to-conv` its 16-22%.
+
+Its remaining findings are specific to driving the ANE through the private
+APIs and have no Core ML analogue to port: the ~119-compiles-per-process limit
+worked around by `exec()`, the single-input packing constraint, and the
+SDPA-`attn_mask` gap (that project decomposes causal attention itself because
+ANE hardware ignores `attn_mask`; `onnxsim/coreml_export.py` never emits a
+fused SDPA op in the first place -- it lowers attention as explicit
+`matmul`/`softmax`/`add`, so there is no mask to be dropped).
+
 ### Compute-unit device placement (`coreml_compute_plan_trace.m`)
 
 `--matmul-to-conv`'s standalone measurement above raised an obvious

--- a/scripts/apple/export_llm_to_coreml.py
+++ b/scripts/apple/export_llm_to_coreml.py
@@ -91,6 +91,26 @@ whether it helps *this* pipeline's shapes (mostly single-token decode, unlike
 the deep/wide conv1x1 chains the cited measurements used) before anyone
 enables it by default.
 
+`--io-dtype fp16` (default `fp32`) changes the exported model's *interface*
+rather than anything inside it: every float input and output is declared
+float16, so Core ML stops converting them at the boundary on every call. An ML
+Program already computes in float16 (`compute_precision`'s default), so an
+fp32 interface only buys a down-conversion on the way in and an up-conversion
+on the way out, over twice the bytes. This pipeline is the shape that pays
+most for that: the KV cache crosses the boundary twice per decode step (in as
+`past_key_values_*`, out as `present_*`) and is by far the largest thing
+moving, growing with every token generated. The ANE reverse-engineering work
+behind README.md's "Theoretical ceiling" numbers measures direct fp16 I/O at
+roughly 37% faster than fp32 I/O over the same buffers
+(https://github.com/maderix/ANE, "How It Works" step 3). Unlike
+`--quantize-weights` it changes no stored value and unlike `--matmul-to-conv`
+it changes no op, so it costs nothing in accuracy relative to the default --
+the computation was fp16 on both sides of the flag; only whether the caller
+sees the fp16 value directly or an upcast copy of it changes.
+`run_llm_decode_benchmark.py` and `check_decode_parity.py` both read their
+feed dtypes off the model's own spec, so they work against either interface
+unchanged.
+
 Usage:
     python export_llm_to_coreml.py HuggingFaceTB/SmolLM2-135M-Instruct \\
         --max-context-length 512 --output smollm2.mlpackage
@@ -133,6 +153,7 @@ def export_llm_to_coreml(
     quantize_weights: str = "none",
     matmul_to_conv: bool = False,
     minimum_deployment_target: str | None = None,
+    io_dtype: str = "fp32",
 ) -> None:
     from optimum.exporters.onnx import main_export
 
@@ -216,6 +237,7 @@ def export_llm_to_coreml(
                 "past_sequence_length + sequence_length": (1, 1, max_context_length),
             },
             "matmul_to_conv": matmul_to_conv,
+            "io_dtype": io_dtype,
         }
         if minimum_deployment_target is not None:
             convert_kwargs["minimum_deployment_target"] = minimum_deployment_target
@@ -326,6 +348,16 @@ def main() -> int:
         "unvalidated on real hardware -- benchmark before trusting it.",
     )
     ap.add_argument(
+        "--io-dtype",
+        choices=["fp32", "fp16"],
+        default="fp32",
+        help="Dtype of the exported model's float inputs and outputs (default: "
+        "fp32). 'fp16' matches what an ML Program already computes in, so Core ML "
+        "stops converting every float tensor -- the whole KV cache, twice per "
+        "decode step -- at the boundary. See the module docstring and README.md's "
+        "'fp16 model interface' section.",
+    )
+    ap.add_argument(
         "--minimum-deployment-target",
         default=None,
         help="Force a minimum Core ML deployment target (e.g. 'iOS18'), overriding "
@@ -346,6 +378,7 @@ def main() -> int:
         quantize_weights=args.quantize_weights,
         matmul_to_conv=args.matmul_to_conv,
         minimum_deployment_target=args.minimum_deployment_target,
+        io_dtype=args.io_dtype,
     )
     return 0
 

--- a/scripts/apple/run_llm_decode_benchmark.py
+++ b/scripts/apple/run_llm_decode_benchmark.py
@@ -98,6 +98,23 @@ class CoreMLDecoder:
             )
         self.max_context_length = max_context_length
 
+        # The model's float interface dtype (see export_llm_to_coreml.py's
+        # --io-dtype): float32 by default, float16 when the boundary conversion
+        # Core ML would otherwise do on every call was exported away. Reported
+        # below so a benchmark run's numbers are readable without cross-checking
+        # which flags produced the .mlpackage.
+        float_dtypes = {
+            self._input_dtypes[i.name]
+            for i in spec.description.input
+            if self._input_dtypes[i.name] in (np.float16, np.float32, np.float64)
+        }
+        if not float_dtypes:
+            self.io_dtype = "none"
+        elif len(float_dtypes) == 1:
+            self.io_dtype = np.dtype(float_dtypes.pop()).name
+        else:
+            self.io_dtype = "mixed"
+
         self._present_names = [
             o.name for o in spec.description.output if o.name.startswith("present_")
         ]
@@ -219,6 +236,7 @@ def main() -> int:
     )
     decoder = CoreMLDecoder(args.mlpackage, compute_units=args.compute_units)
     print(f"Max context length: {decoder.max_context_length} tokens", flush=True)
+    print(f"Model float interface: {decoder.io_dtype}", flush=True)
 
     prompt_ids = tokenizer(args.prompt, return_tensors="np")["input_ids"][0].tolist()
     print(f"Prompt: {args.prompt!r} ({len(prompt_ids)} tokens)", flush=True)

--- a/tests/test_coreml_export.py
+++ b/tests/test_coreml_export.py
@@ -26,7 +26,9 @@ from onnx import numpy_helper, parser
 
 pytest.importorskip("coremltools", reason="coremltools is not installed")
 
-import onnxruntime as ort  # noqa: E402  (imported after the coremltools availability check)
+import coremltools as ct  # noqa: E402  (imported after the availability check above)
+import onnxruntime as ort  # noqa: E402
+from coremltools.converters.mil.mil import types  # noqa: E402
 
 import onnxsim  # noqa: E402
 from onnxsim import coreml_export  # noqa: E402
@@ -450,7 +452,9 @@ def test_zero_length_input_dimension_is_static():
 # ---------------------------------------------------------------------------
 
 
-def _build_ops(model: onnx.ModelProto, dynamic_shapes=None, matmul_to_conv=False):
+def _build_ops(
+    model: onnx.ModelProto, dynamic_shapes=None, matmul_to_conv=False, io_dtype=None
+):
     """Like ``_mil_const_value``, but returns the built MIL function itself
     (not just a folded output value) -- for inspecting *which* ops got
     emitted, or reading an intermediate (not just the final output) value.
@@ -460,6 +464,7 @@ def _build_ops(model: onnx.ModelProto, dynamic_shapes=None, matmul_to_conv=False
         *coreml_export._import_mil(),
         dynamic_shapes,
         matmul_to_conv,
+        io_dtype=io_dtype,
     )
     return prog.functions["main"], flexible_inputs
 
@@ -738,6 +743,170 @@ def test_constant_of_shape_dynamic_fp16():
     mlmodel = onnxsim.export_coreml(model, dynamic_shapes={"N": (1, 2, 8)})
     (out_desc,) = mlmodel.get_spec().description.output
     assert out_desc.name == "y"
+
+
+# ---------------------------------------------------------------------------
+# io_dtype (opt-in: declare the model's float interface fp16 instead of fp32 --
+# see convert_to_coreml's docstring and scripts/apple/README.md's "fp16 model
+# interface" section). An ML Program computes in fp16 regardless, so an fp32
+# interface only buys a pair of boundary conversions; these tests check the
+# declared interface dtypes and that the conversions really disappear.
+# ---------------------------------------------------------------------------
+
+_ARRAY_DTYPE = ct.proto.FeatureTypes_pb2.ArrayFeatureType.ArrayDataType
+
+
+def _io_dtypes(mlmodel):
+    """``([(input name, dtype)], [(output name, dtype)])`` as Core ML declares them."""
+    desc = mlmodel.get_spec().description
+    return (
+        [(i.name, i.type.multiArrayType.dataType) for i in desc.input],
+        [(o.name, o.type.multiArrayType.dataType) for o in desc.output],
+    )
+
+
+def _mixed_dtype_model() -> onnx.ModelProto:
+    """One float input/output and one int32 input/output -- only the float pair
+    can move to fp16 (Core ML has no fp16 form for an integer array)."""
+    model = _model(
+        """
+        mixed (float[1,4] x, int32[1,4] idx) => (float[1,4] y, int32[1,4] z)
+        {
+            y = Relu (x)
+            z = Add (idx, idx)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_io_dtype_defaults_to_fp32():
+    inputs, outputs = _io_dtypes(onnxsim.export_coreml(_mixed_dtype_model()))
+    assert inputs == [("x", _ARRAY_DTYPE.FLOAT32), ("idx", _ARRAY_DTYPE.INT32)]
+    assert outputs == [("y", _ARRAY_DTYPE.FLOAT32), ("z", _ARRAY_DTYPE.INT32)]
+
+
+def test_io_dtype_fp32_is_the_default_spelled_out():
+    explicit = _io_dtypes(onnxsim.export_coreml(_mixed_dtype_model(), io_dtype="fp32"))
+    assert explicit == _io_dtypes(onnxsim.export_coreml(_mixed_dtype_model()))
+
+
+def test_io_dtype_fp16_declares_float16_interface():
+    inputs, outputs = _io_dtypes(
+        onnxsim.export_coreml(_mixed_dtype_model(), io_dtype="fp16")
+    )
+    # Only the float pair moves; the int32 pair is untouched.
+    assert inputs == [("x", _ARRAY_DTYPE.FLOAT16), ("idx", _ARRAY_DTYPE.INT32)]
+    assert outputs == [("y", _ARRAY_DTYPE.FLOAT16), ("z", _ARRAY_DTYPE.INT32)]
+
+
+def test_io_dtype_fp16_removes_the_boundary_casts():
+    # The point of the flag. An ML Program runs in fp16 by default, so with an
+    # fp32 interface coremltools' own compute-precision pass wraps the program
+    # in a cast pair: fp32 input -> fp16 on the way in, fp16 -> fp32 output on
+    # the way out. That is the per-call conversion (and the doubled bytes over
+    # the boundary) `io_dtype="fp16"` exists to delete.
+    model = _model(
+        "boundary (float[2,4] x) => (float[2,4] y) { t = Relu (x)  y = Sqrt (t) }"
+    )
+    onnx.checker.check_model(model)
+
+    def real_ops(mlmodel):
+        # `const` op instances just carry other ops' scalar arguments (here, each
+        # cast's target dtype string) -- not part of the computation.
+        return [t for t, _ in _spec_ops(mlmodel) if t != "const"]
+
+    assert real_ops(onnxsim.export_coreml(model)) == ["cast", "relu", "sqrt", "cast"]
+    # Same computation, no boundary conversions left around it.
+    assert real_ops(onnxsim.export_coreml(model, io_dtype="fp16")) == ["relu", "sqrt"]
+
+
+def test_io_dtype_fp16_leaves_an_already_fp16_graph_alone():
+    # An ONNX graph that is *itself* fp16 already gets an fp16 interface with no
+    # flag at all, and asking for one must not add a redundant cast to itself.
+    model = _model("f16 (float16[2,4] x) => (float16[2,4] y) { y = Relu (x) }")
+    onnx.checker.check_model(model)
+    inputs, outputs = _io_dtypes(onnxsim.export_coreml(model, io_dtype="fp16"))
+    assert inputs == [("x", _ARRAY_DTYPE.FLOAT16)]
+    assert outputs == [("y", _ARRAY_DTYPE.FLOAT16)]
+
+    func, _ = _build_ops(model, io_dtype="fp16")
+    assert [op.op_type for op in func.operations] == ["relu", "identity"]
+
+
+def test_io_dtype_fp16_casts_back_before_lowering_any_node():
+    # The graph body must be lowered against the dtype the *ONNX* graph declares,
+    # not fp16: the flag moves the model boundary, it does not retype the graph.
+    # So an fp32 graph gets one cast straight back to fp32 at each fp16 input,
+    # and one down to fp16 at each float output, with the body untouched between.
+    model = _model("body (float[2,4] x) => (float[2,4] y) { y = Relu (x) }")
+    onnx.checker.check_model(model)
+
+    def op_types(func):
+        # As in test_io_dtype_fp16_removes_the_boundary_casts: a `const` here is
+        # each cast's own dtype argument, not part of the computation.
+        return [op.op_type for op in func.operations if op.op_type != "const"]
+
+    default_func, _ = _build_ops(model)
+    assert op_types(default_func) == ["relu", "identity"]
+
+    fp16_func, _ = _build_ops(model, io_dtype="fp16")
+    assert op_types(fp16_func) == ["cast", "relu", "cast"]
+    (relu,) = [op for op in fp16_func.operations if op.op_type == "relu"]
+    assert types.builtin_to_string(relu.outputs[0].dtype) == "fp32"
+
+
+def test_io_dtype_fp16_defaults_the_deployment_target_to_ios16():
+    # A float16 MLMultiArray interface only exists from iOS16/macOS13 on, so the
+    # flag raises an unset target rather than emitting a model Core ML rejects.
+    mlmodel = onnxsim.export_coreml(_relu_model(), io_dtype="fp16")
+    assert mlmodel.get_spec().specificationVersion == int(ct.target.iOS16)
+
+    # An explicitly higher target is kept as-is.
+    higher = onnxsim.export_coreml(
+        _relu_model(), io_dtype="fp16", minimum_deployment_target="iOS17"
+    )
+    assert higher.get_spec().specificationVersion == int(ct.target.iOS17)
+
+
+def test_io_dtype_fp16_composes_with_dynamic_shapes():
+    # The KV-cache shape this flag is actually aimed at: an input that both
+    # varies in one dimension and carries most of the bytes crossing the
+    # boundary on every decode step.
+    model = _model(
+        "kv (float[1,2,past,4] past_key_values_0_key) => "
+        "(float[1,2,past,4] present_0_key) "
+        "{ present_0_key = Relu (past_key_values_0_key) }"
+    )
+    mlmodel = onnxsim.export_coreml(
+        model, io_dtype="fp16", dynamic_shapes={"past": (0, 1, 16)}
+    )
+    (in_desc,) = mlmodel.get_spec().description.input
+    assert in_desc.type.multiArrayType.dataType == _ARRAY_DTYPE.FLOAT16
+    size_range = in_desc.type.multiArrayType.shapeRange.sizeRanges[2]
+    assert (size_range.lowerBound, size_range.upperBound) == (0, 16)
+    (out_desc,) = mlmodel.get_spec().description.output
+    assert out_desc.type.multiArrayType.dataType == _ARRAY_DTYPE.FLOAT16
+
+
+def test_io_dtype_fp16_below_ios16_raises():
+    with pytest.raises(RuntimeError, match="iOS16/macOS13 or newer"):
+        onnxsim.export_coreml(
+            _relu_model(), io_dtype="fp16", minimum_deployment_target="iOS15"
+        )
+
+
+def test_io_dtype_fp16_on_neuralnetwork_raises():
+    with pytest.raises(RuntimeError, match="requires convert_to='mlprogram'"):
+        onnxsim.export_coreml(
+            _relu_model(), io_dtype="fp16", convert_to="neuralnetwork"
+        )
+
+
+def test_io_dtype_unknown_value_raises():
+    with pytest.raises(RuntimeError, match="Unknown io_dtype"):
+        onnxsim.export_coreml(_relu_model(), io_dtype="bf16")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add support for declaring Core ML model float inputs/outputs as float16 instead of float32 via a new `io_dtype` parameter. This eliminates unnecessary boundary conversions on every inference call, particularly beneficial for large tensors like KV caches that cross the boundary repeatedly during decoding.

## Key Changes

- **Core ML export API** (`onnxsim/coreml_export.py`):
  - Add `io_dtype` parameter to `convert_to_coreml()` and `_build_mil_program()`
  - Implement `_resolve_io_dtype()` to validate the parameter and auto-raise deployment target to iOS16/macOS13 when fp16 is requested without an explicit target
  - Modify `_make_input_spec()` to declare float inputs as fp16 when `io_dtype="fp16"`
  - Insert cast operations at graph boundaries: cast fp16 inputs back to the ONNX graph's declared dtype at entry, cast fp32 outputs to fp16 at exit
  - Add `fresh_io_name()` method to generate unique names for boundary casts

- **CLI and scripting** (`onnxsim/onnx_simplifier.py`, `scripts/apple/export_llm_to_coreml.py`):
  - Add `--coreml-io-dtype` argument to main CLI
  - Add `--io-dtype` argument to `export_llm_to_coreml.py` with detailed docstring explaining the motivation and use cases

- **Benchmarking** (`scripts/apple/run_llm_decode_benchmark.py`):
  - Detect and report the model's float interface dtype in benchmark output

- **Documentation** (`scripts/apple/README.md`, `README.md`):
  - Add comprehensive "fp16 model interface" section explaining the feature, measurements from ANE reverse-engineering work, and composition with other flags
  - Document why INT8 W8A8 and channel-first layout were not adopted despite being documented in the ANE project

- **CI/CD** (`.github/workflows/coreml-integration.yml`):
  - Add benchmark matrix entries for fp16 interface alone and combined with int8 quantization
  - Explicitly set `io_dtype: fp32` for existing baseline entries for clarity

- **Tests** (`tests/test_coreml_export.py`):
  - Add comprehensive test suite covering:
    - Default fp32 behavior
    - fp16 interface declaration
    - Boundary cast removal with fp16 interface
    - Handling of already-fp16 graphs
    - Cast insertion at graph boundaries
    - Deployment target auto-raise to iOS16
    - Composition with dynamic shapes
    - Error cases (iOS15 or lower, neuralnetwork format, unknown dtype values)

## Implementation Details

The feature works by:
1. When `io_dtype="fp16"` is specified, float inputs are declared as fp16 in the Core ML model spec
2. At the MIL function boundary, fp16 inputs are immediately cast back to the ONNX graph's declared dtype (typically fp32) so all ops are lowered against the original graph's types
3. Float outputs are cast from fp32 to fp16 before being returned
4. coremltools' own `compute_precision` pass folds the round-trip casts away, leaving only the boundary conversions removed
5. Integer and bool inputs/outputs are unaffected (Core ML has no fp16 form for them)
6. The feature requires `convert_to="mlprogram"` and iOS16/macOS13 or newer

This is a pure interface change with no accuracy impact: the computation was already fp16 either way; only whether the caller receives the fp16 value directly or an upcast copy of it differs.

https://claude.ai/code/session_01YXHZy3uume7xd1fTMuhai4