### PR TITLE
mcode: a lossless codec proven on the device, and TTS as a third model family

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3290,6 +3290,80 @@ Tests: `test_full_rule_explains_almost_every_stream_byte` and
 ONNX-path Mistral, no device); the `llm_build` layer's coverage is asserted
 by its own test.
 
+### A lossless codec: taking a model apart and putting it back together
+
+Reading mcode and *writing* it are different problems, and the coverage
+number above answers only the first. This is the first half of the second:
+`_decode_mcode()` turns a stream into structured records -- verb, field,
+bank and operand; prefix, payload, tag, register; the companion write's
+address and value -- and `_encode_mcode()` writes those records back out.
+The encoder reads nothing from the original blob, so a byte-exact round trip
+proves the decode captures every bit the forms carry, which is the first
+thing a generator needs.
+
+It round-trips exactly on a real `resnet18d` and on the ONNX-path
+transformer, with **over 95% of the bytes coming from recognised forms** and
+the rest riding along as raw escapes. Rebuilding a whole `.axmodel` -- the
+FlatBuffers header and tail copied verbatim, the stream re-encoded -- gives
+back the original file.
+
+**What that does and does not buy.** It means we can rewrite any field of any
+instruction and emit a valid stream, which is what every hand-patch
+experiment in this file has done by hand. It does *not* mean we can compile a
+new model. Splitting `resnet18d`'s parsed bytes by whether a destination ever
+receives more than one value:
+
+| | `resnet18d` | `llama` layer |
+| --- | --- | --- |
+| single-valued destinations (emit by copying) | 25.3% | 18.4% |
+| varying per op (need a rule) | 74.7% | 81.6% |
+| of those, at destinations whose meaning is documented here | 24.6% | 16.0% |
+
+So roughly a quarter of the stream is template, another sixth follows rules
+this file has verified (the Wbt offset, the four dispatch steps, the tile
+arena, the input size, the two synchronisation channels), and the remaining
+half goes to 627 destinations in `resnet18d` alone that we can parse but not
+compute. The largest single unknown is the `a2` verb: 360 distinct operands
+in `resnet18d`, 206 in the `llama` layer, ~6% of the stream.
+
+And the instruction stream is the small half of the problem. In the compiled
+artifacts the weight table is 99% of the file (`mistral` 21.4 MB against a
+27.5 KB mcode; the `llama` LM head 29.1 MB against 122.8 KB), and its layout
+is not decoded -- individual fields inside it have been located and patched,
+but not laid out from scratch.
+
+**What the two biggest unknowns look like from here.** Both were probed
+while the codec landed, and neither is decoded, but both now have shape:
+
+- **The `a2` operand is a packed record, not an address.** Its low nibble is
+  always 2 or 3 (75 and 62 times in the ONNX-path Mistral), the next nibble
+  steps through 0..15, byte 1 is a small counter (0..4), byte 2 is always
+  16-byte aligned (0x40, 0x10, 0x20, 0x00, 0x30), and byte 3 is zero except
+  for a flag-like 0x82/0x86/0x8b/0x92 on a minority. The *first* `a2` of each
+  op program rises with the op index in 69 of 71 programs, as does that
+  program's Wbt offset, so it carries something ordered per op. Programs
+  carry one to three of them (39, 27 and 2 of 77 in Mistral), never with all
+  operands equal.
+- **The weight table opens with a scale block.** The `llm_build` layer's
+  3,963,652-byte table starts with exactly 1,024 float32 words of 0.125
+  (4,096 bytes) followed by 768 zero words; only 2.9% of the whole table is
+  zero and its byte histogram peaks hard at 0x88/0x78/0x87/0x77, which is
+  what packed sub-byte values around mid-scale look like. The ONNX-path
+  Mistral's 21 MB table has no such prologue and is 0.4% zeros.
+
+**A refinement to "`40 02` is the Wbt offset."** That holds on the CNN and
+ONNX paths -- all 77 of Mistral's offsets land inside its table. It does
+*not* hold literally for `llm_build` layers: 22 of the decode subgraph's 147
+offsets and 12 of the prefill subgraph's 169 point past the end of the table
+they share, clustering around 2.9x its size. So on that path the operand
+addresses a device space that holds the weight table *and* other buffers --
+the KV caches are graph inputs there -- rather than a file offset. The
+hand-patch experiments that established the field remain valid; what changes
+is that a generator cannot compute it from the table alone.
+
+Test: `test_decode_encode_round_trip_is_byte_exact` in
+`tests/test_axera_mcode_structure.py` (fresh builds, no device).
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3364,6 +3364,45 @@ is that a generator cannot compute it from the table alone.
 Test: `test_decode_encode_round_trip_is_byte_exact` in
 `tests/test_axera_mcode_structure.py` (fresh builds, no device).
 
+### A third model family: text-to-speech, and what it did not change
+
+The decoding corpus was two CNNs and two transformers. A vocoder is a third
+shape entirely -- transposed-convolution upsampling, dilated 1-D residual
+convolutions, LeakyReLU, a bounded output -- and it is what text-to-speech
+actually runs on this class of hardware.
+
+**A full TTS graph does not compile, and that is expected.** A Piper voice
+(VITS, 63 MB, 2,755 nodes) carries `RandomNormalLike`, `NonZero`, `CumSum`,
+`Range` and `Shape`: stochastic sampling and data-dependent shapes, none of
+which an NPU compiler takes. Real deployments split the model, keeping the
+text encoder, duration prediction and sampling on the CPU and sending only
+the vocoder to the device. `_vocoder_model()` in the test file is that part,
+built small and static.
+
+**It compiles, and it taught us nothing new about the instruction set --
+which is the result.** The vocoder builds cleanly (`ConvTranspose`,
+`LeakyRelu`, `Tanh`, dilated `Conv`, `max_cycle` 55,183), its stream is
+96.8% explained by the existing rule, and it introduces **zero** verbs, tags
+or registers that the CNN and transformer builds had not already used. Its
+op programs are the same skeleton: `40.02 | 50.01 | 50.01 | [30.03] | a8
+40.03 | 50.03 | 50.01 | a3 | 50.01 | a9 | [a2] | [a1 20.02] | a8 30.02`.
+
+So op type is not encoded by choosing different instructions. Convolution,
+transposed convolution, matrix multiplication and elementwise activation all
+issue the same program shape, and what distinguishes them lives in the
+operand values -- which is exactly where a generator's remaining work is.
+
+**A caution about differencing.** Changing a shape parameter re-lays-out the
+whole stream: stride 8 to 4 moved 45 destinations, channel count 128 to 96
+moved 238, and input length 32 to 64 moved 286 of roughly 1,400. Attribution
+by differencing therefore needs experiments that hold every shape fixed --
+changing only `LeakyRelu`'s alpha still moved 2,171 bytes across 1,649 writes
+to tag 0x81 alone, so even that is not surgical. Single-register attribution
+will need a sharper instrument than model diffing.
+
+Test: `test_tts_vocoder_uses_no_new_instruction_forms` in
+`tests/test_axera_mcode_structure.py` (fresh builds, no device).
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3403,6 +3403,86 @@ will need a sharper instrument than model diffing.
 Test: `test_tts_vocoder_uses_no_new_instruction_forms` in
 `tests/test_axera_mcode_structure.py` (fresh builds, no device).
 
+### Real weights, real speech: the Piper vocoder on the NPU
+
+The synthetic vocoder above answered a question about the instruction set,
+but it had random weights, so its output was noise. The next question is
+whether this NPU can produce *audible* speech, and that needs a trained
+model. It can, and it does.
+
+**Extract the decoder rather than rebuild it.** Hand-building a HiFi-GAN
+shape and loading weights into it means guessing dilations, paddings and
+upsample rates, and a single mismatch turns speech into noise with no error
+message. Lifting the subgraph out of the voice with `onnx.utils.extract_
+model` avoids all of it. The boundary is found by weight name -- whichever
+tensor `dec.conv_pre.weight`'s convolution reads -- because the intermediate
+tensor names are export artefacts and differ between voices.
+
+What comes out of `en_US-lessac-low` is 68 nodes and 47 initializers, and
+nothing else: `Conv` (20), `Add` (24), `LeakyRelu` (16), `ConvTranspose`
+(3), `Div` (3), `Tanh`, `Unsqueeze`. Every one of those is supported. The
+architecture:
+
+| Stage | Shape |
+| --- | --- |
+| latent in | 192 channels |
+| `conv_pre` | 192 to 256, kernel 7 |
+| `ups.0` / `ups.1` / `ups.2` | kernel 16 stride 8, kernel 16 stride 8, kernel 8 stride 4 |
+| channels after each stage | 128, 64, 32 |
+| residual blocks | six, kernels 3/5/7, dilations 1 and 2, 2 and 6, 3 and 12 |
+| `conv_post` | 32 to 1, kernel 7, then `Tanh` |
+
+The three upsampling strides multiply to 256, which is exactly the measured
+ratio of output samples to latent frames at a 16 kHz sample rate.
+
+**The subgraph is the voice.** Frozen to a fixed 64-frame input and fed the
+latent captured from a real utterance, it reproduces the untouched model's
+own waveform at a correlation of 0.99999998. The remaining difference comes
+only from zero-padding the latent out to the compiled length, which is what
+the full graph's own length mask does anyway.
+
+**Quantisation does not destroy it.** Calibrated on real latents drawn from
+the model's own encoder, Pulsar2's end-to-end precision report gives a
+cosine similarity of 0.9943 at the output for a 64-frame build and 0.9909
+for a 256-frame one. On the device:
+
+| Build | Latent frames | Audio | NPU vs CPU correlation |
+| --- | --- | --- | --- |
+| `out_dec` | 64 | 0.94 s | 0.9956 |
+| `out_dec256` | 256 | 2.11 s | 0.9924 |
+
+The 256-frame model compiles to `max_cycle` 12,792,136 and runs in 13.4 ms,
+which is about 300 times faster than the 4.1 seconds of audio it emits.
+
+**This settles an open question, and the contrast is the interesting part.**
+Plain INT8 quantisation collapsed a 30-layer transformer to near-random
+output, so whether a deep convolutional stack would survive was genuinely
+open. It does. The plausible reason is structural: the vocoder is 20
+convolutions deep with additive residual paths and a `Tanh` bounding every
+output sample, where a transformer accumulates attention error across layers
+with nothing bounding it. Depth alone does not predict quantisation
+survival; what the depth is made of does.
+
+**And the mcode confirms the generalisation.** A trained model in a new
+domain, whose weights the decoder had never seen, introduces no new
+instruction forms at all. Both builds use exactly the six known verbs
+(`a1`, `a2`, `a3`, `a7`, `a8`, `a9`) and no tag outside `0x81`-`0x9f` plus
+`0xa1` and the bit-6 odd-register forms, and the codec round-trips both
+byte-exactly. Coverage is 96.47% at 64 frames and 97.29% at 256, in line
+with the transformer builds rather than the CNNs.
+
+One detail worth recording: the 64-frame build uses the odd-register tags
+`0xc1` and `0xe1`, and the 256-frame build uses `0xe1` but not `0xc1`. The
+odd-register forms are therefore optional per build, not a fixed part of
+every stream -- the same model at a different input length simply does not
+need one of them.
+
+Tests: `test_piper_decoder_subgraph_reproduces_the_whole_voice` (CPU only),
+`test_real_piper_decoder_uses_no_new_instruction_forms` (Docker) and
+`test_real_piper_decoder_makes_speech_on_device` (Docker and device) in
+`tests/test_axera_mcode_structure.py`. All three skip unless the voice is in
+the local HuggingFace cache, so the suite stays offline.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/pulsar2_docker.py
+++ b/scripts/axera/pulsar2_docker.py
@@ -718,6 +718,13 @@ def _invoke_axcl(
                 )
             mapping[os.path.normpath(local)] = target
         if pull:
+            # axcl_run_model writes into an existing directory; create it.
+            res = lxc("exec", vm, "--", "mkdir", "-p", f"{remote}/{pull[0]}")
+            if res.returncode != 0:
+                return (
+                    res.returncode,
+                    "lxc exec mkdir failed: " + res.stdout + res.stderr,
+                )
             mapping[os.path.normpath(os.path.join(pull[1], pull[0]))] = (
                 f"{remote}/{pull[0]}"
             )
@@ -734,6 +741,12 @@ def _invoke_axcl(
         )
         log = proc.stdout + proc.stderr
         if pull:
+            # `lxc file pull -r` recreates the directory inside the target, so
+            # an existing (empty) local one would make the results land a level
+            # too deep for the caller's glob.
+            local_out = os.path.join(pull[1], pull[0])
+            if os.path.isdir(local_out) and not os.listdir(local_out):
+                os.rmdir(local_out)
             lxc("file", "pull", "-r", f"{vm}{remote}/{pull[0]}", pull[1], t=600)
         return proc.returncode, log
     finally:

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -3508,6 +3508,105 @@ def test_llm_build_segment_table_is_validated_on_device(tmp_path):
     assert len(same) >= 2 and all(o == baseline for o in same), same
 
 
+def _decode_mcode(mcode, start=None, end=None, **rule):
+    """Decode a stream into records that carry *everything* needed to write it
+    back out -- the counterpart of `_tokenize_mcode`, which returns only what
+    is needed to identify a form. Each record is a dict with a `kind`:
+
+    * `V`: a verb (`verb`, `field`, `bank`, `operand`; 8 bytes, or 7 when the
+      next form starts early and the operand is one byte shorter)
+    * `W`: a companion write (`x`, `field`, `bank`, `operand`)
+    * `S`: a width-rule unit (`p`, `payload`, `tag`, `reg`, `extra`)
+    * `B`: a bare `[tag][register]` pair (`tag`, `reg`, `extra`)
+    * `raw`: one byte no form accounts for (`byte`)
+
+    See the README's "A lossless codec" section.
+    """
+    lo = 297 if start is None else start
+    hi = (len(mcode) - 252) if end is None else end
+    out = []
+    toks = _tokenize_mcode(mcode, start=lo, end=hi, **rule)
+    for i, t in enumerate(toks):
+        o, kind = t[0], t[1]
+        nxt = toks[i + 1][0] if i + 1 < len(toks) else hi
+        n = nxt - o
+        if kind == "V":
+            out.append(
+                {
+                    "kind": "V",
+                    "verb": t[2],
+                    "field": t[3],
+                    "bank": t[4],
+                    "operand": mcode[o + 4 : o + n],
+                }
+            )
+        elif kind == "W":
+            out.append(
+                {
+                    "kind": "W",
+                    "x": t[2],
+                    "field": t[3],
+                    "bank": t[4],
+                    "operand": mcode[o + 3 : o + 7],
+                }
+            )
+        elif kind == "S":
+            p = t[2]
+            # Read the tag from the stream rather than the token: for a unit
+            # whose tag takes an extra byte, `_tokenize_mcode`'s third slot
+            # holds the register, not the tag.
+            out.append(
+                {
+                    "kind": "S",
+                    "p": p,
+                    "payload": mcode[o + 1 : o + 1 + p + 1],
+                    "tag": mcode[o + p + 2],
+                    "reg": mcode[o + p + 3],
+                    "extra": mcode[o + p + 4 : o + n],
+                }
+            )
+        elif kind == "B":
+            out.append(
+                {"kind": "B", "tag": t[2], "reg": t[3], "extra": mcode[o + 2 : o + n]}
+            )
+        else:
+            out.append({"kind": "raw", "byte": t[2]})
+    return out
+
+
+def _encode_mcode(records):
+    """Write decoded records back out as bytes -- the inverse of
+    `_decode_mcode`. Nothing here reads the original stream, so a byte-exact
+    round trip proves the decode captures every bit the forms carry."""
+    out = bytearray()
+    for r in records:
+        kind = r["kind"]
+        if kind == "V":
+            out += bytes([r["verb"], 0, r["field"], r["bank"]]) + r["operand"]
+        elif kind == "W":
+            out += bytes([r["x"], r["field"], r["bank"]]) + r["operand"]
+        elif kind == "S":
+            out += (
+                bytes([r["p"]])
+                + r["payload"]
+                + bytes([r["tag"], r["reg"]])
+                + r["extra"]
+            )
+        elif kind == "B":
+            out += bytes([r["tag"], r["reg"]]) + r["extra"]
+        else:
+            out += bytes([r["byte"]])
+    return bytes(out)
+
+
+def _structured_share(records):
+    """Fraction of the encoded bytes that come from a recognised form rather
+    than a raw escape -- how much of a stream we could write from structure."""
+    total = len(_encode_mcode(records))
+    raw = sum(1 for r in records if r["kind"] == "raw")
+    return (total - raw) / total
+
+
 _ANALYSIS_BUILDS = ("resnet18d", "mistral")
 """The device-free builds the coverage floor is measured on: the real
 resnet18d, and the 1-layer tiny-random-mistral through the ONNX path (the
@@ -3650,3 +3749,27 @@ def test_companion_writes_fill_the_slot_below_the_next_verb(tmp_path):
         covered_with, _ = _nonzero_coverage(mcode)
         assert covered_with > covered_without, (name, covered_without, covered_with)
     assert total >= 20, total
+
+
+def test_decode_encode_round_trip_is_byte_exact(tmp_path):
+    """Confirmed real (see the README's "A lossless codec" section): decoding
+    a real instruction stream into structured records and writing those
+    records back out reproduces the stream byte for byte, on a CNN and on a
+    transformer. The encoder reads nothing from the original, so this proves
+    the decode captures every bit the forms carry -- the first thing an mcode
+    *generator* needs. >= 95% of the bytes come from recognised forms; the
+    rest ride along as raw escapes. Needs Docker, no device.
+    """
+    for name in _ANALYSIS_BUILDS:
+        work = tmp_path / name
+        work.mkdir()
+        mcode = _build_analysis_mcode(name, str(work))
+        lo, hi = _stream_bounds(mcode)
+        records = _decode_mcode(mcode, start=lo, end=hi, **_FULL_RULE)
+        assert _encode_mcode(records) == mcode[lo:hi], name
+        assert _structured_share(records) >= 0.95, (name, _structured_share(records))
+
+        # A whole .axmodel: header and tail are not instructions, so they are
+        # carried verbatim, and the rebuilt blob must equal the original.
+        rebuilt = mcode[:lo] + _encode_mcode(records) + mcode[hi:]
+        assert rebuilt == mcode, name

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -16,11 +16,13 @@ import os
 import re
 import struct
 import sys
+import tempfile
 
 import numpy as np
 import onnx
+import onnx.utils
 import pytest
-from onnx import helper, numpy_helper, parser
+from onnx import TensorProto, helper, numpy_helper, parser
 
 _AXERA_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
@@ -3777,6 +3779,259 @@ def _build_vocoder(work_dir, **kwargs):
     assert result.success, result.error
     ((_, mcode),) = _mcodes_of(result.axmodel_path)
     return mcode
+
+
+_PIPER_REPO = "rhasspy/piper-voices"
+_PIPER_VOICE = "en/en_US/lessac/low/en_US-lessac-low.onnx"
+
+
+def _cached_piper_voice():
+    """The `en_US-lessac-low` Piper voice and its config from the local
+    HuggingFace cache, as `(onnx path, config path)`, else None. Never
+    downloads -- these tests stay offline."""
+    try:
+        from huggingface_hub import hf_hub_download
+
+        model = hf_hub_download(_PIPER_REPO, _PIPER_VOICE, local_files_only=True)
+        config = hf_hub_download(
+            _PIPER_REPO, _PIPER_VOICE + ".json", local_files_only=True
+        )
+        return model, config
+    except Exception:
+        return None
+
+
+def _piper_decoder_input(model):
+    """The tensor a Piper voice feeds to its HiFi-GAN decoder: whatever the
+    `dec.conv_pre` convolution reads. Found by weight name rather than
+    hard-coded, since the intermediate tensor names are export artefacts."""
+    conv = next(
+        n
+        for n in model.graph.node
+        if n.op_type == "Conv"
+        and len(n.input) > 1
+        and n.input[1] == "dec.conv_pre.weight"
+    )
+    return conv.input[0]
+
+
+def _piper_decoder(voice_path, out_path, frames):
+    """The *real* HiFi-GAN decoder lifted out of a Piper VITS voice, with a
+    static `frames`-long latent input.
+
+    The rest of a VITS graph cannot be compiled -- `RandomNormalLike`,
+    `NonZero`, `CumSum` and `Range` are stochastic or data-dependent, so a
+    real deployment keeps the text encoder and duration sampling on the CPU
+    and sends only this decoder to the device. Extracting the subgraph
+    rather than rebuilding it by hand keeps the trained weights *and* the
+    exact dilations, which is what makes the device output audible speech
+    instead of the noise a randomly initialised vocoder emits.
+    """
+    model = onnx.load(voice_path)
+    latent = _piper_decoder_input(model)
+    onnx.utils.extract_model(
+        voice_path,
+        out_path,
+        [latent],
+        [model.graph.output[0].name],
+        check_model=False,
+    )
+    dec = onnx.load(out_path)
+    inp = dec.graph.input[0]
+    del inp.type.tensor_type.shape.dim[:]
+    for value in (1, 192, frames):
+        inp.type.tensor_type.shape.dim.add().dim_value = value
+    inp.name = "z"
+    for node in dec.graph.node:
+        node.input[:] = ["z" if i == latent else i for i in node.input]
+    # The exported output shape is written for the dynamic graph; drop it
+    # and let inference restate it for this fixed length.
+    del dec.graph.output[0].type.tensor_type.shape.dim[:]
+    dec = onnx.shape_inference.infer_shapes(dec)
+    onnx.save(dec, out_path)
+    return dec
+
+
+def _piper_say(voice_path, config_path, phonemes, length_scale=1.0):
+    """Run a Piper voice on the CPU for one phoneme sequence, returning
+    `(latent, audio)` -- the decoder's own input alongside the reference
+    waveform, so a device run of the decoder can be scored against the
+    audio the untouched model produces."""
+    ort = pytest.importorskip("onnxruntime")
+    model = onnx.load(voice_path)
+    latent = _piper_decoder_input(model)
+    model.graph.output.append(
+        helper.make_tensor_value_info(latent, TensorProto.FLOAT, None)
+    )
+    with tempfile.TemporaryDirectory() as td:
+        exposed = os.path.join(td, "piper.onnx")
+        onnx.save(
+            model,
+            exposed,
+            save_as_external_data=True,
+            location="piper.data",
+            all_tensors_to_one_file=True,
+            size_threshold=1024,
+        )
+        session = ort.InferenceSession(exposed, providers=["CPUExecutionProvider"])
+        table = json.load(open(config_path))["phoneme_id_map"]
+        ids = list(table["^"])
+        for phoneme in phonemes:
+            ids += table[phoneme] + table["_"]
+        ids += table["$"]
+        tokens = np.array([ids], dtype=np.int64)
+        audio, z = session.run(
+            [model.graph.output[0].name, latent],
+            {
+                "input": tokens,
+                "input_lengths": np.array([tokens.shape[1]], dtype=np.int64),
+                "scales": np.array([0.667, length_scale, 0.8], dtype=np.float32),
+            },
+        )
+    return np.asarray(z, dtype=np.float32), np.asarray(
+        audio, dtype=np.float32
+    ).squeeze()
+
+
+_PIPER_HELLO = list("h") + ["\u0259", "l", "\u02c8", "o", "\u028a"]
+
+
+def _pad_latent(z, frames):
+    """A latent padded out to the compiled length. Zero is the right filler:
+    the decoder's input is already a flow output multiplied by a length
+    mask, so every frame past the utterance is zero in the untouched graph
+    too."""
+    padded = np.zeros((1, 192, frames), dtype=np.float32)
+    padded[:, :, : z.shape[2]] = z[:, :, :frames]
+    return padded
+
+
+def _build_piper_decoder(work_dir, frames, latents):
+    """Compile the real Piper decoder for the AX650, calibrating on real
+    latents. Returns `(axmodel path, mcode)`."""
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    os.makedirs(os.path.join(work_dir, "config"), exist_ok=True)
+    pulsar2_docker.make_numpy_calibration_tar(
+        os.path.join(work_dir, "dataset", "z.tar"), latents
+    )
+    with open(os.path.join(work_dir, "config", "cfg.json"), "w") as f:
+        json.dump(
+            {
+                "model_type": "ONNX",
+                "npu_mode": "NPU1",
+                "quant": {
+                    "input_configs": [
+                        {
+                            "tensor_name": "z",
+                            "calibration_dataset": "./dataset/z.tar",
+                            "calibration_format": "Numpy",
+                            "calibration_size": len(latents),
+                        }
+                    ],
+                    "calibration_method": "MinMax",
+                    "precision_analysis": False,
+                },
+                "compiler": {"check": 0},
+            },
+            f,
+        )
+    result = pulsar2_docker.build(
+        work_dir, "decoder.onnx", "output", config_path="config/cfg.json"
+    )
+    assert result.success, result.error
+    ((_, mcode),) = _mcodes_of(result.axmodel_path)
+    return result.axmodel_path, mcode
+
+
+def test_piper_decoder_subgraph_reproduces_the_whole_voice(tmp_path):
+    """Confirmed real: the decoder subgraph lifted out of a Piper voice,
+    frozen to a fixed length, reproduces the untouched model's own audio
+    (correlation > 0.9999). That is what licenses treating a device run of
+    this subgraph as a device run of Piper's vocoder. CPU only -- no Docker,
+    no device.
+    """
+    voice = _cached_piper_voice()
+    if voice is None:
+        pytest.skip("the Piper en_US-lessac-low voice is not in the local cache")
+    ort = pytest.importorskip("onnxruntime")
+    frames = 64
+    z, reference = _piper_say(voice[0], voice[1], _PIPER_HELLO)
+    assert z.shape[1] == 192, z.shape
+    # 256 audio samples per latent frame -- the three upsampling stages
+    # multiply out to 8 * 8 * 4.
+    assert reference.size == 256 * z.shape[2], (reference.size, z.shape)
+
+    path = str(tmp_path / "decoder.onnx")
+    _piper_decoder(voice[0], path, frames)
+    session = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
+    out = np.asarray(session.run(None, {"z": _pad_latent(z, frames)})[0]).squeeze()
+    out = out[: reference.size]
+    assert np.corrcoef(out, reference)[0, 1] > 0.9999, np.corrcoef(out, reference)[0, 1]
+
+
+def test_real_piper_decoder_uses_no_new_instruction_forms(tmp_path):
+    """Confirmed real (see the README's "Real weights, real speech"
+    section): the *trained* Piper vocoder -- a different model family, a
+    different domain, weights this decoder has never seen -- compiles to an
+    mcode that introduces no verb and no tag beyond the ones the CNN and
+    transformer builds already used, and the codec round-trips it
+    byte-exactly. Needs Docker, no device.
+    """
+    voice = _cached_piper_voice()
+    if voice is None:
+        pytest.skip("the Piper en_US-lessac-low voice is not in the local cache")
+    frames = 64
+    z, _ = _piper_say(voice[0], voice[1], _PIPER_HELLO)
+    work = tmp_path / "work"
+    work.mkdir()
+    _piper_decoder(voice[0], str(work / "decoder.onnx"), frames)
+    _, mcode = _build_piper_decoder(str(work), frames, [_pad_latent(z, frames)] * 4)
+
+    covered, _ = _nonzero_coverage(mcode, **_FULL_RULE)
+    assert covered >= 0.95, covered
+    lo, hi = _stream_bounds(mcode)
+    records = _decode_mcode(mcode, start=lo, end=hi, **_FULL_RULE)
+    assert _encode_mcode(records) == mcode[lo:hi]
+
+    verbs = {r["verb"] for r in records if r["kind"] == "V"}
+    assert verbs <= _VERBS6, verbs
+    tags = {r["tag"] for r in records if r["kind"] in ("S", "B")}
+    assert tags <= _ALL_TAGS | {0xA1, 0xC1, 0xE1}, tags
+
+
+def test_real_piper_decoder_makes_speech_on_device(tmp_path):
+    """Confirmed on the AX650N: the real Piper vocoder, quantised to INT8
+    and run on the NPU, reproduces the CPU waveform at a correlation above
+    0.98 -- audible speech, not the noise a randomly initialised vocoder
+    emits. This is the end-to-end answer to whether a deep convolutional
+    stack survives this NPU's INT8 quantisation; a 30-layer transformer did
+    not. Needs Docker *and* a device.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device")
+    voice = _cached_piper_voice()
+    if voice is None:
+        pytest.skip("the Piper en_US-lessac-low voice is not in the local cache")
+    ort = pytest.importorskip("onnxruntime")
+    frames = 64
+    z, _ = _piper_say(voice[0], voice[1], _PIPER_HELLO)
+    padded = _pad_latent(z, frames)
+    work = tmp_path / "work"
+    work.mkdir()
+    path = str(work / "decoder.onnx")
+    _piper_decoder(voice[0], path, frames)
+    session = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
+    reference = np.asarray(session.run(None, {"z": padded})[0]).squeeze()
+
+    axmodel, _ = _build_piper_decoder(str(work), frames, [padded] * 4)
+    result = pulsar2_docker.run_on_device_with_inputs(
+        axmodel, {"z": padded.tobytes()}, timeout=300
+    )
+    assert not result.error, result.error
+    out = np.frombuffer(result.outputs[0], dtype=np.float32).squeeze()
+    assert out.size == frames * 256, out.size
+    correlation = float(np.corrcoef(out, reference)[0, 1])
+    assert correlation > 0.98, correlation
 
 
 def test_tts_vocoder_uses_no_new_instruction_forms(tmp_path):

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -3351,7 +3351,7 @@ def test_llm_build_a7_is_a_sync_verb_on_device(tmp_path):
         return [o for o in outcomes if o != "fault"]
 
     base = good(_run_llm_layer(layer, inputs, 3))
-    assert len(base) >= 2 and len(set(base)) == 1, base
+    assert len(base) >= 2 and len(set(base)) == 1, ("baseline", base)
     baseline = base[0]
 
     changed = good(
@@ -3485,7 +3485,7 @@ def test_llm_build_segment_table_is_validated_on_device(tmp_path):
         return path
 
     base = [o for o in _run_llm_layer(layer, inputs, 3) if o != "fault"]
-    assert len(base) >= 2 and len(set(base)) == 1, base
+    assert len(base) >= 2 and len(set(base)) == 1, ("baseline", base)
     baseline = base[0]
 
     load = pulsar2_docker.run_on_device_with_inputs(
@@ -3520,6 +3520,9 @@ def _decode_mcode(mcode, start=None, end=None, **rule):
     * `B`: a bare `[tag][register]` pair (`tag`, `reg`, `extra`)
     * `raw`: one byte no form accounts for (`byte`)
 
+    Every record also carries `at`, its offset in the original stream, so
+    an edit can be scoped to one segment.
+
     See the README's "A lossless codec" section.
     """
     lo = 297 if start is None else start
@@ -3533,6 +3536,7 @@ def _decode_mcode(mcode, start=None, end=None, **rule):
         if kind == "V":
             out.append(
                 {
+                    "at": o,
                     "kind": "V",
                     "verb": t[2],
                     "field": t[3],
@@ -3543,6 +3547,7 @@ def _decode_mcode(mcode, start=None, end=None, **rule):
         elif kind == "W":
             out.append(
                 {
+                    "at": o,
                     "kind": "W",
                     "x": t[2],
                     "field": t[3],
@@ -3557,6 +3562,7 @@ def _decode_mcode(mcode, start=None, end=None, **rule):
             # holds the register, not the tag.
             out.append(
                 {
+                    "at": o,
                     "kind": "S",
                     "p": p,
                     "payload": mcode[o + 1 : o + 1 + p + 1],
@@ -3567,10 +3573,16 @@ def _decode_mcode(mcode, start=None, end=None, **rule):
             )
         elif kind == "B":
             out.append(
-                {"kind": "B", "tag": t[2], "reg": t[3], "extra": mcode[o + 2 : o + n]}
+                {
+                    "at": o,
+                    "kind": "B",
+                    "tag": t[2],
+                    "reg": t[3],
+                    "extra": mcode[o + 2 : o + n],
+                }
             )
         else:
-            out.append({"kind": "raw", "byte": t[2]})
+            out.append({"at": o, "kind": "raw", "byte": t[2]})
     return out
 
 
@@ -3657,6 +3669,162 @@ def _build_analysis_mcode(name, work_dir):
     assert result.success, result.error
     ((_, mcode),) = _mcodes_of(result.axmodel_path)
     return mcode
+
+
+def _vocoder_model(alpha=0.1, tail="Tanh", frames=32, stride=8, dilation=2):
+    """A HiFi-GAN-shaped vocoder -- the part of a text-to-speech model that
+    actually runs on this NPU. A full VITS graph (e.g. a Piper voice) cannot
+    be compiled: it carries `RandomNormalLike`, `NonZero`, `CumSum` and
+    `Range`, which are stochastic or data-dependent, so real deployments keep
+    the text encoder and sampling on the CPU and send only the vocoder to the
+    device. This is that shape: transposed-convolution upsampling, a dilated
+    residual convolution, LeakyReLU and a bounded output.
+    """
+    rng = np.random.RandomState(0)
+    inits, nodes = [], []
+
+    def w(name, shape):
+        inits.append(
+            numpy_helper.from_array((rng.randn(*shape) * 0.05).astype(np.float32), name)
+        )
+        return name
+
+    nodes.append(
+        helper.make_node(
+            "Conv", ["mel", w("w0", (64, 80, 7))], ["h0"], kernel_shape=[7], pads=[3, 3]
+        )
+    )
+    nodes.append(
+        helper.make_node(
+            "ConvTranspose",
+            ["h0", w("w1", (64, 32, 16))],
+            ["u1"],
+            kernel_shape=[16],
+            strides=[stride],
+            pads=[4, 4],
+        )
+    )
+    nodes.append(helper.make_node("LeakyRelu", ["u1"], ["a1"], alpha=alpha))
+    nodes.append(
+        helper.make_node(
+            "Conv",
+            ["a1", w("w2", (32, 32, 3))],
+            ["r1"],
+            kernel_shape=[3],
+            pads=[dilation, dilation],
+            dilations=[dilation],
+        )
+    )
+    nodes.append(helper.make_node("Add", ["a1", "r1"], ["s1"]))
+    nodes.append(
+        helper.make_node(
+            "Conv", ["s1", w("w3", (1, 32, 7))], ["y0"], kernel_shape=[7], pads=[3, 3]
+        )
+    )
+    nodes.append(helper.make_node(tail, ["y0"], ["audio"]))
+    graph = helper.make_graph(
+        nodes,
+        "vocoder",
+        [helper.make_tensor_value_info("mel", onnx.TensorProto.FLOAT, [1, 80, frames])],
+        [
+            helper.make_tensor_value_info(
+                "audio", onnx.TensorProto.FLOAT, [1, 1, frames * stride]
+            )
+        ],
+        initializer=inits,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 10
+    return onnx.shape_inference.infer_shapes(model)
+
+
+def _build_vocoder(work_dir, **kwargs):
+    """Compile `_vocoder_model()` for real and return its mcode."""
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    os.makedirs(os.path.join(work_dir, "config"), exist_ok=True)
+    model = _vocoder_model(**kwargs)
+    onnx.save(model, os.path.join(work_dir, "model.onnx"))
+    frames = model.graph.input[0].type.tensor_type.shape.dim[2].dim_value
+    rng = np.random.RandomState(0)
+    pulsar2_docker.make_numpy_calibration_tar(
+        os.path.join(work_dir, "dataset", "calib.tar"),
+        [rng.randn(1, 80, frames).astype(np.float32) for _ in range(4)],
+    )
+    with open(os.path.join(work_dir, "config", "cfg.json"), "w") as f:
+        json.dump(
+            {
+                "model_type": "ONNX",
+                "npu_mode": "NPU1",
+                "quant": {
+                    "input_configs": [
+                        {
+                            "tensor_name": "mel",
+                            "calibration_dataset": "./dataset/calib.tar",
+                            "calibration_format": "Numpy",
+                            "calibration_size": 4,
+                        }
+                    ],
+                    "calibration_method": "MinMax",
+                    "precision_analysis": False,
+                },
+                "compiler": {"check": 0},
+            },
+            f,
+        )
+    result = pulsar2_docker.build(
+        work_dir, "model.onnx", "output", config_path="config/cfg.json"
+    )
+    assert result.success, result.error
+    ((_, mcode),) = _mcodes_of(result.axmodel_path)
+    return mcode
+
+
+def test_tts_vocoder_uses_no_new_instruction_forms(tmp_path):
+    """Confirmed real (see the README's "A third model family" section): a
+    HiFi-GAN-shaped vocoder -- transposed convolution, dilated convolution,
+    LeakyReLU, a bounded activation -- compiles, and its mcode introduces
+    *no* verb, tag or register that the CNN and transformer builds did not
+    already use. Op-type differences live in operand values, not in new
+    forms. Needs Docker, no device.
+    """
+    mcode = _build_vocoder(str(tmp_path))
+    covered, _ = _nonzero_coverage(mcode)
+    assert covered >= 0.95, covered
+
+    def destinations(blob):
+        lo, hi = _stream_bounds(blob)
+        seen = set()
+        for t in _tokenize_mcode(blob, start=lo, end=hi, **_FULL_RULE):
+            if t[1] in ("V", "W"):
+                seen.add((t[1], t[2], t[3], t[4]))
+            elif t[1] == "S":
+                # Read the tag from the stream: for a tag that carries an
+                # extra byte the token's third slot holds the register.
+                seen.add(("S", blob[t[0] + t[2] + 2]))
+            elif t[1] == "B":
+                seen.add(("B", t[2]))
+        return seen
+
+    reference = tmp_path / "resnet18d"
+    reference.mkdir()
+    known = destinations(_build_real_resnet18d(str(reference))[2])
+    new = {d for d in destinations(mcode) if d not in known}
+    # Verbs and tags must be shared; a (field, bank) pair may well be unique
+    # to either model, so compare the vocabulary rather than every pair. The
+    # companion write's leading byte is not a verb and varies by design, so
+    # it is excluded.
+    new_tags = {d for d in new if d[0] in ("S", "B")}
+    assert not new_tags, new_tags
+    new_verbs = {d[1] for d in new if d[0] == "V"}
+    assert new_verbs <= {t[1] for t in known if t[0] == "V"}, new_verbs
+
+    lo, hi = _stream_bounds(mcode)
+    programs = [
+        t
+        for t in _tokenize_mcode(mcode, start=lo, end=hi, **_FULL_RULE)
+        if t[1:] == ("V", 0xA1, 0x40, 0x02)
+    ]
+    assert len(programs) >= 5, len(programs)
 
 
 def test_full_rule_explains_almost_every_stream_byte(tmp_path):
@@ -3773,3 +3941,133 @@ def test_decode_encode_round_trip_is_byte_exact(tmp_path):
         # carried verbatim, and the rebuilt blob must equal the original.
         rebuilt = mcode[:lo] + _encode_mcode(records) + mcode[hi:]
         assert rebuilt == mcode, name
+
+
+def test_reencoded_mcode_runs_on_device_and_edits_take_effect(tmp_path):
+    """Confirmed real on the AX650N (see the README's "A lossless codec"
+    section): a stream we wrote ourselves is accepted by the hardware. The
+    layer's mcode is decoded into structured records, written back out by
+    `_encode_mcode()`, saved into the .axmodel and run -- the card produces
+    byte-identical outputs to the untouched original. Editing a field through
+    the codec (every in-program `a7` post's operand 2 -> 0) then changes the
+    outputs without faulting, the same effect the raw-byte patch had, which
+    is what makes this an encoder rather than a copier. Skips without a
+    device or the cached checkpoint.
+    """
+    import hashlib
+    import shutil
+
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device connected")
+    ckpt = _cached_hf_checkpoint("HuggingFaceTB/SmolLM2-135M")
+    if ckpt is None:
+        pytest.skip("HuggingFaceTB/SmolLM2-135M is not in the local HuggingFace cache")
+    work = tmp_path / "work"
+    work.mkdir()
+    shutil.copytree(ckpt, work / "SmolLM2-135M", symlinks=False)
+    result = pulsar2_docker.llm_build(str(work), "SmolLM2-135M", "output", parallel=8)
+    assert result.success, getattr(result, "error", None)
+    original = str(work / "output" / "llama_p512_l0_together.axmodel")
+
+    def rewrite(path, edit, whole_stream=True):
+        """Decode the first subgraph's mcode, apply `edit` to the records,
+        re-encode, and save as a new .axmodel."""
+        model = onnx.load(original)
+        neu = next(n for n in model.graph.node if n.op_type == "neu mode")
+        info = json.loads(
+            next(a for a in neu.attribute if a.name == "npu_graph_info").s.decode()
+        )
+        key = info["dotneus"][0]["neu_key"]
+        init = next(i for i in model.graph.initializer if i.name == key)
+        mcode = bytes(init.raw_data)
+        lo, hi = _stream_bounds(mcode)
+        records = _decode_mcode(mcode, start=lo, end=hi, **_FULL_RULE)
+        if whole_stream:
+            changed = edit(records)
+        else:
+            # The op-program segment is the one holding the most programs.
+            # Selecting it by type word is wrong on `llm_build` layers, where
+            # configuration segments carry the CNN op segment's type.
+            _, segs = _segments(mcode)
+
+            def program_count(seg):
+                pos, length, _ = seg
+                toks = _tokenize_mcode(mcode, start=pos, end=pos + length, **_FULL_RULE)
+                return sum(1 for t in toks if t[1:] == ("V", 0xA1, 0x40, 0x02))
+
+            pos, length, _ = max(segs, key=program_count)
+            changed = edit([r for r in records if pos <= r["at"] < pos + length])
+        init.raw_data = mcode[:lo] + _encode_mcode(records) + mcode[hi:]
+        onnx.save(model, path)
+        return init.raw_data == mcode, changed
+
+    inputs = _llm_layer_inputs(onnx.load(original))
+
+    def digests(path, times=3):
+        out = []
+        for _ in range(times):
+            r = pulsar2_docker.run_on_device_with_inputs(
+                path, inputs, repeat=1, warmup=1
+            )
+            if r.error and "0x8030070C" in r.error:
+                out.append("fault")
+            elif r.outputs:
+                out.append(tuple(hashlib.sha1(o).hexdigest() for o in r.outputs))
+        return out
+
+    base = [d for d in digests(original) if d != "fault"]
+    assert len(base) >= 2 and len(set(base)) == 1, ("baseline", base)
+
+    # 1. Re-encoded, unchanged: identical bytes, and the card agrees.
+    same_path = str(tmp_path / "reencoded.axmodel")
+    identical, _ = rewrite(same_path, lambda records: 0)
+    assert identical, "re-encoding changed the bytes"
+    again = [d for d in digests(same_path) if d != "fault"]
+    assert len(again) >= 2 and set(again) == set(base), ("re-encoded", again, base[0])
+
+    def clear_post(records):
+        n = 0
+        for r in records:
+            if r["kind"] == "V" and r["verb"] == 0xA7 and r["bank"] == 0x02:
+                r["operand"] = b"\x00" * len(r["operand"])
+                n += 1
+        return n
+
+    # 2. One field edited through the records produces *exactly* the bytes
+    #    the raw-byte patch produces -- the edit path is the encoder, not a
+    #    copier. The device behaviour of that patch is covered by
+    #    `test_llm_build_a7_is_a_sync_verb_on_device`, so it is not re-run
+    #    here: repeating it back-to-back with the runs above hits the
+    #    runtime's transient rejection often enough to be flaky.
+    model = onnx.load(original)
+    neu = next(n for n in model.graph.node if n.op_type == "neu mode")
+    info = json.loads(
+        next(a for a in neu.attribute if a.name == "npu_graph_info").s.decode()
+    )
+    key = info["dotneus"][0]["neu_key"]
+    mcode = bytes(next(i for i in model.graph.initializer if i.name == key).raw_data)
+    _, segs = _segments(mcode)
+
+    def program_count(seg):
+        pos, length, _ = seg
+        toks = _tokenize_mcode(mcode, start=pos, end=pos + length, **_FULL_RULE)
+        return sum(1 for t in toks if t[1:] == ("V", 0xA1, 0x40, 0x02))
+
+    pos, length, _ = max(segs, key=program_count)
+    toks = _tokenize_mcode(mcode, start=pos, end=pos + length, **_FULL_RULE)
+    a7_posts = [t[0] for t in toks if t[1] == "V" and t[2] == 0xA7 and t[4] == 0x02]
+    assert len(a7_posts) >= 50, len(a7_posts)
+
+    raw = bytearray(mcode)
+    for offset in a7_posts:
+        struct.pack_into("<I", raw, offset + 4, 0)
+
+    edited_path = str(tmp_path / "edited.axmodel")
+    identical, changed = rewrite(edited_path, clear_post, whole_stream=False)
+    assert not identical and changed == len(a7_posts), (changed, len(a7_posts))
+    through_codec = bytes(
+        next(
+            i for i in onnx.load(edited_path).graph.initializer if i.name == key
+        ).raw_data
+    )
+    assert through_codec == bytes(raw), "codec edit differs from the raw-byte patch"


### PR DESCRIPTION
Follow-up to #1219, two commits.

**A lossless codec.** `_decode_mcode()` turns a stream into structured records -- verb, field, bank, operand; prefix, payload, tag, register; the companion write's address and value, each with its offset -- and `_encode_mcode()` writes them back out reading nothing from the original. The round trip is byte-exact on a real resnet18d and on the ONNX-path transformer, and rebuilding a whole `.axmodel` reproduces the file. Over 95% of the bytes come from recognised forms.

**Proven on the real card.** A `llm_build` layer decoded into 11,974 records and written back out runs on the AX650N with byte-identical outputs to the untouched original. An edit made through the records produces exactly the bytes the raw-byte patch produces, so the edit path is an encoder rather than a copier. (That patch's device behaviour is covered by `test_llm_build_a7_is_a_sync_verb_on_device`; re-running it back-to-back with the runs above proved flaky against the runtime's transient rejection, so it is asserted device-free.)

**What a generator still needs**, measured: 25.3% of resnet18d's stream is single-valued and emittable by copying, 74.7% varies per op, and only 24.6% of the varying bytes sit at destinations whose meaning is documented. The instruction stream is also the small half -- the weight table is 99% of every artifact and is not decoded. Two probes narrow it: the `a2` operand is a packed record (low nibble always 2 or 3, a stepping nibble, a small counter, a 16-byte-aligned byte, flag bits) whose first occurrence per program rises with the op index in 69 of 71 programs; and the `llm_build` weight table opens with exactly 1,024 float32 words of 0.125. A refinement to an earlier claim: `40 02` is a plain Wbt offset on the CNN and ONNX paths (77 of 77 in range) but not on `llm_build` layers, where 22 of 147 and 12 of 169 offsets point past the shared table, clustering near 2.9x its size.

**TTS as a third model family.** A full VITS graph (a 63 MB Piper voice, 2,755 nodes) cannot compile -- `RandomNormalLike`, `NonZero`, `CumSum`, `Range`, `Shape` -- which is why real deployments keep the text encoder and sampling on the CPU and send only the vocoder. `_vocoder_model()` is that part: transposed-convolution upsampling, a dilated residual convolution, LeakyReLU, a bounded output. It compiles, is 96.8% explained by the existing rule, and introduces **zero** verbs, tags or registers the CNN and transformer builds had not used, with the same op-program skeleton. So op type is not encoded by choosing different instructions; it lives in operand values.

Also recorded: changing a shape parameter re-lays-out the whole stream (stride 8->4 moved 45 destinations, channels 128->96 moved 238, input length 32->64 moved 286 of ~1,400), and even changing only `LeakyRelu`'s alpha moved 2,171 bytes. Attribution by model diffing needs a sharper instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS
