### PR TITLE
QAT stage 2: graph_grad (reverse-mode AD over an ONNX slice) and apply_qat

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ constant folding until the model stops changing. Around that it offers:
   Face `diffusers` pipeline (Stable Diffusion, SDXL, ...) straight to a
   simplified ONNX deployment directory with
   `onnxsim.export_diffusion_model()`.
+- **[Quantization-aware fine-tuning](#quantization-aware-fine-tuning).**
+  Recover accuracy an INT4 weight-only quantization lost with
+  `onnxsim.apply_qat()`: label-free, block-wise fine-tuning of the fp32
+  weights themselves against the float model's own activations, over any
+  block topology. The training step is emitted as an ONNX graph, so it runs
+  on a GPU, an NPU execution provider or WebGPU via `step_providers=`.
 - **Subgraph simplification.** Simplify `If`/`Loop`/`Scan` subgraph bodies too
   with `--include-subgraph`.
 - **[MLIR export](#exporting-to-mlir-torch-mlir--onnx-mlir).** Hand the simplified
@@ -1214,6 +1220,140 @@ onnxsim.export_diffusion_model(
     save_as_external_data=False,
 )
 ```
+
+## Quantization-aware fine-tuning
+
+onnxsim's post-training quantization passes stop at *rounding*: AdaRound,
+BRECQ, FlexRound, AutoRound and the rest each pick, for every weight, which of
+the two neighbouring integers it rounds to, and nothing more.
+`onnxsim.apply_qat()` goes one step further -- the fp32 weight itself is the
+trained parameter, fake-quantized in the forward against
+`quantize_weight_only_int4`'s block-wise INT4 grid with a straight-through
+estimator, so an element can migrate several codes away from where
+round-to-nearest put it.
+
+It is **label-free**. The float model is the teacher, and the loss is the
+reconstruction error of one block's output against the float model's own
+activations for that block. There are no labels, no dataset API, no metric and
+no training-loop lifecycle -- the lifecycle stays the one onnxsim already has,
+a model in and a model out. Task-loss QAT remains out of scope; the design
+note is [`docs/qat.md`](docs/qat.md), which records both what was built and
+where the boundary is drawn.
+
+Two things here are genuinely new:
+
+- **Any block topology, not just a linear chain.** `apply_brecq` is capped at
+  a strict chain of MatMul/Gemm layers, because every op shape between two
+  quantized layers used to mean another hand-derived backward pass.
+  `onnxsim/graph_grad.py`'s `build_backward` removed that cost: it
+  differentiates a slice of an ONNX graph by walking it in reverse and
+  emitting ordinary ONNX nodes, so a normalization, an activation, a GELU's
+  `Erf`, a Softmax or a residual between two Linears is now simply more nodes
+  in the slice. A block that `apply_brecq` returns byte-identical, because its
+  discovery cannot see that topology at all, can be reconstructed here.
+- **The training step runs on an accelerator.** The fake-quant forward, that
+  backward, and one Adam update per trained tensor are emitted as a single
+  ONNX *step graph* -- a pure `(constants, state, per-step scalars) -> (next
+  state, loss)` function (`onnxsim/qat_graph.py`) -- so the loop runs on
+  whatever execution providers `step_providers=` names: a GPU, an NPU
+  execution provider, or WebGPU in the WASM build, rather than in host numpy.
+  The emitted graph stays inside `qat_graph.EP_FRIENDLY_OPS`, the operator set
+  those backends actually implement, and `onnxsim.backend.Runner` keeps the
+  parameters and the optimizer state resident on the provider's device between
+  steps, so only the per-step scalars go up and the loss comes down.
+
+A block is named by its input and output tensor, exactly the way
+`apply_brecq` names one:
+
+```python
+import onnx
+import onnxsim
+
+float_model = onnx.load("model.onnx")
+quantized = onnxsim.quantize_weight_only_int4(float_model)
+
+# Representative input batches: {input_name: np.ndarray} dicts matching the
+# float model's graph inputs. Random data is the default when omitted; real
+# data (onnxsim.load_huggingface_calibration_data) is a far better target.
+calibration_data = [{"input": batch} for batch in batches]
+
+losses = []  # the reconstruction loss, appended once per step
+tuned = onnxsim.apply_qat(
+    float_model,
+    quantized,
+    block_input_name="input",
+    block_output_name="block_out",
+    calibration_data=calibration_data,
+    losses=losses,
+    step_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+)
+
+onnx.save(tuned, "model_int4_qat.onnx")
+```
+
+Only that block's INT4 weight initializers are rewritten; every other byte of
+the quantized model is untouched. One block is trained per call, so a sliding
+window over a model's blocks is the caller's own loop to write. Naming a block
+that cannot be trained is a loud error rather than a silently unchanged model:
+an op `graph_grad` has no gradient rule for, a block containing no
+`quantize_weight_only_int4`-quantized MatMul/Gemm, or shapes that cannot be
+inferred statically are all refused before any calibration runs.
+`learn_scales=True` trains each weight's per-block quantization scale
+alongside, LSQ-style (off by default, since it makes the problem non-convex in
+two coupled parameter sets at once). The whole calibration set is one
+full-batch objective -- no minibatching, no epochs, a calibration-scale budget
+rather than a training-scale one -- and activation quantization is not wired
+in: this targets `quantize_weight_only_int4`'s weight-only scheme.
+
+### When to reach for it, and when not to
+
+It is **not** uniformly better than `apply_adaround`, and the boundary is worth
+knowing before you spend a thousand Adam steps. On a two-Linear-plus-`Relu`
+block -- a topology `apply_brecq` cannot reconstruct at all -- the
+reconstruction error falls from 16.0 (round-to-nearest) to 6.5, and a GELU
+block's loss falls ~12x. But on a *single* layer, where the objective is
+identical to AdaRound's and only the parametrization differs, freeing the
+weight wins when the calibration activations are low-rank (round-to-nearest
+5.96, AdaRound 3.07, `apply_qat` 1.78) and **loses** when they are full-rank
+(28.5, 14.6, 22.8). The reason is not subtle: a well-determined reconstruction
+problem has its optimum within one quantization step of round-to-nearest, so
+floor/ceil is all the freedom worth having there, and AdaRound's continuous
+relaxation optimizes that restricted problem better than a hard
+straight-through estimator does. Real activations are widely observed to be
+close to low-rank -- the premise the whole reconstruction-based PTQ literature
+leans on -- which is the case for having this at all, though onnxsim has not
+measured that on your model, and "QAT beats AdaRound" is not a claim it
+makes. Both directions are measured in `tests/test_qat.py`, not
+assumed.
+
+So: reach for `apply_qat` for a block no rounding pass here can reconstruct (a
+normalization, an activation, a GELU, a residual in the middle of it), and for
+low-rank calibration activations at 4 bits. Stay with `apply_adaround` for a
+single well-conditioned layer.
+
+### Running AdaRound and AdaQuant on an accelerator
+
+The step-graph machinery is not QAT-only. `apply_adaround` and
+`apply_adaquant` take the same `step_providers=` argument, which runs their
+optimization loop as an ONNX step graph instead of in host numpy:
+
+```python
+tuned = onnxsim.apply_adaround(
+    float_model,
+    quantized_model,
+    calibration_data=batches,
+    providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    step_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+)
+```
+
+`providers=` (unchanged) still selects where the float model's calibration
+activations are captured; `step_providers=` selects where the optimization
+itself runs. Omitting it keeps the existing float64 numpy loop, which is what
+CI runs: it is exact and reproducible, and a non-CPU provider is neither, since
+GPU/NPU reductions reassociate. `apply_qat` has no numpy alternative -- the
+step graph *is* the implementation there -- so `step_providers=None` simply
+means CPU.
 
 ## Projects Using ONNX Simplifier
 

--- a/docs/qat.md
+++ b/docs/qat.md
@@ -1,9 +1,10 @@
 # Delivering QAT in onnxsim: a design note
 
-**Status: design note, with its first two stages implemented.**
-`onnxsim/qat_graph.py` and the converter page's calibration-provider picker
-have landed (see "Staging" below); `apply_qat()` itself has not. This note
-answers "how *could* we deliver quantization-aware training as an onnxsim
+**Status: design note, with stages 0-2 implemented.**
+`onnxsim/qat_graph.py`, `onnxsim/graph_grad.py`, `onnxsim/qat.py`
+(`apply_qat`) and the converter page's calibration-provider picker have all
+landed; the browser fine-tuning panel and the QAT-interop paths have not
+(see "Staging" below). This note answers "how *could* we deliver quantization-aware training as an onnxsim
 feature, and can the training math run on WebGPU or an NPU?" and records the
 shape of the work so the question doesn't have to be re-derived. `docs/nncf-comparison-future-work.md`
 currently lists QAT as out of scope ("QAT needs a training loop with a
@@ -132,11 +133,17 @@ So the accelerator story is not a second backend to write; it is the existing
 to build. Three things it does *not* give for free:
 
 - **Readback dominates if ignored.** A naive loop copies every parameter and
-  every Adam moment host↔device per step. Parameters must stay resident:
-  `IOBinding` on the Python side, and on the web side onnxruntime-web's
-  GPU-buffer tensors with `preferredOutputLocation: "gpu-buffer"` (ORT-web
-  ≥1.17; the converter page is on 1.27), feeding each step's outputs straight
-  back in as the next step's inputs. Only the loss comes back to the host.
+  every Adam moment host-to-device per step. Parameters must stay resident.
+  The Python half of this is done: `backend.Runner.bind_loop` uploads the
+  constants once, allocates the state on the session's device and
+  ping-pongs it between two buffers (binding one buffer as both a step's
+  input and its output is unsafe -- onnxruntime may write an output before
+  it has finished reading its inputs), so only scalars go up and only the
+  loss comes down. On CPU that measures as a wash, which is the expected
+  result and not a disappointment: with the CPU provider the "device" is
+  host memory. The web half remains -- onnxruntime-web's GPU-buffer tensors
+  with `preferredOutputLocation: "gpu-buffer"` (ORT-web >=1.17; the
+  converter page is on 1.27).
 - **NPUs are inference silicon, and it shows.** WebNN, QNN, Core ML and the
   Axera path compile a *fixed* graph, prefer fp16/int8, and often reject
   fp32 accumulation or dynamic shapes. Adam in fp16 is not stable. The
@@ -185,13 +192,51 @@ Each stage is independently shippable and independently useful.
    agrees with the numpy loop it replaces (>95% of elements pick the identical
    floor/ceil decision; the rest is float32-vs-float64 boundary rounding, and
    the reconstruction error lands within 10%) and that both step graphs stay
-   inside an operator allowlist the accelerator backends actually implement.
-2. **`qat.py` / `apply_qat()`** (next). Free weights + LSQ/LSQ+ scales + block-wise
-   teacher distillation over `load_huggingface_calibration_data`, a
-   `QuantizationConfig` flag to reach it from `quantize()`, a doc, and tests
-   in the established style (parser-built models, a *measured* improvement
-   over RTN/AdaRound on a scenario engineered to make them differ, scoped as
-   honestly as `brecq.py` scopes its own).
+   inside `qat_graph.EP_FRIENDLY_OPS`, the operator set the accelerator
+   backends actually implement.
+
+   Since then: `adaquant` is ported onto it too, which is the harder case and
+   the evidence the machinery generalizes -- it optimizes three parameter
+   groups at once (rounding relaxation, activation scale, activation
+   zero-point), so the step graph carries nine state tensors and three
+   `adam_update` calls. It tracks its numpy loop tighter than adaround's port
+   does: identical weight codes on five of six seeds, identical integer
+   zero-point on all six. And the state now stays on the device between
+   steps (`backend.Runner.bind_loop`), which is what makes the accelerator
+   path worth taking rather than merely possible.
+2. **`qat.py` / `apply_qat()` -- done**, and it needed one thing this note
+   did not anticipate. Block-wise teacher distillation over an arbitrary
+   topology means differentiating an arbitrary slice of the graph, which no
+   pass here could do: every gradient in the repo is hand-derived for one
+   fixed shape, which is exactly why `brecq.py` is capped at a linear chain.
+   So `graph_grad.py` came first -- `build_backward` walks a forward slice in
+   reverse and emits the gradient as ordinary ONNX nodes, 20 op rules, each
+   checked against central finite differences, its emission pinned to
+   `qat_graph.EP_FRIENDLY_OPS`. It is a rule table and a reverse walk, not an
+   autograd framework: the ONNX graph is already the tape.
+
+   On top of it, `apply_qat` trains the fp32 weights themselves (a
+   straight-through estimator through the fake-quant, so an element can
+   migrate several codes from where round-to-nearest put it -- the
+   restriction every rounding pass here inherits), optionally the per-block
+   scales LSQ-style, against the float block's own output.
+
+   Measured honestly, and not a uniform win: on a two-Linear-plus-`Relu`
+   block, which `brecq` returns byte-identical because it cannot see that
+   topology at all, reconstruction error falls 16.0 -> 6.5. Against
+   `apply_adaround` on a *single* layer, where the objective is identical
+   and only the parametrization differs, freeing the weight wins on
+   low-rank calibration activations (RTN 5.96 / AdaRound 3.07 / QAT 1.78)
+   and **loses** on full-rank ones (28.5 / 14.6 / 22.8) -- a well-determined
+   reconstruction problem has its optimum within one quantization step of
+   round-to-nearest, so floor/ceil is all the freedom worth having there.
+   Both directions are asserted in `tests/test_qat.py`.
+
+   Still open from this stage's original description: real data via
+   `load_huggingface_calibration_data`, a `QuantizationConfig` flag, a
+   sliding window over blocks and a whole-graph pass, minibatching, and
+   activation quantization (adaquant has the learnable activation scale, it
+   is simply not wired in here).
 3. **Browser QAT panel.** A "fine-tune" panel in the converter page: data
    from `hf_datasets.mjs`, execution from `ort_executor.mjs` on WebGPU, a
    loss curve, and `quantize_metrics.mjs` for the before/after. Client-side
@@ -217,10 +262,30 @@ tuned = onnxsim.apply_adaround(
 ```
 
 Omitting `step_providers` keeps the existing float64 numpy loop, which is what
-CI runs: it is exact and reproducible, and a non-CPU provider is neither. In
-the browser, the Quantize panel's **calibration execution provider** picker
-does the equivalent for calibration's own forward passes (WebGPU, or WebNN's
-GPU/NPU device types).
+CI runs: it is exact and reproducible, and a non-CPU provider is neither.
+`apply_adaquant` takes the same argument. In the browser, the Quantize
+panel's **calibration execution provider** picker does the equivalent for
+calibration's own forward passes (WebGPU, or WebNN's GPU/NPU device types).
+
+Block-wise QAT itself, over a block the caller names by its input and output
+tensor:
+
+```python
+tuned = onnxsim.apply_qat(
+    float_model,
+    quantized_model,           # quantize_weight_only_int4's output
+    block_input_name="hidden",
+    block_output_name="block_out",
+    calibration_data=batches,
+    learn_scales=True,         # LSQ per-block scales alongside the weights
+    step_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+)
+```
+
+There is no numpy alternative there -- the step graph *is* the
+implementation -- so `step_providers=None` simply means CPU. Anything between
+the two named tensors that `graph_grad` can differentiate is fair game; an op
+it cannot is refused up front, before any calibration runs.
 
 To put a *new* algorithm on a step graph: build its gradient with
 `qat_graph.GraphBuilder`, close the loop with `qat_graph.adam_update` and

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -242,6 +242,7 @@ from onnxsim.pruning import (
     weight_sparsity,
 )
 from onnxsim.ptq4vit import apply_ptq4vit_quantization
+from onnxsim.qat import apply_qat
 from onnxsim.qoq import apply_smooth_attention, quantize_weight_only_qoq
 from onnxsim.qronos import apply_qronos
 from onnxsim.quantease import apply_quantease
@@ -306,6 +307,7 @@ __all__ = [
     "apply_fp6_llm_quantization",
     "quantize_dequantize_fp6",
     "apply_brecq",
+    "apply_qat",
     "apply_fptq",
     "apply_owq",
     "apply_bwa_ptq",

--- a/onnxsim/adaquant.py
+++ b/onnxsim/adaquant.py
@@ -380,27 +380,6 @@ def _sum_all(b: qat_graph.GraphBuilder, tensor: str) -> str:
     return b.op("ReduceSum", [tensor], keepdims=0)
 
 
-def _round_to_nearest(b: qat_graph.GraphBuilder, tensor: str) -> str:
-    """``round(tensor)``, built out of the allowlisted ops.
-
-    ONNX has a ``Round``, but WebNN has no rounding operator at all, so it is
-    deliberately absent from :data:`onnxsim.qat_graph.EP_FRIENDLY_OPS` and
-    this composes the same thing instead: a float-to-int32
-    ``Cast`` truncates toward zero, and truncating ``|t| + 0.5`` and
-    re-applying the sign is round-half-away-from-zero. That differs from
-    numpy's (and ``Round``'s) round-half-to-even on *exact* ties only -- an
-    activation whose ``x / scale`` lands on a precise .5, which real
-    calibration data does not do at any measurable rate, and which when it
-    does happen moves that one element's quantized code by one rather than
-    changing the shape of the optimization.
-    """
-    magnitude = b.add(b.op("Abs", [tensor]), b.const(0.5))
-    truncated = b.op("Cast", [magnitude], to=onnx.TensorProto.INT32)
-    return b.mul(
-        b.op("Sign", [tensor]), b.op("Cast", [truncated], to=onnx.TensorProto.FLOAT)
-    )
-
-
 def _build_adaquant_step_graph(num_rows: int, n: int, k: int) -> qat_graph.StepGraph:
     """One Adam step of :func:`_optimize_adaquant`, as an ONNX graph.
 
@@ -464,7 +443,7 @@ def _build_adaquant_step_graph(num_rows: int, n: int, k: int) -> qat_graph.StepG
 
     # Straight-through quantize-dequantize of the activation, stage by stage.
     x_over_s = b.div(x, s_x)
-    xq_raw = b.add(_round_to_nearest(b, x_over_s), zp)
+    xq_raw = b.add(b.round_to_nearest(x_over_s), zp)
     active_x = b.mul(b.greater_mask(xq_raw, 0.0), b.less_mask(xq_raw, _ACT_N_MAX))
     xq_minus_zp = b.sub(b.clip(xq_raw, 0.0, _ACT_N_MAX), zp)
     xdq = b.mul(xq_minus_zp, s_x)

--- a/onnxsim/adaquant.py
+++ b/onnxsim/adaquant.py
@@ -369,24 +369,23 @@ def _optimize_adaquant(
     return _adaquant_results(v, floor_base, log_s, zp)
 
 
-def _sum_all(b: qat_graph.GraphBuilder, tensor: str, count: int) -> str:
+def _sum_all(b: qat_graph.GraphBuilder, tensor: str) -> str:
     """``sum(tensor)`` over every axis, as a scalar.
 
-    Spelled as ``mean * count`` rather than as a ``ReduceSum`` because
-    ``ReduceSum`` is not in the operator set these step graphs restrict
-    themselves to (``tests/test_qat_graph.py``'s allowlist, i.e. what the
-    WebNN/NPU execution providers actually implement) while ``ReduceMean``
-    is, and the element count is known when the graph is built.
+    A one-line wrapper so the gradient expressions below read as the
+    summations they are; ``ReduceSum`` is in
+    :data:`onnxsim.qat_graph.EP_FRIENDLY_OPS`, so no rewriting is needed to
+    keep the graph runnable on an accelerator backend.
     """
-    mean = b.op("ReduceMean", [tensor], keepdims=0)
-    return b.mul(mean, b.const(float(count)))
+    return b.op("ReduceSum", [tensor], keepdims=0)
 
 
 def _round_to_nearest(b: qat_graph.GraphBuilder, tensor: str) -> str:
     """``round(tensor)``, built out of the allowlisted ops.
 
-    ONNX has a ``Round``, but it is not in the set the accelerator backends
-    are known to cover, so this composes the same thing: a float-to-int32
+    ONNX has a ``Round``, but WebNN has no rounding operator at all, so it is
+    deliberately absent from :data:`onnxsim.qat_graph.EP_FRIENDLY_OPS` and
+    this composes the same thing instead: a float-to-int32
     ``Cast`` truncates toward zero, and truncating ``|t| + 0.5`` and
     re-applying the sign is round-half-away-from-zero. That differs from
     numpy's (and ``Round``'s) round-half-to-even on *exact* ties only -- an
@@ -444,9 +443,7 @@ def _build_adaquant_step_graph(num_rows: int, n: int, k: int) -> qat_graph.StepG
     log_s, m_s, vv_s = "log_s", "m_s", "vv_s"
     zp, m_zp, vv_zp = "zp", "m_zp", "vv_zp"
 
-    # exp(log_s). Written as Pow(e, log_s) because Exp is not in the
-    # allowlisted operator set; with a constant base it is the same function.
-    s_x = b.op("Pow", [b.const(np.e), log_s])
+    s_x = b.op("Exp", [log_s])
 
     # h(v), the rectified sigmoid, and its derivative -- _h_and_dhdv's own two
     # lines, with the "is this element still inside the clip" test as a float
@@ -500,8 +497,8 @@ def _build_adaquant_step_graph(num_rows: int, n: int, k: int) -> qat_graph.StepG
     dxdq_ds = b.sub(xq_minus_zp, b.mul(active_x, x_over_s))
     dxdq_dzp = b.mul(s_x, b.sub(active_x, b.const(1.0)))
     # d/d(log s) = d/ds * s, the chain rule for the log-space parametrization.
-    grad_log_s = b.mul(_sum_all(b, b.mul(dl_dxdq, dxdq_ds), num_rows * k), s_x)
-    grad_zp = _sum_all(b, b.mul(dl_dxdq, dxdq_dzp), num_rows * k)
+    grad_log_s = b.mul(_sum_all(b, b.mul(dl_dxdq, dxdq_ds)), s_x)
+    grad_zp = _sum_all(b, b.mul(dl_dxdq, dxdq_dzp))
 
     v_next, m_v_next, vv_v_next = qat_graph.adam_update(
         b, v, grad_v, m_v, vv_v, "w_lr", "m_correction", "v_correction"

--- a/onnxsim/adaquant.py
+++ b/onnxsim/adaquant.py
@@ -91,6 +91,7 @@ each element rounds to is optimized, the same restriction
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
@@ -98,8 +99,14 @@ import numpy as np
 import onnx
 import onnx.numpy_helper
 
-from onnxsim import backend
-from onnxsim.adaround import _GAMMA, _ZETA, _h_and_dhdv, _node_outputs
+from onnxsim import backend, qat_graph
+from onnxsim.adaround import (
+    _GAMMA,
+    _ZETA,
+    _h_and_dhdv,
+    _init_relaxation,
+    _node_outputs,
+)
 from onnxsim.bias_correction import _activation_rows, _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 
@@ -211,6 +218,51 @@ def _find_static_qdq_candidates(
     return candidates
 
 
+def _init_adaquant(
+    w_nk: np.ndarray, scale_n: np.ndarray, x_scale0: float, x_zp0: float
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, float, float]:
+    """This layer's joint optimization problem, at its starting point:
+    ``(scale_nk, v, floor_base, log_s, zp)``.
+
+    Factored out for the same reason
+    :func:`onnxsim.adaround._init_relaxation` is, and it reuses that function
+    for the weight half: the numpy loop and the step-graph loop have to
+    optimize *the same problem from the same warm start*, and the only way to
+    keep that true as either one changes is for there to be a single copy of
+    it. Everything downstream (both optimizers, and
+    :func:`_adaquant_results`) is a pure function of what this returns.
+
+    The activation scale is carried in log space -- so a gradient step can
+    never drive it to zero or negative, which would make the quantizer
+    undefined -- and the ``max(..., 1e-8)`` floor guards the degenerate
+    calibrated scale of exactly 0 (a constant activation) that ``log`` would
+    otherwise turn into ``-inf``. The zero-point starts at the calibrated
+    one, clamped into uint8's range but *not* rounded: keeping it continuous
+    throughout is what lets a gradient reach it at all.
+    """
+    scale_nk = np.repeat(scale_n[:, None], w_nk.shape[1], axis=1)
+    v, floor_base = _init_relaxation(w_nk, scale_nk)
+    log_s = float(np.log(max(x_scale0, 1e-8)))
+    zp = float(np.clip(x_zp0, 0.0, _ACT_N_MAX))
+    return scale_nk, v, floor_base, log_s, zp
+
+
+def _adaquant_results(
+    v: np.ndarray, floor_base: np.ndarray, log_s: float, zp: float
+) -> Tuple[np.ndarray, float, int]:
+    """The deployable values the three optimized parameter groups have
+    settled on -- the last lines of both optimization paths.
+
+    This is where the continuous relaxations become the integers the model
+    actually stores: each element's rounding relaxation collapses to its
+    nearest hard floor/ceil choice, and the zero-point is projected back onto
+    uint8's grid.
+    """
+    h_final, _ = _h_and_dhdv(v)
+    codes_nk = np.clip(floor_base + np.round(h_final), _WEIGHT_N_MIN, _WEIGHT_N_MAX)
+    return codes_nk, float(np.exp(log_s)), int(np.clip(round(zp), 0, 255))
+
+
 def _optimize_adaquant(
     w_nk: np.ndarray,
     scale_n: np.ndarray,
@@ -239,17 +291,8 @@ def _optimize_adaquant(
     zero-point (rounded to the nearest integer in ``[0, 255]``, uint8's
     range).
     """
-    n, k = w_nk.shape
-    scale_nk = np.repeat(scale_n[:, None], k, axis=1)
-
-    ratio = w_nk / scale_nk
-    floor_base = np.floor(ratio)
-    frac = np.clip(ratio - floor_base, 1e-4, 1.0 - 1e-4)
-    sig0 = np.clip((frac - _GAMMA) / (_ZETA - _GAMMA), 1e-4, 1.0 - 1e-4)
-    v = np.log(sig0 / (1.0 - sig0))
-
-    log_s = float(np.log(max(x_scale0, 1e-8)))
-    zp = float(np.clip(x_zp0, 0.0, _ACT_N_MAX))
+    n = w_nk.shape[0]
+    scale_nk, v, floor_base, log_s, zp = _init_adaquant(w_nk, scale_n, x_scale0, x_zp0)
 
     m_v, v2_v = np.zeros_like(v), np.zeros_like(v)
     m_s = v2_s = m_zp = v2_zp = 0.0
@@ -323,11 +366,265 @@ def _optimize_adaquant(
         )
         zp = float(np.clip(zp, 0.0, _ACT_N_MAX))
 
-    h_final, _ = _h_and_dhdv(v)
-    codes_nk = np.clip(floor_base + np.round(h_final), _WEIGHT_N_MIN, _WEIGHT_N_MAX)
-    x_scale = float(np.exp(log_s))
-    x_zero_point = int(np.clip(round(zp), 0, 255))
-    return codes_nk, x_scale, x_zero_point
+    return _adaquant_results(v, floor_base, log_s, zp)
+
+
+def _sum_all(b: qat_graph.GraphBuilder, tensor: str, count: int) -> str:
+    """``sum(tensor)`` over every axis, as a scalar.
+
+    Spelled as ``mean * count`` rather than as a ``ReduceSum`` because
+    ``ReduceSum`` is not in the operator set these step graphs restrict
+    themselves to (``tests/test_qat_graph.py``'s allowlist, i.e. what the
+    WebNN/NPU execution providers actually implement) while ``ReduceMean``
+    is, and the element count is known when the graph is built.
+    """
+    mean = b.op("ReduceMean", [tensor], keepdims=0)
+    return b.mul(mean, b.const(float(count)))
+
+
+def _round_to_nearest(b: qat_graph.GraphBuilder, tensor: str) -> str:
+    """``round(tensor)``, built out of the allowlisted ops.
+
+    ONNX has a ``Round``, but it is not in the set the accelerator backends
+    are known to cover, so this composes the same thing: a float-to-int32
+    ``Cast`` truncates toward zero, and truncating ``|t| + 0.5`` and
+    re-applying the sign is round-half-away-from-zero. That differs from
+    numpy's (and ``Round``'s) round-half-to-even on *exact* ties only -- an
+    activation whose ``x / scale`` lands on a precise .5, which real
+    calibration data does not do at any measurable rate, and which when it
+    does happen moves that one element's quantized code by one rather than
+    changing the shape of the optimization.
+    """
+    magnitude = b.add(b.op("Abs", [tensor]), b.const(0.5))
+    truncated = b.op("Cast", [magnitude], to=onnx.TensorProto.INT32)
+    return b.mul(
+        b.op("Sign", [tensor]), b.op("Cast", [truncated], to=onnx.TensorProto.FLOAT)
+    )
+
+
+def _build_adaquant_step_graph(num_rows: int, n: int, k: int) -> qat_graph.StepGraph:
+    """One Adam step of :func:`_optimize_adaquant`, as an ONNX graph.
+
+    Node for node the same computation the numpy loop performs -- the same
+    rectified-sigmoid weight relaxation, the same step-by-step straight-
+    through quantize-dequantize of the activation, the same annealed
+    regularizer, the same Adam -- expressed so it can run on an execution
+    provider instead of on the host. See :mod:`onnxsim.qat_graph` for why a
+    hand-derived gradient can be written as an inference graph at all, and
+    ``docs/qat.md`` for what it is for.
+
+    The one structural difference from
+    :func:`onnxsim.adaround._build_rounding_step_graph` is what the step
+    updates: AdaQuant optimizes three parameter groups jointly, so there are
+    three :func:`onnxsim.qat_graph.adam_update` calls (it is a per-tensor
+    update) and nine state tensors -- the per-element relaxation ``v`` plus
+    the two rank-0 activation parameters, each with its own pair of Adam
+    moments. They share one learning rate each (``w_lr`` for the weight
+    relaxation, ``a_lr`` for both activation parameters, matching the numpy
+    loop's two rates) and one pair of bias corrections, since every group
+    takes its first step on the same iteration.
+
+    Critically, the quantize-then-dequantize chain is emitted as the four
+    separate stages the gradient is derived through (divide, round, offset,
+    clip) rather than as a ``QuantizeLinear``/``DequantizeLinear`` pair: the
+    scale's gradient lives entirely in the *difference* between ``x / s`` and
+    its rounded value, so a formulation that hid the rounding inside one op
+    would have nothing to differentiate. This module's own docstring explains
+    the same point for the numpy loop.
+
+    Shapes are baked in at build time (``x`` is ``[num_rows, k]``, the weight
+    ``[n, k]``): the accelerator backends this exists for -- WebNN and the NPU
+    execution providers -- compile a graph once and want static shapes, and a
+    step graph is rebuilt per layer anyway.
+    """
+    b = qat_graph.GraphBuilder()
+
+    x, y_float, floor_base, scale = "x", "y_float", "floor_base", "scale"
+    v, m_v, vv_v = "v", "m_v", "vv_v"
+    log_s, m_s, vv_s = "log_s", "m_s", "vv_s"
+    zp, m_zp, vv_zp = "zp", "m_zp", "vv_zp"
+
+    # exp(log_s). Written as Pow(e, log_s) because Exp is not in the
+    # allowlisted operator set; with a constant base it is the same function.
+    s_x = b.op("Pow", [b.const(np.e), log_s])
+
+    # h(v), the rectified sigmoid, and its derivative -- _h_and_dhdv's own two
+    # lines, with the "is this element still inside the clip" test as a float
+    # 0/1 mask rather than a Where.
+    s = b.sigmoid(v)
+    raw = b.add(b.mul(s, b.const(_ZETA - _GAMMA)), b.const(_GAMMA))
+    h = b.clip(raw, 0.0, 1.0)
+    active = b.mul(b.greater_mask(raw, 0.0), b.less_mask(raw, 1.0))
+    ds = b.mul(s, b.sub(b.const(1.0), s))
+    dh_dv = b.mul(active, b.mul(ds, b.const(_ZETA - _GAMMA)))
+
+    # The soft weight this relaxation currently implies.
+    raw_w = b.add(floor_base, h)
+    w_hat = b.mul(b.clip(raw_w, _WEIGHT_N_MIN, _WEIGHT_N_MAX), scale)
+    active_w = b.mul(
+        b.greater_mask(raw_w, _WEIGHT_N_MIN), b.less_mask(raw_w, _WEIGHT_N_MAX)
+    )
+
+    # Straight-through quantize-dequantize of the activation, stage by stage.
+    x_over_s = b.div(x, s_x)
+    xq_raw = b.add(_round_to_nearest(b, x_over_s), zp)
+    active_x = b.mul(b.greater_mask(xq_raw, 0.0), b.less_mask(xq_raw, _ACT_N_MAX))
+    xq_minus_zp = b.sub(b.clip(xq_raw, 0.0, _ACT_N_MAX), zp)
+    xdq = b.mul(xq_minus_zp, s_x)
+
+    # The layer's reconstruction error against the float model's own output,
+    # and the loss gradient every parameter group's gradient flows out of.
+    y_hat = b.matmul(xdq, b.transpose(w_hat))  # [num_rows, n]
+    diff = b.sub(y_hat, y_float)
+    dl_dy = b.mul(diff, b.const(2.0 / (num_rows * n)))
+
+    dl_dw_hat = b.matmul(b.transpose(dl_dy), xdq)  # [n, k]
+    dl_dh = b.mul(dl_dw_hat, b.mul(active_w, scale))
+    grad_v = b.mul(dl_dh, dh_dv)
+
+    # The rounding regularizer, pulling each relaxation toward a hard 0/1.
+    # `reg_scale` is the caller's reg_param, or 0 during the warm start -- a
+    # scalar fed per step, so the warm start needs no second graph.
+    u = b.sub(b.mul(b.const(2.0), h), b.const(1.0))
+    sign_u = b.op("Sign", [u])
+    pow_u = b.op("Pow", [b.op("Abs", [u]), b.sub("beta", b.const(1.0))])
+    dreg_dh = b.mul(
+        b.mul(b.mul(b.const(-2.0), "reg_scale"), "beta"), b.mul(sign_u, pow_u)
+    )
+    grad_v = b.add(grad_v, b.mul(dreg_dh, dh_dv))
+
+    # The activation branch: the same loss gradient, pushed back through the
+    # dequantize (a pass-through scaled by s), the clip (1 inside, 0 outside)
+    # and the round (1, by the straight-through estimator).
+    dl_dxdq = b.matmul(dl_dy, w_hat)  # [num_rows, k]
+    dxdq_ds = b.sub(xq_minus_zp, b.mul(active_x, x_over_s))
+    dxdq_dzp = b.mul(s_x, b.sub(active_x, b.const(1.0)))
+    # d/d(log s) = d/ds * s, the chain rule for the log-space parametrization.
+    grad_log_s = b.mul(_sum_all(b, b.mul(dl_dxdq, dxdq_ds), num_rows * k), s_x)
+    grad_zp = _sum_all(b, b.mul(dl_dxdq, dxdq_dzp), num_rows * k)
+
+    v_next, m_v_next, vv_v_next = qat_graph.adam_update(
+        b, v, grad_v, m_v, vv_v, "w_lr", "m_correction", "v_correction"
+    )
+    log_s_next, m_s_next, vv_s_next = qat_graph.adam_update(
+        b, log_s, grad_log_s, m_s, vv_s, "a_lr", "m_correction", "v_correction"
+    )
+    zp_stepped, m_zp_next, vv_zp_next = qat_graph.adam_update(
+        b, zp, grad_zp, m_zp, vv_zp, "a_lr", "m_correction", "v_correction"
+    )
+    # The zero-point is re-clamped into uint8's range every step, not just at
+    # the end: the forward pass's own clip is what the whole activation
+    # gradient is derived through, so a zero-point that wandered outside the
+    # representable range would saturate every element and silently kill it.
+    zp_next = b.clip(zp_stepped, 0.0, _ACT_N_MAX)
+
+    return qat_graph.make_step_graph(
+        b,
+        constants={
+            x: [num_rows, k],
+            y_float: [num_rows, n],
+            floor_base: [n, k],
+            scale: [n, k],
+        },
+        state={
+            v: ([n, k], v_next),
+            m_v: ([n, k], m_v_next),
+            vv_v: ([n, k], vv_v_next),
+            log_s: ([], log_s_next),
+            m_s: ([], m_s_next),
+            vv_s: ([], vv_s_next),
+            zp: ([], zp_next),
+            m_zp: ([], m_zp_next),
+            vv_zp: ([], vv_zp_next),
+        },
+        scalars=["w_lr", "a_lr", "reg_scale", "beta", "m_correction", "v_correction"],
+        loss=b.mean_square(diff),
+        name="onnxsim_adaquant_step",
+    )
+
+
+def _optimize_adaquant_on_graph(
+    w_nk: np.ndarray,
+    scale_n: np.ndarray,
+    x: np.ndarray,
+    x_scale0: float,
+    x_zp0: float,
+    num_iterations: int,
+    weight_learning_rate: float,
+    activation_learning_rate: float,
+    reg_param: float,
+    warm_start: float,
+    beta_range: Tuple[float, float],
+    providers: Optional[Sequence[str]],
+) -> Tuple[np.ndarray, float, int]:
+    """:func:`_optimize_adaquant`, run through :mod:`onnxsim.qat_graph`
+    instead of in host numpy, on ``providers``.
+
+    Same optimization, up to the float32 the step graph computes in (the numpy
+    loop uses float64, which is not something a GPU/NPU execution provider
+    offers). The activation branch is where that shows most: an element whose
+    ``x / scale`` sits within a float32 ulp of a .5 boundary can round to a
+    different integer in the two paths, which perturbs the scale and
+    zero-point gradients slightly -- so the two agree closely, not exactly.
+    """
+    scale_nk, v0, floor_base, log_s0, zp0 = _init_adaquant(
+        w_nk, scale_n, x_scale0, x_zp0
+    )
+    step = _build_adaquant_step_graph(x.shape[0], w_nk.shape[0], w_nk.shape[1])
+
+    warm_start_iters = int(num_iterations * warm_start)
+    beta_start, beta_end = beta_range
+
+    def scalars(t: int) -> Dict[str, float]:
+        values = {
+            "w_lr": weight_learning_rate,
+            "a_lr": activation_learning_rate,
+        }
+        if t >= warm_start_iters:
+            progress = (t - warm_start_iters) / max(
+                1, num_iterations - warm_start_iters - 1
+            )
+            values["reg_scale"] = reg_param
+            values["beta"] = beta_start + (beta_end - beta_start) * progress
+        else:
+            # The regularizer is switched off by its own weight rather than by
+            # a second graph. `beta` still needs a value Pow can evaluate --
+            # 1.0 makes the (zero-weighted) term |u|^0, finite everywhere.
+            values["reg_scale"] = 0.0
+            values["beta"] = 1.0
+        values.update(qat_graph.adam_bias_corrections(t))
+        return values
+
+    zero = np.zeros((), dtype=np.float64)
+    final = qat_graph.run_step_graph(
+        step,
+        constants={
+            "x": x,
+            "y_float": x @ w_nk.T,
+            "floor_base": floor_base,
+            "scale": scale_nk,
+        },
+        state={
+            "v": v0,
+            "m_v": np.zeros_like(v0),
+            "vv_v": np.zeros_like(v0),
+            "log_s": np.asarray(log_s0, dtype=np.float64),
+            "m_s": zero,
+            "vv_s": zero,
+            "zp": np.asarray(zp0, dtype=np.float64),
+            "m_zp": zero,
+            "vv_zp": zero,
+        },
+        num_steps=num_iterations,
+        scalars=scalars,
+        providers=providers,
+    )
+    return _adaquant_results(
+        final["v"].astype(np.float64),
+        floor_base,
+        float(final["log_s"]),
+        float(final["zp"]),
+    )
 
 
 def apply_adaquant(
@@ -343,6 +640,7 @@ def apply_adaquant(
     warm_start: float = 0.2,
     beta_range: Tuple[float, float] = (20.0, 2.0),
     providers: Optional[Sequence[str]] = None,
+    step_providers: Optional[Sequence[str]] = None,
 ) -> onnx.ModelProto:
     """Optimizes AdaQuant-style joint weight-rounding + activation-clip-range
     calibration for every :func:`onnxsim.quantize_static`-quantized
@@ -390,6 +688,14 @@ def apply_adaquant(
             iterations after ``warm_start``
     :param providers: onnxruntime execution providers to run ``float_model``
             on when capturing calibration activations
+    :param step_providers: onnxruntime execution providers to run the *Adam
+            optimization itself* on, as an ONNX step graph
+            (:mod:`onnxsim.qat_graph`) rather than in host numpy -- the way to
+            reach a GPU, an NPU execution provider, or (in the WASM build)
+            WebGPU with this loop. ``None``, the default, keeps the in-process
+            float64 numpy loop, which is exact and deterministic; a step graph
+            computes in float32, so its result agrees closely rather than
+            bit-exactly. See ``docs/qat.md``.
     :returns: ``quantized_model`` with every matched layer's weight INT8
             codes and activation (scale, zero_point) initializers rewritten
             to their jointly-optimized values (same shapes/dtypes -- the
@@ -452,7 +758,14 @@ def apply_adaquant(
         x_scale0 = float(onnx.numpy_helper.to_array(x_scale_init).reshape(-1)[0])
         x_zp0 = float(onnx.numpy_helper.to_array(x_zp_init).reshape(-1)[0])
 
-        codes_nk, x_scale, x_zp = _optimize_adaquant(
+        optimize = (
+            _optimize_adaquant
+            if step_providers is None
+            else functools.partial(
+                _optimize_adaquant_on_graph, providers=step_providers
+            )
+        )
+        codes_nk, x_scale, x_zp = optimize(
             w_nk,
             scale_n,
             x,

--- a/onnxsim/backend.py
+++ b/onnxsim/backend.py
@@ -375,6 +375,101 @@ def run_model(
     return _run_with_reference(model, inputs, output_names, custom_lib, providers)
 
 
+# Which onnxruntime ``OrtValue`` device an execution provider keeps its tensors
+# on, for :meth:`Runner.bind_loop`. The strings are the ones onnxruntime's own
+# ``get_ort_device_type`` accepts; a provider missing from this table is bound
+# on the CPU, which is always *correct* -- onnxruntime then inserts the same
+# host-to-device copy the unbound path pays -- just not always the fastest
+# place. The ROCm/MIGraphX entries reuse the CUDA device enum, which is what
+# onnxruntime's ROCm build itself does; if that guess is ever wrong the
+# allocation raises and :meth:`Runner.bind_loop` degrades to the unbound path,
+# so it cannot produce a wrong answer.
+_PROVIDER_DEVICES: Dict[str, str] = {
+    "CPUExecutionProvider": "cpu",
+    "CUDAExecutionProvider": "cuda",
+    "TensorrtExecutionProvider": "cuda",
+    "ROCMExecutionProvider": "cuda",
+    "MIGraphXExecutionProvider": "cuda",
+    "CANNExecutionProvider": "cann",
+    "DmlExecutionProvider": "dml",
+    "WebGpuExecutionProvider": "webgpu",
+}
+
+# onnxruntime reports an output's type as a string like ``"tensor(float)"``.
+# Only tensor element types with a numpy equivalent can be pre-allocated as a
+# bound output buffer; anything else (a sequence, a map, a type numpy has no
+# dtype for) makes :meth:`Runner.bind_loop` decline.
+_ORT_TYPE_TO_NUMPY: Dict[str, Any] = {
+    "tensor(float)": np.float32,
+    "tensor(double)": np.float64,
+    "tensor(float16)": np.float16,
+    "tensor(int64)": np.int64,
+    "tensor(int32)": np.int32,
+    "tensor(int16)": np.int16,
+    "tensor(int8)": np.int8,
+    "tensor(uint64)": np.uint64,
+    "tensor(uint32)": np.uint32,
+    "tensor(uint16)": np.uint16,
+    "tensor(uint8)": np.uint8,
+    "tensor(bool)": np.bool_,
+}
+
+
+def _binding_device(providers: Optional[Sequence[Provider]]) -> Tuple[str, int]:
+    """The ``(device_type, device_id)`` to allocate bound tensors on for
+    ``providers``.
+
+    The *first* provider decides: onnxruntime tries the list in priority order
+    and only falls back for operators the leading provider cannot run, so its
+    device is where a step graph's tensors want to live. An unrecognized
+    provider, or one whose options do not name a device, gets ``("cpu", 0)`` --
+    see :data:`_PROVIDER_DEVICES` for why that is safe.
+    """
+    if not providers:
+        return "cpu", 0
+    provider = providers[0]
+    device = _PROVIDER_DEVICES.get(_provider_name(provider), "cpu")
+    device_id = 0
+    if isinstance(provider, (tuple, list)) and len(provider) > 1:
+        options = provider[1]
+        if isinstance(options, dict):
+            requested = options.get("device_id", 0)
+            if isinstance(requested, (int, str)):
+                try:
+                    device_id = int(requested)
+                except ValueError:
+                    device_id = 0
+    return device, device_id
+
+
+def _static_output_spec(meta: Any) -> Optional[Tuple[List[int], Any]]:
+    """``(shape, numpy dtype)`` for an onnxruntime output whose buffer can be
+    allocated up front, or ``None`` when it cannot.
+
+    A bound output needs a buffer before the run that fills it, so every
+    dimension has to be a concrete integer -- onnxruntime reports a symbolic or
+    unknown dimension as a string or ``None`` -- and the element type has to be
+    one numpy can hold. Returning ``None`` is not an error: it is how
+    :meth:`Runner.bind_loop` decides that this model is not one it can bind,
+    and the caller keeps using the ordinary feed-per-call path.
+    """
+    ort_type = getattr(meta, "type", None)
+    if not isinstance(ort_type, str):
+        return None
+    dtype = _ORT_TYPE_TO_NUMPY.get(ort_type)
+    if dtype is None:
+        return None
+    shape = getattr(meta, "shape", None)
+    if shape is None:
+        return None
+    dims: List[int] = []
+    for dim in shape:
+        if not isinstance(dim, int) or isinstance(dim, bool) or dim < 0:
+            return None
+        dims.append(dim)
+    return dims, dtype
+
+
 class Runner:
     """A model prepared once and run many times.
 
@@ -451,3 +546,226 @@ class Runner:
         else:
             outputs = cast(List[np.ndarray], self._sess.run(self._output_names, inputs))
         return OrderedDict(zip(self._output_names, outputs))
+
+    def bind_loop(
+        self,
+        constants: Dict[str, np.ndarray],
+        state: Dict[str, Tuple[str, np.ndarray]],
+    ) -> Optional["BoundStepLoop"]:
+        """Prepare a device-resident, state-threading loop over this model, or
+        return ``None`` if this backend cannot provide one.
+
+        :meth:`__call__` re-sends every input on every call, because that is
+        what ``InferenceSession.run`` takes: a fresh ``{name: numpy array}``
+        dict. For an optimization loop that is the wrong shape of API. The
+        constants (calibration activations, a reconstruction target) never
+        change, and the state (the parameter being trained, Adam's moments) is
+        produced by the previous step -- so on a non-CPU provider every step
+        pays a host-to-device copy of *everything*, plus a device-to-host copy
+        back, for tensors that never needed to leave the device. Over a few
+        hundred steps that transfer, not the arithmetic, is the loop.
+
+        ``IOBinding`` is onnxruntime's answer: bind a tensor once, run against
+        the binding. This method uploads the constants once, allocates the
+        state on the session's device, and hands back a
+        :class:`BoundStepLoop` that runs step after step with only the
+        per-step scalars going up and only the explicitly fetched outputs
+        coming down.
+
+        :param constants: inputs whose value is the same on every step. Copied
+                to the device once. The copy is defensive: a caller's array
+                would otherwise stay aliased by the binding for the loop's
+                whole life.
+        :param state: ``{input name: (output name, initial value)}`` -- the
+                inputs each step re-supplies from the previous step's output.
+                The output is required to have the same shape and dtype as the
+                input it feeds; that is the step-graph contract
+                (:func:`onnxsim.qat_graph.make_step_graph` builds exactly this)
+                and it is verified here against the session's own metadata.
+
+        Returns ``None`` -- meaning "run the ordinary way" -- whenever binding
+        cannot be set up: no onnxruntime (the reference evaluator has no
+        binding and no devices), an onnxruntime too old for ``io_binding``, an
+        output whose buffer cannot be pre-allocated (dynamic shape, or a type
+        numpy cannot hold), a shape that contradicts the model, or an
+        allocation the provider refuses. Binding is a pure optimization, so
+        every one of those is a reason to fall back rather than to fail: the
+        caller gets the same numbers either way.
+        """
+        if not _HAS_ONNXRUNTIME or not hasattr(self._sess, "io_binding"):
+            return None
+        # Everything below is best-effort. A broad except is deliberate here:
+        # any failure at all -- an unavailable device string, an allocator that
+        # refuses, an onnxruntime whose binding API differs -- must land the
+        # caller on the unbound path, never on a traceback, because binding
+        # changes nothing about the answer.
+        try:
+            device_type, device_id = _binding_device(self._providers)
+            metadata = {o.name: o for o in self._sess.get_outputs()}
+            state_outputs = {name: out for name, (out, _) in state.items()}
+            produced = set(state_outputs.values())
+            if not produced <= set(metadata):
+                return None
+
+            buffers: Dict[str, List[Any]] = {}
+            for name, (out, value) in state.items():
+                array = np.ascontiguousarray(value)
+                spec = _static_output_spec(metadata[out])
+                if spec is None:
+                    return None
+                shape, dtype = spec
+                if tuple(shape) != array.shape or np.dtype(dtype) != array.dtype:
+                    return None
+                # Two buffers per state tensor, alternated by
+                # :meth:`BoundStepLoop.step` -- see its comment for why one
+                # would not be safe. Both are allocated by onnxruntime rather
+                # than wrapped around the caller's numpy array: on the CPU
+                # ``ortvalue_from_numpy`` aliases the array it is given, so a
+                # single buffer would make the caller's own initial state the
+                # loop's scratch space.
+                pair = [
+                    rt.OrtValue.ortvalue_from_shape_and_type(
+                        list(array.shape), dtype, device_type, device_id
+                    )
+                    for _ in range(2)
+                ]
+                # The one copy of the state the loop pays: the initial value
+                # into the buffer onnxruntime allocated for it.
+                pair[0].update_inplace(array)
+                buffers[name] = pair
+
+            binding = self._sess.io_binding()
+            # onnxruntime requires *every* model output to be bound before
+            # ``run_with_iobinding``, not only the ones this Runner fetches, so
+            # each non-state output gets a host buffer whether the caller reads
+            # it or not.
+            host_outputs: "OrderedDict[str, Any]" = OrderedDict()
+            for name, meta in metadata.items():
+                if name in produced:
+                    continue
+                spec = _static_output_spec(meta)
+                if spec is None:
+                    return None
+                shape, dtype = spec
+                value = rt.OrtValue.ortvalue_from_shape_and_type(shape, dtype, "cpu", 0)
+                host_outputs[name] = value
+                binding.bind_ortvalue_output(name, value)
+
+            # The constants: copied to the device once, bound once, never
+            # touched again. This is the whole point of the exercise.
+            resident: List[Any] = []
+            for name, value in constants.items():
+                array = np.array(value, copy=True, order="C")
+                ort_value = rt.OrtValue.ortvalue_from_numpy(
+                    array, device_type, device_id
+                )
+                resident.append(ort_value)
+                binding.bind_ortvalue_input(name, ort_value)
+
+            return BoundStepLoop(
+                self._sess,
+                self._run_options,
+                binding,
+                device_type,
+                buffers,
+                state_outputs,
+                host_outputs,
+                resident,
+            )
+        except Exception:
+            return None
+
+
+class BoundStepLoop:
+    """One step of a state-threading loop, run against onnxruntime tensors that
+    stay where the execution provider put them.
+
+    Created by :meth:`Runner.bind_loop`, never directly. The loop it serves is
+    the one :func:`onnxsim.qat_graph.run_step_graph` runs: a pure
+    ``(constants, state, per-step scalars) -> (next state, loss)`` function
+    applied over and over, each step's state outputs becoming the next step's
+    state inputs. Expressed through ``InferenceSession.run`` that costs a full
+    round trip of the state per step; expressed through ``IOBinding`` the state
+    never leaves the device at all, and what crosses the bus is a handful of
+    scalars up and (only if the caller asked for it) a scalar loss down.
+
+    The buffers are owned here and reused, so an instance is single-threaded
+    and stateful by construction: :meth:`step` advances it, :meth:`state` reads
+    where it got to.
+    """
+
+    def __init__(
+        self,
+        sess: Any,
+        run_options: Any,
+        binding: Any,
+        device_type: str,
+        buffers: Dict[str, List[Any]],
+        state_outputs: Dict[str, str],
+        host_outputs: "OrderedDict[str, Any]",
+        resident: List[Any],
+    ) -> None:
+        self._sess = sess
+        self._run_options = run_options
+        self._binding = binding
+        self._device_type = device_type
+        self._buffers = buffers
+        self._state_outputs = state_outputs
+        self._host_outputs = host_outputs
+        # Held only to keep the constants' device memory (and, on the CPU, the
+        # numpy arrays onnxruntime's OrtValues alias rather than copy) alive
+        # for as long as the binding refers to it.
+        self._resident = resident
+        self._slot = 0
+
+    def step(self, scalars: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+        """Run one step and return the host-side outputs.
+
+        ``scalars`` are the only inputs that go up per step: they are bound
+        from host memory each time (they are rank-0, so the transfer is
+        nothing), while the constants stay bound from :meth:`Runner.bind_loop`
+        and the state is bound from the buffers below.
+        """
+        for name, value in scalars.items():
+            self._binding.bind_cpu_input(name, value)
+
+        # Ping-pong: read this step's state out of one buffer, write the next
+        # state into the other, then swap. The single-buffer version -- bind
+        # the same OrtValue as both the state input and the state output --
+        # looks natural and is a correctness trap: onnxruntime is free to begin
+        # writing an output before it has finished reading every input, and
+        # free to hand a bound output buffer straight back to the next
+        # ``run_with_iobinding`` call, so a step could overwrite the very
+        # values it is still computing from. Two buffers make each run's read
+        # set and write set disjoint, which costs one extra tensor per state
+        # entry and removes the question entirely.
+        source, target = self._slot, 1 - self._slot
+        for name, output in self._state_outputs.items():
+            self._binding.bind_ortvalue_input(name, self._buffers[name][source])
+            self._binding.bind_ortvalue_output(output, self._buffers[name][target])
+
+        if self._device_type != "cpu":
+            # On a real device the copies onnxruntime issues for the bound
+            # inputs and outputs are asynchronous; on the CPU there is nothing
+            # to wait for, so skip the call rather than pay it 400 times.
+            self._binding.synchronize_inputs()
+        self._sess.run_with_iobinding(self._binding, self._run_options)
+        if self._device_type != "cpu":
+            self._binding.synchronize_outputs()
+        self._slot = target
+
+        # The host buffers are reused across steps, so the caller sees this
+        # step's values only until the next one -- which is all
+        # ``run_step_graph`` needs (it turns the loss into a float immediately).
+        return {name: value.numpy() for name, value in self._host_outputs.items()}
+
+    def state(self) -> "OrderedDict[str, np.ndarray]":
+        """The current state, copied back to the host as numpy arrays.
+
+        Copied, not aliased: the buffers behind it are this loop's own scratch
+        space and the next :meth:`step` would write through them.
+        """
+        return OrderedDict(
+            (name, self._buffers[name][self._slot].numpy().copy())
+            for name in self._state_outputs
+        )

--- a/onnxsim/graph_grad.py
+++ b/onnxsim/graph_grad.py
@@ -1,0 +1,674 @@
+"""Reverse-mode automatic differentiation over a slice of an ONNX graph, with
+the gradient itself emitted as ordinary ONNX nodes.
+
+:mod:`onnxsim.qat_graph` explains why a training step can run on an inference
+runtime at all: a hand-derived backward pass is plain dataflow, so it is
+expressible as an ordinary ONNX graph and therefore runs wherever an ONNX
+model runs -- CUDA, an NPU execution provider, WebGPU in the browser. This
+module removes the "hand-derived" part of that sentence.
+
+**Why that matters.** Every gradient in this repo today is written out by
+hand, once per pass, for one fixed expression:
+:func:`onnxsim.adaround._build_rounding_step_graph` is twenty lines of
+carefully transcribed chain rule for *one* layer's reconstruction error. That
+scales as long as the forward is a single MatMul, and stops scaling the
+moment it is not -- which is exactly the wall :mod:`onnxsim.brecq` documents
+in its own docstring: its block discovery recognizes only a **linear chain**
+of MatMul/Gemm layers with no normalization or activation node in between,
+because every additional op shape would mean another hand-derived backward.
+Block-wise QAT (``docs/qat.md``, deliverable B) needs the gradient of a real
+transformer block -- MatMuls, a GELU, a residual Add, a Softmax -- against
+its own output, and nobody should transcribe that by hand.
+
+So: given the block's forward nodes, walk them in reverse, and for each one
+append the nodes computing its vector-Jacobian product. The output is more
+ONNX nodes in the same :class:`onnxsim.qat_graph.GraphBuilder`, so the result
+composes with :func:`onnxsim.qat_graph.adam_update` and
+:func:`onnxsim.qat_graph.make_step_graph` exactly as a hand-derived gradient
+does, and reaches the same execution providers.
+
+**What this is not.** It is not an autograd framework: there is no tape, no
+``Tensor`` wrapper, no ``Gradient`` operator, and no runtime involvement --
+differentiation happens once, at graph build time, and what ships is an
+inference graph. It is also deliberately incomplete: a rule exists for the
+ops a quantization-reconstruction block is made of
+(:data:`SUPPORTED_OPS`), and an op without a rule raises
+:class:`UnsupportedOpError` rather than being approximated or skipped. That
+conservative boundary is the same one :mod:`onnxsim.pruning` and
+:mod:`onnxsim.finetune` draw: refusing a case is recoverable, silently
+emitting a wrong gradient is not -- it shows up as a model that trains to a
+slightly worse answer, which is nearly impossible to attribute after the
+fact.
+
+**The one subtlety worth naming up front: broadcasting.** ``Add``, ``Mul``,
+``Div`` and friends broadcast their inputs numpy-style, and the gradient of a
+broadcast is a *sum* over the axes that were broadcast. A rule that returns
+the incoming gradient unchanged for ``[4, 3] + [3]`` produces a ``[4, 3]``
+gradient for a ``[3]`` parameter; ONNX will happily carry that shape
+mismatch into the optimizer, where it broadcasts again and updates the
+parameter with four times the intended step. Every rule here therefore
+routes each contribution through :meth:`_Backward.reduce_to`, and
+``tests/test_graph_grad.py`` tests broadcasting shapes on their own.
+
+Everything is float32 at opset 17 / IR version 8 -- the pairing
+:mod:`onnxsim.qat_graph` already builds and the accelerator backends already
+run.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import onnx
+
+from onnxsim import qat_graph
+
+# The complete set of operators the rules below can emit. Same standard the
+# step graphs in ``tests/test_qat_graph.py`` are held to, and for the same
+# reason: this machinery exists so training can run on WebGPU and NPU
+# execution providers, and a backward graph that reached for a convenient op
+# no such provider implements would be numerically perfect and practically
+# useless. Everything here is plain arithmetic, a comparison, a reduction or
+# a reshape. Deliberately absent: ``Where`` and boolean logic (a mask is a
+# float 0/1 from ``Cast(Greater(...))``, multiplied in -- ``GraphBuilder``'s
+# own convention), ``Expand`` (a broadcast is a multiply by a constant
+# instead, see :func:`_grad_reduce`), and anything resembling control flow.
+BACKWARD_OPS = frozenset(
+    {
+        "Add",
+        "Cast",
+        "Div",
+        "Exp",
+        "Greater",
+        "Less",
+        "MatMul",
+        "Mul",
+        "Neg",
+        "ReduceSum",
+        "Reshape",
+        "Sub",
+        "Transpose",
+    }
+)
+
+
+class UnsupportedOpError(ValueError):
+    """Raised for a node whose op type has no VJP rule.
+
+    Also raised for a node whose op type *is* covered but whose particular
+    configuration is not (a 1-D ``MatMul`` operand, a ``Reduce*`` whose
+    reduced axes cannot be recovered from the shapes alone). The distinction
+    does not matter to a caller: either way this module refuses to
+    differentiate that node, and the caller must exclude it from the slice --
+    which is the point. Guessing would produce a gradient that is quietly
+    wrong.
+    """
+
+
+def _attr(node: onnx.NodeProto, name: str, default: Any) -> Any:
+    """One of ``node``'s attributes by name, or ``default``.
+
+    Typed loosely on purpose: an ONNX attribute is an int, a float or a list
+    of ints depending on which one it is, and every caller below knows which
+    it asked for.
+    """
+    for attribute in node.attribute:
+        if attribute.name == name:
+            return onnx.helper.get_attribute_value(attribute)
+    return default
+
+
+class _Backward:
+    """Build-time state shared by the rules: the builder they append to, and
+    the static shape of every tensor in the slice.
+
+    Shapes are needed at build time, not run time, because the two things a
+    correct VJP cannot do without -- undoing a broadcast, and undoing a
+    reduction -- are both shape arithmetic. Requiring them up front is also
+    why this module never emits ``Shape``/``Gather`` plumbing, which is the
+    part of a generic autodiff implementation that accelerator backends
+    handle worst.
+    """
+
+    def __init__(
+        self, b: qat_graph.GraphBuilder, shapes: Dict[str, Sequence[int]]
+    ) -> None:
+        self.b = b
+        self.shapes = shapes
+
+    def shape(self, name: str) -> Tuple[int, ...]:
+        if name not in self.shapes:
+            raise ValueError(
+                f"no static shape given for tensor {name!r}; build_backward needs "
+                "the shape of every value the slice touches"
+            )
+        return tuple(int(d) for d in self.shapes[name])
+
+    def int64_const(self, values: Sequence[int], hint: str = "i") -> str:
+        """An int64 initializer, for the ``axes``/``shape`` inputs that
+        ``ReduceSum`` and ``Reshape`` take as tensors from opset 13 on.
+
+        ``GraphBuilder.const`` is float32-only, which is right for everything
+        it was written for; these two are the exceptions.
+        """
+        array = np.asarray(list(values), dtype=np.int64)
+        name = self.b.name(hint)
+        self.b.initializer.append(onnx.numpy_helper.from_array(array, name))
+        return name
+
+    def reduce_to(
+        self, grad: str, grad_shape: Sequence[int], target_shape: Sequence[int]
+    ) -> str:
+        """Sums ``grad`` back down to ``target_shape``, undoing a numpy-style
+        broadcast.
+
+        A binary op broadcasts a ``[3]`` operand against a ``[4, 3]`` one by
+        replicating it four times; each replica gets its own gradient, and the
+        gradient of the original is their sum. Leading axes the operand did
+        not have at all are summed away entirely; axes it had as size 1 are
+        summed with ``keepdims`` and then reshaped back, since ONNX's
+        ``ReduceSum`` cannot drop *some* axes and keep others as size 1 in one
+        node.
+        """
+        grad_shape = tuple(int(d) for d in grad_shape)
+        target_shape = tuple(int(d) for d in target_shape)
+        if grad_shape == target_shape:
+            return grad
+
+        offset = len(grad_shape) - len(target_shape)
+        if offset < 0:
+            raise ValueError(
+                f"cannot reduce a gradient of shape {grad_shape} to {target_shape}: "
+                "the gradient has fewer dimensions than the tensor it belongs to"
+            )
+        axes = list(range(offset))
+        for i, dim in enumerate(target_shape):
+            actual = grad_shape[offset + i]
+            if dim == actual:
+                continue
+            if dim == 1:
+                axes.append(offset + i)
+            else:
+                raise ValueError(
+                    f"gradient shape {grad_shape} is not a broadcast of {target_shape}"
+                )
+
+        out = grad
+        if axes:
+            out = self.b.op(
+                "ReduceSum",
+                [out, self.int64_const(axes, "axes")],
+                "unbcast",
+                keepdims=1,
+            )
+        summed = tuple(1 if i in set(axes) else d for i, d in enumerate(grad_shape))
+        if summed != target_shape:
+            out = self.b.op(
+                "Reshape", [out, self.int64_const(target_shape, "shape")], "unbcast"
+            )
+        return out
+
+    def transpose_last_two(self, name: str, shape: Sequence[int]) -> str:
+        """``name`` with its last two axes swapped -- what a MatMul's own VJP
+        needs, and what a bare ``Transpose`` (which reverses *all* axes) would
+        get wrong for a batched operand."""
+        rank = len(shape)
+        perm = list(range(rank - 2)) + [rank - 1, rank - 2]
+        return self.b.transpose(name, perm)
+
+    def mask_greater(self, x: str, bound: str) -> str:
+        """``(x > bound)`` as a float32 0/1 tensor, with ``bound`` a tensor
+        name rather than ``GraphBuilder.greater_mask``'s python float."""
+        gt = self.b.op("Greater", [x, bound])
+        return self.b.op("Cast", [gt], to=onnx.TensorProto.FLOAT)
+
+    def mask_less(self, x: str, bound: str) -> str:
+        """``(x < bound)`` as a float32 0/1 tensor."""
+        lt = self.b.op("Less", [x, bound])
+        return self.b.op("Cast", [lt], to=onnx.TensorProto.FLOAT)
+
+
+# A rule takes the build context, the forward node, and the name of the
+# gradient flowing into that node's single output; it appends nodes and
+# returns one gradient name per node input (``None`` where an input takes no
+# gradient -- a ``Reshape``'s shape operand, a ``Clip``'s bounds).
+Rule = Callable[[_Backward, onnx.NodeProto, str], List[Optional[str]]]
+
+
+def _grad_matmul(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    a, b = node.input[0], node.input[1]
+    sa, sb = ctx.shape(a), ctx.shape(b)
+    if len(sa) < 2 or len(sb) < 2:
+        # ONNX MatMul promotes a 1-D operand to a matrix and then removes the
+        # inserted axis from the result. Differentiating that means undoing
+        # the removal, which is a different code path from the batched case
+        # and is not worth carrying until a block needs it.
+        raise UnsupportedOpError(
+            f"MatMul with a 1-D operand is not differentiated here (node "
+            f"{node.output[0]!r}, operand shapes {sa} and {sb})"
+        )
+    # dA = G @ B^T, dB = A^T @ G, both then summed back over whatever batch
+    # axes broadcasting replicated.
+    batch = tuple(np.broadcast_shapes(sa[:-2], sb[:-2]))
+    ga = ctx.b.matmul(g, ctx.transpose_last_two(b, sb))
+    gb = ctx.b.matmul(ctx.transpose_last_two(a, sa), g)
+    return [
+        ctx.reduce_to(ga, batch + (sa[-2], sa[-1]), sa),
+        ctx.reduce_to(gb, batch + (sb[-2], sb[-1]), sb),
+    ]
+
+
+def _grad_gemm(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    alpha = float(_attr(node, "alpha", 1.0))
+    beta = float(_attr(node, "beta", 1.0))
+    trans_a = bool(_attr(node, "transA", 0))
+    trans_b = bool(_attr(node, "transB", 0))
+    a, b = node.input[0], node.input[1]
+    sa, sb = ctx.shape(a), ctx.shape(b)
+    if len(sa) != 2 or len(sb) != 2:
+        raise UnsupportedOpError(
+            f"Gemm expects 2-D A and B, got {sa} and {sb} (node {node.output[0]!r})"
+        )
+
+    # Y = alpha * A' B' + beta * C, with A' = A^T when transA. Differentiate
+    # with respect to A' and B' first -- that is the plain matrix-product VJP
+    # -- then transpose back into A's and B's own layouts. alpha scales the
+    # incoming gradient once instead of scaling both results.
+    gs = ctx.b.mul(g, ctx.b.const(alpha)) if alpha != 1.0 else g
+    ga = ctx.b.matmul(gs, b if trans_b else ctx.b.transpose(b, [1, 0]))
+    if trans_a:
+        ga = ctx.b.transpose(ga, [1, 0])
+    gb = ctx.b.matmul(a if trans_a else ctx.b.transpose(a, [1, 0]), gs)
+    if trans_b:
+        gb = ctx.b.transpose(gb, [1, 0])
+
+    grads: List[Optional[str]] = [ga, gb]
+    if len(node.input) > 2:
+        if node.input[2]:
+            # C broadcasts against [M, N], so its gradient needs the same
+            # broadcast-undoing every elementwise rule needs.
+            gc = ctx.reduce_to(g, ctx.shape(node.output[0]), ctx.shape(node.input[2]))
+            grads.append(ctx.b.mul(gc, ctx.b.const(beta)) if beta != 1.0 else gc)
+        else:
+            # C spelled as an omitted optional input ("") rather than left off
+            # the node entirely -- there is no tensor to give a gradient to.
+            grads.append(None)
+    return grads
+
+
+def _grad_add(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    out = ctx.shape(node.output[0])
+    return [
+        ctx.reduce_to(g, out, ctx.shape(node.input[0])),
+        ctx.reduce_to(g, out, ctx.shape(node.input[1])),
+    ]
+
+
+def _grad_sub(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    out = ctx.shape(node.output[0])
+    # Negate after reducing, not before: the reduced tensor is the smaller of
+    # the two, so this is the same value for fewer elementwise operations.
+    gb = ctx.reduce_to(g, out, ctx.shape(node.input[1]))
+    return [ctx.reduce_to(g, out, ctx.shape(node.input[0])), ctx.b.op("Neg", [gb])]
+
+
+def _grad_mul(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    a, b = node.input[0], node.input[1]
+    out = ctx.shape(node.output[0])
+    return [
+        ctx.reduce_to(ctx.b.mul(g, b), out, ctx.shape(a)),
+        ctx.reduce_to(ctx.b.mul(g, a), out, ctx.shape(b)),
+    ]
+
+
+def _grad_div(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    a, b = node.input[0], node.input[1]
+    y = node.output[0]
+    out = ctx.shape(y)
+    # d/db (a/b) = -a/b^2 = -y/b, reusing the forward quotient rather than
+    # recomputing a square: one fewer node and no risk of overflowing b^2.
+    gb = ctx.b.op("Neg", [ctx.b.div(ctx.b.mul(g, y), b)])
+    return [
+        ctx.reduce_to(ctx.b.div(g, b), out, ctx.shape(a)),
+        ctx.reduce_to(gb, out, ctx.shape(b)),
+    ]
+
+
+def _grad_neg(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    return [ctx.b.op("Neg", [g])]
+
+
+def _grad_identity(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    # An alias, not a node: the gradient of the output *is* the gradient of
+    # the input, and emitting an Identity to say so would only add a copy.
+    return [g]
+
+
+def _grad_relu(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    # The subgradient at exactly 0 is taken as 0 (strict Greater), matching
+    # the straight-through masks adaround.py already builds.
+    return [ctx.b.mul(g, ctx.b.greater_mask(node.input[0], 0.0))]
+
+
+def _grad_sigmoid(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    # y (1 - y), from the forward output: the forward already computed the
+    # sigmoid, so the backward never calls it again.
+    y = node.output[0]
+    dy = ctx.b.mul(y, ctx.b.sub(ctx.b.const(1.0), y))
+    return [ctx.b.mul(g, dy)]
+
+
+def _grad_tanh(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    y = node.output[0]
+    dy = ctx.b.sub(ctx.b.const(1.0), ctx.b.mul(y, y))
+    return [ctx.b.mul(g, dy)]
+
+
+def _grad_erf(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    # 2/sqrt(pi) * exp(-x^2). This one is here entirely for GELU, which
+    # docs/qat.md's block-wise fine-tuning meets in every transformer FFN.
+    x = node.input[0]
+    dy = ctx.b.mul(
+        ctx.b.const(2.0 / np.sqrt(np.pi)),
+        ctx.b.op("Exp", [ctx.b.op("Neg", [ctx.b.mul(x, x)])]),
+    )
+    return [ctx.b.mul(g, dy)]
+
+
+def _grad_exp(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    return [ctx.b.mul(g, node.output[0])]
+
+
+def _grad_sqrt(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    # 0.5 / sqrt(x), again reusing the forward result. Singular at x = 0, as
+    # the derivative genuinely is -- not something to paper over here.
+    return [ctx.b.div(ctx.b.mul(g, ctx.b.const(0.5)), node.output[0])]
+
+
+def _grad_transpose(
+    ctx: _Backward, node: onnx.NodeProto, g: str
+) -> List[Optional[str]]:
+    rank = len(ctx.shape(node.input[0]))
+    perm = _attr(node, "perm", None)
+    axes = list(reversed(range(rank))) if perm is None else [int(p) for p in perm]
+    inverse = [0] * rank
+    for position, axis in enumerate(axes):
+        inverse[axis] = position
+    return [ctx.b.transpose(g, inverse)]
+
+
+def _grad_reshape(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    shape = ctx.shape(node.input[0])
+    return [ctx.b.op("Reshape", [g, ctx.int64_const(shape, "shape")]), None]
+
+
+def _reduced_axes(
+    node: onnx.NodeProto, in_shape: Tuple[int, ...], out_shape: Tuple[int, ...]
+) -> List[int]:
+    """Which axes a ``Reduce*`` node reduced over.
+
+    From opset 13 the axes are a *tensor input*, and ``build_backward`` is
+    given nodes and shapes but not the initializers behind them, so the axes
+    have to be recovered from the shapes. With ``keepdims=1`` that is exact
+    (a reduced axis is one that became 1). With ``keepdims=0`` the axes were
+    deleted, and recovering them means asking which deletions produce the
+    observed output shape -- usually one answer, but ``[3, 3] -> [3]`` has
+    two that disagree about where the gradient goes, and that case is refused
+    rather than guessed. An explicit ``axes`` *attribute* (the pre-opset-13
+    spelling, still seen on older graphs) short-circuits all of this.
+    """
+    rank = len(in_shape)
+    attribute = _attr(node, "axes", None)
+    if attribute is not None:
+        return sorted({int(a) % rank for a in attribute})
+
+    keepdims = bool(_attr(node, "keepdims", 1))
+    if keepdims:
+        if len(out_shape) != rank:
+            raise UnsupportedOpError(
+                f"{node.op_type} with keepdims=1 changed rank {rank} to "
+                f"{len(out_shape)} (node {node.output[0]!r})"
+            )
+        # An axis that is 1 on both sides may or may not have been reduced,
+        # and it makes no difference: summing over a length-1 axis and
+        # broadcasting back over it are both the identity.
+        return [i for i in range(rank) if out_shape[i] == 1 and in_shape[i] != 1]
+
+    dropped = rank - len(out_shape)
+    if dropped < 0 or rank > 16:
+        raise UnsupportedOpError(
+            f"cannot recover the reduced axes of {node.output[0]!r} from shapes "
+            f"{in_shape} -> {out_shape}"
+        )
+    candidates = [
+        combo
+        for combo in itertools.combinations(range(rank), dropped)
+        if tuple(d for i, d in enumerate(in_shape) if i not in combo) == out_shape
+    ]
+    if not candidates:
+        raise UnsupportedOpError(
+            f"no set of reduced axes takes {in_shape} to {out_shape} "
+            f"(node {node.output[0]!r})"
+        )
+    # Two candidates that disagree only about length-1 axes imply the same
+    # backward graph, so compare what actually gets built rather than the
+    # axis sets themselves.
+    expanded = {
+        tuple(1 if i in combo else d for i, d in enumerate(in_shape))
+        for combo in candidates
+    }
+    if len(expanded) != 1:
+        raise UnsupportedOpError(
+            f"the reduced axes of {node.output[0]!r} are ambiguous from shapes "
+            f"{in_shape} -> {out_shape}; use keepdims=1 so they can be recovered"
+        )
+    return list(candidates[0])
+
+
+def _grad_reduce(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    """``ReduceSum`` and ``ReduceMean``: broadcast the gradient back over the
+    axes that were reduced away, scaled by 1/count for the mean.
+
+    The broadcast is a multiply by a constant rather than an ``Expand``,
+    which keeps the emitted graph inside :data:`BACKWARD_OPS`. The constant
+    only spans the *reduced* axes (size 1 everywhere else) and broadcasting
+    does the rest, so it costs the size of the reduction rather than the size
+    of the tensor.
+    """
+    x = node.input[0]
+    in_shape = ctx.shape(x)
+    out_shape = ctx.shape(node.output[0])
+    rest: List[Optional[str]] = [None] * (len(node.input) - 1)
+    axes = set(_reduced_axes(node, in_shape, out_shape))
+    if not axes:
+        return [g] + rest
+
+    keepdims_shape = tuple(1 if i in axes else d for i, d in enumerate(in_shape))
+    grad = g
+    if out_shape != keepdims_shape:
+        grad = ctx.b.op("Reshape", [grad, ctx.int64_const(keepdims_shape, "shape")])
+
+    fill = 1.0
+    if node.op_type == "ReduceMean":
+        fill = 1.0 / float(np.prod([in_shape[i] for i in axes]))
+    ones_shape = tuple(d if i in axes else 1 for i, d in enumerate(in_shape))
+    ones = ctx.b.const(np.full(ones_shape, fill, dtype=np.float32), "bcast")
+    return [ctx.b.mul(grad, ones)] + rest
+
+
+def _grad_softmax(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    # dx = y * (g - sum(g * y)) along the softmax axis. Written from the
+    # forward output y, so the backward re-runs neither the exponential nor
+    # its normalization.
+    y = node.output[0]
+    rank = len(ctx.shape(node.input[0]))
+    axis = int(_attr(node, "axis", -1)) % rank
+    total = ctx.b.op(
+        "ReduceSum", [ctx.b.mul(g, y), ctx.int64_const([axis], "axes")], keepdims=1
+    )
+    return [ctx.b.mul(y, ctx.b.sub(g, total))]
+
+
+def _grad_clip(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    """Pass the gradient through where the input was strictly inside the
+    bounds, zero it elsewhere.
+
+    The bounds are used as the tensors they are, so their values need not be
+    known at build time -- and the comparison is strict, so an input sitting
+    exactly on a bound gets no gradient. That matches the straight-through
+    masks in :mod:`onnxsim.adaround` (``greater_mask`` * ``less_mask``) and
+    keeps a clamped-to-the-limit parameter from drifting further out.
+    """
+    x = node.input[0]
+    rest: List[Optional[str]] = [None] * (len(node.input) - 1)
+    mask: Optional[str] = None
+    if len(node.input) > 1 and node.input[1]:
+        mask = ctx.mask_greater(x, node.input[1])
+    if len(node.input) > 2 and node.input[2]:
+        upper = ctx.mask_less(x, node.input[2])
+        mask = upper if mask is None else ctx.b.mul(mask, upper)
+    if mask is None:
+        return [g] + rest
+    return [ctx.b.mul(g, mask)] + rest
+
+
+_RULES: Dict[str, Rule] = {
+    "Add": _grad_add,
+    "Clip": _grad_clip,
+    "Div": _grad_div,
+    "Erf": _grad_erf,
+    "Exp": _grad_exp,
+    "Gemm": _grad_gemm,
+    "Identity": _grad_identity,
+    "MatMul": _grad_matmul,
+    "Mul": _grad_mul,
+    "Neg": _grad_neg,
+    "ReduceMean": _grad_reduce,
+    "ReduceSum": _grad_reduce,
+    "Relu": _grad_relu,
+    "Reshape": _grad_reshape,
+    "Sigmoid": _grad_sigmoid,
+    "Softmax": _grad_softmax,
+    "Sqrt": _grad_sqrt,
+    "Sub": _grad_sub,
+    "Tanh": _grad_tanh,
+    "Transpose": _grad_transpose,
+}
+
+# The op types :func:`build_backward` can differentiate. Callers that pick
+# the slice themselves -- block discovery for QAT, say -- should test against
+# this rather than rediscovering the list by catching
+# :class:`UnsupportedOpError`.
+SUPPORTED_OPS = frozenset(_RULES)
+
+
+def build_backward(
+    b: qat_graph.GraphBuilder,
+    nodes: Sequence[onnx.NodeProto],
+    shapes: Dict[str, Sequence[int]],
+    grad_outputs: Dict[str, str],
+    targets: Sequence[str],
+) -> Dict[str, str]:
+    """Appends the reverse-mode gradient of ``nodes`` to ``b`` and returns
+    where each target's gradient landed.
+
+    The forward slice is differentiated by walking it backwards: each node's
+    rule turns the gradient of its output into gradients of its inputs, and a
+    tensor read by several nodes collects the sum of their contributions
+    (which is the chain rule for a value used more than once -- a residual
+    connection's own input being the case that matters here).
+
+    Nothing is added to the forward graph, and no forward node is modified:
+    the rules read the forward tensors by name, including node *outputs*
+    where reusing them is cheaper than recomputing (``Sigmoid``, ``Tanh``,
+    ``Exp``, ``Sqrt``, ``Softmax``). So the caller must place these nodes
+    after the forward ones in the same graph, and keep the forward
+    intermediates available -- which for a step graph they always are, since
+    it is one graph evaluated once.
+
+    :param b: the builder to append gradient nodes to. Passing the same
+            builder the forward was built with is the normal case; the point
+            is that the result composes with
+            :func:`onnxsim.qat_graph.adam_update` and
+            :func:`onnxsim.qat_graph.make_step_graph`.
+    :param nodes: the forward nodes to differentiate, topologically ordered
+            (the order they appear in a valid ONNX graph). Nodes outside the
+            slice -- everything upstream of its inputs, everything downstream
+            of where ``grad_outputs`` starts -- must not be included.
+    :param shapes: the static shape of every tensor the slice touches, its
+            inputs and outputs included. ``onnx.shape_inference.infer_shapes``
+            on the forward model is the usual source.
+    :param grad_outputs: ``{forward tensor name: tensor holding dL/d(that
+            tensor)}``, the seed of the backward pass -- typically the single
+            output of the block, with the gradient of the reconstruction loss
+            against it. Seeding an *intermediate* tensor is allowed and adds
+            to whatever the slice itself contributes to it, which is what an
+            auxiliary loss on an intermediate activation means.
+    :param targets: the tensors to return gradients for -- the parameters
+            being trained, and any activation whose gradient the caller wants
+            to propagate further.
+    :returns: ``{target name: the tensor holding its gradient}``. A returned
+            name may be one of ``grad_outputs``' own values when the path is
+            a pure alias (a lone ``Identity``), so it is not guaranteed to be
+            produced by a node in ``b``.
+    :raises UnsupportedOpError: for a node this module will not
+            differentiate. It is raised for *every* node in the slice with an
+            unknown op type, including one no gradient reaches, so a caller
+            learns the slice is out of scope from the shape of the graph
+            rather than from whether a particular seed happened to reach it.
+    :raises ValueError: if a target is not reachable from ``grad_outputs``
+            through ``nodes`` (a disconnected target almost always means the
+            slice or the target list is wrong, and a zero gradient would hide
+            it), or if a shape is missing from ``shapes``.
+    """
+    ctx = _Backward(b, shapes)
+    grads: Dict[str, str] = dict(grad_outputs)
+
+    for node in reversed(list(nodes)):
+        rule = _RULES.get(node.op_type)
+        if rule is None:
+            raise UnsupportedOpError(
+                f"no gradient rule for op type {node.op_type!r} "
+                f"(node {node.name or node.output[0]!r}); "
+                f"onnxsim.graph_grad differentiates {sorted(SUPPORTED_OPS)}"
+            )
+        if len(node.output) != 1:
+            raise UnsupportedOpError(
+                f"{node.op_type} has {len(node.output)} outputs; only "
+                "single-output nodes are differentiated here"
+            )
+        g = grads.get(node.output[0])
+        if g is None:
+            # Nothing downstream depends on this node, so every gradient it
+            # would produce is zero. Emitting those zeros would be correct
+            # and pure waste.
+            continue
+        contributions = rule(ctx, node, g)
+        if len(contributions) != len(node.input):
+            raise AssertionError(
+                f"the {node.op_type} rule returned {len(contributions)} gradients "
+                f"for {len(node.input)} inputs"
+            )
+        for name, contribution in zip(node.input, contributions):
+            if not name or contribution is None:
+                continue
+            # A tensor read by several nodes -- or twice by one node, as in
+            # Mul(x, x) -- accumulates. Reverse topological order guarantees
+            # every reader is visited before the producer, so by the time a
+            # producer asks for its output gradient the sum is complete.
+            existing = grads.get(name)
+            grads[name] = (
+                contribution if existing is None else b.add(existing, contribution)
+            )
+
+    result: Dict[str, str] = {}
+    for target in targets:
+        if target not in grads:
+            raise ValueError(
+                f"no gradient reaches {target!r}: it is not downstream of any of "
+                f"{sorted(grad_outputs)} within the given nodes"
+            )
+        result[target] = grads[target]
+    return result

--- a/onnxsim/qat.py
+++ b/onnxsim/qat.py
@@ -41,7 +41,8 @@ backward emitted by :func:`onnxsim.graph_grad.build_backward`, and one
 execution provider ``step_providers=`` names -- CUDA, an NPU EP, WebGPU in
 the WASM build -- and it stays inside
 :data:`onnxsim.qat_graph.EP_FRIENDLY_OPS` to make that real rather than
-nominal (no ``Round``: :func:`onnxsim.adaquant._round_to_nearest` composes
+nominal (no ``Round``:
+:meth:`onnxsim.qat_graph.GraphBuilder.round_to_nearest` composes
 one out of ``Sign``/``Abs``/``Cast``, and this reuses it).
 
 **What this deliberately is not, and does not claim.**
@@ -110,7 +111,6 @@ import onnx.numpy_helper
 import onnx.shape_inference
 
 from onnxsim import backend, graph_grad, qat_graph
-from onnxsim.adaquant import _round_to_nearest
 from onnxsim.adaround import _Candidate, _find_int4_matmul_candidates, _pack_int4
 from onnxsim.bias_correction import _add_probe_outputs
 from onnxsim.calibration import Tensors, generate_random_calibration_data
@@ -126,7 +126,8 @@ _PREFIX = "qat__"
 
 
 def _round_half_away(x: np.ndarray) -> np.ndarray:
-    """Host-side twin of :func:`onnxsim.adaquant._round_to_nearest`.
+    """Host-side twin of
+    :meth:`onnxsim.qat_graph.GraphBuilder.round_to_nearest`.
 
     The export must round the trained master weights exactly the way the
     trained forward did, or the model that ships is not the model whose loss
@@ -266,11 +267,12 @@ def _emit_fake_quant(
 
     Clipping happens *before* rounding rather than after. The two commute
     here because the bounds are integers, and doing it in this order leaves
-    :func:`onnxsim.adaquant._round_to_nearest` with an argument already
+    :meth:`onnxsim.qat_graph.GraphBuilder.round_to_nearest` with an argument
+    already
     bounded to [-7, 7], where its float-to-int32 cast is exact.
     """
     ratio = b.div(w, scale_full)
-    code = _round_to_nearest(b, b.clip(ratio, _N_MIN, _N_MAX))
+    code = b.round_to_nearest(b.clip(ratio, _N_MIN, _N_MAX))
     b.nodes.append(onnx.helper.make_node("Mul", [code, scale_full], [out_name]))
     active = b.mul(
         b.greater_mask(ratio, _N_MIN),

--- a/onnxsim/qat.py
+++ b/onnxsim/qat.py
@@ -1,0 +1,884 @@
+"""Label-free, block-wise quantization-aware fine-tuning -- ``docs/qat.md``'s
+deliverable B, the "knowledge-distillation QAT" that stage 2 of that note
+describes.
+
+Read :mod:`onnxsim.brecq` first. It already optimizes a *block's own final
+output* reconstruction error rather than each layer's own, which is the
+objective this module keeps unchanged. Two things it does not do, and this
+module does:
+
+1. **Any topology :mod:`onnxsim.graph_grad` can differentiate.** BRECQ's own
+   block discovery recognizes a strict linear chain of MatMul/Gemm layers
+   (plus an optional trailing residual ``Add``), and its own docstring says
+   why: every op shape between two quantized layers would mean another
+   hand-derived backward pass. :mod:`onnxsim.graph_grad` removed that cost --
+   it differentiates a slice of an ONNX graph by walking it in reverse and
+   emitting ordinary ONNX nodes -- so a normalization, an activation, a
+   GELU's ``Erf``, a residual, or a Softmax between two Linears is now just
+   more nodes in the slice. That is the headline change here.
+2. **The float weights themselves move.** Every reconstruction pass in this
+   repository -- AdaRound, BRECQ, FOEM, FlexRound, AutoRound -- optimizes
+   only *which of the two neighbouring integers* a weight rounds to. That
+   restriction is what makes them rounding passes. Here the fp32 weight is
+   the trained parameter, fake-quantized in the forward against the same
+   block-wise INT4 grid, with a straight-through estimator through the
+   ``round``/``clip``: an element can migrate several codes away from its
+   round-to-nearest starting point if the block's output error says it
+   should. That is what makes this QAT rather than a seventh rounding pass.
+
+Optionally (``learn_scales=True``) each weight's per-block quantization
+*scale* is trained alongside, LSQ-style (Esser et al., 2020, "Learned Step
+Size Quantization"). The gradient is the one :mod:`onnxsim.autoround`
+already derives in numpy -- ``d(w_hat)/d(scale)`` is ``code - w/scale`` where
+the element is inside the clipping range and just ``code`` where it
+saturates -- summed over each scale's own block.
+
+**Everything runs as one ONNX step graph.** The fake-quant forward, the
+backward emitted by :func:`onnxsim.graph_grad.build_backward`, and one
+:func:`onnxsim.qat_graph.adam_update` per trained tensor are a single pure
+``(constants, state, scalars) -> (next state, loss)`` function, driven by
+:func:`onnxsim.qat_graph.run_step_graph`. So the loop reaches whatever
+execution provider ``step_providers=`` names -- CUDA, an NPU EP, WebGPU in
+the WASM build -- and it stays inside
+:data:`onnxsim.qat_graph.EP_FRIENDLY_OPS` to make that real rather than
+nominal (no ``Round``: :func:`onnxsim.adaquant._round_to_nearest` composes
+one out of ``Sign``/``Abs``/``Cast``, and this reuses it).
+
+**What this deliberately is not, and does not claim.**
+
+- *Not task-loss QAT.* There are no labels, no dataset API, no metric and no
+  training lifecycle -- ``docs/qat.md``'s deliverable C, unchanged and still
+  out of scope. The teacher's own activations are the only target, so the
+  ceiling is "reproduce the float block", not "recover task accuracy the
+  float block never had". Label-free distillation QAT is not paper-QAT
+  accuracy and should not be advertised as it.
+- *Not whole-model training.* One caller-named block per call, exactly
+  :mod:`onnxsim.brecq`'s contract (``block_input_name`` /
+  ``block_output_name``). A sliding window over blocks, and an end-to-end
+  pass afterwards, are the caller's loop to write.
+- *Not activation quantization.* This targets
+  :func:`onnxsim.quantize_weight_only_int4`'s weight-only scheme, the same
+  one AdaRound/BRECQ/FOEM target. Learnable activation scales exist in-tree
+  (:mod:`onnxsim.adaquant`) but are not wired in here.
+- *Full-batch gradient descent.* The whole calibration set is one static
+  tensor baked into the step graph's shapes, as in every other
+  reconstruction pass here -- no minibatching, no epochs. That is a
+  calibration-scale budget, not a training-scale one.
+- *Measured, not assumed, and not a uniform win.* ``tests/test_qat.py``
+  measures both claims rather than asserting them, and one of the two has a
+  boundary worth stating here. On a two-Linear-plus-``Relu`` block the
+  reconstruction error falls from 16.0 (round-to-nearest) to 6.5, and a
+  GELU block's loss falls ~12x -- topologies no existing pass here can
+  reconstruct at all. Against :func:`onnxsim.apply_adaround` on a *single*
+  layer, where the objective is identical and only the parametrization
+  differs, freeing the weight wins when the calibration activations are
+  low-rank (rank 1: RTN 5.96, AdaRound 3.07, this 1.78) and **loses** when
+  they are full-rank (rank 16: RTN 28.5, AdaRound 14.6, this 22.8). The
+  reason is not subtle: a well-determined reconstruction problem has its
+  optimum within one quantization step of round-to-nearest, so floor/ceil is
+  all the freedom worth having and AdaRound's continuous rectified-sigmoid
+  relaxation optimizes that restricted problem better than a hard
+  straight-through estimator on a piecewise-constant loss does. Real
+  calibration activations are strongly low-rank, which is why this is worth
+  having -- but "QAT beats AdaRound" is not a claim this module makes.
+
+**What the block contract accepts and refuses.** Refusing is loud
+everywhere: a caller who names a block this cannot train gets a
+:class:`ValueError`, never a silently unchanged model. The slice is the
+intersection of the two directions -- nodes downstream of
+``block_input_name`` *and* upstream of ``block_output_name`` -- so naming a
+boundary cannot drag in a subgraph on the far side of it. A tensor the slice
+reads that is neither produced inside it nor an initializer is captured from
+the float model as another teacher-forced constant (so a residual arriving
+from further upstream, or a second graph input, is fine). It is refused if
+``block_output_name`` is not produced by a node, if any node in the slice
+has an op type :data:`onnxsim.graph_grad.SUPPORTED_OPS` does not cover
+(including one no gradient reaches -- the same standard
+:func:`onnxsim.graph_grad.build_backward` holds itself to), if the slice
+contains no ``quantize_weight_only_int4``-quantized MatMul/Gemm to train, or
+if the block's shapes cannot be inferred statically at opset 17.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import onnx.shape_inference
+
+from onnxsim import backend, graph_grad, qat_graph
+from onnxsim.adaquant import _round_to_nearest
+from onnxsim.adaround import _Candidate, _find_int4_matmul_candidates, _pack_int4
+from onnxsim.bias_correction import _add_probe_outputs
+from onnxsim.calibration import Tensors, generate_random_calibration_data
+
+# quantize_weight_only_int4's symmetric INT4 range, same constants
+# onnxsim.brecq pins for the same scheme.
+_N_MIN = -7.0
+_N_MAX = 7.0
+
+# Every name this module introduces into the step graph starts here, so it
+# cannot collide with a tensor name carried over from the float model.
+_PREFIX = "qat__"
+
+
+def _round_half_away(x: np.ndarray) -> np.ndarray:
+    """Host-side twin of :func:`onnxsim.adaquant._round_to_nearest`.
+
+    The export must round the trained master weights exactly the way the
+    trained forward did, or the model that ships is not the model whose loss
+    was measured. ``np.round`` is half-to-even and the step graph's rounding
+    is half-away-from-zero; the two differ only on exact ties, but matching
+    them costs one line.
+    """
+    return np.sign(x) * np.floor(np.abs(x) + 0.5)
+
+
+@dataclass
+class _Trained:
+    """One quantized layer's trainable state inside the step graph.
+
+    ``w`` is the fp32 master weight in the *storage* layout the graph's own
+    initializer uses ([K, N] for a MatMul, [N, K] for a ``transB`` Gemm) --
+    unlike :mod:`onnxsim.adaround` and :mod:`onnxsim.brecq`, which normalize
+    to [N, K], because nothing here needs a normalized layout: the forward
+    consumes the weight exactly where the block's own node reads it, and the
+    scale's blocked axis is carried explicitly instead.
+    """
+
+    candidate: _Candidate
+    w_input: str
+    m_input: str
+    v_input: str
+    w_shape: Tuple[int, int]
+    w_init: np.ndarray
+    scale_axis: int
+    scale_shape: Tuple[int, int]
+    scale_init: np.ndarray
+    scale_input: Optional[str] = None
+    ms_input: Optional[str] = None
+    vs_input: Optional[str] = None
+    # Filled in as the graph is built.
+    w_next: str = ""
+    m_next: str = ""
+    v_next: str = ""
+    scale_next: str = ""
+    ms_next: str = ""
+    vs_next: str = ""
+
+
+def _int64_const(b: qat_graph.GraphBuilder, values: Sequence[int]) -> str:
+    """An int64 initializer, for the ``shape``/``axes`` tensor inputs
+    ``Reshape`` and ``ReduceSum`` take from opset 13 on.
+    :meth:`onnxsim.qat_graph.GraphBuilder.const` is float32-only, which is
+    right for everything it was written for; these are the exceptions."""
+    array = np.asarray(list(values), dtype=np.int64)
+    name = b.name("i64")
+    b.initializer.append(onnx.numpy_helper.from_array(array, name))
+    return name
+
+
+def _blocked_shapes(
+    w_shape: Tuple[int, int], scale_shape: Tuple[int, int], axis: int, block_size: int
+) -> Tuple[List[int], List[int]]:
+    """The rank-3 views that turn a blocked scale into a full-size one and a
+    full-size gradient back into a blocked one.
+
+    A block-wise scale has one value per ``block_size`` consecutive weights
+    along the reduction axis, so both directions are the same reshape: split
+    that axis into ``(num_blocks, block_size)``, and the scale is the same
+    tensor with a 1 in the ``block_size`` slot. Returns
+    ``(split_weight_shape, scale_shape_with_a_1)``.
+    """
+    d = list(w_shape)
+    s = list(scale_shape)
+    if axis not in (0, 1):
+        raise ValueError(f"unsupported blocked axis {axis} for a 2-D weight")
+    other = 1 - axis
+    if s[other] != d[other] or s[axis] * block_size != d[axis]:
+        # np.repeat(...)[:, :k] is how the numpy passes tolerate a ragged
+        # final block. Doing the same inside a graph would mean a Slice on a
+        # dimension the accelerator backends compile statically, and the
+        # scheme this targets never produces one (K is always a multiple of
+        # its own block size), so it is refused instead of approximated.
+        raise ValueError(
+            f"weight shape {tuple(d)} is not an exact block-wise tiling of scale "
+            f"shape {tuple(s)} with block_size {block_size} on axis {axis}"
+        )
+    split = d[:axis] + [s[axis], block_size] + d[axis + 1 :]
+    with_one = s[:axis] + [s[axis], 1] + s[axis + 1 :]
+    return split, with_one
+
+
+def _broadcast_scale(
+    b: qat_graph.GraphBuilder,
+    scale: str,
+    w_shape: Tuple[int, int],
+    scale_shape: Tuple[int, int],
+    axis: int,
+    block_size: int,
+) -> str:
+    """A per-block scale expanded to one value per weight element.
+
+    ``Expand`` would say this in one node, but it is outside
+    :data:`onnxsim.qat_graph.EP_FRIENDLY_OPS`; multiplying by a constant of
+    ones broadcasts identically and costs the size of one block.
+    """
+    split, with_one = _blocked_shapes(w_shape, scale_shape, axis, block_size)
+    ones_shape = [1] * len(split)
+    ones_shape[axis + 1] = block_size
+    reshaped = b.op("Reshape", [scale, _int64_const(b, with_one)])
+    tiled = b.mul(reshaped, b.const(np.ones(ones_shape, dtype=np.float32), "ones"))
+    return b.op("Reshape", [tiled, _int64_const(b, list(w_shape))])
+
+
+def _sum_over_blocks(
+    b: qat_graph.GraphBuilder,
+    grad: str,
+    w_shape: Tuple[int, int],
+    scale_shape: Tuple[int, int],
+    axis: int,
+    block_size: int,
+) -> str:
+    """The transpose of :func:`_broadcast_scale`: one scale is shared by a
+    whole block of weights, so its gradient is the sum of theirs."""
+    split, _ = _blocked_shapes(w_shape, scale_shape, axis, block_size)
+    reshaped = b.op("Reshape", [grad, _int64_const(b, split)])
+    return b.op(
+        "ReduceSum", [reshaped, _int64_const(b, [axis + 1])], "blocksum", keepdims=0
+    )
+
+
+def _emit_fake_quant(
+    b: qat_graph.GraphBuilder, w: str, scale_full: str, out_name: str
+) -> Tuple[str, str, str]:
+    """``w_hat = clip(round(w / s), -7, 7) * s``, written into ``out_name``.
+
+    Returns ``(code, ratio, active)`` -- everything the straight-through
+    backward below needs. ``active`` is a float 0/1 mask of the elements
+    strictly inside the clipping range, which is where ``round``'s
+    straight-through derivative of 1 is allowed to pass anything through at
+    all; a saturated element's weight has no local influence on the block's
+    output and must not be moved by the reconstruction gradient.
+
+    Clipping happens *before* rounding rather than after. The two commute
+    here because the bounds are integers, and doing it in this order leaves
+    :func:`onnxsim.adaquant._round_to_nearest` with an argument already
+    bounded to [-7, 7], where its float-to-int32 cast is exact.
+    """
+    ratio = b.div(w, scale_full)
+    code = _round_to_nearest(b, b.clip(ratio, _N_MIN, _N_MAX))
+    b.nodes.append(onnx.helper.make_node("Mul", [code, scale_full], [out_name]))
+    active = b.mul(
+        b.greater_mask(ratio, _N_MIN),
+        b.less_mask(ratio, _N_MAX),
+    )
+    return code, ratio, active
+
+
+def _slice_block(
+    graph: onnx.GraphProto, block_input_name: str, block_output_name: str
+) -> Tuple[List[onnx.NodeProto], List[str]]:
+    """The nodes that lie between ``block_input_name`` and
+    ``block_output_name``: those downstream of the first *and* upstream of the
+    second.
+
+    Returns ``(nodes in graph order, externally-supplied tensor names)``.
+    Intersecting the two directions is what makes the block boundary mean
+    what a caller expects. Walking backwards from the output alone and merely
+    stopping at the block input would keep following every *other* path out of
+    the output -- a residual arriving from before the block would drag the
+    whole earlier subgraph in with it, and the caller would find layers they
+    never named being retrained.
+
+    An "external" tensor is one the slice reads but does not produce and which
+    is not an initializer: ``block_input_name`` itself, and anything entering
+    the block sideways (that residual, an attention mask fed as a second graph
+    input). Those are teacher-forced -- captured from the float model and fed
+    to the step graph as constants, exactly as ``block_input_name`` is, which
+    is the approximation every block-wise reconstruction method makes.
+    """
+    initializers = {t.name for t in graph.initializer}
+    producer: Dict[str, int] = {}
+    for index, node in enumerate(graph.node):
+        for output in node.output:
+            if output:
+                producer[output] = index
+
+    if block_output_name not in producer:
+        raise ValueError(
+            f"block output {block_output_name!r} is not produced by any node in the "
+            "float graph; a block must end at a computed tensor"
+        )
+
+    # Forward: which nodes actually depend on the block input. The graph is
+    # topologically ordered, so one pass suffices.
+    downstream: Set[str] = {block_input_name}
+    forward: Set[int] = set()
+    for index, node in enumerate(graph.node):
+        if any(name in downstream for name in node.input):
+            forward.add(index)
+            downstream.update(name for name in node.output if name)
+
+    # Backward from the block output, confined to those nodes.
+    used: Set[int] = set()
+    external: Set[str] = set()
+    seen: Set[str] = set()
+    stack = [block_output_name]
+    while stack:
+        name = stack.pop()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        if name in initializers:
+            continue
+        owner = producer.get(name)
+        if owner is None or owner not in forward:
+            external.add(name)
+            continue
+        if owner in used:
+            continue
+        used.add(owner)
+        stack.extend(graph.node[owner].input)
+
+    nodes = [node for index, node in enumerate(graph.node) if index in used]
+    return nodes, sorted(external)
+
+
+def _refuse_unsupported(nodes: Sequence[onnx.NodeProto]) -> None:
+    """Every op in the slice must have a gradient rule, checked before any
+    calibration data is run.
+
+    Tested against :data:`onnxsim.graph_grad.SUPPORTED_OPS` rather than by
+    catching :class:`onnxsim.graph_grad.UnsupportedOpError` from
+    ``build_backward``, which is what that module's own docstring asks
+    callers who pick their own slice to do -- and it means the caller learns
+    the block is out of scope in milliseconds rather than after a full
+    activation capture.
+    """
+    unsupported = sorted(
+        {n.op_type for n in nodes if n.op_type not in graph_grad.SUPPORTED_OPS}
+    )
+    if unsupported:
+        raise graph_grad.UnsupportedOpError(
+            f"the block contains {unsupported}, which onnxsim.graph_grad cannot "
+            f"differentiate; it differentiates {sorted(graph_grad.SUPPORTED_OPS)}. "
+            "Choose block boundaries that exclude those nodes."
+        )
+
+
+def _block_shapes(
+    float_model: onnx.ModelProto,
+    nodes: Sequence[onnx.NodeProto],
+    externals: Dict[str, np.ndarray],
+    block_output_name: str,
+    block_output: np.ndarray,
+) -> Dict[str, Sequence[int]]:
+    """Static shapes for every tensor the slice touches -- what
+    :func:`onnxsim.graph_grad.build_backward` requires of its caller.
+
+    Inferred from a standalone model containing only the slice, whose inputs
+    carry the *concrete* shapes of the captured calibration activations. The
+    float model's own graph inputs are usually symbolic (``float[batch, K]``),
+    and a symbolic dimension is exactly what a step graph cannot have: the
+    accelerator backends this exists for compile a fixed graph, and undoing a
+    broadcast at build time needs real numbers.
+
+    Inference runs at opset 17, the pairing :mod:`onnxsim.qat_graph` emits, so
+    a node the step graph could not legally carry is refused here rather than
+    at session-creation time.
+    """
+    used = {name for node in nodes for name in node.input if name}
+    initializers = [t for t in float_model.graph.initializer if t.name in used]
+    inputs = [
+        onnx.helper.make_tensor_value_info(
+            name, onnx.TensorProto.FLOAT, list(value.shape)
+        )
+        for name, value in sorted(externals.items())
+    ]
+    outputs = [
+        onnx.helper.make_tensor_value_info(
+            block_output_name, onnx.TensorProto.FLOAT, list(block_output.shape)
+        )
+    ]
+    graph = onnx.helper.make_graph(
+        list(nodes), "qat_block", inputs, outputs, initializer=initializers
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model.ir_version = 8
+    try:
+        inferred = onnx.shape_inference.infer_shapes(model, strict_mode=True)
+    except Exception as error:  # noqa: BLE001 -- re-raised with the block's context
+        raise ValueError(
+            f"cannot statically infer the block's shapes at opset 17: {error}"
+        ) from error
+
+    shapes: Dict[str, Sequence[int]] = {}
+    for value in (
+        list(inferred.graph.input)
+        + list(inferred.graph.output)
+        + list(inferred.graph.value_info)
+    ):
+        dims = [d.dim_value for d in value.type.tensor_type.shape.dim]
+        if any(d <= 0 for d in dims):
+            raise ValueError(
+                f"tensor {value.name!r} in the block has a non-static shape; "
+                "block-wise QAT needs every shape known at build time"
+            )
+        shapes[value.name] = dims
+    for t in inferred.graph.initializer:
+        shapes[t.name] = list(t.dims)
+
+    missing = sorted(
+        {
+            name
+            for node in nodes
+            for name in list(node.input) + list(node.output)
+            if name
+        }
+        - set(shapes)
+    )
+    if missing:
+        raise ValueError(
+            f"shape inference did not produce a shape for {missing} in the block"
+        )
+    return shapes
+
+
+def _capture(
+    float_model: onnx.ModelProto,
+    names: Sequence[str],
+    calibration_data: Sequence[Tensors],
+    providers: Optional[Sequence[backend.Provider]],
+) -> Dict[str, np.ndarray]:
+    """Runs the float model on the calibration data and returns each probed
+    tensor concatenated over batches along axis 0.
+
+    Unlike :func:`onnxsim.bias_correction._activation_rows`, which the
+    per-layer passes use, the captured rank is kept as-is. A single layer's
+    reconstruction only ever needs the set of rows that multiply ``W``, so
+    flattening ``[batch, seq, K]`` to ``[batch * seq, K]`` is exact there. A
+    *block* is not rank-agnostic: it may contain a ``Softmax`` over a
+    particular axis, a ``Reshape`` with a baked-in target, or a ``MatMul``
+    that broadcasts over leading dimensions, and all three change meaning if
+    the leading axes are collapsed. Concatenating along axis 0 keeps the
+    block seeing the shape it was written for; it does assume axis 0 is a
+    batch axis the block treats independently, which is what a calibration
+    batch axis is.
+    """
+    probe = _add_probe_outputs(float_model, names)
+    collected: Dict[str, List[np.ndarray]] = {name: [] for name in names}
+    for batch in calibration_data:
+        out = backend.run_model(probe, batch, providers=providers)
+        for name in names:
+            collected[name].append(np.asarray(out[name], dtype=np.float32))
+
+    captured: Dict[str, np.ndarray] = {}
+    for name, arrays in collected.items():
+        trailing = {a.shape[1:] for a in arrays}
+        if len(trailing) != 1:
+            raise ValueError(
+                f"calibration batches disagree on the shape of {name!r} "
+                f"({sorted(trailing)}); every batch must differ only in its "
+                "leading axis"
+            )
+        captured[name] = np.concatenate(arrays, axis=0)
+    return captured
+
+
+def _plan_trained(
+    candidates: Sequence[_Candidate], learn_scales: bool
+) -> List[_Trained]:
+    """One :class:`_Trained` per quantized layer in the block, with its
+    master weight seeded from the *float* model's own weight -- so step 0 of
+    the loop reproduces round-to-nearest exactly, and every later step is a
+    measured improvement on it rather than on an arbitrary re-initialization.
+    """
+    planned: List[_Trained] = []
+    for i, candidate in enumerate(candidates):
+        w = onnx.numpy_helper.to_array(candidate.w_float_init).astype(np.float32)
+        scale = onnx.numpy_helper.to_array(candidate.ws_init).astype(np.float32)
+        trained = _Trained(
+            candidate=candidate,
+            w_input=f"{_PREFIX}w{i}",
+            m_input=f"{_PREFIX}mw{i}",
+            v_input=f"{_PREFIX}vw{i}",
+            w_shape=(int(w.shape[0]), int(w.shape[1])),
+            w_init=w,
+            scale_axis=candidate.axis,
+            scale_shape=(int(scale.shape[0]), int(scale.shape[1])),
+            scale_init=scale,
+        )
+        if learn_scales:
+            trained.scale_input = f"{_PREFIX}s{i}"
+            trained.ms_input = f"{_PREFIX}ms{i}"
+            trained.vs_input = f"{_PREFIX}vs{i}"
+        planned.append(trained)
+    return planned
+
+
+def _build_step_graph(
+    trained: Sequence[_Trained],
+    nodes: Sequence[onnx.NodeProto],
+    shapes: Dict[str, Sequence[int]],
+    block_initializers: Sequence[onnx.TensorProto],
+    externals: Dict[str, np.ndarray],
+    block_output_name: str,
+    block_output_shape: Sequence[int],
+    learn_scales: bool,
+) -> qat_graph.StepGraph:
+    """The whole loop as one graph: fake-quant forward, block forward,
+    reconstruction loss, backward, Adam.
+
+    The ordering is the only subtle part. :func:`graph_grad.build_backward`
+    reads forward tensors by name (including node *outputs*, where reusing a
+    ``Sigmoid``/``Softmax`` result is cheaper than recomputing it), so every
+    node it differentiates must already sit in the builder ahead of the nodes
+    it appends. Hence: fake-quant, then the block's own nodes verbatim, then
+    the loss seed, then the backward, then the optimizer.
+    """
+    b = qat_graph.GraphBuilder(_PREFIX)
+    b.initializer.extend(block_initializers)
+
+    # 1. Fake-quantize each trained master weight into the tensor name the
+    #    block's own node already reads, so the block's nodes need no
+    #    rewriting at all -- the weight initializer simply became a computed
+    #    value.
+    per_layer = []
+    for t in trained:
+        block_size = t.candidate.block_size
+        if t.scale_input is None:
+            scale = b.const(t.scale_init, "scale")
+        else:
+            scale = t.scale_input
+        scale_full = _broadcast_scale(
+            b, scale, t.w_shape, t.scale_shape, t.scale_axis, block_size
+        )
+        weight_name = t.candidate.float_node.input[1]
+        code, ratio, active = _emit_fake_quant(b, t.w_input, scale_full, weight_name)
+        per_layer.append((t, weight_name, scale_full, code, ratio, active))
+
+    # 2. The block itself, node for node as the float graph wrote it.
+    b.nodes.extend(nodes)
+
+    # 3. The objective: MSE of the student block's output against the
+    #    teacher's, and its gradient, which is the seed of the backward pass.
+    teacher = f"{_PREFIX}teacher"
+    diff = b.sub(block_output_name, teacher)
+    n_elems = int(np.prod(list(block_output_shape)))
+    dl_dy = b.mul(diff, b.const(2.0 / n_elems))
+
+    # 4. The backward pass over the block, emitted as ONNX nodes.
+    grads = graph_grad.build_backward(
+        b,
+        nodes,
+        shapes,
+        {block_output_name: dl_dy},
+        [weight_name for _, weight_name, _, _, _, _ in per_layer],
+    )
+
+    # 5. Straight through the fake-quant, into the master weight and (if
+    #    asked for) the scale, then one Adam step each.
+    for t, weight_name, _scale_full, code, ratio, active in per_layer:
+        g = grads[weight_name]  # dL/d(w_hat), in the weight's storage layout
+        # STE: d(w_hat)/d(w) is 1 inside the clipping range and 0 outside.
+        # The scale cancels -- w_hat = round(w/s)*s -- which is why a
+        # straight-through weight gradient is just the masked output
+        # gradient, with no scale factor anywhere.
+        t.w_next, t.m_next, t.v_next = qat_graph.adam_update(
+            b,
+            t.w_input,
+            b.mul(g, active),
+            t.m_input,
+            t.v_input,
+            f"{_PREFIX}lr",
+            "m_correction",
+            "v_correction",
+        )
+        if t.scale_input is None:
+            continue
+        # LSQ's scale gradient, the same one onnxsim.autoround derives:
+        # d(w_hat)/d(s) = code - w/s where the element is inside the clipping
+        # range (the gap between the integer it rounds to and the exact
+        # ratio) and just `code` where it saturates.
+        dwhat_ds = b.sub(code, b.mul(active, ratio))
+        g_scale = _sum_over_blocks(
+            b,
+            b.mul(g, dwhat_ds),
+            t.w_shape,
+            t.scale_shape,
+            t.scale_axis,
+            t.candidate.block_size,
+        )
+        t.scale_next, t.ms_next, t.vs_next = qat_graph.adam_update(
+            b,
+            t.scale_input,
+            g_scale,
+            str(t.ms_input),
+            str(t.vs_input),
+            f"{_PREFIX}lr_scale",
+            "m_correction",
+            "v_correction",
+        )
+
+    constants: Dict[str, Sequence[int]] = {
+        name: list(value.shape) for name, value in sorted(externals.items())
+    }
+    constants[teacher] = list(block_output_shape)
+
+    state: Dict[str, Tuple[Sequence[int], str]] = {}
+    for t in trained:
+        state[t.w_input] = (list(t.w_shape), t.w_next)
+        state[t.m_input] = (list(t.w_shape), t.m_next)
+        state[t.v_input] = (list(t.w_shape), t.v_next)
+        if t.scale_input is not None:
+            state[t.scale_input] = (list(t.scale_shape), t.scale_next)
+            state[str(t.ms_input)] = (list(t.scale_shape), t.ms_next)
+            state[str(t.vs_input)] = (list(t.scale_shape), t.vs_next)
+
+    scalars = [f"{_PREFIX}lr", "m_correction", "v_correction"]
+    if learn_scales:
+        scalars.append(f"{_PREFIX}lr_scale")
+
+    return qat_graph.make_step_graph(
+        b,
+        constants=constants,
+        state=state,
+        scalars=scalars,
+        loss=b.mean_square(diff),
+        name="onnxsim_qat_step",
+    )
+
+
+def apply_qat(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    block_input_name: str,
+    block_output_name: str,
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    num_iterations: int = 1000,
+    learning_rate: float = 1e-4,
+    learn_scales: bool = False,
+    scale_learning_rate: float = 1e-5,
+    lr_decay: bool = True,
+    providers: Optional[Sequence[backend.Provider]] = None,
+    step_providers: Optional[Sequence[backend.Provider]] = None,
+    losses: Optional[List[float]] = None,
+) -> onnx.ModelProto:
+    """Fine-tunes one block's INT4 weights against the float model's own
+    output for that block -- label-free, teacher-distilled QAT. See this
+    module's own docstring for the technique, what it refuses, and what it
+    does not claim.
+
+    The block is named the way :func:`onnxsim.apply_brecq` names one, by its
+    input and output tensor. Unlike ``apply_brecq``, whatever lies between
+    them is fair game as long as :mod:`onnxsim.graph_grad` has a rule for it
+    -- an activation, a normalization, a GELU, a Softmax, a residual -- and
+    unlike every rounding pass here, the fp32 weights themselves are what
+    gets optimized.
+
+    :param float_model: the original (unquantized) onnx ModelProto or file
+            path. It is the teacher: its activations at
+            ``block_output_name`` are the only target, and its weights seed
+            the trained master weights.
+    :param quantized_model: a quantized version of ``float_model`` (onnx
+            ModelProto or file path), produced by
+            :func:`onnxsim.quantize_weight_only_int4`. Layers quantized by
+            any other scheme (or left unquantized) are left untouched, and a
+            block containing none of them is an error rather than a no-op.
+            Assumes ``quantized_model`` was produced from ``float_model``
+            without renaming any MatMul/Gemm node's own output tensor -- true
+            of every onnxsim ``quantize_*`` function.
+    :param block_input_name: the activation entering the block. The backward
+            walk that discovers the block's nodes stops here.
+    :param block_output_name: the block's own final output, the tensor whose
+            reconstruction error is the loss.
+    :param calibration_data: representative input batches. Each batch is a
+            ``{input_name: np.ndarray}`` dict matching ``float_model``'s graph
+            inputs -- see :func:`onnxsim.generate_random_calibration_data`
+            (the default when omitted) and
+            :func:`onnxsim.load_huggingface_calibration_data` (real data, a
+            far more representative target than random input). All batches
+            are concatenated into one full-batch objective, so their shapes
+            may differ only in the leading axis.
+    :param num_samples: random batches to generate when ``calibration_data``
+            is omitted
+    :param seed: seed for the random calibration data (ignored if
+            ``calibration_data`` is supplied)
+    :param num_iterations: Adam steps to run over the block
+    :param learning_rate: Adam learning rate for the fp32 master weights.
+            The natural scale to compare it against is the quantization step
+            itself: an element has to travel about half a step to change
+            which integer it rounds to, so ``num_iterations *
+            learning_rate`` well below the typical step size means nothing
+            can move at all, and well above it means everything thrashes.
+    :param learn_scales: also train each weight's per-block quantization
+            scale, LSQ-style. Off by default because it makes the problem
+            non-convex in two coupled parameter sets at once (the same
+            caution :mod:`onnxsim.autoround` documents) and because it
+            rewrites the scale initializers, which the weight-only path
+            leaves byte-identical.
+    :param scale_learning_rate: Adam learning rate for the scales when
+            ``learn_scales`` is on. Smaller than ``learning_rate`` by
+            default: one scale is shared by a whole block of weights, so a
+            step of the same size is a far larger change to the model.
+    :param lr_decay: anneal both learning rates linearly to zero across the
+            run. On by default because the objective is piecewise constant in
+            the master weights -- the loss only moves when an element crosses
+            a rounding boundary -- so a constant learning rate leaves the
+            final iterate wherever the last step happened to put it, which
+            can be worse than a step earlier. Annealing makes the end of the
+            run settle instead. Turn it off to hold the rate fixed.
+    :param providers: onnxruntime execution providers to run ``float_model``
+            on when capturing the teacher's activations
+    :param step_providers: onnxruntime execution providers to run the
+            optimization itself on, as an ONNX step graph
+            (:mod:`onnxsim.qat_graph`) -- the way to reach a GPU, an NPU
+            execution provider, or WebGPU with this loop. ``None`` means CPU.
+            Unlike :func:`onnxsim.apply_adaround`, there is no host-numpy
+            alternative here: the step graph *is* the implementation, so this
+            selects where it runs rather than whether it is used.
+    :param losses: when given, the reconstruction loss is appended to it once
+            per step -- the cheapest way to see whether a block actually
+            trained, and what the tests here assert on.
+    :returns: ``quantized_model`` with the block's INT4 weight initializers
+            (and, if ``learn_scales``, their scale initializers) rewritten.
+            Every other byte of the model is untouched.
+    :raises ValueError: if the block cannot be discovered, is not closed at
+            statically-known shapes, or contains no quantized layer to train
+    :raises onnxsim.graph_grad.UnsupportedOpError: if any node in the block
+            has no gradient rule
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+
+    nodes, externals = _slice_block(
+        float_model.graph, block_input_name, block_output_name
+    )
+    if not nodes:
+        raise ValueError(
+            f"no nodes lie between {block_input_name!r} and {block_output_name!r}"
+        )
+    _refuse_unsupported(nodes)
+
+    slice_outputs = {out for node in nodes for out in node.output if out}
+    candidates = [
+        c
+        for c in _find_int4_matmul_candidates(float_model, quantized_model)
+        if c.output_name in slice_outputs
+    ]
+    if not candidates:
+        raise ValueError(
+            f"the block between {block_input_name!r} and {block_output_name!r} "
+            "contains no quantize_weight_only_int4-quantized MatMul/Gemm layer to "
+            "train"
+        )
+
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            float_model, num_samples=num_samples, seed=seed
+        )
+
+    captured = _capture(
+        float_model,
+        sorted(set(externals) | {block_output_name}),
+        calibration_data,
+        providers,
+    )
+    teacher_output = captured[block_output_name]
+    external_values = {name: captured[name] for name in externals}
+
+    shapes = _block_shapes(
+        float_model, nodes, external_values, block_output_name, teacher_output
+    )
+
+    trained = _plan_trained(candidates, learn_scales)
+    trained_weight_names = {t.candidate.float_node.input[1] for t in trained}
+    used = {name for node in nodes for name in node.input if name}
+    block_initializers = [
+        t
+        for t in float_model.graph.initializer
+        if t.name in used and t.name not in trained_weight_names
+    ]
+
+    step = _build_step_graph(
+        trained,
+        nodes,
+        shapes,
+        block_initializers,
+        external_values,
+        block_output_name,
+        list(teacher_output.shape),
+        learn_scales,
+    )
+
+    constants: Dict[str, np.ndarray] = dict(external_values)
+    constants[f"{_PREFIX}teacher"] = teacher_output
+    state: Dict[str, np.ndarray] = {}
+    for t in trained:
+        state[t.w_input] = t.w_init
+        state[t.m_input] = np.zeros_like(t.w_init)
+        state[t.v_input] = np.zeros_like(t.w_init)
+        if t.scale_input is not None:
+            state[t.scale_input] = t.scale_init
+            state[str(t.ms_input)] = np.zeros_like(t.scale_init)
+            state[str(t.vs_input)] = np.zeros_like(t.scale_init)
+
+    def scalars(t: int) -> Dict[str, float]:
+        decay = 1.0 - t / num_iterations if lr_decay else 1.0
+        values = {
+            f"{_PREFIX}lr": learning_rate * decay,
+            f"{_PREFIX}lr_scale": scale_learning_rate * decay,
+        }
+        if not learn_scales:
+            del values[f"{_PREFIX}lr_scale"]
+        values.update(qat_graph.adam_bias_corrections(t))
+        return values
+
+    final = qat_graph.run_step_graph(
+        step,
+        constants=constants,
+        state=state,
+        num_steps=num_iterations,
+        scalars=scalars,
+        providers=step_providers,
+        losses=losses,
+    )
+
+    new_codes: Dict[str, np.ndarray] = {}
+    new_scales: Dict[str, np.ndarray] = {}
+    for t in trained:
+        w = final[t.w_input].astype(np.float64)
+        scale = (
+            final[t.scale_input].astype(np.float64)
+            if t.scale_input is not None
+            else t.scale_init.astype(np.float64)
+        )
+        scale_full = np.repeat(scale, t.candidate.block_size, axis=t.scale_axis)
+        codes = np.clip(_round_half_away(w / scale_full), _N_MIN, _N_MAX)
+        new_codes[t.candidate.wq_name] = codes.astype(np.int8)
+        if t.scale_input is not None:
+            new_scales[t.candidate.ws_init.name] = scale.astype(np.float32)
+
+    tuned = onnx.ModelProto()
+    tuned.CopyFrom(quantized_model)
+    for initializer in tuned.graph.initializer:
+        codes = new_codes.get(initializer.name)
+        if codes is not None:
+            initializer.raw_data = _pack_int4(codes)
+            continue
+        scale_array = new_scales.get(initializer.name)
+        if scale_array is not None:
+            initializer.CopyFrom(
+                onnx.numpy_helper.from_array(scale_array, name=initializer.name)
+            )
+    return tuned

--- a/onnxsim/qat_graph.py
+++ b/onnxsim/qat_graph.py
@@ -83,6 +83,49 @@ _IR_VERSION = 8
 # Adam's own standard hyper-parameters, matching the hand-rolled loops in
 # adaround.py/adaquant.py/brecq.py exactly so a ported loop keeps its
 # behaviour.
+# The operator set a step graph restricts itself to.
+#
+# The point of expressing a training step as an ONNX graph is that it runs
+# wherever inference runs -- including onnxruntime-web's WebGPU backend and
+# the WebNN/NPU execution providers, which implement far less than the full
+# ONNX operator set. A step graph that reached for a convenient operator one
+# of those cannot run would pass every numerical test and still be useless
+# for the thing this module exists for, so the ops a builder may emit are
+# pinned here and asserted in tests (``tests/test_qat_graph.py``,
+# ``tests/test_graph_grad.py``, ``tests/test_adaquant_step_graph.py``).
+#
+# What is deliberately absent: control flow, boolean logic ops (a mask is a
+# float 0/1 from ``Cast(Greater(...))``, multiplied in), ``Where``,
+# ``Expand``, and ``Round`` -- WebNN has no rounding operator at all, which is
+# why :mod:`onnxsim.adaquant` composes one out of ``Sign``/``Abs``/``Cast``.
+# Adding to this set is a real decision: check the operator actually has
+# coverage on the WebGPU and WebNN backends first, not just on ORT's CPU
+# kernels.
+EP_FRIENDLY_OPS = frozenset(
+    {
+        "Abs",
+        "Add",
+        "Cast",
+        "Clip",
+        "Div",
+        "Exp",
+        "Greater",
+        "Less",
+        "MatMul",
+        "Mul",
+        "Neg",
+        "Pow",
+        "ReduceMean",
+        "ReduceSum",
+        "Reshape",
+        "Sigmoid",
+        "Sign",
+        "Sqrt",
+        "Sub",
+        "Transpose",
+    }
+)
+
 ADAM_BETA1 = 0.9
 ADAM_BETA2 = 0.999
 ADAM_EPS = 1e-8

--- a/onnxsim/qat_graph.py
+++ b/onnxsim/qat_graph.py
@@ -80,9 +80,6 @@ from onnxsim import backend
 _OPSET = 17
 _IR_VERSION = 8
 
-# Adam's own standard hyper-parameters, matching the hand-rolled loops in
-# adaround.py/adaquant.py/brecq.py exactly so a ported loop keeps its
-# behaviour.
 # The operator set a step graph restricts itself to.
 #
 # The point of expressing a training step as an ONNX graph is that it runs
@@ -126,6 +123,9 @@ EP_FRIENDLY_OPS = frozenset(
     }
 )
 
+# Adam's own standard hyper-parameters, matching the hand-rolled loops in
+# adaround.py/adaquant.py/brecq.py exactly so a ported loop keeps its
+# behaviour.
 ADAM_BETA1 = 0.9
 ADAM_BETA2 = 0.999
 ADAM_EPS = 1e-8

--- a/onnxsim/qat_graph.py
+++ b/onnxsim/qat_graph.py
@@ -37,13 +37,23 @@ build's model-executor trampoline (``docs/wasm_ort_web.md``) hands the same
 graph to onnxruntime-web, whose provider list already offers ``webgpu`` and
 WebNN's ``gpu``/``npu`` device types (``docs/webnn.md``).
 
+The tensors also *stay* where that provider put them. :func:`run_step_graph`
+binds the graph's constants and its state through onnxruntime's ``IOBinding``
+(``bind_state=True``, the default, via
+:meth:`onnxsim.backend.Runner.bind_loop`): the calibration activations are
+uploaded once at setup, each step's state outputs become the next step's state
+inputs without a round trip through host numpy, and only the per-step scalars
+go up and the loss comes down. On CPU that saves a memcpy or two; on a
+provider whose bus is PCIe it is the difference between a loop that is
+arithmetic and a loop that is transfers.
+
 **What it does not buy, and the honest limits.**
 
-- *Feeds are re-sent every step.* The calibration activations are re-fed on every
-  call, so on a non-CPU provider the loop currently pays a host-to-device copy
-  per step. Keeping tensors device-resident (``IOBinding`` in Python, ORT-web
-  GPU-buffer tensors in the browser) is the follow-up; the graph shape here --
-  state in, state out -- is exactly what that needs.
+- *Residency is the Python half only.* ``IOBinding`` covers onnxruntime in
+  Python. The browser half of the same idea -- ORT-web's GPU-buffer tensors
+  with ``preferredOutputLocation: "gpu-buffer"``, fed straight back in as the
+  next step's inputs -- is still to do, so the WASM path re-sends its feeds
+  every step.
 - *Precision.* Step graphs are built in float32, not the float64 the numpy
   loops use: fp64 is what accelerators do not have. Results therefore agree
   with the numpy path closely rather than bit-exactly.
@@ -265,6 +275,45 @@ def make_step_graph(
     )
 
 
+def _run_bound_loop(
+    bound: backend.BoundStepLoop,
+    step: StepGraph,
+    num_steps: int,
+    scalar_feeds: Callable[[int], Dict[str, np.ndarray]],
+    losses: Optional[List[float]],
+) -> Optional[Dict[str, np.ndarray]]:
+    """Drive ``bound`` for ``num_steps``, or return ``None`` if onnxruntime
+    refuses to run the binding.
+
+    Some execution providers accept a binding at setup time and only fail when
+    a run actually reaches them, so "can this be bound?" is not fully knowable
+    until the first ``run_with_iobinding``. Rather than leave the caller half
+    way through a loop on a path that does not work, this reports the failure
+    and lets :func:`run_step_graph` re-run the whole thing unbound: the step
+    graph is a pure function of its state, so starting over from the same
+    initial state reproduces exactly the same trajectory.
+
+    ``losses`` is only extended once the whole loop has succeeded, so an
+    abandoned attempt leaves no half-written diagnostics behind. The scalars
+    callback is deliberately called *outside* the guarded region -- an
+    exception from the caller's own code is the caller's bug, not a binding
+    failure, and must not be swallowed into a silent fallback.
+    """
+    collected: List[float] = []
+    want_loss = losses is not None and step.loss_name is not None
+    for t in range(num_steps):
+        feeds = scalar_feeds(t)
+        try:
+            out = bound.step(feeds)
+        except Exception:
+            return None
+        if want_loss:
+            collected.append(float(out[str(step.loss_name)]))
+    if losses is not None:
+        losses.extend(collected)
+    return dict(bound.state())
+
+
 def run_step_graph(
     step: StepGraph,
     constants: Dict[str, np.ndarray],
@@ -273,6 +322,7 @@ def run_step_graph(
     scalars: Optional[Callable[[int], Dict[str, float]]] = None,
     providers: Optional[Sequence[backend.Provider]] = None,
     losses: Optional[List[float]] = None,
+    bind_state: bool = True,
 ) -> Dict[str, np.ndarray]:
     """Runs ``step`` ``num_steps`` times, threading its state through, and
     returns the final state.
@@ -291,6 +341,26 @@ def run_step_graph(
             run the step on. ``None`` means CPU.
     :param losses: when given, the step graph's loss output is appended to it
             once per step. Reading it back costs a scalar transfer per step.
+    :param bind_state: keep the constants and the state resident on the
+            execution provider's device across steps, via onnxruntime's
+            ``IOBinding`` (:meth:`onnxsim.backend.Runner.bind_loop`), instead
+            of re-sending every tensor as a feed on every step. This is the
+            follow-up this module's docstring names, and it is on by default
+            because it is what makes a non-CPU provider worth using: the
+            constants go up once, the state never comes down between steps,
+            and only the per-step scalars and (if asked for) the loss cross
+            the bus. It is transparent -- the same numbers come back either
+            way, and anything that stops the binding from working falls back
+            to the feed-per-step path on its own, so a caller never has to
+            know which one ran.
+
+            Turn it off to force the feed-per-step path: when debugging a
+            provider whose binding support is suspect and the unbound result
+            is the reference to compare against, when a profiler's per-step
+            input/output attribution is more useful than the speed, or when
+            the extra device buffer per state tensor (binding double-buffers
+            the state, see :class:`onnxsim.backend.BoundStepLoop`) is not
+            affordable.
     """
     fetch = list(step.state.values())
     if losses is not None and step.loss_name is not None:
@@ -298,14 +368,29 @@ def run_step_graph(
     runner = backend.Runner(step.model, output_names=fetch, providers=providers)
 
     fixed = {k: np.asarray(v, dtype=np.float32) for k, v in constants.items()}
-    current = {k: np.asarray(v, dtype=np.float32) for k, v in state.items()}
+    initial = {k: np.asarray(v, dtype=np.float32) for k, v in state.items()}
+
+    def scalar_feeds(t: int) -> Dict[str, np.ndarray]:
+        if scalars is None:
+            return {}
+        return {k: np.asarray(v, dtype=np.float32) for k, v in scalars(t).items()}
+
+    # A caller who left out one of the graph's state inputs gets the unbound
+    # path's error about a missing feed, not a KeyError from the setup below.
+    if bind_state and set(step.state) <= set(initial):
+        bound = runner.bind_loop(
+            fixed, {name: (out, initial[name]) for name, out in step.state.items()}
+        )
+        if bound is not None:
+            final = _run_bound_loop(bound, step, num_steps, scalar_feeds, losses)
+            if final is not None:
+                return final
+
+    current = dict(initial)
     for t in range(num_steps):
         feeds = dict(fixed)
         feeds.update(current)
-        if scalars is not None:
-            feeds.update(
-                {k: np.asarray(v, dtype=np.float32) for k, v in scalars(t).items()}
-            )
+        feeds.update(scalar_feeds(t))
         out = runner(feeds)
         current = {name: out[output] for name, output in step.state.items()}
         if losses is not None and step.loss_name is not None:

--- a/onnxsim/qat_graph.py
+++ b/onnxsim/qat_graph.py
@@ -205,6 +205,27 @@ class GraphBuilder:
         lt = self.op("Less", [a, self.const(threshold)])
         return self.op("Cast", [lt], to=onnx.TensorProto.FLOAT)
 
+    def round_to_nearest(self, a: str) -> str:
+        """``round(a)``, composed rather than emitted as ``Round``.
+
+        WebNN has no rounding operator at all, so ``Round`` is deliberately
+        absent from :data:`EP_FRIENDLY_OPS` -- and a fake-quant forward, which
+        is what every caller of this wants it for, is exactly the code that
+        must run on those backends. A float-to-int32 ``Cast`` truncates toward
+        zero, so truncating ``|a| + 0.5`` and re-applying the sign is
+        round-half-away-from-zero. That differs from ``Round``'s (and numpy's)
+        round-half-to-even on *exact* ties only: a value landing on a precise
+        .5, which real calibration data does not do at any measurable rate,
+        and which when it happens moves one element's code by one rather than
+        changing the shape of the optimization.
+        """
+        magnitude = self.add(self.op("Abs", [a]), self.const(0.5))
+        truncated = self.op("Cast", [magnitude], to=onnx.TensorProto.INT32)
+        return self.mul(
+            self.op("Sign", [a]),
+            self.op("Cast", [truncated], to=onnx.TensorProto.FLOAT),
+        )
+
     def mean_square(self, a: str) -> str:
         """``mean(a * a)`` as a scalar, for a reported loss."""
         sq = self.mul(a, a)

--- a/tests/test_adaquant_step_graph.py
+++ b/tests/test_adaquant_step_graph.py
@@ -1,0 +1,288 @@
+"""Tests for ``onnxsim.adaquant``'s step-graph path -- AdaQuant's joint
+optimization over weight rounding *and* the activation's (scale, zero_point)
+expressed as an ONNX graph (``onnxsim/qat_graph.py``, ``docs/qat.md``) so it
+can run on a GPU, an NPU execution provider, or WebGPU instead of only in host
+numpy.
+
+``onnxsim.adaround``'s own port is tested in ``tests/test_qat_graph.py``;
+these are the questions that port's tests cannot answer for this one, because
+AdaQuant optimizes strictly more. Three things matter:
+
+1. the graph really is the same optimization as the numpy loop it replaces,
+   over all *three* parameter groups at once -- not merely another one that
+   also happens to help;
+2. it stays inside the operator set the accelerator backends actually
+   implement (a step graph that reached for a convenient op no NPU execution
+   provider supports would pass every numerical test here and still be useless
+   for what it exists for); and
+3. ``apply_adaquant(..., step_providers=...)`` still produces a valid,
+   improved model end to end.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+# The allowlist tests/test_qat_graph.py pins for every step graph, imported
+# rather than copied so the two cannot drift: whatever that file decides the
+# accelerator backends cover, this graph is held to as well.
+from test_qat_graph import _ALLOWED_OPS
+
+import onnxsim
+from onnxsim import adaquant
+
+ort = pytest.importorskip("onnxruntime")
+
+_NUMPY_LOOP_KWARGS = dict(
+    num_iterations=200,
+    weight_learning_rate=0.1,
+    activation_learning_rate=0.01,
+    reg_param=0.01,
+    warm_start=0.2,
+    beta_range=(20.0, 2.0),
+)
+
+
+def _layer_case(seed, rows=40, n=8, k=32):
+    """One layer's optimization problem: real-shaped activations, a float
+    weight with its symmetric per-output-channel INT8 scale, and the min-max
+    calibrated activation (scale, zero_point) AdaQuant starts from.
+
+    The activation gets a couple of large, positively-shifted channels for the
+    same reason ``tests/test_adaquant.py`` does: a calibrated zero-point that
+    is neither 0 nor 128 is what gives the joint optimization something to do
+    on the activation side at all.
+    """
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((rows, k))
+    for channel in (3, 7):
+        x[:, channel % k] = x[:, channel % k] * 15.0 + 8.0
+    w = rng.standard_normal((n, k)) * 0.5
+    scale_n = np.abs(w).max(axis=1) / 127.0
+
+    x_min, x_max = min(0.0, float(x.min())), max(0.0, float(x.max()))
+    x_scale = (x_max - x_min) / 255.0
+    x_zp = float(np.clip(round(-x_min / x_scale), 0, 255))
+    return x, w, scale_n, x_scale, x_zp
+
+
+def _reconstruction_error(x, w, scale_n, codes, x_scale, x_zp):
+    """``||x @ w.T - dequantize(quantize(x)) @ (codes * scale).T||`` -- the
+    loss AdaQuant actually minimizes, including the activation's own
+    quantization, evaluated at a candidate solution."""
+    scale_nk = np.repeat(scale_n[:, None], w.shape[1], axis=1)
+    xq = np.clip(np.round(x / x_scale) + x_zp, 0.0, 255.0)
+    xdq = (xq - x_zp) * x_scale
+    return float(np.linalg.norm(x @ w.T - xdq @ (codes * scale_nk).T))
+
+
+def _round_to_nearest_codes(w, scale_n):
+    scale_nk = np.repeat(scale_n[:, None], w.shape[1], axis=1)
+    return np.clip(np.round(w / scale_nk), -127.0, 127.0)
+
+
+def test_adaquant_step_graph_agrees_with_the_numpy_loop():
+    """The step-graph path is the same optimization ``_optimize_adaquant``
+    performs, over all three parameter groups jointly.
+
+    Measured over five seeds, the two paths pick the *identical* floor/ceil
+    decision for at least 99% of weight elements, land on the same integer
+    zero-point, and agree on the activation scale to better than 1% relative
+    -- the residual being float32-vs-float64 boundary rounding, which for this
+    algorithm has two entry points rather than AdaRound's one: an element
+    whose relaxation sits near h = 0.5, and an activation whose ``x / scale``
+    sits within an ulp of a .5 boundary and so quantizes to a different
+    integer in the two paths.
+    """
+    for seed in range(5):
+        x, w, scale_n, x_scale0, x_zp0 = _layer_case(seed)
+
+        numpy_codes, numpy_scale, numpy_zp = adaquant._optimize_adaquant(
+            w, scale_n, x, x_scale0, x_zp0, **_NUMPY_LOOP_KWARGS
+        )
+        graph_codes, graph_scale, graph_zp = adaquant._optimize_adaquant_on_graph(
+            w, scale_n, x, x_scale0, x_zp0, providers=None, **_NUMPY_LOOP_KWARGS
+        )
+
+        assert (numpy_codes == graph_codes).mean() > 0.99
+        assert graph_zp == numpy_zp
+        assert graph_scale == pytest.approx(numpy_scale, rel=1e-2)
+
+        # And they arrive at the same place on the objective, which is better
+        # than the round-to-nearest weights and calibrated range they started
+        # from.
+        rtn_err = _reconstruction_error(
+            x, w, scale_n, _round_to_nearest_codes(w, scale_n), x_scale0, x_zp0
+        )
+        numpy_err = _reconstruction_error(
+            x, w, scale_n, numpy_codes, numpy_scale, numpy_zp
+        )
+        graph_err = _reconstruction_error(
+            x, w, scale_n, graph_codes, graph_scale, graph_zp
+        )
+        assert graph_err < rtn_err
+        assert graph_err == pytest.approx(numpy_err, rel=0.05)
+
+
+def test_adaquant_step_graph_optimizes_the_activation_range_too():
+    """The activation branch is actually being optimized, not just carried:
+    the scale and zero-point the graph path returns have moved off the
+    calibrated warm start, and the loss is lower *at fixed weights* than it
+    would be with the calibrated range."""
+    x, w, scale_n, x_scale0, x_zp0 = _layer_case(1)
+    codes, x_scale, x_zp = adaquant._optimize_adaquant_on_graph(
+        w, scale_n, x, x_scale0, x_zp0, providers=None, **_NUMPY_LOOP_KWARGS
+    )
+
+    assert x_scale != pytest.approx(x_scale0, rel=1e-6)
+    assert 0 <= x_zp <= 255
+    tuned = _reconstruction_error(x, w, scale_n, codes, x_scale, x_zp)
+    warm_start = _reconstruction_error(x, w, scale_n, codes, x_scale0, x_zp0)
+    assert tuned < warm_start
+
+
+def test_adaquant_step_graph_is_a_valid_model_declaring_all_nine_state_tensors():
+    step = adaquant._build_adaquant_step_graph(8, 3, 4)
+    onnx.checker.check_model(step.model)
+
+    input_names = {i.name for i in step.model.graph.input}
+    output_names = {o.name for o in step.model.graph.output}
+    assert set(step.state) <= input_names
+    assert set(step.state.values()) <= output_names
+    assert step.loss_name in output_names
+    # Three parameter groups, each with its own pair of Adam moments: the
+    # relaxation is per weight element, the activation's two are rank-0.
+    assert set(step.state) == {
+        "v",
+        "m_v",
+        "vv_v",
+        "log_s",
+        "m_s",
+        "vv_s",
+        "zp",
+        "m_zp",
+        "vv_zp",
+    }
+
+
+def test_adaquant_step_graph_stays_within_broadly_supported_ops():
+    step = adaquant._build_adaquant_step_graph(8, 3, 4)
+    used = {node.op_type for node in step.model.graph.node}
+    assert used <= _ALLOWED_OPS, f"unsupported ops in step graph: {used - _ALLOWED_OPS}"
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _matmul_model(K, N, seed):
+    rng = np.random.default_rng(seed)
+    weight = (rng.standard_normal((K, N)) * 0.5).astype(np.float32)
+    return _model(
+        f"""
+        g (float[batch,{K}] X) => (float[batch,{N}] Y)
+        {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [onnx.numpy_helper.from_array(weight, "W")],
+    )
+
+
+def _calibration(K, rows, seed):
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((rows, K)).astype(np.float32)
+    for channel in (3, 7):
+        x[:, channel] = x[:, channel] * 15.0 + 8.0
+    return x
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)[0].astype(np.float64)
+
+
+def test_apply_adaquant_on_a_step_graph_beats_the_untuned_quantized_model():
+    """End to end through the public API: ``step_providers`` moves the joint
+    optimization onto an execution provider, and what comes back is still a
+    valid, AdaQuant-improved model whose untouched tensors are untouched."""
+    K, N, rows = 64, 16, 64
+    model = _matmul_model(K, N, seed=0)
+    x = _calibration(K, rows, seed=1)
+    calibration_data = [{"X": x}]
+
+    quant = onnxsim.quantize_static(model, calibration_data=calibration_data)
+    assert any(n.op_type == "QuantizeLinear" for n in quant.graph.node)
+
+    tuned = onnxsim.apply_adaquant(
+        model,
+        quant,
+        calibration_data=calibration_data,
+        num_iterations=200,
+        step_providers=["CPUExecutionProvider"],
+    )
+    onnx.checker.check_model(tuned)
+
+    reference = _run(model, {"X": x})
+    quant_err = np.linalg.norm(reference - _run(quant, {"X": x}))
+    tuned_err = np.linalg.norm(reference - _run(tuned, {"X": x}))
+    assert tuned_err < quant_err
+
+    # AdaQuant promises to rewrite exactly three kinds of initializer -- the
+    # weight's INT8 codes and the activation's scale/zero-point -- and to
+    # leave everything else, the weight's own per-channel scale included,
+    # byte-identical. Shapes and dtypes are preserved throughout.
+    before = {t.name: t for t in quant.graph.initializer}
+    after = {t.name: t for t in tuned.graph.initializer}
+    assert set(before) == set(after)
+    ql = next(n for n in tuned.graph.node if n.op_type == "QuantizeLinear")
+    activation_params = {ql.input[1], ql.input[2]}
+    weight_codes = {
+        n.input[0]
+        for n in tuned.graph.node
+        if n.op_type == "DequantizeLinear" and n.input[0] in before
+    }
+    changed = {
+        name
+        for name in before
+        if before[name].SerializeToString() != after[name].SerializeToString()
+    }
+    assert changed <= activation_params | weight_codes
+    assert changed & weight_codes, "no weight was actually retuned"
+    for name in before:
+        assert list(before[name].dims) == list(after[name].dims)
+        assert before[name].data_type == after[name].data_type
+
+
+def test_apply_adaquant_step_providers_are_validated():
+    """An execution provider the installed onnxruntime does not have fails
+    loudly rather than silently running on the CPU -- backend.validate_providers'
+    own contract, inherited by the step-graph path."""
+    K, N, rows = 32, 8, 16
+    model = _matmul_model(K, N, seed=2)
+    x = _calibration(K, rows, seed=3)
+    calibration_data = [{"X": x}]
+    quant = onnxsim.quantize_static(model, calibration_data=calibration_data)
+
+    with pytest.raises(ValueError, match="not available"):
+        onnxsim.apply_adaquant(
+            model,
+            quant,
+            calibration_data=calibration_data,
+            num_iterations=5,
+            step_providers=["NoSuchExecutionProvider"],
+        )

--- a/tests/test_graph_grad.py
+++ b/tests/test_graph_grad.py
@@ -769,6 +769,12 @@ def test_the_emitted_backward_stays_inside_the_operator_allowlist():
     # allowlist is not padded with ops no rule can actually produce.
     assert emitted == set(graph_grad.BACKWARD_OPS)
 
+    # And this module's own allowlist has to sit inside the package-wide one a
+    # step graph is held to -- an emitted backward is appended to the same
+    # builder as the forward, so anything it can produce is something the
+    # execution provider has to be able to run.
+    assert graph_grad.BACKWARD_OPS <= qat_graph.EP_FRIENDLY_OPS
+
 
 def test_an_unsupported_op_is_refused():
     """No rule means no gradient -- not a zero, not a straight-through

--- a/tests/test_graph_grad.py
+++ b/tests/test_graph_grad.py
@@ -1,0 +1,964 @@
+"""Tests for ``onnxsim.graph_grad`` -- reverse-mode differentiation of an ONNX
+slice, emitted as ONNX nodes.
+
+A gradient is the one kind of code whose bugs do not announce themselves: a
+wrong VJP still produces a finite number of the right shape, the optimizer
+still runs, and the only symptom is that training converges somewhere
+slightly worse. So almost every test here is the same experiment -- build a
+small forward graph, emit its backward with
+:func:`onnxsim.graph_grad.build_backward`, run both through onnxruntime, and
+check the result against a central finite difference of the same forward
+evaluated in float64 by onnx's reference evaluator. The finite difference is
+an independent implementation in a different precision through a different
+runtime, which is what makes it worth comparing against; the tolerances are
+set by the float32 the backward graph itself computes in, not by the
+reference.
+
+Two things beyond correctness are also checked, for the same reason
+``tests/test_qat_graph.py`` checks them: that the emitted graph stays inside
+the operator allowlist the accelerator execution providers actually
+implement, and that an op with no rule is refused loudly instead of silently
+skipped.
+"""
+
+import math
+
+import numpy as np
+import onnx
+import onnx.parser
+import onnx.shape_inference
+import pytest
+from onnx.reference import ReferenceEvaluator
+from onnx.reference.op_run import OpRun
+
+from onnxsim import graph_grad, qat_graph
+
+ort = pytest.importorskip("onnxruntime")
+
+
+class Erf(OpRun):  # noqa: D101 -- the class name is how the evaluator binds it
+    """A float64 ``Erf`` for the reference evaluator.
+
+    onnx's own reference implementation rounds to float32
+    (``np.vectorize(erf, otypes=["f"])``) whatever it is given, which leaves
+    the finite difference below with ~1e-7 of noise over a 1e-5 step -- a 1%
+    error, an order of magnitude worse than the float32 gradient it is meant
+    to be the reference for. This one keeps the precision the rest of the
+    reference forward runs in.
+    """
+
+    op_domain = ""
+
+    def _run(self, x):
+        return (np.vectorize(math.erf, otypes=[np.float64])(x).astype(x.dtype),)
+
+
+# Same opset/IR pairing qat_graph builds its step graphs with.
+_HEADER = '<ir_version: 8, opset_import: ["": 17]>'
+
+# Step for the central difference. The reference forward runs in float64, so
+# this can be small enough for the O(h^2) truncation error to fall well below
+# the float32 noise in the graph being tested without round-off taking over.
+_H = 1e-5
+
+
+def _model(body: str) -> onnx.ModelProto:
+    return onnx.parser.parse_model(f"{_HEADER}\n{body}")
+
+
+def _static_shapes(model: onnx.ModelProto) -> dict:
+    """Every tensor's static shape -- what ``build_backward`` asks its caller
+    for, obtained the way a real caller would."""
+    inferred = onnx.shape_inference.infer_shapes(model, strict_mode=True)
+    shapes = {}
+    for value in (
+        list(inferred.graph.input)
+        + list(inferred.graph.output)
+        + list(inferred.graph.value_info)
+    ):
+        shapes[value.name] = [d.dim_value for d in value.type.tensor_type.shape.dim]
+    for initializer in inferred.graph.initializer:
+        shapes[initializer.name] = list(initializer.dims)
+    return shapes
+
+
+def _as_double(model: onnx.ModelProto) -> onnx.ModelProto:
+    """The same forward, retyped float64.
+
+    The point of the reference is to be *more* accurate than the thing under
+    test; running the finite difference in the float32 the backward graph
+    uses would measure the two against the same round-off and prove nothing.
+    """
+    doubled = onnx.ModelProto()
+    doubled.CopyFrom(model)
+    for value in list(doubled.graph.input) + list(doubled.graph.output):
+        if value.type.tensor_type.elem_type == onnx.TensorProto.FLOAT:
+            value.type.tensor_type.elem_type = onnx.TensorProto.DOUBLE
+    converted = []
+    for initializer in doubled.graph.initializer:
+        array = onnx.numpy_helper.to_array(initializer)
+        if array.dtype == np.float32:
+            array = array.astype(np.float64)
+        converted.append(onnx.numpy_helper.from_array(array, initializer.name))
+    del doubled.graph.initializer[:]
+    doubled.graph.initializer.extend(converted)
+    return doubled
+
+
+def _backward_model(model: onnx.ModelProto, targets, seed_name="dY"):
+    """``model``'s forward nodes followed by the emitted backward, as one
+    graph whose outputs are the requested gradients.
+
+    Wiring the backward into the *same* graph as the forward is not a test
+    convenience -- it is the contract: the rules read forward tensors
+    (including intermediate node outputs) by name, so they only mean anything
+    where those tensors exist.
+    """
+    shapes = _static_shapes(model)
+    output = model.graph.output[0].name
+    b = qat_graph.GraphBuilder("bw_")
+    grads = graph_grad.build_backward(
+        b, list(model.graph.node), shapes, {output: seed_name}, targets
+    )
+
+    emitted = {node.op_type for node in b.nodes}
+    assert emitted <= graph_grad.BACKWARD_OPS, (
+        f"backward graph reached outside the allowlist: "
+        f"{sorted(emitted - graph_grad.BACKWARD_OPS)}"
+    )
+
+    # A returned gradient can be an alias of an existing tensor (Identity
+    # emits no node at all), and a graph output has to be produced by a node,
+    # so each one is copied out under a stable name.
+    nodes = list(model.graph.node) + list(b.nodes)
+    outputs = []
+    for target in targets:
+        name = f"grad_{target}"
+        nodes.append(onnx.helper.make_node("Identity", [grads[target]], [name]))
+        outputs.append(
+            onnx.helper.make_tensor_value_info(
+                name, onnx.TensorProto.FLOAT, shapes[target]
+            )
+        )
+    inputs = list(model.graph.input) + [
+        onnx.helper.make_tensor_value_info(
+            seed_name, onnx.TensorProto.FLOAT, shapes[output]
+        )
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "backward",
+        inputs,
+        outputs,
+        initializer=list(model.graph.initializer) + list(b.initializer),
+    )
+    built = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    built.ir_version = 8
+    onnx.checker.check_model(built)
+    return built
+
+
+def _feeds(model: onnx.ModelProto, rng, overrides=None) -> dict:
+    """Random float32 values for every graph input.
+
+    float32 rather than float64 so the analytic and the finite-difference
+    paths start from bit-identical inputs -- otherwise the comparison would
+    also be measuring the rounding of the inputs themselves.
+    """
+    overrides = overrides or {}
+    feeds = {}
+    for value in model.graph.input:
+        name = value.name
+        shape = [d.dim_value for d in value.type.tensor_type.shape.dim]
+        if name in overrides:
+            feeds[name] = np.asarray(overrides[name](rng, shape), dtype=np.float32)
+        else:
+            feeds[name] = rng.standard_normal(shape).astype(np.float32)
+    return feeds
+
+
+def _finite_difference(evaluator, feeds64, target, seed):
+    """d/d(target) of ``sum(forward(feeds) * seed)``, by central differences.
+
+    That scalar is exactly the quantity a VJP computes: seeding the backward
+    with ``seed`` and asking for ``target``'s gradient must give the same
+    thing, for every ``seed``.
+    """
+    working = {k: np.array(v, dtype=np.float64) for k, v in feeds64.items()}
+    flat = working[target].reshape(-1)
+    result = np.empty_like(flat)
+    for i in range(flat.size):
+        original = flat[i]
+        flat[i] = original + _H
+        plus = float((evaluator.run(None, working)[0] * seed).sum())
+        flat[i] = original - _H
+        minus = float((evaluator.run(None, working)[0] * seed).sum())
+        flat[i] = original
+        result[i] = (plus - minus) / (2.0 * _H)
+    return result.reshape(working[target].shape)
+
+
+def _check(model, targets=None, overrides=None, seed=0, rtol=2e-3, atol=2e-4):
+    """The whole experiment: emitted gradients against finite differences."""
+    rng = np.random.default_rng(seed)
+    targets = targets or [value.name for value in model.graph.input]
+    feeds = _feeds(model, rng, overrides)
+
+    backward = _backward_model(model, targets)
+    output_shape = _static_shapes(model)[model.graph.output[0].name]
+    grad_seed = rng.standard_normal(output_shape).astype(np.float32)
+    session = ort.InferenceSession(
+        backward.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    analytic = session.run([f"grad_{t}" for t in targets], dict(feeds, dY=grad_seed))
+
+    evaluator = ReferenceEvaluator(_as_double(model), new_ops=[Erf])
+    feeds64 = {k: v.astype(np.float64) for k, v in feeds.items()}
+    for target, got in zip(targets, analytic):
+        expected = _finite_difference(
+            evaluator, feeds64, target, grad_seed.astype(np.float64)
+        )
+        assert got.shape == expected.shape, f"{target}: {got.shape} != {expected.shape}"
+        np.testing.assert_allclose(got, expected, rtol=rtol, atol=atol)
+    return backward
+
+
+def _positive(rng, shape):
+    return np.abs(rng.standard_normal(shape)) + 0.5
+
+
+def _away_from_zero(rng, shape):
+    x = rng.standard_normal(shape)
+    return np.where(x >= 0, x + 0.5, x - 0.5)
+
+
+# Every rule, one small graph each. Shapes are kept tiny because the finite
+# difference costs two full forward passes per element.
+_CASES = {
+    "matmul": (
+        """
+        g (float[3,4] A, float[4,5] B) => (float[3,5] Y) {
+          Y = MatMul(A, B)
+        }
+        """,
+        None,
+    ),
+    "matmul_batched": (
+        """
+        g (float[2,3,4] A, float[2,4,5] B) => (float[2,3,5] Y) {
+          Y = MatMul(A, B)
+        }
+        """,
+        None,
+    ),
+    "matmul_broadcast_batch": (
+        """
+        g (float[1,3,4] A, float[2,4,5] B) => (float[2,3,5] Y) {
+          Y = MatMul(A, B)
+        }
+        """,
+        None,
+    ),
+    "matmul_rank_mix": (
+        """
+        g (float[2,3,4] A, float[4,5] B) => (float[2,3,5] Y) {
+          Y = MatMul(A, B)
+        }
+        """,
+        None,
+    ),
+    "add": (
+        """
+        g (float[3,4] A, float[3,4] B) => (float[3,4] Y) {
+          Y = Add(A, B)
+        }
+        """,
+        None,
+    ),
+    "sub": (
+        """
+        g (float[3,4] A, float[3,4] B) => (float[3,4] Y) {
+          Y = Sub(A, B)
+        }
+        """,
+        None,
+    ),
+    "mul": (
+        """
+        g (float[3,4] A, float[3,4] B) => (float[3,4] Y) {
+          Y = Mul(A, B)
+        }
+        """,
+        None,
+    ),
+    "div": (
+        """
+        g (float[3,4] A, float[3,4] B) => (float[3,4] Y) {
+          Y = Div(A, B)
+        }
+        """,
+        {"B": _away_from_zero},
+    ),
+    "neg": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Neg(A)
+        }
+        """,
+        None,
+    ),
+    "identity": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Identity(A)
+        }
+        """,
+        None,
+    ),
+    "relu": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Relu(A)
+        }
+        """,
+        None,
+    ),
+    "sigmoid": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Sigmoid(A)
+        }
+        """,
+        None,
+    ),
+    "tanh": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Tanh(A)
+        }
+        """,
+        None,
+    ),
+    "erf": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Erf(A)
+        }
+        """,
+        None,
+    ),
+    "exp": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Exp(A)
+        }
+        """,
+        None,
+    ),
+    "sqrt": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Sqrt(A)
+        }
+        """,
+        {"A": _positive},
+    ),
+    "transpose_default": (
+        """
+        g (float[2,3,4] A) => (float[4,3,2] Y) {
+          Y = Transpose(A)
+        }
+        """,
+        None,
+    ),
+    "transpose_perm": (
+        """
+        g (float[2,3,4] A) => (float[3,2,4] Y) {
+          Y = Transpose <perm = [1, 0, 2]> (A)
+        }
+        """,
+        None,
+    ),
+    "reshape": (
+        """
+        g (float[2,3,4] A) => (float[6,4] Y)
+        <int64[2] target = {6, 4}>
+        {
+          Y = Reshape(A, target)
+        }
+        """,
+        None,
+    ),
+    "reducesum_keepdims": (
+        """
+        g (float[2,3,4] A) => (float[2,1,4] Y)
+        <int64[1] axes = {1}>
+        {
+          Y = ReduceSum <keepdims = 1> (A, axes)
+        }
+        """,
+        None,
+    ),
+    "reducesum_dropdims": (
+        """
+        g (float[2,3,4] A) => (float[2,4] Y)
+        <int64[1] axes = {1}>
+        {
+          Y = ReduceSum <keepdims = 0> (A, axes)
+        }
+        """,
+        None,
+    ),
+    "reducesum_all": (
+        """
+        g (float[2,3] A) => (float Y) {
+          Y = ReduceSum <keepdims = 0> (A)
+        }
+        """,
+        None,
+    ),
+    # ReduceMean only takes its axes as a tensor input from opset 18; at the
+    # opset 17 this whole module targets they are still an attribute, so both
+    # spellings of "which axes" get exercised across these two cases.
+    "reducemean_axes_attribute": (
+        """
+        g (float[2,3,4] A) => (float[2,3,1] Y) {
+          Y = ReduceMean <axes = [2], keepdims = 1> (A)
+        }
+        """,
+        None,
+    ),
+    "reducemean_dropdims": (
+        """
+        g (float[2,3,4] A) => (float[2,4] Y) {
+          Y = ReduceMean <axes = [1], keepdims = 0> (A)
+        }
+        """,
+        None,
+    ),
+    "reducemean_all": (
+        """
+        g (float[3,4] A) => (float Y) {
+          Y = ReduceMean <keepdims = 0> (A)
+        }
+        """,
+        None,
+    ),
+    "softmax_last_axis": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Softmax (A)
+        }
+        """,
+        None,
+    ),
+    "softmax_first_axis": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Softmax <axis = 0> (A)
+        }
+        """,
+        None,
+    ),
+    "clip": (
+        """
+        g (float[3,4] A) => (float[3,4] Y)
+        <float lo = {-0.5}, float hi = {0.5}>
+        {
+          Y = Clip(A, lo, hi)
+        }
+        """,
+        None,
+    ),
+    "clip_lower_only": (
+        """
+        g (float[3,4] A) => (float[3,4] Y)
+        <float lo = {-0.25}>
+        {
+          Y = Clip(A, lo)
+        }
+        """,
+        None,
+    ),
+}
+
+
+@pytest.mark.parametrize("seed", [0, 1])
+@pytest.mark.parametrize("case", sorted(_CASES), ids=sorted(_CASES))
+def test_rule_matches_finite_differences(case, seed):
+    # Two draws rather than one: a single random point can miss a sign error
+    # on a term that happens to be small there, and the finite difference is
+    # cheap at these sizes.
+    body, overrides = _CASES[case]
+    _check(_model(body), overrides=overrides, seed=seed)
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        "",
+        "<alpha = 0.75>",
+        "<beta = 0.5>",
+        "<alpha = 1.5, beta = -0.25>",
+        "<transB = 1>",
+        "<transA = 1>",
+        "<transA = 1, transB = 1, alpha = 0.5, beta = 2.0>",
+    ],
+    ids=["plain", "alpha", "beta", "alpha_beta", "transB", "transA", "everything"],
+)
+def test_gemm_honours_its_attributes(attributes):
+    """Gemm's four attributes each change the gradient, and getting one of
+    them wrong is invisible in the forward -- the Y a wrongly-differentiated
+    Gemm produces is still correct."""
+    trans_a = "transA = 1" in attributes
+    trans_b = "transB = 1" in attributes
+    a_shape = "4,3" if trans_a else "3,4"
+    b_shape = "5,4" if trans_b else "4,5"
+    _check(
+        _model(
+            f"""
+            g (float[{a_shape}] A, float[{b_shape}] B, float[5] C)
+                => (float[3,5] Y) {{
+              Y = Gemm {attributes} (A, B, C)
+            }}
+            """
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "op", ["Add", "Sub", "Mul", "Div"], ids=["add", "sub", "mul", "div"]
+)
+@pytest.mark.parametrize(
+    "a_shape,b_shape,out_shape",
+    [
+        ("4,3", "3", "4,3"),
+        ("4,1", "1,3", "4,3"),
+        ("3", "4,3", "4,3"),
+        ("2,3,4", "4", "2,3,4"),
+        ("1,3,1", "2,1,4", "2,3,4"),
+    ],
+    ids=["row", "outer", "left_smaller", "batched", "both_broadcast"],
+)
+def test_broadcasting_gradients_are_reduced_to_the_input_shape(
+    op, a_shape, b_shape, out_shape
+):
+    """The single most common way a VJP goes quietly wrong: a broadcast
+    operand's gradient must be summed over the axes that were replicated, and
+    reshaped back to the operand's own shape. A gradient of the wrong shape
+    does not fail -- it broadcasts again inside the optimizer and applies a
+    multiple of the intended step."""
+    overrides = {"B": _away_from_zero} if op == "Div" else None
+    _check(
+        _model(
+            f"""
+            g (float[{a_shape}] A, float[{b_shape}] B) => (float[{out_shape}] Y) {{
+              Y = {op}(A, B)
+            }}
+            """
+        ),
+        overrides=overrides,
+    )
+
+
+@pytest.mark.parametrize(
+    "grad_shape,target_shape",
+    [
+        ((4, 3), (3,)),
+        ((4, 3), (1, 3)),
+        ((4, 3), (4, 1)),
+        ((2, 3, 4), (4,)),
+        ((2, 3, 4), (1, 3, 1)),
+        ((2, 3, 4), ()),
+        ((2, 3, 4), (2, 3, 4)),
+    ],
+)
+def test_reduce_to_matches_a_numpy_broadcast_reduction(grad_shape, target_shape):
+    """The broadcast-undoing helper on its own, against the numpy sum it is
+    supposed to be."""
+    b = qat_graph.GraphBuilder()
+    ctx = graph_grad._Backward(b, {})
+    out = ctx.reduce_to("G", grad_shape, target_shape)
+    reduced = onnx.helper.make_node("Identity", [out], ["R"])
+    graph = onnx.helper.make_graph(
+        b.nodes + [reduced],
+        "reduce_to",
+        [
+            onnx.helper.make_tensor_value_info(
+                "G", onnx.TensorProto.FLOAT, list(grad_shape)
+            )
+        ],
+        [
+            onnx.helper.make_tensor_value_info(
+                "R", onnx.TensorProto.FLOAT, list(target_shape)
+            )
+        ],
+        initializer=b.initializer,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+
+    g = np.random.default_rng(0).standard_normal(grad_shape).astype(np.float32)
+    session = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    got = session.run(None, {"G": g})[0]
+
+    offset = len(grad_shape) - len(target_shape)
+    axes = tuple(range(offset)) + tuple(
+        offset + i
+        for i, d in enumerate(target_shape)
+        if d == 1 and grad_shape[offset + i] != 1
+    )
+    expected = g.sum(axis=axes).reshape(target_shape)
+    assert got.shape == expected.shape
+    np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+# Blocks rather than single ops: gradient accumulation, and the two halves of
+# a transformer layer. Kept beside `_CASES` because the allowlist test needs
+# both corpora -- accumulation is the only thing that emits an `Add`.
+_BLOCKS = {
+    "shared_input": """
+        g (float[3,4] A, float[3,4] B) => (float[3,4] Y) {
+          T = Mul(A, B)
+          U = Add(T, A)
+          Y = Mul(U, A)
+        }
+        """,
+    "gelu_block": """
+        g (float[4,6] X, float[6,8] W1, float[8] B1, float[8,6] W2, float[6] B2)
+            => (float[4,6] Y)
+        <float half = {0.5}, float one = {1.0}, float inv_sqrt2 = {0.70710678}>
+        {
+          H = MatMul(X, W1)
+          Hb = Add(H, B1)
+          S = Mul(Hb, inv_sqrt2)
+          E = Erf(S)
+          Ep = Add(E, one)
+          Hh = Mul(half, Ep)
+          G = Mul(Hb, Hh)
+          P = MatMul(G, W2)
+          Pb = Add(P, B2)
+          Y = Add(Pb, X)
+        }
+        """,
+    "attention_block": """
+        g (float[2,3,4] Q, float[2,3,4] K, float[2,3,4] V) => (float[2,3,4] Y)
+        <float scale = {0.5}>
+        {
+          Kt = Transpose <perm = [0, 2, 1]> (K)
+          L = MatMul(Q, Kt)
+          Ls = Mul(L, scale)
+          P = Softmax (Ls)
+          Y = MatMul(P, V)
+        }
+        """,
+}
+
+
+def test_a_tensor_consumed_twice_sums_its_gradients():
+    """``A`` reaches the output down two paths, so its gradient is the sum of
+    both. Dropping one is the classic residual-connection bug, and it is
+    invisible unless the two paths are compared against a reference."""
+    backward = _check(_model(_BLOCKS["shared_input"]))
+    # The sum is a real Add in the graph, not an accident of the arithmetic.
+    assert sum(node.op_type == "Add" for node in backward.graph.node) >= 1
+
+
+def test_a_gradient_seeded_on_an_intermediate_tensor_is_added_in():
+    """Seeding an intermediate value adds to what the slice itself
+    contributes to it, which is what an auxiliary loss on an activation
+    means. Checked against the equivalent single-seed graph rather than
+    against a number, so the claim being tested is the additivity itself."""
+    model = _model(
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          H = Mul(A, A)
+          Y = Tanh(H)
+        }
+        """
+    )
+    shapes = _static_shapes(model)
+    b = qat_graph.GraphBuilder("bw_")
+    grads = graph_grad.build_backward(
+        b, list(model.graph.node), shapes, {"Y": "dY", "H": "dH"}, ["A"]
+    )
+    nodes = list(model.graph.node) + list(b.nodes)
+    nodes.append(onnx.helper.make_node("Identity", [grads["A"]], ["grad_A"]))
+    graph = onnx.helper.make_graph(
+        nodes,
+        "seeded",
+        list(model.graph.input)
+        + [
+            onnx.helper.make_tensor_value_info(n, onnx.TensorProto.FLOAT, [3, 4])
+            for n in ("dY", "dH")
+        ],
+        [onnx.helper.make_tensor_value_info("grad_A", onnx.TensorProto.FLOAT, [3, 4])],
+        initializer=list(b.initializer),
+    )
+    model2 = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model2.ir_version = 8
+    onnx.checker.check_model(model2)
+
+    rng = np.random.default_rng(7)
+    a = rng.standard_normal((3, 4)).astype(np.float32)
+    dy = rng.standard_normal((3, 4)).astype(np.float32)
+    dh = rng.standard_normal((3, 4)).astype(np.float32)
+    session = ort.InferenceSession(
+        model2.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    both = session.run(None, {"A": a, "dY": dy, "dH": dh})[0]
+    only_y = session.run(None, {"A": a, "dY": dy, "dH": np.zeros_like(dh)})[0]
+    only_h = session.run(None, {"A": a, "dY": np.zeros_like(dy), "dH": dh})[0]
+    np.testing.assert_allclose(both, only_y + only_h, rtol=1e-5, atol=1e-6)
+    # dL/dH = dh flowing through H = A*A gives 2*A*dh; a sanity anchor on the
+    # intermediate seed actually being used at all.
+    np.testing.assert_allclose(only_h, 2.0 * a * dh, rtol=1e-5, atol=1e-6)
+
+
+def test_a_transformer_style_block_end_to_end():
+    """Two linear layers, a GELU in its exact ``erf`` form, and a residual
+    Add -- the shape :mod:`onnxsim.brecq` cannot currently reconstruct
+    because its block discovery only walks a linear MatMul chain, and the
+    reason this module exists (``docs/qat.md``, deliverable B).
+
+    Note ``X`` feeds both the first projection and the residual, so this also
+    exercises gradient accumulation through a whole block rather than through
+    a three-node toy.
+    """
+    _check(_model(_BLOCKS["gelu_block"]))
+
+
+def test_an_attention_style_block_end_to_end():
+    """The other half of a transformer block: a scaled dot product, a
+    Softmax, and a second MatMul, batched over heads."""
+    _check(_model(_BLOCKS["attention_block"]))
+
+
+def test_the_emitted_backward_stays_inside_the_operator_allowlist():
+    """Every rule at once, checked against :data:`graph_grad.BACKWARD_OPS`.
+
+    The allowlist is not decoration: this machinery exists so a training step
+    can run on WebGPU and NPU execution providers, and a backward graph using
+    an op none of them implement would pass every numerical test above and
+    still be useless for what it is for.
+    """
+    emitted = set()
+    bodies = [body for body, _ in _CASES.values()] + list(_BLOCKS.values())
+    for body in bodies:
+        model = _model(body)
+        b = qat_graph.GraphBuilder()
+        graph_grad.build_backward(
+            b,
+            list(model.graph.node),
+            _static_shapes(model),
+            {model.graph.output[0].name: "dY"},
+            [value.name for value in model.graph.input],
+        )
+        emitted |= {node.op_type for node in b.nodes}
+
+    # Exact equality, both ways: nothing escapes the allowlist, and the
+    # allowlist is not padded with ops no rule can actually produce.
+    assert emitted == set(graph_grad.BACKWARD_OPS)
+
+
+def test_an_unsupported_op_is_refused():
+    """No rule means no gradient -- not a zero, not a straight-through
+    approximation. Refusing is recoverable; a quietly wrong gradient is
+    not."""
+    model = _model(
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Sin(A)
+        }
+        """
+    )
+    b = qat_graph.GraphBuilder()
+    with pytest.raises(graph_grad.UnsupportedOpError, match="Sin"):
+        graph_grad.build_backward(
+            b, list(model.graph.node), _static_shapes(model), {"Y": "dY"}, ["A"]
+        )
+
+
+def test_an_unsupported_op_is_refused_even_when_no_gradient_reaches_it():
+    """The refusal is a property of the slice, not of where the seed happens
+    to reach: a caller should learn its block is out of scope from the block,
+    not from which tensor it asked about."""
+    model = _model(
+        """
+        g (float[3,4] A) => (float[3,4] Y, float[3,4] Z) {
+          Y = Relu(A)
+          Z = Sin(A)
+        }
+        """
+    )
+    b = qat_graph.GraphBuilder()
+    with pytest.raises(graph_grad.UnsupportedOpError, match="Sin"):
+        graph_grad.build_backward(
+            b, list(model.graph.node), _static_shapes(model), {"Y": "dY"}, ["A"]
+        )
+
+
+def test_a_matmul_with_a_1d_operand_is_refused():
+    """A covered op type in a configuration the rule does not handle is
+    refused the same way an uncovered op type is -- the caller's remedy is
+    the same either way."""
+    model = _model(
+        """
+        g (float[3,4] A, float[4] B) => (float[3] Y) {
+          Y = MatMul(A, B)
+        }
+        """
+    )
+    b = qat_graph.GraphBuilder()
+    with pytest.raises(graph_grad.UnsupportedOpError, match="1-D"):
+        graph_grad.build_backward(
+            b, list(model.graph.node), _static_shapes(model), {"Y": "dY"}, ["A"]
+        )
+
+
+def test_ambiguous_reduced_axes_are_refused():
+    """``[3, 3] -> [3]`` with ``keepdims=0`` could have reduced either axis,
+    and the two answers put the gradient in different places. The axes are a
+    tensor input the slice does not carry, so this is refused rather than
+    guessed."""
+    model = _model(
+        """
+        g (float[3,3] A) => (float[3] Y)
+        <int64[1] axes = {0}>
+        {
+          Y = ReduceSum <keepdims = 0> (A, axes)
+        }
+        """
+    )
+    b = qat_graph.GraphBuilder()
+    with pytest.raises(graph_grad.UnsupportedOpError, match="ambiguous"):
+        graph_grad.build_backward(
+            b, list(model.graph.node), _static_shapes(model), {"Y": "dY"}, ["A"]
+        )
+
+
+def test_a_disconnected_target_is_refused():
+    """Returning a zero gradient for a target nothing reaches would hide a
+    wrong slice or a typo in a parameter name."""
+    model = _model(
+        """
+        g (float[3,4] A, float[3,4] B) => (float[3,4] Y) {
+          Y = Relu(A)
+        }
+        """
+    )
+    b = qat_graph.GraphBuilder()
+    with pytest.raises(ValueError, match="no gradient reaches"):
+        graph_grad.build_backward(
+            b, list(model.graph.node), _static_shapes(model), {"Y": "dY"}, ["A", "B"]
+        )
+
+
+def test_a_missing_shape_is_refused():
+    """Shapes are what makes undoing a broadcast possible at build time;
+    a missing one has to be an error, not a shrug."""
+    model = _model(
+        """
+        g (float[4,3] A, float[3] B) => (float[4,3] Y) {
+          Y = Mul(A, B)
+        }
+        """
+    )
+    b = qat_graph.GraphBuilder()
+    with pytest.raises(ValueError, match="no static shape"):
+        graph_grad.build_backward(
+            b, list(model.graph.node), {"Y": [4, 3], "A": [4, 3]}, {"Y": "dY"}, ["A"]
+        )
+
+
+def test_the_backward_composes_into_a_step_graph_that_trains():
+    """The point of emitting ONNX rather than computing numbers: the result
+    drops straight into :mod:`onnxsim.qat_graph`'s Adam step and optimizes,
+    on whatever execution provider the caller names.
+
+    The task is deliberately one no hand-derived gradient in this repo covers
+    -- fitting a two-layer block with a GELU in the middle against a teacher's
+    output, which is exactly ``docs/qat.md``'s block reconstruction in
+    miniature.
+    """
+    rows, k, hidden = 16, 4, 6
+    forward = _model(
+        f"""
+        g (float[{rows},{k}] x, float[{k},{hidden}] w1, float[{hidden},{k}] w2)
+            => (float[{rows},{k}] y_hat)
+        <float half = {{0.5}}, float one = {{1.0}}, float inv_sqrt2 = {{0.70710678}}>
+        {{
+          h = MatMul(x, w1)
+          s = Mul(h, inv_sqrt2)
+          e = Erf(s)
+          ep = Add(e, one)
+          hh = Mul(half, ep)
+          gelu = Mul(h, hh)
+          y_hat = MatMul(gelu, w2)
+        }}
+        """
+    )
+    shapes = _static_shapes(forward)
+
+    b = qat_graph.GraphBuilder()
+    b.nodes.extend(forward.graph.node)
+    b.initializer.extend(forward.graph.initializer)
+    diff = b.sub("y_hat", "y")
+    dl_dy = b.mul(diff, b.const(2.0 / (rows * k)))
+    grads = graph_grad.build_backward(
+        b, list(forward.graph.node), shapes, {"y_hat": dl_dy}, ["w2"]
+    )
+    w2_next, m_next, v_next = qat_graph.adam_update(
+        b, "w2", grads["w2"], "m", "vv", "lr", "m_correction", "v_correction"
+    )
+    step = qat_graph.make_step_graph(
+        b,
+        constants={"x": [rows, k], "y": [rows, k], "w1": [k, hidden]},
+        state={
+            "w2": ([hidden, k], w2_next),
+            "m": ([hidden, k], m_next),
+            "vv": ([hidden, k], v_next),
+        },
+        scalars=["lr", "m_correction", "v_correction"],
+        loss=b.mean_square(diff),
+    )
+    onnx.checker.check_model(step.model)
+
+    rng = np.random.default_rng(21)
+    x = rng.standard_normal((rows, k)).astype(np.float32)
+    w1 = rng.standard_normal((k, hidden)).astype(np.float32)
+    w2_true = rng.standard_normal((hidden, k)).astype(np.float32)
+    teacher = ReferenceEvaluator(_as_double(forward), new_ops=[Erf])
+    y = teacher.run(
+        None,
+        {
+            "x": x.astype(np.float64),
+            "w1": w1.astype(np.float64),
+            "w2": w2_true.astype(np.float64),
+        },
+    )[0].astype(np.float32)
+
+    losses: list = []
+    final = qat_graph.run_step_graph(
+        step,
+        constants={"x": x, "y": y, "w1": w1},
+        state={
+            "w2": np.zeros_like(w2_true),
+            "m": np.zeros_like(w2_true),
+            "vv": np.zeros_like(w2_true),
+        },
+        num_steps=1500,
+        scalars=lambda t: dict(lr=0.05, **qat_graph.adam_bias_corrections(t)),
+        losses=losses,
+    )
+    assert losses[-1] < losses[0] * 1e-4
+    np.testing.assert_allclose(final["w2"], w2_true, rtol=1e-2, atol=1e-2)

--- a/tests/test_qat.py
+++ b/tests/test_qat.py
@@ -1,0 +1,716 @@
+"""Tests for ``onnxsim.apply_qat`` (see ``onnxsim/qat.py``) -- label-free,
+block-wise quantization-aware fine-tuning: the float model is the teacher, the
+quantized model is the student, and the loss is the block's own output
+reconstruction error.
+
+Two claims separate this from the six rounding passes already in the tree, and
+each is *measured* here rather than assumed:
+
+1. the block may be any topology :mod:`onnxsim.graph_grad` can differentiate,
+   including the activation-between-two-Linears shape
+   :func:`onnxsim.apply_brecq` refuses outright (asserted directly: BRECQ
+   returns the model unchanged on the very graph this trains);
+2. the fp32 weights themselves move, not only their floor/ceil choice.
+
+Claim 2 is the one with a nuance, and the test that makes it records the
+nuance instead of hiding it: freeing the weights wins where the reconstruction
+problem is *underdetermined*, and loses to AdaRound's smoother relaxation
+where it is not. Both directions are measured below.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+from onnxsim import graph_grad, qat, qat_graph
+
+ort = pytest.importorskip("onnxruntime")
+
+# quantize_weight_only_int4's own fixed block size, so every weight dimension
+# below is a multiple of it.
+D = 32
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _quantize_chain_int4(model, weight_names):
+    # Verbatim in spirit from tests/test_brecq.py, and for the same reason:
+    # onnxsim.quantize_weight_only_int4 only quantizes a MatMul whose
+    # activation input is a graph input, so a multi-layer chain comes back
+    # with only its first layer quantized. To get a fully quantized block,
+    # quantize each named weight's MatMul in isolation -- where it *is* the
+    # first layer -- through the real production pass, then splice the
+    # resulting DequantizeLinear and its Wq/Ws back into the chain. The codes
+    # are exactly the ones the real pass produces; only the assembly is by
+    # hand.
+    original = {t.name: t for t in model.graph.initializer}
+    quantized = onnx.ModelProto()
+    quantized.CopyFrom(model)
+
+    nodes = []
+    initializers = [
+        t for t in quantized.graph.initializer if t.name not in weight_names
+    ]
+    for index, node in enumerate(quantized.graph.node):
+        if node.op_type not in ("MatMul", "Gemm") or node.input[1] not in weight_names:
+            nodes.append(node)
+            continue
+        weight_name = node.input[1]
+        weight = original[weight_name]
+        k, n = weight.dims[0], weight.dims[1]
+        isolated = _model(
+            f"""
+            h (float[batch,{k}] Ain) => (float[batch,{n}] Aout)
+            {{
+              Aout = MatMul(Ain, {weight_name})
+            }}
+            """,
+            [weight],
+        )
+        isolated_q = onnxsim.quantize_weight_only_int4(isolated)
+        dq = next(x for x in isolated_q.graph.node if x.op_type == "DequantizeLinear")
+        wq = next(t for t in isolated_q.graph.initializer if t.name == dq.input[0])
+        ws = next(t for t in isolated_q.graph.initializer if t.name == dq.input[1])
+
+        suffix = f"_{index}"
+        wq_renamed = onnx.TensorProto()
+        wq_renamed.CopyFrom(wq)
+        wq_renamed.name += suffix
+        ws_renamed = onnx.TensorProto()
+        ws_renamed.CopyFrom(ws)
+        ws_renamed.name += suffix
+        dq_out = f"{weight_name}_dq{suffix}"
+
+        new_dq = onnx.NodeProto()
+        new_dq.CopyFrom(dq)
+        new_dq.input[0] = wq_renamed.name
+        new_dq.input[1] = ws_renamed.name
+        new_dq.output[0] = dq_out
+        initializers.extend([wq_renamed, ws_renamed])
+        nodes.append(new_dq)
+
+        new_node = onnx.NodeProto()
+        new_node.CopyFrom(node)
+        new_node.input[1] = dq_out
+        nodes.append(new_node)
+
+    del quantized.graph.node[:]
+    quantized.graph.node.extend(nodes)
+    del quantized.graph.initializer[:]
+    quantized.graph.initializer.extend(initializers)
+    return quantized
+
+
+def _dequantize_int4_for(model, matmul_output_name):
+    """The effective float weight the quantized model actually deploys for one
+    MatMul -- same decode as ``tests/test_brecq.py``'s own helper."""
+    matmul = next(n for n in model.graph.node if n.output[0] == matmul_output_name)
+    dq = next(n for n in model.graph.node if n.output[0] == matmul.input[1])
+    wq = next(t for t in model.graph.initializer if t.name == dq.input[0])
+    ws = next(t for t in model.graph.initializer if t.name == dq.input[1])
+    block_size = next(a.i for a in dq.attribute if a.name == "block_size")
+    axis = next((a.i for a in dq.attribute if a.name == "axis"), 1)
+
+    dims = list(wq.dims)
+    numel = int(np.prod(dims))
+    raw = np.frombuffer(wq.raw_data, dtype=np.uint8)
+    lo = (raw & 0x0F).astype(np.int8)
+    hi = ((raw >> 4) & 0x0F).astype(np.int8)
+    lo = np.where(lo >= 8, lo - 16, lo)
+    hi = np.where(hi >= 8, hi - 16, hi)
+    codes = np.empty(numel, dtype=np.int8)
+    codes[0::2] = lo[: (numel + 1) // 2]
+    codes[1::2] = hi[: numel // 2]
+    codes = codes.reshape(dims).astype(np.float64)
+
+    scale = onnx.numpy_helper.to_array(ws).astype(np.float64)
+    return codes * np.repeat(scale, block_size, axis=axis)
+
+
+def _relu_block_model(seed=0):
+    """Two Linears with a ``Relu`` between them, plus a residual.
+
+    The single node in the middle is the whole point: :mod:`onnxsim.brecq`'s
+    block discovery requires each layer's activation input to be *exactly* the
+    previous layer's output, so this topology is invisible to it -- which
+    ``test_a_block_brecq_cannot_discover_at_all`` asserts rather than assumes.
+    """
+    rng = np.random.default_rng(seed)
+    w1 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    w2 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    return _model(
+        f"""
+        g (float[batch,{D}] X) => (float[batch,{D}] Yout)
+        {{
+          Y1 = MatMul(X, W1)
+          A1 = Relu(Y1)
+          Y2 = MatMul(A1, W2)
+          Yout = Add(Y2, X)
+        }}
+        """,
+        [_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+
+
+def _correlated_calibration(rank, num_samples=64, noise=0.05, seed=100):
+    """Calibration rows spanning only ``rank`` directions.
+
+    ``rank`` is the knob every measured comparison here turns. A low-rank
+    activation makes ``||X (W - W_hat)||`` massively underdetermined -- whole
+    subspaces of integer weights reconstruct the layer equally well, and the
+    good ones are nowhere near round-to-nearest. A full-rank one pins the
+    optimum next to RTN, where floor/ceil is all the freedom there is to use.
+    """
+    rng = np.random.default_rng(seed)
+    latent = rng.standard_normal((num_samples, rank)).astype(np.float32)
+    projection = rng.standard_normal((rank, D)).astype(np.float32)
+    x = latent @ projection
+    x += rng.standard_normal((num_samples, D)).astype(np.float32) * noise
+    return x
+
+
+def _relu_block_error(model, x, w1, w2):
+    """``||teacher - student||`` for the whole ``_relu_block_model`` block,
+    computed from the deployed integer weights rather than from the training
+    loop's own numbers."""
+    hidden = np.maximum(x.astype(np.float64) @ _dequantize_int4_for(model, "Y1"), 0.0)
+    student = hidden @ _dequantize_int4_for(model, "Y2") + x.astype(np.float64)
+    teacher = np.maximum(x.astype(np.float64) @ w1.astype(np.float64), 0.0) @ w2.astype(
+        np.float64
+    ) + x.astype(np.float64)
+    return np.linalg.norm(teacher - student)
+
+
+def _weights_of(model):
+    return {t.name: onnx.numpy_helper.to_array(t) for t in model.graph.initializer}
+
+
+def _quant_tensors_for(model, matmul_output_name):
+    """``(codes initializer name, scale initializer name)`` for one quantized
+    MatMul, found the way the pass itself finds them: through the
+    ``DequantizeLinear`` feeding the node's weight input."""
+    matmul = next(n for n in model.graph.node if n.output[0] == matmul_output_name)
+    dq = next(n for n in model.graph.node if n.output[0] == matmul.input[1])
+    return dq.input[0], dq.input[1]
+
+
+def test_a_block_brecq_cannot_discover_at_all_trains_below_round_to_nearest():
+    """The headline: an activation between two Linears.
+
+    :func:`onnxsim.apply_brecq` -- the closest existing pass, and the one that
+    already optimizes the *block's* output rather than each layer's -- returns
+    this model completely unchanged, because its discovery walks only a linear
+    MatMul/Gemm chain. Asserted here, not assumed, so the claim cannot rot.
+
+    Measured on this scenario (rank-2 calibration, seed 0): round-to-nearest
+    leaves a block reconstruction error of ~16.0; 1000 Adam steps take it to
+    ~6.5, a ~60% reduction, with the training loss falling ~5x.
+    """
+    model = _relu_block_model(seed=0)
+    x = _correlated_calibration(rank=2)
+    calibration_data = [{"X": x}]
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+
+    unchanged = onnxsim.apply_brecq(
+        model, quant, blocks=[("X", "Yout")], calibration_data=calibration_data
+    )
+    assert unchanged.SerializeToString() == quant.SerializeToString()
+
+    w1 = onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == "W1")
+    )
+    w2 = onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == "W2")
+    )
+
+    losses = []
+    tuned = onnxsim.apply_qat(
+        model, quant, "X", "Yout", calibration_data=calibration_data, losses=losses
+    )
+    onnx.checker.check_model(tuned)
+
+    rtn_error = _relu_block_error(quant, x, w1, w2)
+    qat_error = _relu_block_error(tuned, x, w1, w2)
+    assert qat_error < 0.6 * rtn_error
+    # The loop really optimized, rather than the improvement coming from
+    # somewhere else: the reported block loss falls monotonically enough to
+    # end several times below where it started.
+    assert losses[-1] < 0.3 * losses[0]
+
+
+def test_a_gelu_block_trains():
+    """The other topology ``docs/qat.md`` names: a transformer FFN, GELU in
+    its exact ``erf`` form, with the block input feeding both the first
+    projection and the residual (so the backward has to accumulate two
+    gradient paths into it). Nothing about the pass is special-cased for it --
+    it is simply more nodes with rules in
+    :data:`onnxsim.graph_grad.SUPPORTED_OPS`."""
+    rng = np.random.default_rng(0)
+    hidden = 64
+    w1 = (rng.standard_normal((D, hidden)) * 0.3).astype(np.float32)
+    w2 = (rng.standard_normal((hidden, D)) * 0.3).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{D}] X) => (float[batch,{D}] Yout)
+        <float half = {{0.5}}, float one = {{1.0}}, float inv_sqrt2 = {{0.70710678}}>
+        {{
+          H = MatMul(X, W1)
+          S = Mul(H, inv_sqrt2)
+          E = Erf(S)
+          Ep = Add(E, one)
+          Hh = Mul(half, Ep)
+          G = Mul(H, Hh)
+          P = MatMul(G, W2)
+          Yout = Add(P, X)
+        }}
+        """,
+        [_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+    x = _correlated_calibration(rank=2)
+
+    losses = []
+    tuned = onnxsim.apply_qat(
+        model, quant, "X", "Yout", calibration_data=[{"X": x}], losses=losses
+    )
+    onnx.checker.check_model(tuned)
+    # ~0.35 -> ~0.03 as measured; the assertion is deliberately looser than
+    # the observed margin so it tracks the mechanism, not the seed.
+    assert losses[-1] < 0.25 * losses[0]
+
+
+def test_freeing_the_weights_beats_optimizing_only_their_rounding():
+    """Claim 2, isolated as cleanly as it can be.
+
+    The block here is a *single* layer, so ``apply_qat``'s objective is
+    literally the one :func:`onnxsim.apply_adaround` already minimizes for
+    that layer -- the block's output *is* the layer's output. The only thing
+    that differs is what is free: AdaRound may push each element to the
+    integer below or the integer above, and nowhere else; ``apply_qat`` moves
+    the fp32 weight itself, so an element may migrate several codes.
+
+    Measured, rank-1 calibration, seed 0: RTN 5.96, AdaRound 3.07, QAT 1.78 --
+    a 42% further reduction on top of AdaRound. Across seeds 0-7 the direction
+    held every time, by between 0.5% (seed 7) and 44%.
+
+    **This is scenario-dependent, and the dependence is the interesting
+    part.** Repeat the same experiment with full-rank calibration
+    (``rank=16``) and it inverts: RTN 28.5, AdaRound 14.6, QAT 22.8 -- AdaRound
+    wins by 36%. That is not a defect in either. When the activations span
+    every direction, the reconstruction optimum sits within one quantization
+    step of round-to-nearest, floor/ceil is therefore all the freedom that is
+    useful, and AdaRound's continuous rectified-sigmoid relaxation optimizes
+    that restricted problem better than a hard straight-through estimator on a
+    piecewise-constant loss does. When the activations are low-rank the
+    optimum is far away, outside AdaRound's box entirely, and only a free
+    weight can reach it. Real calibration activations are strongly low-rank,
+    which is why this is worth having -- but "QAT always beats AdaRound" is
+    not a claim this module makes, and the second half of this test measures
+    exactly the case where it is false.
+    """
+    model = _relu_block_model(seed=0)
+    w1 = onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == "W1")
+    ).astype(np.float64)
+
+    def layer_error(candidate_model, x):
+        teacher = x.astype(np.float64) @ w1
+        student = x.astype(np.float64) @ _dequantize_int4_for(candidate_model, "Y1")
+        return np.linalg.norm(teacher - student)
+
+    def errors(rank):
+        x = _correlated_calibration(rank=rank)
+        calibration_data = [{"X": x}]
+        quant = _quantize_chain_int4(model, {"W1", "W2"})
+        adaround = onnxsim.apply_adaround(
+            model, quant, calibration_data=calibration_data
+        )
+        tuned = onnxsim.apply_qat(
+            model, quant, "X", "Y1", calibration_data=calibration_data
+        )
+        return (
+            layer_error(quant, x),
+            layer_error(adaround, x),
+            layer_error(tuned, x),
+        )
+
+    rtn, adaround, tuned = errors(rank=1)
+    assert tuned < adaround < rtn
+
+    # The honest other half: where the problem is well determined, optimizing
+    # only the rounding -- with a better-conditioned relaxation -- wins.
+    rtn_full, adaround_full, tuned_full = errors(rank=16)
+    assert adaround_full < rtn_full
+    assert tuned_full < rtn_full
+    assert adaround_full < tuned_full
+
+
+def test_an_unsupported_op_in_the_block_is_refused():
+    """A block containing an op :mod:`onnxsim.graph_grad` has no rule for is
+    an error, not a quietly unchanged model. Silently skipping is how a caller
+    ends up believing a block was fine-tuned when it never was."""
+    rng = np.random.default_rng(0)
+    w = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{D}] X) => (float[batch,{D}] Y2)
+        {{
+          Y1 = MatMul(X, W)
+          S = Sin(Y1)
+          Y2 = MatMul(S, W)
+        }}
+        """,
+        [_f32(w, "W")],
+    )
+    quant = _quantize_chain_int4(model, {"W"})
+    with pytest.raises(graph_grad.UnsupportedOpError, match="Sin"):
+        onnxsim.apply_qat(
+            model,
+            quant,
+            "X",
+            "Y2",
+            calibration_data=[{"X": _correlated_calibration(rank=4)}],
+        )
+
+
+def test_a_block_with_nothing_quantized_in_it_is_refused():
+    """The other half of the same contract: a block that matches no
+    ``quantize_weight_only_int4`` layer has nothing to train, so saying so
+    beats returning the input unchanged and letting the caller assume it
+    worked."""
+    model = _relu_block_model(seed=0)
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+    with pytest.raises(ValueError, match="no quantize_weight_only_int4"):
+        onnxsim.apply_qat(
+            model,
+            quant,
+            "Y1",
+            "A1",  # just the Relu -- no quantized layer inside
+            calibration_data=[{"X": _correlated_calibration(rank=4)}],
+        )
+
+
+def test_a_block_output_that_is_not_computed_is_refused():
+    model = _relu_block_model(seed=0)
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+    with pytest.raises(ValueError, match="not produced by any node"):
+        onnxsim.apply_qat(
+            model,
+            quant,
+            "X",
+            "X",
+            calibration_data=[{"X": _correlated_calibration(rank=4)}],
+        )
+
+
+def test_only_the_blocks_own_weight_initializers_change():
+    """Everything outside the trained block must come back byte-identical --
+    including the second block's weights, every scale, and the graph itself.
+    A pass that rewrote more than it claimed would be nearly impossible to
+    notice downstream."""
+    rng = np.random.default_rng(3)
+    weights = [(rng.standard_normal((D, D)) * 0.3).astype(np.float32) for _ in range(3)]
+    model = _model(
+        f"""
+        g (float[batch,{D}] X) => (float[batch,{D}] Y3)
+        {{
+          Y1 = MatMul(X, W1)
+          A1 = Relu(Y1)
+          Y2 = MatMul(A1, W2)
+          A2 = Relu(Y2)
+          Y3 = MatMul(A2, W3)
+        }}
+        """,
+        [_f32(w, f"W{i + 1}") for i, w in enumerate(weights)],
+    )
+    quant = _quantize_chain_int4(model, {"W1", "W2", "W3"})
+    tuned = onnxsim.apply_qat(
+        model,
+        quant,
+        "X",
+        "Y2",  # the first two layers only; W3's layer is outside the block
+        calibration_data=[{"X": _correlated_calibration(rank=2)}],
+    )
+
+    # The graph -- nodes, inputs, outputs, opset, everything but initializer
+    # payloads -- is untouched.
+    before = onnx.ModelProto()
+    before.CopyFrom(quant)
+    after = onnx.ModelProto()
+    after.CopyFrom(tuned)
+    del before.graph.initializer[:]
+    del after.graph.initializer[:]
+    assert before.SerializeToString() == after.SerializeToString()
+
+    trained = {_quant_tensors_for(quant, name)[0] for name in ("Y1", "Y2")}
+    old = {t.name: t for t in quant.graph.initializer}
+    new = {t.name: t for t in tuned.graph.initializer}
+    assert set(old) == set(new)
+    changed = {
+        name
+        for name in old
+        if old[name].SerializeToString() != new[name].SerializeToString()
+    }
+    assert changed <= trained
+    # ...and it did in fact change something, so the assertion above is not
+    # passing vacuously.
+    assert changed
+
+
+def test_the_weight_only_path_leaves_every_scale_byte_identical():
+    """``learn_scales=False`` is the default precisely because it keeps this
+    guarantee, the same one :func:`onnxsim.apply_adaround` makes."""
+    model = _relu_block_model(seed=1)
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+    tuned = onnxsim.apply_qat(
+        model,
+        quant,
+        "X",
+        "Yout",
+        calibration_data=[{"X": _correlated_calibration(rank=2)}],
+    )
+    old, new = _weights_of(quant), _weights_of(tuned)
+    for matmul in ("Y1", "Y2"):
+        scale_name = _quant_tensors_for(quant, matmul)[1]
+        np.testing.assert_array_equal(old[scale_name], new[scale_name])
+
+
+def test_learn_scales_moves_the_scales_and_still_reconstructs():
+    """LSQ's scale gradient wired in. The scales move (so the gradient is
+    reaching them at all) and the block still reconstructs better than
+    round-to-nearest -- the honest bar, since jointly optimizing two coupled
+    parameter sets is a harder problem than either alone, exactly the caution
+    :mod:`onnxsim.autoround` documents for its own clip ratio."""
+    model = _relu_block_model(seed=0)
+    x = _correlated_calibration(rank=2)
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+    w1 = onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == "W1")
+    )
+    w2 = onnx.numpy_helper.to_array(
+        next(t for t in model.graph.initializer if t.name == "W2")
+    )
+
+    tuned = onnxsim.apply_qat(
+        model,
+        quant,
+        "X",
+        "Yout",
+        calibration_data=[{"X": x}],
+        learn_scales=True,
+        scale_learning_rate=1e-4,
+    )
+    onnx.checker.check_model(tuned)
+
+    old, new = _weights_of(quant), _weights_of(tuned)
+    moved = 0
+    for matmul in ("Y1", "Y2"):
+        scale_name = _quant_tensors_for(quant, matmul)[1]
+        before, after = old[scale_name], new[scale_name]
+        assert before.shape == after.shape
+        if not np.array_equal(before, after):
+            moved += 1
+    assert moved == 2
+
+    assert _relu_block_error(tuned, x, w1, w2) < _relu_block_error(quant, x, w1, w2)
+
+
+def test_end_to_end_on_the_cpu_step_provider():
+    """The whole loop through ``step_providers=``, which is the boundary
+    ``docs/qat.md`` says carries this to CUDA, an NPU EP or WebGPU
+    unmodified. CPU is the one CI can assert on; the point of the test is
+    that the provider path is exercised at all and produces a model
+    onnxruntime will actually load."""
+    model = _relu_block_model(seed=2)
+    x = _correlated_calibration(rank=2, num_samples=32)
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+
+    tuned = onnxsim.apply_qat(
+        model,
+        quant,
+        "X",
+        "Yout",
+        calibration_data=[{"X": x}],
+        num_iterations=50,
+        providers=["CPUExecutionProvider"],
+        step_providers=["CPUExecutionProvider"],
+    )
+    onnx.checker.check_model(tuned)
+
+    session = ort.InferenceSession(
+        tuned.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (out,) = session.run(None, {"X": x})
+    assert out.shape == x.shape
+    assert np.all(np.isfinite(out))
+
+
+def test_codes_stay_inside_the_int4_grid():
+    """A free fp32 weight can wander anywhere; the exported codes may not.
+    ``quantize_weight_only_int4``'s grid is symmetric ``[-7, 7]`` and the
+    clip in the fake-quant forward is the only thing keeping the export
+    inside it."""
+    model = _relu_block_model(seed=4)
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+    tuned = onnxsim.apply_qat(
+        model,
+        quant,
+        "X",
+        "Yout",
+        calibration_data=[{"X": _correlated_calibration(rank=2) * 4}],
+        learning_rate=1e-2,  # deliberately far too large, to push the weights out
+    )
+    checked = 0
+    for t in tuned.graph.initializer:
+        if t.data_type != onnx.TensorProto.INT4:
+            continue
+        checked += 1
+        numel = int(np.prod(list(t.dims)))
+        raw = np.frombuffer(t.raw_data, dtype=np.uint8)
+        lo = (raw & 0x0F).astype(np.int8)
+        hi = ((raw >> 4) & 0x0F).astype(np.int8)
+        lo = np.where(lo >= 8, lo - 16, lo)
+        hi = np.where(hi >= 8, hi - 16, hi)
+        codes = np.empty(numel, dtype=np.int8)
+        codes[0::2] = lo[: (numel + 1) // 2]
+        codes[1::2] = hi[: numel // 2]
+        assert np.all(codes >= -7) and np.all(codes <= 7)
+    assert checked == 2
+
+
+def test_the_step_graph_stays_inside_the_execution_provider_allowlist(monkeypatch):
+    """The reason all of this is expressed as ONNX rather than numpy is that
+    it must run on WebGPU and NPU execution providers, and an op none of them
+    implement would pass every numerical test above while making the whole
+    exercise pointless. So: everything the optimizer machinery emits -- the
+    fake-quant forward, the loss, the backward, Adam -- stays inside
+    :data:`onnxsim.qat_graph.EP_FRIENDLY_OPS`. The block's *own* nodes are
+    excluded, since those are whatever the user's model already contains."""
+    model = _relu_block_model(seed=0)
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+
+    captured = {}
+    real = qat_graph.run_step_graph
+
+    def spy(step, **kwargs):
+        captured["step"] = step
+        return real(step, **kwargs)
+
+    monkeypatch.setattr(qat.qat_graph, "run_step_graph", spy)
+    onnxsim.apply_qat(
+        model,
+        quant,
+        "X",
+        "Yout",
+        calibration_data=[{"X": _correlated_calibration(rank=2, num_samples=8)}],
+        num_iterations=1,
+        learn_scales=True,
+    )
+
+    block_ops = {n.op_type for n in model.graph.node}
+    emitted = {n.op_type for n in captured["step"].model.graph.node} - block_ops
+    assert emitted <= set(qat_graph.EP_FRIENDLY_OPS), sorted(
+        emitted - set(qat_graph.EP_FRIENDLY_OPS)
+    )
+
+
+def test_a_residual_arriving_from_upstream_of_the_block_is_teacher_forced():
+    """A block whose output adds in a tensor produced *before*
+    ``block_input_name`` is still a closed block: the extra tensor is captured
+    from the float model and fed in as another constant, exactly as the block
+    input itself is. That is the same teacher-forcing every block-wise
+    reconstruction method does, and without it the discovery would have to
+    refuse a shape real residual networks are full of."""
+    rng = np.random.default_rng(5)
+    w0 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    w1 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{D}] X) => (float[batch,{D}] Yout)
+        {{
+          Y0 = MatMul(X, W0)
+          A0 = Relu(Y0)
+          Y1 = MatMul(A0, W1)
+          Yout = Add(Y1, Y0)
+        }}
+        """,
+        [_f32(w0, "W0"), _f32(w1, "W1")],
+    )
+    quant = _quantize_chain_int4(model, {"W0", "W1"})
+    losses = []
+    tuned = onnxsim.apply_qat(
+        model,
+        quant,
+        "A0",  # the block starts after the activation; Y0 enters sideways
+        "Yout",
+        calibration_data=[{"X": _correlated_calibration(rank=2)}],
+        losses=losses,
+    )
+    onnx.checker.check_model(tuned)
+    assert losses[-1] < losses[0]
+
+    # Only the layer inside the block (W1's) was retrained; W0's codes are
+    # outside it and must be untouched.
+    old, new = _weights_of(quant), _weights_of(tuned)
+    outside = _quant_tensors_for(quant, "Y0")[0]
+    np.testing.assert_array_equal(old[outside], new[outside])
+
+
+def test_a_transb_gemm_trains_on_the_other_blocked_axis():
+    """A ``Gemm`` with ``transB=1`` stores its weight ``[N, K]`` and blocks
+    its scale along axis 1, the mirror image of a ``MatMul``'s ``[K, N]``
+    weight blocked along axis 0. Both directions of the reshape that expands
+    a per-block scale to per-element (and sums a per-element gradient back
+    into per-block) are therefore exercised only if both layouts are tested,
+    and a transposed reshape is exactly the kind of bug that produces a
+    plausible-looking but wrong model."""
+    rng = np.random.default_rng(0)
+    weight = (rng.standard_normal((64, D)) * 0.3).astype(np.float32)  # [N, K]
+    model = _model(
+        f"""
+        g (float[8,{D}] X) => (float[8,64] Y)
+        {{
+          Y = Gemm <transB = 1> (X, W)
+        }}
+        """,
+        [_f32(weight, "W")],
+    )
+    quant = onnxsim.quantize_weight_only_int4(model)
+    x = _correlated_calibration(rank=2, num_samples=8)
+
+    losses = []
+    tuned = onnxsim.apply_qat(
+        model,
+        quant,
+        "X",
+        "Y",
+        calibration_data=[{"X": x}],
+        learn_scales=True,
+        losses=losses,
+    )
+    onnx.checker.check_model(tuned)
+    assert losses[-1] < 0.5 * losses[0]
+
+    codes_name, scale_name = _quant_tensors_for(quant, "Y")
+    old, new = _weights_of(quant), _weights_of(tuned)
+    assert list(old[scale_name].shape) == list(new[scale_name].shape) == [64, 1]
+    assert not np.array_equal(old[codes_name], new[codes_name])

--- a/tests/test_qat_graph.py
+++ b/tests/test_qat_graph.py
@@ -21,29 +21,10 @@ from onnxsim import adaround, backend, qat_graph
 
 ort = pytest.importorskip("onnxruntime")
 
-# Operators a step graph may use. Everything here is a plain arithmetic,
-# comparison or reduction op with broad coverage across onnxruntime's
-# execution providers (including onnxruntime-web's WebGPU backend and the
-# WebNN/NPU ones). Ops deliberately kept out: control flow, boolean logic,
-# Where, anything that would make a graph runnable only on the CPU.
-_ALLOWED_OPS = {
-    "Abs",
-    "Add",
-    "Cast",
-    "Clip",
-    "Div",
-    "Greater",
-    "Less",
-    "MatMul",
-    "Mul",
-    "Pow",
-    "ReduceMean",
-    "Sigmoid",
-    "Sign",
-    "Sqrt",
-    "Sub",
-    "Transpose",
-}
+# The operator set a step graph may emit is the package's own, not a copy of
+# it: two allowlists that drift apart would each certify a graph the other
+# rejects. See qat_graph.EP_FRIENDLY_OPS for what earns a place in it.
+_ALLOWED_OPS = qat_graph.EP_FRIENDLY_OPS
 
 
 def _linear_fit_step_graph(rows, k, n):

--- a/tests/test_qat_graph.py
+++ b/tests/test_qat_graph.py
@@ -17,7 +17,7 @@ import onnx
 import pytest
 
 import onnxsim
-from onnxsim import adaround, qat_graph
+from onnxsim import adaround, backend, qat_graph
 
 ort = pytest.importorskip("onnxruntime")
 
@@ -292,3 +292,230 @@ def test_apply_adaround_step_providers_are_validated():
             num_iterations=5,
             step_providers=["NoSuchExecutionProvider"],
         )
+
+
+# --- Device-resident state (``bind_state``) ----------------------------------
+#
+# ``run_step_graph`` keeps the constants and the state on the execution
+# provider's device between steps, through onnxruntime's ``IOBinding``
+# (``onnxsim.backend.Runner.bind_loop``). That is an optimization, so the tests
+# below are about it changing *nothing*: the same numbers as the feed-per-step
+# path, no corruption from onnxruntime reusing a bound buffer, and a clean
+# fallback whenever the binding cannot be set up or cannot run.
+
+
+def _linear_fit_case(seed, rows=48, k=8, n=6):
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((rows, k))
+    y = x @ rng.standard_normal((n, k)).T
+    return x, y, np.zeros((n, k))
+
+
+def test_bound_and_unbound_loops_agree():
+    """The whole contract of ``bind_state``: it moves tensors, not numbers.
+
+    Exact equality, not a tolerance -- same graph, same provider, same values,
+    only a different way of handing onnxruntime the buffers -- so any
+    divergence here is a real bug rather than float noise.
+    """
+    x, y, zeros = _linear_fit_case(20)
+    step = _linear_fit_step_graph(x.shape[0], x.shape[1], y.shape[1])
+
+    bound_losses: list = []
+    unbound_losses: list = []
+    bound = _run_linear_fit(step, x, y, num_steps=150, losses=bound_losses)
+    unbound = qat_graph.run_step_graph(
+        step,
+        constants={"x": x, "y": y},
+        state={"w": zeros, "m": zeros, "vv": zeros},
+        num_steps=150,
+        scalars=lambda t: dict(lr=0.1, **qat_graph.adam_bias_corrections(t)),
+        losses=unbound_losses,
+        bind_state=False,
+    )
+
+    for name in ("w", "m", "vv"):
+        np.testing.assert_array_equal(bound[name], unbound[name])
+    assert bound_losses == unbound_losses
+    assert len(bound_losses) == 150
+
+
+def test_bound_state_is_not_corrupted_by_buffer_reuse():
+    """onnxruntime may hand a bound output buffer back on the next run, so a
+    loop that fed a step's output straight back in as the next step's input --
+    while binding that same buffer as an output again -- could read values a
+    kernel is concurrently overwriting. ``BoundStepLoop`` double-buffers to
+    make each run's reads and writes disjoint.
+
+    The check: one bound loop of twelve chained steps against twelve one-step
+    bound loops. Every one-step loop allocates its own binding and its own
+    buffers, so no buffer can possibly survive from one step into the next
+    there; if reuse were corrupting the chained loop, the two would drift
+    apart. They agree exactly instead.
+    """
+    x, y, zeros = _linear_fit_case(21)
+    step = _linear_fit_step_graph(x.shape[0], x.shape[1], y.shape[1])
+
+    chained = _run_linear_fit(step, x, y, num_steps=12)
+
+    fresh = {"w": zeros, "m": zeros, "vv": zeros}
+    for t in range(12):
+        fresh = qat_graph.run_step_graph(
+            step,
+            constants={"x": x, "y": y},
+            state=fresh,
+            num_steps=1,
+            scalars=lambda _, t=t: dict(lr=0.1, **qat_graph.adam_bias_corrections(t)),
+        )
+
+    for name in ("w", "m", "vv"):
+        np.testing.assert_array_equal(chained[name], fresh[name])
+
+
+def test_bound_loop_leaves_the_callers_arrays_alone():
+    """The state arrays a caller passes in are inputs, not scratch space.
+
+    Worth its own test because onnxruntime's CPU ``OrtValue`` wraps the numpy
+    buffer it is given rather than copying it, so binding a caller's array
+    directly as one half of the ping-pong pair would quietly turn the caller's
+    initial state into the loop's working memory.
+    """
+    x, y, _ = _linear_fit_case(22)
+    step = _linear_fit_step_graph(x.shape[0], x.shape[1], y.shape[1])
+    start = {
+        name: np.full((y.shape[1], x.shape[1]), 0.25, dtype=np.float32)
+        for name in ("w", "m", "vv")
+    }
+    before = {name: value.copy() for name, value in start.items()}
+
+    final = qat_graph.run_step_graph(
+        step,
+        constants={"x": x, "y": y},
+        state=start,
+        num_steps=8,
+        scalars=lambda t: dict(lr=0.1, **qat_graph.adam_bias_corrections(t)),
+    )
+
+    for name, value in before.items():
+        np.testing.assert_array_equal(start[name], value)
+    assert not np.array_equal(final["w"], before["w"])
+
+
+def test_bound_loop_falls_back_when_a_bound_run_fails(monkeypatch):
+    """A provider that accepts a binding and then refuses to run against it --
+    an onnxruntime build without ``IOBinding`` support for that EP -- must land
+    the caller on the feed-per-step path, with the right answer and exactly one
+    loss per step rather than a half-written list from the abandoned attempt.
+    """
+    x, y, zeros = _linear_fit_case(23)
+    step = _linear_fit_step_graph(x.shape[0], x.shape[1], y.shape[1])
+    reference_losses: list = []
+    reference = qat_graph.run_step_graph(
+        step,
+        constants={"x": x, "y": y},
+        state={"w": zeros, "m": zeros, "vv": zeros},
+        num_steps=40,
+        scalars=lambda t: dict(lr=0.1, **qat_graph.adam_bias_corrections(t)),
+        losses=reference_losses,
+        bind_state=False,
+    )
+
+    attempts = []
+
+    def refuse(self, iobinding, run_options=None):
+        attempts.append(iobinding)
+        raise RuntimeError("this provider has no IOBinding support")
+
+    monkeypatch.setattr(ort.InferenceSession, "run_with_iobinding", refuse)
+
+    losses: list = []
+    final = _run_linear_fit(step, x, y, num_steps=40, losses=losses)
+
+    # The binding was really tried -- which is also this file's evidence that
+    # the default path through ``run_step_graph`` is the bound one.
+    assert len(attempts) == 1
+    for name in ("w", "m", "vv"):
+        np.testing.assert_array_equal(final[name], reference[name])
+    assert losses == reference_losses
+
+
+def test_bind_state_falls_back_to_the_reference_evaluator(monkeypatch):
+    """Without onnxruntime there is no binding and no device to bind to, and
+    ``bind_state=True`` still has to run -- through onnx's reference evaluator,
+    which is what the whole backend degrades to (onnxsim/onnxsim#441)."""
+    x, y, zeros = _linear_fit_case(24, rows=16, k=4, n=3)
+    step = _linear_fit_step_graph(x.shape[0], x.shape[1], y.shape[1])
+    reference = _run_linear_fit(step, x, y, num_steps=30)
+
+    monkeypatch.setattr(backend, "_HAS_ONNXRUNTIME", False)
+    assert backend.Runner(step.model).bind_loop({}, {}) is None
+
+    final = _run_linear_fit(step, x, y, num_steps=30)
+    for name in ("w", "m", "vv"):
+        # Both compute in float32; the two implementations' arithmetic differs
+        # in the last bits, and 30 Adam steps amplify that a little.
+        np.testing.assert_allclose(final[name], reference[name], rtol=0, atol=1e-5)
+
+
+def test_bind_loop_declines_an_output_it_cannot_preallocate():
+    """A bound output needs its buffer before the run that fills it, so a
+    dynamic output shape is not bindable. ``bind_loop`` says so by returning
+    ``None`` -- the caller's cue to run the ordinary way -- instead of raising.
+    """
+    model = onnx.parser.parse_model(
+        """
+        <ir_version: 8, opset_import: ["": 17]>
+        g (float[N,2] s) => (float[N,2] out) {
+          out = Add(s, s)
+        }
+        """
+    )
+    runner = backend.Runner(model)
+    state = {"s": ("out", np.ones((3, 2), dtype=np.float32))}
+    assert runner.bind_loop({}, state) is None
+    # ... and the unbound call it falls back to still works.
+    np.testing.assert_array_equal(
+        runner({"s": np.ones((3, 2), dtype=np.float32)})["out"],
+        np.full((3, 2), 2.0, dtype=np.float32),
+    )
+
+
+def test_bind_loop_declines_a_state_output_of_a_different_shape():
+    """State threading requires the output to be shaped like the input it feeds
+    back into. A graph that reshapes its state is not one this loop can carry,
+    and saying so up front beats discovering it as a binding error mid-loop."""
+    model = onnx.parser.parse_model(
+        """
+        <ir_version: 8, opset_import: ["": 17]>
+        g (float[2,3] s) => (float[3,2] out) {
+          out = Transpose<perm = [1, 0]>(s)
+        }
+        """
+    )
+    runner = backend.Runner(model)
+    assert (
+        runner.bind_loop({}, {"s": ("out", np.ones((2, 3), dtype=np.float32))}) is None
+    )
+
+
+def test_runner_call_still_returns_an_ordered_dict():
+    """``Runner.__call__`` is the interface constant folding and the other
+    callers use; the binding path is additive and must not have touched it."""
+    x, y, _ = _linear_fit_case(25, rows=8, k=3, n=2)
+    step = _linear_fit_step_graph(x.shape[0], x.shape[1], y.shape[1])
+    zeros = np.zeros((y.shape[1], x.shape[1]), dtype=np.float32)
+    runner = backend.Runner(step.model, output_names=[step.state["w"]])
+    out = runner(
+        {
+            "x": x.astype(np.float32),
+            "y": y.astype(np.float32),
+            "w": zeros,
+            "m": zeros,
+            "vv": zeros,
+            "lr": np.asarray(0.1, dtype=np.float32),
+            "m_correction": np.asarray(10.0, dtype=np.float32),
+            "v_correction": np.asarray(1000.0, dtype=np.float32),
+        }
+    )
+    assert list(out) == [step.state["w"]]
+    assert out[step.state["w"]].shape == zeros.shape


### PR DESCRIPTION
Follow-up to #1217, which landed `docs/qat.md` and the step-graph machinery. This implements stage 2 of that note, plus the prerequisite the note did not anticipate.

## The prerequisite: `onnxsim/graph_grad.py`

Block-wise distillation over an arbitrary topology means differentiating an arbitrary slice of the graph, and no pass here could do that. Every gradient in the repo is hand-derived for one fixed shape — which is exactly why `brecq.py`'s own docstring caps it at a strict linear chain of MatMul/Gemm and says an interleaved BatchNorm/ReLU/LayerNorm is out of scope: each one would be new math.

`build_backward` walks a forward slice in reverse, turns each node's output gradient into its input gradients through a per-op rule, and sums the contributions of a tensor read more than once. The rules emit ordinary ONNX nodes into a `qat_graph.GraphBuilder`, so the result composes with `adam_update`/`make_step_graph` and runs wherever the execution provider says — the same property that made the step graph work: a hand-derived backward is just dataflow.

It is a rule table and a reverse walk, not an autograd framework. The ONNX graph is already the tape.

20 rules: MatMul (batched, broadcast batch dims), Gemm (alpha/beta/transA/transB), Add, Sub, Mul, Div, Neg, Identity, Relu, Sigmoid, Tanh, Erf, Exp, Sqrt, Transpose, Reshape, ReduceSum, ReduceMean, Softmax, Clip. Refusal is the house convention: an unknown op, a 1-D MatMul operand, an unreachable target or a missing shape raises rather than guessing, and a gradient w.r.t. a non-float input is `None` rather than approximated.

Two things that needed care, both documented in place: broadcasting (reducing a gradient back to its input's shape is the classic silent-wrong-VJP bug, so it has one helper every rule routes through and its own tests), and recovering a Reduce's axes, which opset 13 moved to a tensor input `build_backward` never sees — derived from shapes where exact, refused where genuinely ambiguous.

## Stage 2: `onnxsim/qat.py` — `apply_qat`

Label-free, block-wise quantization-aware fine-tuning. The float model is the teacher, the loss is the block's own output reconstruction error — `brecq`'s objective, unchanged. What is new:

- **Any topology `graph_grad` can differentiate.** A normalization, an activation, a GELU's `Erf`, a residual or a Softmax between two Linears is now just more nodes in the slice.
- **The float weights themselves move.** AdaRound, BRECQ, FOEM, FlexRound and AutoRound all optimize only *which of two neighbouring integers* a weight rounds to — that restriction is what makes them rounding passes. Here the fp32 weight is trained through a straight-through fake-quant, so an element can migrate several codes from where round-to-nearest put it. `learn_scales=True` trains each per-block scale alongside, LSQ-style.

The slice is the intersection of "downstream of `block_input_name`" and "upstream of `block_output_name`" — a backwards-only walk let a residual `Add(Y1, Y0)` drag the whole pre-block subgraph in and retrain layers the caller never named. Anything the slice reads but does not produce is teacher-forced from the float model.

### Measured, and not a uniform win

On a two-Linear-plus-`Relu` block — which `apply_brecq` returns byte-identical, because it cannot see that topology — reconstruction error falls 16.0 → 6.5, and a GELU block's loss ~12×.

Against `apply_adaround` on a **single layer**, where the objective is identical and only the parametrization differs:

| calibration activations | RTN | AdaRound | apply_qat |
| --- | --- | --- | --- |
| rank 1 (underdetermined) | 5.96 | 3.07 | **1.78** |
| rank 16 (full) | 28.5 | **14.6** | 22.8 |

Freeing the weight **loses** on the full-rank case. A well-determined reconstruction problem has its optimum within one quantization step of round-to-nearest, so floor/ceil is all the freedom worth having, and AdaRound's continuous rectified-sigmoid relaxation optimizes that restricted problem better than a hard STE on a piecewise-constant loss. Both directions are asserted in `tests/test_qat.py`, and nothing here claims QAT beats AdaRound.

## Also in this PR

- **`adaquant` ported onto the step graph** — the harder second port, and the evidence the machinery generalizes: three parameter groups optimized jointly, so nine state tensors and three `adam_update` calls. Tracks its numpy loop tighter than adaround's port does (identical weight codes on 5 of 6 seeds, identical integer zero-point on all 6).
- **Device-resident step state** — `Runner.bind_loop` uploads constants once and ping-pongs the state on the device through `IOBinding`. Binding one buffer as both a step's input and its output is unsafe (ORT may write an output before finishing its input reads), and `ortvalue_from_numpy` wraps a caller's array on CPU rather than copying it — both have tests. Layered fallback, never the caller's problem. **On CPU this measures as a wash, ±3%**, which is expected: with the CPU provider the "device" is host memory. The win is the GPU/NPU path this CPU-only build cannot measure.
- **One operator allowlist.** Two had grown up in parallel and disagreed; `qat_graph.EP_FRIENDLY_OPS` is now canonical, in the package, documenting the criterion (coverage on ORT-web's WebGPU backend and the WebNN/NPU providers, not merely ORT's CPU kernels) and what is deliberately absent — including `Round`, WebNN having no rounding operator, which is why one is composed out of `Sign`/`Abs`/`Cast`.

## Tests

`tests/test_graph_grad.py` (104), `tests/test_qat.py` (14), `tests/test_adaquant_step_graph.py` (6), plus additions to `tests/test_qat_graph.py`. Every VJP rule is checked against central finite differences of the same forward in float64; both allowlists are asserted in both directions. `ruff` clean, `mypy` at the repo's pre-existing 34-error baseline.

## Still open

Real data via `load_huggingface_calibration_data`, a sliding window over blocks and a whole-graph pass, minibatching, activation quantization, and stages 3–4 of `docs/qat.md` (browser fine-tuning panel, QAT interop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_