### PR TITLE
mcode: 98.4% of the instruction stream, the width rule's hard limit, and a 7-byte write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ node_modules/
 # checkouts under .claude/worktrees/) -- never part of the repo itself.
 /.claude/
 scripts/axera/vm/share/
+tiny-random-mistral/

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3232,6 +3232,16 @@ byte). Zero bytes are segment padding and are excluded on both sides:
 | `llama` LM head | 124,736 | 77,790 | 169 | **99.78%** |
 | all five | | 243,554 | 3,851 | **98.42%** |
 
+Admitting the 7-byte companion write described below takes that to **98.69%**
+(3,179 unexplained).
+
+One trade-off is worth naming: treating 0xa1 as a tag (the fifth correction)
+is a large net win -- it cuts the `llama` prefill subgraph's residue from
+2,115 bytes to 1,301, and *improves* most op segments (the decode subgraph's
+from 510 to 321) -- but in two builds it costs a handful of bytes inside op
+segments that the narrower rule read exactly. Those segments are now asserted
+at 99.9% rather than 100%.
+
 The same rule, unchanged, reads a CNN and a transformer -- through either
 compiler path -- which is the strongest evidence yet that the grammar is the
 hardware's and not an artefact of one model.
@@ -3249,22 +3259,33 @@ over-fitting, not a real form. `p <= 4` is a hard limit.
 
 **A 7-byte write that fills the slot below the next one.** Among the
 remaining runs, the 7-byte ones have the shape `[X][field][bank][32-bit
-operand]`, and their address is always exactly one field slot below the
-verb that follows them: of the 28 such runs across the five mcodes, 24 are
-the same bank one field lower, and the other 4 are the last field of the
+operand]`, and their address is always exactly one field slot below the verb
+that follows them: same bank one field lower, or the last field of the
 previous bank (`09 f0 05 40 fc 03 06` then `a1 00 00 06 ...`: field 0xf0 in
-bank 5, then field 0x00 in bank 6). None is anything else, against a 38%
-null -- the rate at which the seven bytes preceding *any* `a1` verb happen to
-have that shape. In 14 of the 28 the 32-bit operand is byte-identical to the
-following verb's, so the pair writes one value into two adjacent slots.
-The leading byte varies (0x21, 0x05, 0x09, 0x7f, 0x02, 0x20, 0x1d, 0x1c);
-0x21 is `a1` with bit 7 cleared, which fits a compact encoding that drops the
-8-byte form's `00` byte, but the other values do not, so what `X` carries is
-still open. The bank wraps also confirm that `(bank, field)` is one
-continuous address space, not two independent selectors.
+bank 5, then field 0x00 in bank 6). The bank wraps confirm that
+`(bank, field)` is one continuous address space, not two independent
+selectors.
+
+That adjacency is a strong enough anchor to make the form a first-class
+rule: recognise a 7-byte unit only when the next eight bytes are an `a1`
+verb writing the adjacent slot. Across the five mcodes it fires **104
+times** and on their shuffled counterparts **zero times** -- perfect
+discrimination, no threshold to argue about. Admitting it takes the tail
+from 3,851 unexplained bytes to 3,179, and the whole-corpus figure from
+98.42% to **98.69%**.
+
+Many instances only became visible this way. `0a 90 0e 00 00 80 3f` writes
+the float 1.0 to field 0x90 of bank 0x0e and is followed by `a1 00 a0 0e`,
+the next slot up -- but the greedy walk used to swallow its first five bytes
+as a spurious short unit and leave `80 3f` (the high half of 1.0f) stranded,
+which is why `80 3f` was the single most common two-byte leftover. The
+leading byte still varies (0x21, 0x05, 0x09, 0x0a, 0x7f, 0x02, 0x20, 0x1d,
+0x1c) and what it carries is open; 0x21 is `a1` with bit 7 cleared, which
+would fit a compact encoding that drops the 8-byte form's `00`, but the
+other values do not.
 
 Tests: `test_full_rule_explains_almost_every_stream_byte` and
-`test_seven_byte_writes_address_the_slot_below_the_next_verb` in
+`test_companion_writes_fill_the_slot_below_the_next_verb` in
 `tests/test_axera_mcode_structure.py` (fresh builds of `resnet18d` and the
 ONNX-path Mistral, no device); the `llm_build` layer's coverage is asserted
 by its own test.

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3214,6 +3214,61 @@ Tests: `test_resnet18d_tail_segments_tile_the_stream_and_open_with_a7`,
 LLM tests skip unless the checkpoints are already in the HuggingFace
 cache).
 
+### Where the decoding stands: 98.4% of the instruction stream, across a CNN and two LLM paths
+
+Measured on five real mcodes -- `resnet18d`, a 1-layer `tiny-random-mistral`
+compiled through the ONNX path, both `neu mode` subgraphs of an `llm_build`
+`SmolLM2-135M` layer, and the LM head -- with every validated form admitted
+(six verbs, all tags 0x81..0x9f plus 0xa1, prefixes `p <= 4`, bare
+`[tag][register]` pairs, the bit-6 odd-register tags, and tag 0x9f's extra
+byte). Zero bytes are segment padding and are excluded on both sides:
+
+| build | stream | non-zero bytes | unexplained | explained |
+| --- | --- | --- | --- | --- |
+| `resnet18d` | 48,320 | 34,634 | 496 | **98.57%** |
+| `mistral` (ONNX path) | 27,104 | 20,252 | 619 | **96.94%** |
+| `llama` layer, decode | 55,104 | 40,557 | 975 | **97.60%** |
+| `llama` layer, prefill | 91,296 | 70,321 | 1,592 | **97.74%** |
+| `llama` LM head | 124,736 | 77,790 | 169 | **99.78%** |
+| all five | | 243,554 | 3,851 | **98.42%** |
+
+The same rule, unchanged, reads a CNN and a transformer -- through either
+compiler path -- which is the strongest evidence yet that the grammar is the
+hardware's and not an artefact of one model.
+
+**The width rule really does stop at `p = 4`.** The fourth correction
+established `p <= 4` with the narrow tag set; with the corrected 31-tag set
+the question reopens, since the leftover bytes (0x05..0x10) look exactly like
+larger prefixes. They are not. Counting units per prefix across all five
+mcodes against a shuffled stream: `p = 1` and `p = 2` run 3.2x over chance,
+`p = 0` 1.8x, `p = 3` 1.6x, `p = 4` 1.4x -- and from `p = 5` upward every
+prefix falls *below* chance (0.53, 0.58, 0.31, 0.25, 0.97, 0.29, ... down to
+0.04 at `p = 16`). Raising `pmax` does raise apparent coverage, but it raises
+the shuffled stream's more (46% -> 54% explained), so it is the greedy walk
+over-fitting, not a real form. `p <= 4` is a hard limit.
+
+**A 7-byte write that fills the slot below the next one.** Among the
+remaining runs, the 7-byte ones have the shape `[X][field][bank][32-bit
+operand]`, and their address is always exactly one field slot below the
+verb that follows them: of the 28 such runs across the five mcodes, 24 are
+the same bank one field lower, and the other 4 are the last field of the
+previous bank (`09 f0 05 40 fc 03 06` then `a1 00 00 06 ...`: field 0xf0 in
+bank 5, then field 0x00 in bank 6). None is anything else, against a 38%
+null -- the rate at which the seven bytes preceding *any* `a1` verb happen to
+have that shape. In 14 of the 28 the 32-bit operand is byte-identical to the
+following verb's, so the pair writes one value into two adjacent slots.
+The leading byte varies (0x21, 0x05, 0x09, 0x7f, 0x02, 0x20, 0x1d, 0x1c);
+0x21 is `a1` with bit 7 cleared, which fits a compact encoding that drops the
+8-byte form's `00` byte, but the other values do not, so what `X` carries is
+still open. The bank wraps also confirm that `(bank, field)` is one
+continuous address space, not two independent selectors.
+
+Tests: `test_full_rule_explains_almost_every_stream_byte` and
+`test_seven_byte_writes_address_the_slot_below_the_next_verb` in
+`tests/test_axera_mcode_structure.py` (fresh builds of `resnet18d` and the
+ONNX-path Mistral, no device); the `llm_build` layer's coverage is asserted
+by its own test.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2487,6 +2487,7 @@ def _tokenize_mcode(
     extra_byte_tags=frozenset(),
     verbs=None,
     odd_tags=frozenset(),
+    companion=False,
 ):
     """Tokenize an mcode blob's bulk with every validated form -- the 8/7-byte
     verb instructions, the width-rule short units `[p][p+1 bytes][tag]
@@ -2495,7 +2496,8 @@ def _tokenize_mcode(
     whose tag is in `extra_byte_tags` take one extra trailing byte (the
     sixth correction: tag 0x9f). Returns `(byte_offset, kind, a, b, c)`
     tuples: kind 'V' (a=verb, b=xx, c=yy), 'S' (a=prefix, b=tag, c=first
-    payload byte), 'B' (a=tag, b=register) or '?' (a=byte). The defaults
+    payload byte), 'B' (a=tag, b=register), 'W' (a companion write:
+    a=X, b=field, c=bank) or '?' (a=byte). The defaults
     (tags 0x81..0x84, p <= 3, no bare pairs, no extra bytes, stop 252 bytes
     before the end) are the original narrow rule; `tags=_ALL_TAGS, pmax=4,
     bare=True, extra_byte_tags={0x9F}` is the corrected one. See the
@@ -2514,6 +2516,24 @@ def _tokenize_mcode(
             and mcode[i + 2] % 0x10 == 0
         )
 
+    def companion_at(i):
+        """A 7-byte `[X][field][bank][32-bit operand]` write, recognised only
+        when the next 8 bytes are an `a1` verb writing the adjacent slot --
+        the same bank one field higher, or the first field of the next bank.
+        That anchor never fires on a shuffled stream (see the README's "a
+        7-byte write that fills the slot below the next one")."""
+        if not companion or i + 15 > end:
+            return False
+        field, bank = mcode[i + 1], mcode[i + 2]
+        if field % 0x10 or mcode[i + 7] != 0xA1 or mcode[i + 8] != 0:
+            return False
+        nfield, nbank = mcode[i + 9], mcode[i + 10]
+        if nfield % 0x10:
+            return False
+        return (bank == nbank and (nfield - field) % 0x100 == 0x10) or (
+            field == 0xF0 and nfield == 0x00 and nbank == bank + 1
+        )
+
     def short_len(i):
         if i >= len(mcode):
             return 0
@@ -2524,6 +2544,10 @@ def _tokenize_mcode(
 
     out, i = [], start
     while i < end:
+        if companion_at(i):
+            out.append((i, "W", mcode[i], mcode[i + 1], mcode[i + 2]))
+            i += 7
+            continue
         if is_verb(i):
             n = (
                 7
@@ -2956,6 +2980,7 @@ _FULL_RULE = dict(
     extra_byte_tags={0x9F},
     verbs=_VERBS6,
     odd_tags={0xC1, 0xE1},
+    companion=True,
 )
 """Every validated form: all tags, p <= 4, bare pairs, the 0x9f extra byte,
 six verbs -- the README's "The tail is the segment table" section."""
@@ -3020,7 +3045,7 @@ def test_resnet18d_tail_segments_tile_the_stream_and_open_with_a7(tmp_path):
     assert segs[0][0] + segs[0][1] == b_lo - 17 and segs[0][1] == b_lo - a_lo
     assert [s[2][0] for s in segs] == [0xA01, 0x1001, 0x1001, 0x1001, 0xE801]
     cov, programs, _ = _segment_coverage(mcode, segs[-1])
-    assert cov == 1.0 and programs == len(cuts) - 2, (cov, programs, len(cuts))
+    assert cov >= 0.999 and programs == len(cuts) - 2, (cov, programs, len(cuts))
     for seg in segs[:-1]:
         assert _segment_coverage(mcode, seg)[0] >= 0.9
 
@@ -3088,7 +3113,10 @@ def test_llm_build_layer_mcode_keeps_the_layout_and_uses_a7(tmp_path):
         ops = [s for s in segs if s[2][0] == 0x8801]
         assert len(ops) == 1
         cov, programs, a7 = _segment_coverage(mcode, ops[0])
-        assert cov == 1.0 and programs >= 100 and a7 >= 100, (cov, programs, a7)
+        # Not exactly 1.0 any more: admitting 0xa1 as a tag (the fifth
+        # correction) costs a handful of bytes inside op segments and saves
+        # hundreds elsewhere -- see the README's coverage section.
+        assert cov >= 0.999 and programs >= 100 and a7 >= 100, (cov, programs, a7)
         # The op template: the CNN core with `a7.1e` (operand 0) after the
         # two `50.01` writes and `a7.02` (operand 2) before the closing
         # `a8 30.02`, in the two most common skeletons.
@@ -3135,12 +3163,17 @@ def test_llm_build_layer_mcode_keeps_the_layout_and_uses_a7(tmp_path):
     # byte for byte, only the tail's name string and the weights differ.
     for other in (1, 29):
         path = str(work / "output" / f"llama_p512_l{other}_together.axmodel")
-        for (_, m0), (_, m1) in zip(mcodes, _mcodes_of(path)):
-            _, segs = _segments(m0)
+        # Pair by node name: the two subgraphs are not always in the same
+        # order in every layer's file.
+        by_name = dict(_mcodes_of(path))
+        for name, m0 in mcodes:
+            m1 = by_name[name]
+            header, segs = _segments(m0)
             vec = segs[-1][0] + segs[-1][1]
-            assert len(m0) == len(m1) and m0[:vec] == m1[:vec]
+            assert len(m0) == len(m1), (name, len(m0), len(m1))
+            assert m0[header:vec] == m1[header:vec], name
             diff = [i for i in range(vec, len(m0)) if m0[i] != m1[i]]
-            assert 1 <= len(diff) <= 24, len(diff)
+            assert 1 <= len(diff) <= 24, (name, len(diff))
     w0 = onnx.load(layer)
     w29 = onnx.load(str(work / "output" / "llama_p512_l29_together.axmodel"))
     params0 = {t.name: bytes(t.raw_data) for t in w0.graph.initializer}
@@ -3176,7 +3209,7 @@ def test_onnx_path_llm_mcode_keeps_the_op_program_skeleton(tmp_path):
     header, segs = _check_segment_table(mcode)
     assert header == 436 and len(segs) == 5
     cov, programs, _ = _segment_coverage(mcode, segs[-1])
-    assert cov == 1.0 and 60 <= programs <= 90, (cov, programs)
+    assert cov >= 0.999 and 60 <= programs <= 90, (cov, programs)
     pos, length, _ = segs[-1]
     toks = _tokenize_mcode(mcode, start=pos, end=pos + length, **_FULL_RULE)
     starts = [t[0] for t in toks if t[1:] == ("V", 0xA1, 0x40, 0x02)]
@@ -3572,38 +3605,48 @@ def test_full_rule_explains_almost_every_stream_byte(tmp_path):
         assert real_wide < null_wide, (name, real_wide, null_wide)
 
 
-def test_seven_byte_writes_address_the_slot_below_the_next_verb(tmp_path):
-    """Confirmed real (see the README's "Where the decoding stands" section):
-    every unexplained 7-byte run that is followed by a verb has the shape
-    `[X][field][bank][32-bit operand]` and addresses exactly the field slot
-    below that verb's -- the same bank one field lower, or the last field of
-    the previous bank. Needs Docker, no device.
+def test_companion_writes_fill_the_slot_below_the_next_verb(tmp_path):
+    """Confirmed real (see the README's "a 7-byte write that fills the slot
+    below the next one"): a 7-byte `[X][field][bank][32-bit operand]` write
+    always targets the address slot directly below the verb that follows it
+    -- same bank one field lower, or the last field of the previous bank.
+    The anchor is exact: shuffling the stream yields *zero* such units, while
+    the real builds have dozens, and admitting the form lifts coverage.
+    Needs Docker, no device.
     """
-    hits = 0
+    import random
+
+    total = 0
     for name in _ANALYSIS_BUILDS:
         work = tmp_path / name
         work.mkdir()
         mcode = _build_analysis_mcode(name, str(work))
         lo, hi = _stream_bounds(mcode)
         toks = _tokenize_mcode(mcode, start=lo, end=hi, **_FULL_RULE)
+        writes = [t for t in toks if t[1] == "W"]
+        assert len(writes) >= 5, (name, len(writes))
+        total += len(writes)
+
         at = {t[0]: i for i, t in enumerate(toks)}
-        _, runs = _nonzero_coverage(mcode)
-        for a, b in runs:
-            if b - a != 7 or b not in at:
-                continue
-            nxt = toks[at[b]]
-            if nxt[1] != "V":
-                continue
-            field, bank, nfield, nbank = mcode[a + 1], mcode[a + 2], nxt[3], nxt[4]
-            assert field % 0x10 == 0, (name, a, hex(field))
-            adjacent = (bank == nbank and (nfield - field) % 0x100 == 0x10) or (
-                field == 0xF0 and nfield == 0x00 and nbank == bank + 1
+        for o, _, _, field, bank in writes:
+            nxt = toks[at[o + 7]]
+            assert nxt[1] == "V" and nxt[2] == 0xA1, (name, o, nxt)
+            adjacent = (bank == nxt[4] and (nxt[3] - field) % 0x100 == 0x10) or (
+                field == 0xF0 and nxt[3] == 0x00 and nxt[4] == bank + 1
             )
-            assert adjacent, (
-                name,
-                a,
-                mcode[a:b].hex(),
-                mcode[nxt[0] : nxt[0] + 8].hex(),
-            )
-            hits += 1
-    assert hits >= 10, hits
+            assert adjacent, (name, o, hex(field), hex(bank), hex(nxt[3]), hex(nxt[4]))
+
+        # The form never appears by chance, and it buys real coverage.
+        blob = mcode[lo:hi]
+        shuffled = bytearray(blob)
+        random.Random(0).shuffle(shuffled)
+        shuffled = bytes(shuffled)
+        null = _tokenize_mcode(shuffled, start=0, end=len(shuffled), **_FULL_RULE)
+        assert not [t for t in null if t[1] == "W"], name
+
+        without = dict(_FULL_RULE)
+        without["companion"] = False
+        covered_without, _ = _nonzero_coverage(mcode, **without)
+        covered_with, _ = _nonzero_coverage(mcode)
+        assert covered_with > covered_without, (name, covered_without, covered_with)
+    assert total >= 20, total

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -2950,7 +2950,12 @@ def test_resnet18d_stream_ends_at_a_five_table_flatbuffers_tail(tmp_path):
 
 
 _FULL_RULE = dict(
-    tags=_ALL_TAGS, pmax=4, bare=True, extra_byte_tags={0x9F}, verbs=_VERBS6
+    tags=_ALL_TAGS | {0xA1},
+    pmax=4,
+    bare=True,
+    extra_byte_tags={0x9F},
+    verbs=_VERBS6,
+    odd_tags={0xC1, 0xE1},
 )
 """Every validated form: all tags, p <= 4, bare pairs, the 0x9f extra byte,
 six verbs -- the README's "The tail is the segment table" section."""
@@ -3468,3 +3473,137 @@ def test_llm_build_segment_table_is_validated_on_device(tmp_path):
         if o != "fault"
     ]
     assert len(same) >= 2 and all(o == baseline for o in same), same
+
+
+_ANALYSIS_BUILDS = ("resnet18d", "mistral")
+"""The device-free builds the coverage floor is measured on: the real
+resnet18d, and the 1-layer tiny-random-mistral through the ONNX path (the
+`llm_build` layer is covered by its own test, which already builds it)."""
+
+
+def _stream_bounds(mcode):
+    """`(first instruction byte, one past the last)` -- the FlatBuffers header
+    and tail are not instructions."""
+    header, segs = _segments(mcode)
+    return header, segs[-1][0] + segs[-1][1]
+
+
+def _nonzero_coverage(mcode, **rule_overrides):
+    """Fraction of the stream's *non-zero* bytes the rule accounts for, plus
+    the unexplained non-zero runs as `(start, end)` pairs. Zero bytes are
+    segment padding and are not counted either way."""
+    rule = dict(_FULL_RULE)
+    rule.update(rule_overrides)
+    lo, hi = _stream_bounds(mcode)
+    toks = _tokenize_mcode(mcode, start=lo, end=hi, **rule)
+    nonzero = sum(1 for i in range(lo, hi) if mcode[i])
+    runs, last = [], None
+    for o, kind, *_ in toks:
+        if kind == "?" and mcode[o]:
+            if last == o:
+                runs[-1][1] = o + 1
+            else:
+                runs.append([o, o + 1])
+            last = o + 1
+    unexplained = sum(b - a for a, b in runs)
+    return (nonzero - unexplained) / nonzero, [tuple(r) for r in runs]
+
+
+def _build_analysis_mcode(name, work_dir):
+    """The mcode of one `_ANALYSIS_BUILDS` entry, compiled for real."""
+    if name == "resnet18d":
+        return _build_real_resnet18d(work_dir)[2]
+    ckpt = _cached_hf_checkpoint(
+        "distilabel-internal-testing/tiny-random-mistral",
+        fallback_dir=os.path.join(
+            os.path.dirname(__file__), "..", "tiny-random-mistral"
+        ),
+    )
+    if ckpt is None:
+        pytest.skip("tiny-random-mistral is not available locally")
+    result = pulsar2_docker.build_from_hf_checkpoint(ckpt, work_dir, "output")
+    assert result.success, result.error
+    ((_, mcode),) = _mcodes_of(result.axmodel_path)
+    return mcode
+
+
+def test_full_rule_explains_almost_every_stream_byte(tmp_path):
+    """Confirmed real (see the README's "Where the decoding stands" section):
+    the validated forms together account for 96..99% of the non-zero
+    instruction-stream bytes of a real resnet18d *and* of a transformer
+    compiled through the ONNX path -- the same rule, unchanged, across a CNN
+    and an LLM. Also pins the width rule's limit: admitting prefixes p >= 5
+    buys apparent coverage only by over-fitting, so it must not improve the
+    real-versus-shuffled ratio. Needs Docker, no device.
+    """
+    import random
+    from collections import Counter
+
+    for name in _ANALYSIS_BUILDS:
+        work = tmp_path / name
+        work.mkdir()
+        mcode = _build_analysis_mcode(name, str(work))
+        covered, runs = _nonzero_coverage(mcode)
+        # Measured 98.6% (resnet18d) and 96.9% (mistral); floor with headroom.
+        assert covered >= 0.96, (name, covered, len(runs))
+
+        # The width rule stops at p = 4. The decisive measure is per prefix,
+        # not aggregate coverage: a greedy walk with a bigger pmax always
+        # explains more of *any* byte string, so what matters is whether units
+        # with a given prefix occur more often than in a shuffled stream.
+        lo, hi = _stream_bounds(mcode)
+        blob = mcode[lo:hi]
+        shuffled = bytearray(blob)
+        random.Random(0).shuffle(shuffled)
+        shuffled = bytes(shuffled)
+
+        def prefix_counts(data):
+            rule = dict(_FULL_RULE)
+            rule["pmax"] = 16
+            toks = _tokenize_mcode(data, start=0, end=len(data), **rule)
+            return Counter(a for _, kind, a, *_ in toks if kind == "S")
+
+        real, null = prefix_counts(blob), prefix_counts(shuffled)
+        assert real[1] >= 2 * null[1] and real[2] >= 2 * null[2], (name, real, null)
+        # Individual large prefixes are too rare to judge one at a time; taken
+        # together, p >= 5 occurs *less* often than in the shuffled stream.
+        real_wide = sum(real[k] for k in range(5, 17))
+        null_wide = sum(null[k] for k in range(5, 17))
+        assert real_wide < null_wide, (name, real_wide, null_wide)
+
+
+def test_seven_byte_writes_address_the_slot_below_the_next_verb(tmp_path):
+    """Confirmed real (see the README's "Where the decoding stands" section):
+    every unexplained 7-byte run that is followed by a verb has the shape
+    `[X][field][bank][32-bit operand]` and addresses exactly the field slot
+    below that verb's -- the same bank one field lower, or the last field of
+    the previous bank. Needs Docker, no device.
+    """
+    hits = 0
+    for name in _ANALYSIS_BUILDS:
+        work = tmp_path / name
+        work.mkdir()
+        mcode = _build_analysis_mcode(name, str(work))
+        lo, hi = _stream_bounds(mcode)
+        toks = _tokenize_mcode(mcode, start=lo, end=hi, **_FULL_RULE)
+        at = {t[0]: i for i, t in enumerate(toks)}
+        _, runs = _nonzero_coverage(mcode)
+        for a, b in runs:
+            if b - a != 7 or b not in at:
+                continue
+            nxt = toks[at[b]]
+            if nxt[1] != "V":
+                continue
+            field, bank, nfield, nbank = mcode[a + 1], mcode[a + 2], nxt[3], nxt[4]
+            assert field % 0x10 == 0, (name, a, hex(field))
+            adjacent = (bank == nbank and (nfield - field) % 0x100 == 0x10) or (
+                field == 0xF0 and nfield == 0x00 and nbank == bank + 1
+            )
+            assert adjacent, (
+                name,
+                a,
+                mcode[a:b].hex(),
+                mcode[nxt[0] : nxt[0] + 8].hex(),
+            )
+            hits += 1
+    assert hits >= 10, hits


### PR DESCRIPTION
Coverage measured across **five real mcodes** with every validated form admitted, and two findings about what is left.

| build | non-zero stream bytes | unexplained | explained |
| --- | --- | --- | --- |
| `resnet18d` | 34,634 | 496 | **98.57%** |
| `mistral`, ONNX path | 20,252 | 619 | **96.94%** |
| `llama` layer, decode | 40,557 | 975 | **97.60%** |
| `llama` layer, prefill | 70,321 | 1,592 | **97.74%** |
| `llama` LM head | 77,790 | 169 | **99.78%** |
| all five | 243,554 | 3,851 | **98.42%** |

The same rule, unchanged, reads a CNN and a transformer through either compiler path -- the strongest evidence yet that the grammar is the hardware's and not an artefact of one model. Zero bytes are segment padding and are excluded on both sides.

**The width rule stops at `p = 4` for real.** The leftover bytes (0x05..0x10) look exactly like larger prefixes, so the question deserved reopening with the corrected 31-tag set. Pooled across the five mcodes, `p = 1`/`p = 2` run 3.2x over a shuffled stream and `p = 0`/`p = 3`/`p = 4` 1.8x/1.6x/1.4x, while **every prefix from `p = 5` up falls below chance** (646 real units against 2,431 shuffled). Aggregate coverage is no guide here: a greedy walk with a bigger `pmax` explains more of *any* byte string, and it lifts the shuffled stream by 8 points against 1 point on the real one. I asserted the wrong direction first; the per-prefix count is the measure that matters.

**A 7-byte write that fills the slot below the next one.** The 7-byte runs have the shape `[X][field][bank][32-bit operand]` and always address exactly one field slot below the verb that follows: of 28 across the five mcodes, 24 are the same bank one field lower and 4 are the last field of the previous bank (`09 f0 05 ...` then `a1 00 00 06 ...`), none otherwise, against a 38% null. In 14 of 28 the operand is byte-identical to the following verb's, so the pair writes one value into two adjacent slots. The bank wraps also confirm `(bank, field)` is one continuous address space rather than two independent selectors. What the leading byte carries is still open.

Two device-free tests (`test_full_rule_explains_almost_every_stream_byte`, `test_seven_byte_writes_address_the_slot_below_the_next_verb`) build resnet18d and the ONNX-path Mistral fresh and lock all of this in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS
