### PR TITLE
QAT: whole-model block discovery, the sequential walk, and QDQ interop

### DIFF
--- a/docs/qat.md
+++ b/docs/qat.md
@@ -1,10 +1,10 @@
 # Delivering QAT in onnxsim: a design note
 
-**Status: design note, with stages 0-2 implemented.**
+**Status: design note, with stages 0-2 and 4 implemented.**
 `onnxsim/qat_graph.py`, `onnxsim/graph_grad.py`, `onnxsim/qat.py`
-(`apply_qat`) and the converter page's calibration-provider picker have all
-landed; the browser fine-tuning panel and the QAT-interop paths have not
-(see "Staging" below). This note answers "how *could* we deliver quantization-aware training as an onnxsim
+(`apply_qat`, `apply_qat_all_blocks`), `onnxsim/qat_interop.py` and the
+converter page's calibration-provider picker have all landed; the browser
+fine-tuning panel (stage 3) has not (see "Staging" below). This note answers "how *could* we deliver quantization-aware training as an onnxsim
 feature, and can the training math run on WebGPU or an NPU?" and records the
 shape of the work so the question doesn't have to be re-derived. `docs/nncf-comparison-future-work.md`
 currently lists QAT as out of scope ("QAT needs a training loop with a
@@ -44,7 +44,7 @@ has never had. So split the feature there.
 
 ## Three deliverables, only two of which we should build
 
-### A. QAT interop (graph-only, no training)
+### A. QAT interop (graph-only, no training) -- built, see stage 4
 
 Consume and produce QAT artifacts without running any training:
 
@@ -232,17 +232,51 @@ Each stage is independently shippable and independently useful.
    round-to-nearest, so floor/ceil is all the freedom worth having there.
    Both directions are asserted in `tests/test_qat.py`.
 
+   The walk over blocks landed since: `discover_qat_blocks` plans the whole
+   model without the caller naming a tensor, and `apply_qat_all_blocks`
+   trains the plan in order. Boundary discovery is a liveness argument
+   rather than a pattern match -- cut wherever exactly one tensor is live
+   across a gap, since a slice bounded that way is self-contained -- so
+   residual connections *place* the boundaries instead of defeating them,
+   and a span containing an op `graph_grad` cannot differentiate becomes a
+   gap between blocks rather than a failure of the model. The walk is
+   sequential by default: each block's target is the teacher's output but
+   its input is recaptured from the student after the previous blocks were
+   tuned, which differs from what `adaround`/`brecq` do (capture once, never
+   re-run the student) and measured better on every seed tried (whole-model
+   output error on a 4-layer chain: 400.3 round-to-nearest, 206.2
+   capture-once, 168.1 sequential). Note that sequential's *per-block*
+   losses read higher, because a dirtier input is a harder reconstruction
+   problem -- the block-local loss is not the quantity that matters.
+
    Still open from this stage's original description: real data via
-   `load_huggingface_calibration_data`, a `QuantizationConfig` flag, a
-   sliding window over blocks and a whole-graph pass, minibatching, and
-   activation quantization (adaquant has the learnable activation scale, it
-   is simply not wired in here).
+   `load_huggingface_calibration_data`, a `QuantizationConfig` flag, an
+   end-to-end pass against the model's own output (a block is always the
+   unit of optimization), minibatching, and activation quantization
+   (adaquant has the learnable activation scale, it is simply not wired in
+   here).
 3. **Browser QAT panel.** A "fine-tune" panel in the converter page: data
    from `hf_datasets.mjs`, execution from `ort_executor.mjs` on WebGPU, a
    loss curve, and `quantize_metrics.mjs` for the before/after. Client-side
    QAT with no server is something none of the comparable tools offer.
-4. **QAT interop (A).** Ingest externally-trained QDQ scales; emit the
-   fake-quant model for external trainers.
+4. **QAT interop (A) -- done.** `onnxsim/qat_interop.py`.
+   `quantize_static_keeping_qdq_scales` reads the parameters a QAT export
+   already carries, canonicalizes back to float only the pairs onnxsim can
+   re-emit, calibrates *only* the tensors with no usable annotation (a fully
+   annotated export needs no calibration data at all), and writes the
+   learned values back bit-exactly -- re-deriving a weight's integer codes
+   from its learned scale, since swapping the scale alone would change what
+   the weight dequantizes to. `export_fake_quant` closes the round trip,
+   naming the initializers a trainer should make learnable (returned, and
+   also stamped into `metadata_props`, since a round trip goes through a
+   saved file -- but non-load-bearing, because ingest re-derives everything
+   structurally). Refusal is a documented table and a refused pair is left
+   in the graph exactly as authored.
+
+   Why this matters more than it sounds: a learned scale is usually
+   deliberately *tighter* than the observed min/max, clipping outliers to
+   spend the codes where the values are. Re-deriving it, which is what
+   `quantize_static` would silently do, is a regression rather than a wash.
 
 ## Using what has landed
 

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -249,6 +249,17 @@ from onnxsim.qat import (
     apply_qat_all_blocks,
     discover_qat_blocks,
 )
+from onnxsim.qat_interop import (
+    FakeQuantExport,
+    QdqAnnotation,
+    QdqIngestResult,
+    QdqScan,
+    SkippedQdq,
+    export_fake_quant,
+    find_existing_qdq,
+    quantize_static_keeping_qdq_scales,
+    strip_existing_qdq,
+)
 from onnxsim.qoq import apply_smooth_attention, quantize_weight_only_qoq
 from onnxsim.qronos import apply_qronos
 from onnxsim.quantease import apply_quantease
@@ -318,6 +329,15 @@ __all__ = [
     "discover_qat_blocks",
     "QATBlock",
     "QATBlockResult",
+    "quantize_static_keeping_qdq_scales",
+    "export_fake_quant",
+    "find_existing_qdq",
+    "strip_existing_qdq",
+    "QdqAnnotation",
+    "QdqScan",
+    "QdqIngestResult",
+    "SkippedQdq",
+    "FakeQuantExport",
     "apply_fptq",
     "apply_owq",
     "apply_bwa_ptq",

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -242,7 +242,13 @@ from onnxsim.pruning import (
     weight_sparsity,
 )
 from onnxsim.ptq4vit import apply_ptq4vit_quantization
-from onnxsim.qat import apply_qat
+from onnxsim.qat import (
+    QATBlock,
+    QATBlockResult,
+    apply_qat,
+    apply_qat_all_blocks,
+    discover_qat_blocks,
+)
 from onnxsim.qoq import apply_smooth_attention, quantize_weight_only_qoq
 from onnxsim.qronos import apply_qronos
 from onnxsim.quantease import apply_quantease
@@ -308,6 +314,10 @@ __all__ = [
     "quantize_dequantize_fp6",
     "apply_brecq",
     "apply_qat",
+    "apply_qat_all_blocks",
+    "discover_qat_blocks",
+    "QATBlock",
+    "QATBlockResult",
     "apply_fptq",
     "apply_owq",
     "apply_bwa_ptq",

--- a/onnxsim/qat.py
+++ b/onnxsim/qat.py
@@ -53,10 +53,16 @@ one out of ``Sign``/``Abs``/``Cast``, and this reuses it).
   ceiling is "reproduce the float block", not "recover task accuracy the
   float block never had". Label-free distillation QAT is not paper-QAT
   accuracy and should not be advertised as it.
-- *Not whole-model training.* One caller-named block per call, exactly
-  :mod:`onnxsim.brecq`'s contract (``block_input_name`` /
-  ``block_output_name``). A sliding window over blocks, and an end-to-end
-  pass afterwards, are the caller's loop to write.
+- *Not end-to-end training.* :func:`apply_qat` still trains one
+  caller-named block per call, exactly :mod:`onnxsim.brecq`'s contract
+  (``block_input_name`` / ``block_output_name``), and
+  :func:`apply_qat_all_blocks` walks a whole model one block at a time --
+  discovering the blocks with :func:`discover_qat_blocks` and, by default,
+  feeding each one the student's own activation so it corrects what its
+  predecessors left behind. What is still absent is a final pass that
+  backpropagates through the *entire* graph at once against the model's own
+  output; a block is always the unit of optimization, and the teacher's
+  activations are always the target.
 - *Not activation quantization.* This targets
   :func:`onnxsim.quantize_weight_only_int4`'s weight-only scheme, the same
   one AdaRound/BRECQ/FOEM target. Learnable activation scales exist in-tree
@@ -84,8 +90,11 @@ one out of ``Sign``/``Abs``/``Cast``, and this reuses it).
   having -- but "QAT beats AdaRound" is not a claim this module makes.
 
 **What the block contract accepts and refuses.** Refusing is loud
-everywhere: a caller who names a block this cannot train gets a
-:class:`ValueError`, never a silently unchanged model. The slice is the
+wherever the caller named the block: :func:`apply_qat` on a block it cannot
+train raises :class:`ValueError`, never returning a silently unchanged
+model. :func:`apply_qat_all_blocks` inverts that -- nobody named those
+blocks, so an untrainable one is skipped with its reason recorded in the
+returned :class:`QATBlockResult` and the walk continues. The slice is the
 intersection of the two directions -- nodes downstream of
 ``block_input_name`` *and* upstream of ``block_output_name`` -- so naming a
 boundary cannot drag in a subgraph on the far side of it. A tensor the slice
@@ -102,7 +111,7 @@ if the block's shapes cannot be inferred statically at opset 17.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
@@ -657,6 +666,182 @@ def _build_step_graph(
     )
 
 
+@dataclass
+class _BlockPlan:
+    """Everything about one block that can be decided from the two graphs
+    alone, before any calibration data exists.
+
+    Separated out because both entry points need exactly this and nothing
+    more: :func:`apply_qat` builds one from the names its caller supplied,
+    and :func:`discover_qat_blocks` builds one per candidate boundary pair it
+    proposes -- using the plan's construction as the *validation* of that
+    proposal, so discovery and the single-block path can never disagree about
+    what a legal block is.
+    """
+
+    input_name: str
+    output_name: str
+    nodes: List[onnx.NodeProto]
+    externals: List[str]
+    candidates: List[_Candidate]
+
+
+def _plan_block(
+    float_model: onnx.ModelProto,
+    quantized_model: onnx.ModelProto,
+    block_input_name: str,
+    block_output_name: str,
+) -> _BlockPlan:
+    """Slices the block out of the float graph and checks the three things
+    that make it trainable at all: it is non-empty, every op in it has a
+    gradient rule, and at least one of its layers is INT4-quantized.
+
+    Deliberately does *not* check shapes -- that needs the concrete
+    calibration activations, so it happens later in :func:`_train_block`.
+    """
+    nodes, externals = _slice_block(
+        float_model.graph, block_input_name, block_output_name
+    )
+    if not nodes:
+        raise ValueError(
+            f"no nodes lie between {block_input_name!r} and {block_output_name!r}"
+        )
+    _refuse_unsupported(nodes)
+
+    slice_outputs = {out for node in nodes for out in node.output if out}
+    candidates = [
+        c
+        for c in _find_int4_matmul_candidates(float_model, quantized_model)
+        if c.output_name in slice_outputs
+    ]
+    if not candidates:
+        raise ValueError(
+            f"the block between {block_input_name!r} and {block_output_name!r} "
+            "contains no quantize_weight_only_int4-quantized MatMul/Gemm layer to "
+            "train"
+        )
+    return _BlockPlan(
+        input_name=block_input_name,
+        output_name=block_output_name,
+        nodes=nodes,
+        externals=externals,
+        candidates=candidates,
+    )
+
+
+def _train_block(
+    float_model: onnx.ModelProto,
+    quantized_model: onnx.ModelProto,
+    plan: _BlockPlan,
+    external_values: Dict[str, np.ndarray],
+    teacher_output: np.ndarray,
+    *,
+    num_iterations: int,
+    learning_rate: float,
+    learn_scales: bool,
+    scale_learning_rate: float,
+    lr_decay: bool,
+    step_providers: Optional[Sequence[backend.Provider]],
+    losses: Optional[List[float]],
+) -> onnx.ModelProto:
+    """Runs the whole optimization for one already-planned, already-captured
+    block and returns ``quantized_model`` with that block's initializers
+    rewritten.
+
+    ``external_values`` are the block's inputs -- ``plan.input_name`` and
+    anything entering sideways -- and ``teacher_output`` is the target. Which
+    *model* those two came from is the caller's decision, and it is the whole
+    difference between :func:`apply_qat`'s one-block contract and
+    :func:`apply_qat_all_blocks`'s sequential walk: the target is always the
+    teacher's, but the inputs may be the teacher's or the student's.
+    """
+    shapes = _block_shapes(
+        float_model, plan.nodes, external_values, plan.output_name, teacher_output
+    )
+
+    trained = _plan_trained(plan.candidates, learn_scales)
+    trained_weight_names = {t.candidate.float_node.input[1] for t in trained}
+    used = {name for node in plan.nodes for name in node.input if name}
+    block_initializers = [
+        t
+        for t in float_model.graph.initializer
+        if t.name in used and t.name not in trained_weight_names
+    ]
+
+    step = _build_step_graph(
+        trained,
+        plan.nodes,
+        shapes,
+        block_initializers,
+        external_values,
+        plan.output_name,
+        list(teacher_output.shape),
+        learn_scales,
+    )
+
+    constants: Dict[str, np.ndarray] = dict(external_values)
+    constants[f"{_PREFIX}teacher"] = teacher_output
+    state: Dict[str, np.ndarray] = {}
+    for t in trained:
+        state[t.w_input] = t.w_init
+        state[t.m_input] = np.zeros_like(t.w_init)
+        state[t.v_input] = np.zeros_like(t.w_init)
+        if t.scale_input is not None:
+            state[t.scale_input] = t.scale_init
+            state[str(t.ms_input)] = np.zeros_like(t.scale_init)
+            state[str(t.vs_input)] = np.zeros_like(t.scale_init)
+
+    def scalars(t: int) -> Dict[str, float]:
+        decay = 1.0 - t / num_iterations if lr_decay else 1.0
+        values = {
+            f"{_PREFIX}lr": learning_rate * decay,
+            f"{_PREFIX}lr_scale": scale_learning_rate * decay,
+        }
+        if not learn_scales:
+            del values[f"{_PREFIX}lr_scale"]
+        values.update(qat_graph.adam_bias_corrections(t))
+        return values
+
+    final = qat_graph.run_step_graph(
+        step,
+        constants=constants,
+        state=state,
+        num_steps=num_iterations,
+        scalars=scalars,
+        providers=step_providers,
+        losses=losses,
+    )
+
+    new_codes: Dict[str, np.ndarray] = {}
+    new_scales: Dict[str, np.ndarray] = {}
+    for t in trained:
+        w = final[t.w_input].astype(np.float64)
+        scale = (
+            final[t.scale_input].astype(np.float64)
+            if t.scale_input is not None
+            else t.scale_init.astype(np.float64)
+        )
+        scale_full = np.repeat(scale, t.candidate.block_size, axis=t.scale_axis)
+        codes = np.clip(_round_half_away(w / scale_full), _N_MIN, _N_MAX)
+        new_codes[t.candidate.wq_name] = codes.astype(np.int8)
+        if t.scale_input is not None:
+            new_scales[t.candidate.ws_init.name] = scale.astype(np.float32)
+
+    tuned = onnx.ModelProto()
+    tuned.CopyFrom(quantized_model)
+    for initializer in tuned.graph.initializer:
+        codes = new_codes.get(initializer.name)
+        if codes is not None:
+            initializer.raw_data = _pack_int4(codes)
+            continue
+        scale_array = new_scales.get(initializer.name)
+        if scale_array is not None:
+            initializer.CopyFrom(
+                onnx.numpy_helper.from_array(scale_array, name=initializer.name)
+            )
+    return tuned
+
+
 def apply_qat(
     float_model: Union[str, onnx.ModelProto],
     quantized_model: Union[str, onnx.ModelProto],
@@ -763,27 +948,9 @@ def apply_qat(
     if isinstance(quantized_model, str):
         quantized_model = onnx.load(quantized_model, load_external_data=False)
 
-    nodes, externals = _slice_block(
-        float_model.graph, block_input_name, block_output_name
+    plan = _plan_block(
+        float_model, quantized_model, block_input_name, block_output_name
     )
-    if not nodes:
-        raise ValueError(
-            f"no nodes lie between {block_input_name!r} and {block_output_name!r}"
-        )
-    _refuse_unsupported(nodes)
-
-    slice_outputs = {out for node in nodes for out in node.output if out}
-    candidates = [
-        c
-        for c in _find_int4_matmul_candidates(float_model, quantized_model)
-        if c.output_name in slice_outputs
-    ]
-    if not candidates:
-        raise ValueError(
-            f"the block between {block_input_name!r} and {block_output_name!r} "
-            "contains no quantize_weight_only_int4-quantized MatMul/Gemm layer to "
-            "train"
-        )
 
     if calibration_data is None:
         calibration_data = generate_random_calibration_data(
@@ -792,95 +959,541 @@ def apply_qat(
 
     captured = _capture(
         float_model,
-        sorted(set(externals) | {block_output_name}),
+        sorted(set(plan.externals) | {plan.output_name}),
         calibration_data,
         providers,
     )
-    teacher_output = captured[block_output_name]
-    external_values = {name: captured[name] for name in externals}
-
-    shapes = _block_shapes(
-        float_model, nodes, external_values, block_output_name, teacher_output
-    )
-
-    trained = _plan_trained(candidates, learn_scales)
-    trained_weight_names = {t.candidate.float_node.input[1] for t in trained}
-    used = {name for node in nodes for name in node.input if name}
-    block_initializers = [
-        t
-        for t in float_model.graph.initializer
-        if t.name in used and t.name not in trained_weight_names
-    ]
-
-    step = _build_step_graph(
-        trained,
-        nodes,
-        shapes,
-        block_initializers,
-        external_values,
-        block_output_name,
-        list(teacher_output.shape),
-        learn_scales,
-    )
-
-    constants: Dict[str, np.ndarray] = dict(external_values)
-    constants[f"{_PREFIX}teacher"] = teacher_output
-    state: Dict[str, np.ndarray] = {}
-    for t in trained:
-        state[t.w_input] = t.w_init
-        state[t.m_input] = np.zeros_like(t.w_init)
-        state[t.v_input] = np.zeros_like(t.w_init)
-        if t.scale_input is not None:
-            state[t.scale_input] = t.scale_init
-            state[str(t.ms_input)] = np.zeros_like(t.scale_init)
-            state[str(t.vs_input)] = np.zeros_like(t.scale_init)
-
-    def scalars(t: int) -> Dict[str, float]:
-        decay = 1.0 - t / num_iterations if lr_decay else 1.0
-        values = {
-            f"{_PREFIX}lr": learning_rate * decay,
-            f"{_PREFIX}lr_scale": scale_learning_rate * decay,
-        }
-        if not learn_scales:
-            del values[f"{_PREFIX}lr_scale"]
-        values.update(qat_graph.adam_bias_corrections(t))
-        return values
-
-    final = qat_graph.run_step_graph(
-        step,
-        constants=constants,
-        state=state,
-        num_steps=num_iterations,
-        scalars=scalars,
-        providers=step_providers,
+    return _train_block(
+        float_model,
+        quantized_model,
+        plan,
+        {name: captured[name] for name in plan.externals},
+        captured[plan.output_name],
+        num_iterations=num_iterations,
+        learning_rate=learning_rate,
+        learn_scales=learn_scales,
+        scale_learning_rate=scale_learning_rate,
+        lr_decay=lr_decay,
+        step_providers=step_providers,
         losses=losses,
     )
 
-    new_codes: Dict[str, np.ndarray] = {}
-    new_scales: Dict[str, np.ndarray] = {}
-    for t in trained:
-        w = final[t.w_input].astype(np.float64)
-        scale = (
-            final[t.scale_input].astype(np.float64)
-            if t.scale_input is not None
-            else t.scale_init.astype(np.float64)
+
+@dataclass(frozen=True)
+class QATBlock:
+    """One trainable block :func:`discover_qat_blocks` found, named the way
+    :func:`apply_qat` names one.
+
+    ``input_name``/``output_name`` are exactly what a caller would have passed
+    to :func:`apply_qat` by hand, so a plan is inspectable, diffable and
+    replayable one block at a time. The rest is metadata about what the
+    boundary pair actually resolved to -- useful for deciding whether the plan
+    is the one you wanted before spending a training budget on it.
+    """
+
+    input_name: str
+    output_name: str
+    #: Output tensor of every ``quantize_weight_only_int4``-quantized
+    #: MatMul/Gemm inside the block, in graph order. Never empty: a slice with
+    #: nothing to train is not a block.
+    quantized_outputs: Tuple[str, ...]
+    #: Tensors the block reads but does not produce, ``input_name`` included.
+    #: These are teacher-forced -- see :func:`_slice_block`.
+    external_inputs: Tuple[str, ...]
+    #: Op types inside the block, deduplicated and sorted. Every one of them
+    #: is in :data:`onnxsim.graph_grad.SUPPORTED_OPS`, by construction.
+    op_types: Tuple[str, ...]
+    num_nodes: int
+
+
+@dataclass
+class QATBlockResult:
+    """What happened to one block during :func:`apply_qat_all_blocks`.
+
+    ``trained`` and ``skipped_reason`` are mutually exclusive: a block either
+    trained (and ``losses`` has one entry per Adam step) or was skipped with a
+    reason string. A skip is never silent and never fatal -- see
+    :func:`apply_qat_all_blocks` for why that is the right trade here and
+    the opposite of :func:`apply_qat`'s own loud refusal.
+    """
+
+    block: QATBlock
+    trained: bool
+    skipped_reason: Optional[str] = None
+    losses: List[float] = field(default_factory=list)
+
+    @property
+    def initial_loss(self) -> Optional[float]:
+        """The block's reconstruction error before the first Adam step, i.e.
+        at round-to-nearest. ``None`` if the block was skipped."""
+        return self.losses[0] if self.losses else None
+
+    @property
+    def final_loss(self) -> Optional[float]:
+        """The block's reconstruction error after the last step. Compare it
+        against :attr:`initial_loss` -- the *ratio* is the only meaningful
+        number, since blocks differ in output scale and in element count."""
+        return self.losses[-1] if self.losses else None
+
+
+def _liveness_cuts(
+    graph: onnx.GraphProto, primary_input: Optional[str]
+) -> List[Tuple[int, str]]:
+    """Every index at which the graph narrows to a single live activation,
+    with the tensor that survives it.
+
+    This is the whole of boundary discovery, and it is a liveness argument
+    rather than a pattern match. Walk the nodes in their (topological) graph
+    order and track which tensors are *live* at each gap between node ``p``
+    and node ``p + 1``: produced at or before ``p``, and still read after it
+    (a graph output counts as read by the outside world). A gap where exactly
+    one tensor is live is a place the graph can be cut without severing
+    anything else, so the slice on either side is self-contained -- which is
+    precisely the property :func:`_slice_block` needs its two boundaries to
+    have.
+
+    The pleasant consequence is that residual connections *place* the
+    boundaries instead of defeating them. Inside ``y = f(x) + x`` the skip
+    tensor ``x`` is live alongside every intermediate, so no gap in the middle
+    of the residual is a cut, and the first cut after ``x`` is the residual
+    ``Add``'s own output -- exactly where a person would have drawn the block
+    boundary of a ResNet BasicBlock or a transformer sub-layer, derived rather
+    than special-cased.
+
+    Two things are excluded from the live set:
+
+    - **Initializers.** They are not activations; every block gets its own
+      copy in its step graph.
+    - **Graph inputs other than** ``primary_input``. A second graph input --
+      an attention mask, a position id tensor -- is byte-identical in the
+      teacher and the student, so teacher-forcing it into a block is exact
+      rather than an approximation, and letting it span the whole graph would
+      otherwise suppress every cut in a model that has one.
+
+    ``primary_input`` itself is *kept* in the live set, so a residual from the
+    model's own input still binds a block together (and its block ends at the
+    residual's output, not before it).
+
+    What this cannot see: a tensor computed purely from initializers -- a
+    pre-transposed weight shared by several layers, say -- is counted as an
+    ordinary live activation, so it suppresses cuts across its whole live
+    range. That is conservative in the safe direction (fewer, larger blocks,
+    or none) rather than the unsafe one.
+    """
+    initializers = {t.name for t in graph.initializer}
+    graph_inputs = {i.name for i in graph.input if i.name not in initializers}
+    ignored = {name for name in graph_inputs if name != primary_input}
+
+    # A tensor is live until its last consumer; a graph output is live past
+    # the end of the graph, so it is never dropped before the final gap.
+    last_use: Dict[str, int] = {}
+    for index, node in enumerate(graph.node):
+        for name in node.input:
+            if name and name not in initializers and name not in ignored:
+                last_use[name] = index
+    for out in graph.output:
+        if out.name and out.name not in initializers and out.name not in ignored:
+            last_use[out.name] = len(graph.node)
+
+    cuts: List[Tuple[int, str]] = []
+    live: Set[str] = {
+        name
+        for name in graph_inputs
+        if name not in ignored and last_use.get(name, -1) > -1
+    }
+    if len(live) == 1:
+        cuts.append((-1, next(iter(live))))
+    for index, node in enumerate(graph.node):
+        for name in node.output:
+            if name and name not in ignored and last_use.get(name, -1) > index:
+                live.add(name)
+        live = {name for name in live if last_use.get(name, -1) > index}
+        if len(live) == 1:
+            cuts.append((index, next(iter(live))))
+    return cuts
+
+
+def _primary_graph_input(graph: onnx.GraphProto) -> Optional[str]:
+    """The graph input the most nodes depend on -- the main activation path.
+
+    A heuristic, and named as one. Models with several inputs almost always
+    have one carrying the activations and the others carrying masks or ids,
+    and "reaches the most nodes" separates those reliably in practice while
+    being independent of naming conventions. Ties go to the earlier graph
+    input. It only decides which input keeps its power to *prevent* a cut
+    (see :func:`_liveness_cuts`); getting it wrong costs block granularity,
+    not correctness, because every non-chosen input is teacher-forced exactly.
+    """
+    initializers = {t.name for t in graph.initializer}
+    candidates = [i.name for i in graph.input if i.name not in initializers]
+    if not candidates:
+        return None
+
+    best_name, best_reach = candidates[0], -1
+    for name in candidates:
+        reached = {name}
+        count = 0
+        for node in graph.node:
+            if any(inp in reached for inp in node.input if inp):
+                count += 1
+                reached.update(out for out in node.output if out)
+        if count > best_reach:
+            best_name, best_reach = name, count
+    return best_name
+
+
+def discover_qat_blocks(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    max_layers_per_block: int = 2,
+) -> List[QATBlock]:
+    """Partitions the model into a sequence of blocks :func:`apply_qat` can
+    train, without the caller naming a single tensor.
+
+    This is the piece ``docs/qat.md`` lists as missing and
+    :mod:`onnxsim.brecq`'s docstring explicitly declines to attempt ("the
+    caller identifies a block by two tensor names"). BRECQ's reason was that
+    auto-detection looked architecture-specific; it is not, once the question
+    is asked in the right terms. Two properties make a slice trainable, and
+    both are decidable from the graph:
+
+    1. **Differentiable.** Every op inside must be in
+       :data:`onnxsim.graph_grad.SUPPORTED_OPS`, since the step graph
+       contains a backward pass over the block's own nodes.
+    2. **Self-contained.** The block must be cuttable out of the graph
+       without severing an activation that some other part of the graph is
+       still using. :func:`_liveness_cuts` finds exactly those places, by
+       liveness rather than by recognizing architectures -- read its
+       docstring, it is the substance of this function.
+
+    Blocks are then the spans between consecutive cuts, with two adjustments:
+
+    - **Unsupported ops become gaps, not failures.** A span containing an op
+      with no gradient rule cannot be a block, so it is skipped and the next
+      block starts after it. A model with one ``Sin`` in the middle trains
+      everything either side of it instead of being refused outright, which
+      is the behaviour that makes whole-model QAT usable at all; the
+      alternative -- :func:`apply_qat`'s loud refusal -- is right for a
+      caller who *named* a block and wrong for a caller who named none.
+    - **Spans are merged up to** ``max_layers_per_block`` **quantized
+      layers.** A cut exists between every pair of layers in a plain MLP, so
+      without merging every block would be a single layer and the whole point
+      of block-wise reconstruction (letting layers inside a block cancel each
+      other's error, :mod:`onnxsim.brecq`'s own argument) would be lost. The
+      default of 2 is the paired-projection shape BRECQ's Section 4 targets
+      -- a ResNet BasicBlock's two convolutions, a transformer FFN's up/down
+      pair. A span with no quantized layer in it (a lone activation) never
+      closes a block; it is absorbed into the next one.
+
+    **What discovery cannot see, and therefore does not promise.** It never
+    runs the model, so it cannot know whether a block's shapes are statically
+    inferable -- a dynamic ``Reshape``, a symbolic dimension that survives
+    inference -- and a block that fails on that is discovered here and
+    skipped later, by :func:`apply_qat_all_blocks`, with the reason recorded.
+    It also has no notion of which blocks *matter*: it will happily propose a
+    block whose quantization error is already negligible, and it has no
+    sensitivity metric to rank them (:mod:`onnxsim.precision_estimator` is
+    where such a thing would come from). And it inherits every limit of
+    :func:`_liveness_cuts`: a graph with a long-lived constant-derived tensor,
+    or with multi-output branches that never reconverge, simply yields fewer
+    or no cuts, and therefore fewer or no blocks -- an empty plan, not an
+    error.
+
+    :param float_model: the teacher, as an onnx ModelProto or a file path.
+            Boundaries are found in *this* graph, since it is the one whose
+            nodes the step graph differentiates.
+    :param quantized_model: its :func:`onnxsim.quantize_weight_only_int4`
+            counterpart, used only to find which layers are actually
+            quantized -- a block must contain at least one.
+    :param max_layers_per_block: how many quantized layers to merge into one
+            block before closing it. 1 gives per-layer blocks (more, cheaper
+            steps, no intra-block error cancellation); a large value gives
+            one block per gap between undifferentiable ops.
+    :returns: the blocks in graph order, possibly empty. Consecutive blocks
+            need not be adjacent: a gap between two of them is a region
+            nothing here can train.
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+    if max_layers_per_block < 1:
+        raise ValueError("max_layers_per_block must be at least 1")
+
+    graph = float_model.graph
+    cuts = _liveness_cuts(graph, _primary_graph_input(graph))
+    quantized_outputs = {
+        c.output_name
+        for c in _find_int4_matmul_candidates(float_model, quantized_model)
+    }
+
+    # Walk the spans between consecutive cuts, accumulating them into blocks.
+    # ``start`` is the cut the pending block opens at; ``layers`` counts the
+    # quantized layers accumulated since then.
+    pairs: List[Tuple[str, str]] = []
+    start: Optional[Tuple[int, str]] = cuts[0] if cuts else None
+    layers = 0
+    for previous, current in zip(cuts, cuts[1:]):
+        span = graph.node[previous[0] + 1 : current[0] + 1]
+        if any(node.op_type not in graph_grad.SUPPORTED_OPS for node in span):
+            # A gap. Close whatever was pending *before* it (the pending
+            # block ends at the last cut that is still on the trainable side)
+            # and reopen after it.
+            if start is not None and layers and start[0] < previous[0]:
+                pairs.append((start[1], previous[1]))
+            start, layers = current, 0
+            continue
+        if start is None:
+            start = previous
+        layers += sum(
+            1 for node in span for out in node.output if out in quantized_outputs
         )
-        scale_full = np.repeat(scale, t.candidate.block_size, axis=t.scale_axis)
-        codes = np.clip(_round_half_away(w / scale_full), _N_MIN, _N_MAX)
-        new_codes[t.candidate.wq_name] = codes.astype(np.int8)
-        if t.scale_input is not None:
-            new_scales[t.candidate.ws_init.name] = scale.astype(np.float32)
+        if layers >= max_layers_per_block:
+            pairs.append((start[1], current[1]))
+            start, layers = current, 0
+    if start is not None and layers and cuts and start[0] < cuts[-1][0]:
+        pairs.append((start[1], cuts[-1][1]))
+
+    blocks: List[QATBlock] = []
+    for input_name, output_name in pairs:
+        try:
+            plan = _plan_block(float_model, quantized_model, input_name, output_name)
+        except ValueError:
+            # Defensive: the span construction above already guarantees a
+            # non-empty, supported, quantized slice. Rather than trust that
+            # invariant, the plan itself is the check -- and a boundary pair
+            # that somehow fails it is dropped rather than handed to a caller
+            # who would only fail on it later.
+            continue
+        blocks.append(
+            QATBlock(
+                input_name=input_name,
+                output_name=output_name,
+                quantized_outputs=tuple(c.output_name for c in plan.candidates),
+                external_inputs=tuple(plan.externals),
+                op_types=tuple(sorted({n.op_type for n in plan.nodes})),
+                num_nodes=len(plan.nodes),
+            )
+        )
+    return blocks
+
+
+def _capture_student_inputs(
+    student: onnx.ModelProto,
+    names: Sequence[str],
+    calibration_data: Sequence[Tensors],
+    providers: Optional[Sequence[backend.Provider]],
+    fallback: Dict[str, np.ndarray],
+) -> Dict[str, np.ndarray]:
+    """The student's own activations at ``names``, falling back to the
+    teacher's for any name the student's graph does not have.
+
+    ``quantize_weight_only_int4`` never renames a node's output, so an
+    activation named in the float graph is named identically in the quantized
+    one and this fallback is normally unused. It exists for the one case
+    :func:`_slice_block` can produce that is not an activation: a tensor
+    computed entirely from initializers, which a quantizer is free to fold or
+    rewrite. Capturing the teacher's value for such a tensor is exact anyway.
+    """
+    present = {i.name for i in student.graph.input}
+    present.update(out for node in student.graph.node for out in node.output if out)
+    wanted = [name for name in names if name in present]
+    captured = dict(fallback)
+    if wanted:
+        captured.update(_capture(student, wanted, calibration_data, providers))
+    return {name: captured[name] for name in names}
+
+
+def apply_qat_all_blocks(
+    float_model: Union[str, onnx.ModelProto],
+    quantized_model: Union[str, onnx.ModelProto],
+    blocks: Optional[Sequence[QATBlock]] = None,
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_samples: int = 8,
+    seed: int = 0,
+    num_iterations: int = 1000,
+    learning_rate: float = 1e-4,
+    learn_scales: bool = False,
+    scale_learning_rate: float = 1e-5,
+    lr_decay: bool = True,
+    sequential: bool = True,
+    max_layers_per_block: int = 2,
+    providers: Optional[Sequence[backend.Provider]] = None,
+    step_providers: Optional[Sequence[backend.Provider]] = None,
+) -> Tuple[onnx.ModelProto, List[QATBlockResult]]:
+    """Trains every block :func:`discover_qat_blocks` finds, in graph order --
+    :func:`apply_qat` lifted from one caller-named block to the whole model.
+
+    **The design decision that matters: where each block's input comes
+    from.** Every block's optimization *target* is the teacher's output for
+    that block; that is not in question and is what makes this label-free.
+    The question is what to feed the block's input, and there are two honest
+    answers:
+
+    - ``sequential=True`` (**the default**): re-run the *student* -- the
+      quantized model as tuned so far -- before each block, and feed that
+      block the activation the deployed model will actually present to it.
+      Block *k* therefore sees the error blocks 0..k-1 left behind and spends
+      its own capacity correcting it, while still aiming at the teacher's
+      clean output. This is the standard sequential block-reconstruction
+      setup, and it is the reason the walk is worth more than *N* independent
+      calls to :func:`apply_qat`. It costs one forward pass of the student
+      per block -- inference, not training, and negligible beside
+      ``num_iterations`` optimizer steps.
+    - ``sequential=False``: capture everything once, from the float model,
+      before any block is touched. This is what :mod:`onnxsim.adaround` and
+      :mod:`onnxsim.brecq` do, and it is cheaper by exactly one forward pass
+      per block. It is also strictly the *independence assumption*
+      :mod:`onnxsim.brecq`'s own docstring identifies as the flaw in
+      per-layer reconstruction, applied one level up: it assumes every
+      earlier block was reconstructed perfectly, so a later block optimizes
+      against an input the deployed model never produces.
+
+    Sequential is the default because the assumption it drops is known to be
+    false -- quantization error compounds down a network, that is the entire
+    premise of block reconstruction. It is not, however, a free win:
+    ``tests/test_qat.py`` measures both modes on a deliberately
+    error-compounding model and records which one actually won, rather than
+    asserting the expected direction. On a shallow model with small
+    quantization error the two modes land within noise of each other, and on
+    any model the sequential input is *noisier* -- the student's activation
+    carries the earlier blocks' residual error, which acts a little like
+    input jitter. That is usually a regularizer and occasionally a handicap.
+
+    **Failures are per block, not per model.** A block that cannot be trained
+    -- an op with no gradient rule that discovery could not have foreseen, a
+    shape that will not infer statically, a slice with no quantized layer --
+    is skipped, the reason is recorded in its :class:`QATBlockResult`, and
+    the walk continues. That is the opposite of :func:`apply_qat`, which
+    refuses loudly, and the difference is deliberate: refusing loudly is
+    right when the caller *named* the thing that cannot be trained, and wrong
+    when they named nothing and one block out of forty is unusual. Nothing is
+    dropped silently -- every discovered block appears in the returned list,
+    trained or not.
+
+    :param float_model: the teacher (onnx ModelProto or file path). Its
+            activations are every block's target and its weights seed every
+            block's trained master weights.
+    :param quantized_model: its :func:`onnxsim.quantize_weight_only_int4`
+            counterpart -- the student, and the model that is returned with
+            its INT4 initializers rewritten.
+    :param blocks: the plan to walk. ``None`` runs :func:`discover_qat_blocks`
+            with ``max_layers_per_block``. Pass an explicit list to inspect,
+            filter or reorder the plan first -- e.g. to train only the blocks
+            a sensitivity analysis flagged.
+    :param calibration_data: representative input batches, as
+            :func:`apply_qat` takes them. All batches are concatenated into
+            one full-batch objective per block.
+    :param num_samples: random batches to generate when ``calibration_data``
+            is omitted
+    :param seed: seed for that random calibration data
+    :param num_iterations: Adam steps per block. The total budget is this
+            times the number of blocks, so a whole-model walk usually wants a
+            smaller value than a single :func:`apply_qat` call would.
+    :param learning_rate: Adam learning rate for the fp32 master weights
+    :param learn_scales: also train each weight's per-block quantization
+            scale, LSQ-style, in every block
+    :param scale_learning_rate: Adam learning rate for those scales
+    :param lr_decay: anneal both learning rates to zero within each block
+    :param sequential: feed each block the student's own activation rather
+            than the teacher's -- see above. ``True`` by default.
+    :param max_layers_per_block: passed to :func:`discover_qat_blocks` when
+            ``blocks`` is not given
+    :param providers: execution providers for the activation captures (both
+            the teacher's and, in sequential mode, the student's)
+    :param step_providers: execution providers for the optimization itself,
+            as an ONNX step graph -- the path to CUDA, an NPU EP or WebGPU
+    :returns: ``(tuned model, one QATBlockResult per discovered block)``. The
+            model is ``quantized_model`` with every successfully trained
+            block's initializers rewritten and nothing else touched; if no
+            block trained it is an unmodified copy.
+    """
+    if isinstance(float_model, str):
+        float_model = onnx.load(float_model, load_external_data=False)
+    if isinstance(quantized_model, str):
+        quantized_model = onnx.load(quantized_model, load_external_data=False)
+
+    if blocks is None:
+        blocks = discover_qat_blocks(
+            float_model, quantized_model, max_layers_per_block=max_layers_per_block
+        )
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            float_model, num_samples=num_samples, seed=seed
+        )
+
+    # Plans are built once, against the *original* quantized model. Training a
+    # block rewrites initializer payloads and never the graph, so a plan --
+    # which is nodes, tensor names and candidate metadata -- stays valid for
+    # the whole walk. Master weights are seeded from the float model in every
+    # case (see :func:`_plan_trained`), so no plan depends on the tuned state.
+    plans: List[Optional[_BlockPlan]] = []
+    results: List[QATBlockResult] = []
+    for block in blocks:
+        try:
+            plans.append(
+                _plan_block(
+                    float_model, quantized_model, block.input_name, block.output_name
+                )
+            )
+            results.append(QATBlockResult(block=block, trained=False))
+        except ValueError as error:
+            plans.append(None)
+            results.append(
+                QATBlockResult(
+                    block=block, trained=False, skipped_reason=f"cannot plan: {error}"
+                )
+            )
+
+    # One teacher pass for the whole walk: every block's target, and (in
+    # capture-once mode) every block's input too. The teacher never changes,
+    # so re-running it per block would buy nothing.
+    wanted: Set[str] = set()
+    for plan in plans:
+        if plan is not None:
+            wanted.update(plan.externals)
+            wanted.add(plan.output_name)
+    teacher = (
+        _capture(float_model, sorted(wanted), calibration_data, providers)
+        if wanted
+        else {}
+    )
 
     tuned = onnx.ModelProto()
     tuned.CopyFrom(quantized_model)
-    for initializer in tuned.graph.initializer:
-        codes = new_codes.get(initializer.name)
-        if codes is not None:
-            initializer.raw_data = _pack_int4(codes)
+    for plan, result in zip(plans, results):
+        if plan is None:
             continue
-        scale_array = new_scales.get(initializer.name)
-        if scale_array is not None:
-            initializer.CopyFrom(
-                onnx.numpy_helper.from_array(scale_array, name=initializer.name)
+        if sequential:
+            # The one extra forward pass this mode costs. It has to happen
+            # here, not once up front, because ``tuned`` has changed since the
+            # previous block: that is the entire point.
+            inputs = _capture_student_inputs(
+                tuned, plan.externals, calibration_data, providers, teacher
             )
-    return tuned
+        else:
+            inputs = {name: teacher[name] for name in plan.externals}
+        try:
+            tuned = _train_block(
+                float_model,
+                tuned,
+                plan,
+                inputs,
+                teacher[plan.output_name],
+                num_iterations=num_iterations,
+                learning_rate=learning_rate,
+                learn_scales=learn_scales,
+                scale_learning_rate=scale_learning_rate,
+                lr_decay=lr_decay,
+                step_providers=step_providers,
+                losses=result.losses,
+            )
+        except (ValueError, graph_grad.UnsupportedOpError) as error:
+            # A step graph that was half-built cannot have touched ``tuned``
+            # -- _train_block only rewrites initializers on a fresh copy, as
+            # its very last act -- so the walk resumes from an intact model.
+            result.losses.clear()
+            result.skipped_reason = f"training failed: {error}"
+            continue
+        result.trained = True
+    return tuned, results

--- a/onnxsim/qat_interop.py
+++ b/onnxsim/qat_interop.py
@@ -1,0 +1,1302 @@
+"""QAT interop: consume and produce fake-quant (QDQ) graphs without training.
+
+This is "deliverable A" of ``docs/qat.md`` -- the half of quantization-aware
+training that is pure graph rewriting. Nothing here runs a training loop, and
+nothing here needs calibration data for a tensor whose quantization
+parameters the model already carries.
+
+Two directions, and they are inverses of each other:
+
+**Ingest** (:func:`quantize_static_keeping_qdq_scales`). A model exported from
+PyTorch/TensorFlow QAT arrives as a QDQ graph whose scales and zero-points
+were *learned* -- they are the output of hours of training, and they are
+generally **not** what observing the tensor's min/max would produce (a trained
+scale usually clips: it trades a few saturated outliers for a finer step on
+the bulk of the distribution). :func:`onnxsim.quantize_static` would re-derive
+them from calibration and throw the learned values away, silently, with no
+error and only a small accuracy loss to show for it. So this module detects
+the QDQ pairs already present, canonicalizes them back to the float graph the
+rest of onnxsim's pipeline expects, re-runs the ordinary static-quantization
+rewrite, and then writes the learned parameters back over the ones the rewrite
+just computed. A tensor with no existing QDQ pair is calibrated normally, so a
+*partially* quantized export is handled rather than refused -- and when every
+quantizable tensor is annotated, no calibration data is needed or asked for at
+all.
+
+**Egress** (:func:`export_fake_quant`). Emit a QDQ model from a float model
+plus a chosen scheme, naming the initializers an external trainer should make
+learnable. Together with ingest this closes a round trip: onnxsim picks the
+scheme, the user trains the scales in their framework, onnxsim re-imports
+them.
+
+Why write the learned values back *after* the rewrite instead of feeding them
+in as a calibration range
+---------------------------------------------------------------------------
+``QuantizeStatic`` takes a ``{tensor: (min, max)}`` range and derives
+``(scale, zero_point)`` from it in C++ (``ComputeAsymmetricUint8QuantParams``
+in ``passes/static_quantize_matmul.h``). That map is invertible -- a learned
+``(scale, zp)`` corresponds to the range ``(-zp*scale, (levels-zp)*scale)`` --
+so the ranges *could* carry the learned values in. They are passed in, because
+the pass will not fire on a tensor that has no range at all. But the round trip
+goes through two float32 divisions and a ``round``, so it is only exact to
+within an ulp or two, and "the learned value survives" is the entire point of
+this path. Writing the exact learned tensor back over the emitted initializer
+afterwards makes the guarantee bit-exact rather than nearly so.
+
+What this module refuses
+------------------------
+Conservative in the house style: a QDQ pair it does not fully understand is
+left exactly where it is rather than guessed at, and the caller is told which
+one and why (:class:`SkippedQdq`, reachable from every entry point's result).
+See :data:`SKIP_REASONS` for the list. In particular a pair whose scale is not
+a constant initializer, whose zero-point has an unexpected dtype, or whose
+per-axis scale length disagrees with the tensor's own dimension along the axis
+it claims, is never canonicalized -- so it survives into the output untouched
+instead of being re-derived from a guess.
+
+Not covered, deliberately
+-------------------------
+- **Blocked quantization** (opset 21's ``block_size`` attribute) is refused
+  rather than canonicalized; onnxsim's static-quantization rewrite has no
+  blocked activation scheme to re-emit it into.
+- **QDQ inside subgraphs** (``If``/``Loop`` bodies) is not detected, and a
+  top-level pair whose dequantized output is referenced from a subgraph is
+  refused.
+- **Per-axis activation scales** are detected and reported but cannot be
+  preserved: ``quantize_static``'s activation scheme is per-tensor. The tensor
+  falls back to calibration and says so.
+- **Asymmetric or non-int8 learned weight quantizers** are understood but not
+  re-emitted: onnxsim's weight scheme is symmetric int8 per output channel, so
+  such a weight is reported and falls back to onnxsim's own round-to-nearest
+  scale. A symmetric int8 one *is* preserved, codes and all.
+- **Per-layer bit-width selection** (``mixed_precision.py``,
+  ``precision_estimator.py``) is not wired into :func:`export_fake_quant`; it
+  emits one scheme for the whole model.
+
+And one behaviour worth knowing rather than a gap: ingest runs the *whole*
+static-quantization rewrite, so the model it returns may quantize more nodes
+than the input model did -- an export that fake-quantized only some of its
+layers comes back with the rest quantized too, from calibration.
+``QdqIngestResult.recalibrated`` lists exactly those.
+"""
+
+import dataclasses
+import json
+from typing import Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+
+import onnxsim.onnxsim_cpp2py_export as C
+from onnxsim.calibration import Tensors, calibrate, generate_random_calibration_data
+from onnxsim.model_info import METADATA_PREFIX
+
+__all__ = [
+    "QdqAnnotation",
+    "SkippedQdq",
+    "QdqScan",
+    "QdqIngestResult",
+    "FakeQuantExport",
+    "SKIP_REASONS",
+    "LEARNABLE_SCALES_KEY",
+    "LEARNABLE_ZERO_POINTS_KEY",
+    "find_existing_qdq",
+    "strip_existing_qdq",
+    "quantize_static_keeping_qdq_scales",
+    "export_fake_quant",
+]
+
+
+# Every reason string this module ever reports, with what it means. Kept as a
+# single documented table (rather than only as string literals at the raise
+# sites) so a caller can branch on a reason without reading the source, and so
+# adding a refusal without documenting it is visibly incomplete.
+SKIP_REASONS: Dict[str, str] = {
+    # -- detection: the pattern is not a canonicalizable QDQ pair --
+    "dequantize_input_not_recognized": (
+        "DequantizeLinear's input is neither a QuantizeLinear output nor a "
+        "constant integer initializer, so there is no float tensor to "
+        "canonicalize back to"
+    ),
+    "mismatched_quantization_params": (
+        "the QuantizeLinear and DequantizeLinear of the pair do not name the "
+        "same scale/zero-point tensors (or the same axis), so the pair is not "
+        "a round trip through one quantizer"
+    ),
+    "quantized_tensor_reused": (
+        "the integer tensor between Quantize and Dequantize has another "
+        "consumer (or is a graph output), so removing the pair would change "
+        "what the graph computes"
+    ),
+    "dequantize_output_is_graph_output": (
+        "the dequantized tensor is a graph output; rewiring its consumers "
+        "would drop a name the model promises to produce"
+    ),
+    "referenced_in_subgraph": (
+        "the dequantized tensor is read from inside an If/Loop body, which "
+        "this module does not rewrite"
+    ),
+    # -- detection: the parameters themselves are not usable --
+    "scale_not_constant": "the scale input is not a constant initializer",
+    "zero_point_not_constant": ("the zero-point input is not a constant initializer"),
+    "unsupported_scale_dtype": "the scale initializer is not float32",
+    "unsupported_zero_point_dtype": (
+        "the zero-point initializer's dtype is not one of uint8/int8/uint16/int16"
+    ),
+    "zero_point_shape_mismatch": ("the zero-point's shape differs from the scale's"),
+    "non_positive_scale": "the scale is not finite and strictly positive",
+    "blocked_quantization_unsupported": (
+        "the pair uses opset-21 blocked quantization (block_size), which has "
+        "no counterpart in onnxsim's static-quantization scheme"
+    ),
+    "axis_shape_unknown": (
+        "the scale is per-axis but the quantized tensor's shape along that "
+        "axis is not statically known, so the claim cannot be checked"
+    ),
+    "axis_shape_mismatch": (
+        "the per-axis scale's length differs from the quantized tensor's "
+        "dimension along the axis it claims"
+    ),
+    # -- ingest: detected and canonicalized, but not carried into the output --
+    "not_a_quantizable_tensor": (
+        "onnxsim's static quantization has no place for this tensor (it is "
+        "not the activation or weight of a MatMul/Gemm/Conv it quantizes), so "
+        "the pair was left in the graph untouched rather than re-emitted"
+    ),
+    "per_axis_activation_unsupported": (
+        "the learned activation scale is per-axis; quantize_static's "
+        "activation scheme is per-tensor, so this tensor was recalibrated"
+    ),
+    "activation_zero_point_dtype_mismatch": (
+        "the learned activation zero-point's dtype is not the one this scheme "
+        "emits (uint8 for int8, uint16 for int16)"
+    ),
+    "activation_zero_point_out_of_range": (
+        "the learned activation zero-point lies outside the scheme's code "
+        "range, so no (min, max) range reproduces it"
+    ),
+    "weight_dtype_not_int8": (
+        "the learned weight quantization does not store int8 codes; onnxsim's "
+        "weight scheme is symmetric int8, so it cannot carry it"
+    ),
+    "weight_zero_point_not_symmetric": (
+        "the learned weight quantization is asymmetric (non-zero zero-point); "
+        "onnxsim's weight scheme is symmetric int8, so it cannot carry it"
+    ),
+    "weight_scale_shape_mismatch": (
+        "the learned weight scale's length or axis does not match the "
+        "per-output-channel scale onnxsim emits for this weight"
+    ),
+    "quantize_node_not_emitted": (
+        "the static-quantization rewrite did not quantize this tensor after "
+        "all (e.g. the model's opset is below 13), so there was nothing to "
+        "write the learned parameters into"
+    ),
+    "quantization_params_shared": (
+        "the emitted scale/zero-point initializer is shared with another "
+        "consumer, so overwriting it would change that consumer too"
+    ),
+}
+
+# metadata_props keys :func:`export_fake_quant` stamps onto the model. See its
+# docstring for why the names are carried *both* here and in the returned
+# lists.
+LEARNABLE_SCALES_KEY = METADATA_PREFIX + "qat.learnable_scales"
+LEARNABLE_ZERO_POINTS_KEY = METADATA_PREFIX + "qat.learnable_zero_points"
+
+_SUPPORTED_ZP_DTYPES = {
+    onnx.TensorProto.UINT8,
+    onnx.TensorProto.INT8,
+    onnx.TensorProto.UINT16,
+    onnx.TensorProto.INT16,
+}
+
+# (activation zero-point dtype, number of steps between the smallest and
+# largest code) for each scheme this module can re-emit -- exactly what
+# ComputeAsymmetricUint8QuantParams / ...Uint16QuantParams divide by.
+_SCHEMES = {
+    "int8": (onnx.TensorProto.UINT8, 255.0),
+    "int16": (onnx.TensorProto.UINT16, 65535.0),
+}
+
+# The ops whose activation/weight quantize_static rewrites, so ingest can tell
+# a QDQ pair it can re-emit from one it must leave alone.
+_QUANTIZED_OPS = ("MatMul", "Gemm", "Conv")
+
+
+@dataclasses.dataclass(frozen=True)
+class QdqAnnotation:
+    """One QuantizeLinear/DequantizeLinear pair already present in a model,
+    read back as the quantization of a single float tensor.
+
+    ``tensor_name`` is the *float* tensor the pair brackets -- the name the
+    graph uses once the pair is canonicalized away, which is what every other
+    part of onnxsim (calibration ranges,
+    ``onnxsim_cpp2py_export.list_quantizable_activations``) addresses tensors
+    by. ``scale``/``zero_point`` are the learned values themselves, already
+    materialized as numpy arrays: they are the thing worth preserving, and a
+    caller that only wants to *inspect* an export's learned parameters can
+    stop here without going anywhere near the rest of this module.
+    """
+
+    tensor_name: str
+    role: str  # "activation" (a runtime value) or "weight" (a constant)
+    scale: np.ndarray  # float32, scalar for per-tensor
+    zero_point: np.ndarray  # integer, same shape as `scale`
+    zero_point_dtype: int  # an onnx.TensorProto enum value
+    axis: Optional[int]  # None when the scale is per-tensor
+    scale_name: str
+    zero_point_name: Optional[str]  # None when the pair omitted the input
+    quantize_node: Optional[str]  # output name of the QuantizeLinear, if any
+    dequantize_node: str  # output name of the DequantizeLinear
+
+    @property
+    def per_tensor(self) -> bool:
+        return self.axis is None
+
+
+@dataclasses.dataclass(frozen=True)
+class SkippedQdq:
+    """A QDQ pattern this module declined to act on, and why.
+
+    ``reason`` is a key of :data:`SKIP_REASONS`. Skipping is never silent and
+    never fatal: the pair stays in the graph exactly as authored, so the model
+    keeps whatever quantization it had -- the caller simply learns that
+    onnxsim did not take responsibility for it.
+    """
+
+    tensor_name: str
+    reason: str
+    node: str  # output name of the node the refusal was raised on
+
+    def __str__(self) -> str:
+        return f"{self.tensor_name}: {self.reason} ({SKIP_REASONS[self.reason]})"
+
+
+@dataclasses.dataclass(frozen=True)
+class QdqScan:
+    """What :func:`find_existing_qdq` found: the pairs it understood, and the
+    ones it refused.
+    """
+
+    annotations: Tuple[QdqAnnotation, ...]
+    skipped: Tuple[SkippedQdq, ...]
+
+    def by_name(self) -> Dict[str, QdqAnnotation]:
+        return {a.tensor_name: a for a in self.annotations}
+
+    @property
+    def activations(self) -> Tuple[QdqAnnotation, ...]:
+        return tuple(a for a in self.annotations if a.role == "activation")
+
+    @property
+    def weights(self) -> Tuple[QdqAnnotation, ...]:
+        return tuple(a for a in self.annotations if a.role == "weight")
+
+
+@dataclasses.dataclass(frozen=True)
+class QdqIngestResult:
+    """The output of :func:`quantize_static_keeping_qdq_scales`.
+
+    Four disjoint accounts of every quantizable tensor, so "did my learned
+    scale survive?" is answerable without diffing two models:
+
+    - ``preserved`` -- the learned scale/zero-point are in ``model``, bit-exact.
+    - ``recalibrated`` -- no usable annotation, so the tensor was calibrated
+      the ordinary way.
+    - ``unpreserved`` -- an annotation was found and understood, but this
+      scheme could not carry it; the tensor fell back to calibration.
+    - ``scan.skipped`` -- a QDQ pattern was refused outright and left in the
+      graph untouched.
+    """
+
+    model: onnx.ModelProto
+    scan: QdqScan
+    preserved: Tuple[str, ...]
+    recalibrated: Tuple[str, ...]
+    unpreserved: Tuple[SkippedQdq, ...]
+    calibration_ran: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class FakeQuantExport:
+    """The output of :func:`export_fake_quant`: a QDQ model plus the names of
+    the initializers an external trainer should make learnable.
+    """
+
+    model: onnx.ModelProto
+    learnable_scales: Tuple[str, ...]
+    learnable_zero_points: Tuple[str, ...]
+
+    @property
+    def learnable_tensors(self) -> Tuple[str, ...]:
+        """Every initializer a QAT trainer may touch, scales first.
+
+        Only ``learnable_scales`` are float tensors a gradient can move
+        directly; ``learnable_zero_points`` are integer-typed, so a trainer
+        that learns them too (LSQ+ does) has to round back to their dtype at
+        every step. They are listed separately for exactly that reason.
+        """
+        return self.learnable_scales + self.learnable_zero_points
+
+
+# --------------------------------------------------------------------------- #
+# Graph inspection helpers
+# --------------------------------------------------------------------------- #
+def _load(model: Union[str, onnx.ModelProto]) -> onnx.ModelProto:
+    if isinstance(model, str):
+        return onnx.load(model, load_external_data=False)
+    return model
+
+
+def _infer(model: onnx.ModelProto) -> onnx.ModelProto:
+    """``model`` with value_info filled in, or ``model`` unchanged on failure.
+
+    Both entry points run this before handing a graph to the C++ rewrite,
+    because ``ListQuantizableActivations``/``StaticQuantizeMatMul`` skip any
+    node whose activation input has no *declared* element type -- an
+    intermediate tensor of a graph that was never shape-inferred looks like
+    "not float32" to them and is silently left unquantized. A QAT export's
+    interesting tensors are exactly those intermediates, so inferring first is
+    the difference between preserving a learned scale and reporting that there
+    was nowhere to put it. Inference only adds value_info, so a model it fails
+    on is simply used as-is.
+    """
+    try:
+        return onnx.shape_inference.infer_shapes(model, strict_mode=False)
+    except Exception:
+        return model
+
+
+def _attr(node: onnx.NodeProto, name: str) -> Optional[onnx.AttributeProto]:
+    for attr in node.attribute:
+        if attr.name == name:
+            return attr
+    return None
+
+
+def _iter_subgraphs(graph: onnx.GraphProto) -> Iterator[onnx.GraphProto]:
+    for node in graph.node:
+        for attr in node.attribute:
+            if attr.HasField("g"):
+                yield attr.g
+                yield from _iter_subgraphs(attr.g)
+            for sub in attr.graphs:
+                yield sub
+                yield from _iter_subgraphs(sub)
+
+
+def _subgraph_reads(graph: onnx.GraphProto) -> Set[str]:
+    """Every tensor name read by a node inside any nested subgraph.
+
+    A subgraph can close over a name from the enclosing graph, so a top-level
+    QDQ pair whose output is read from an ``If``/``Loop`` body cannot be
+    rewired by only touching top-level nodes.
+    """
+    names: Set[str] = set()
+    for sub in _iter_subgraphs(graph):
+        for node in sub.node:
+            names.update(node.input)
+        names.update(o.name for o in sub.output)
+    return names
+
+
+def _use_counts(graph: onnx.GraphProto) -> Dict[str, int]:
+    """How many times each tensor name is consumed at the top level, counting a
+    graph output as one use.
+    """
+    counts: Dict[str, int] = {}
+    for node in graph.node:
+        for name in node.input:
+            if name:
+                counts[name] = counts.get(name, 0) + 1
+    for out in graph.output:
+        counts[out.name] = counts.get(out.name, 0) + 1
+    return counts
+
+
+def _producers(graph: onnx.GraphProto) -> Dict[str, onnx.NodeProto]:
+    return {out: node for node in graph.node for out in node.output if out}
+
+
+def _static_shapes(model: onnx.ModelProto) -> Dict[str, Tuple[Optional[int], ...]]:
+    """``{tensor_name: shape}`` for every tensor whose shape is statically
+    known, with ``None`` for a symbolic dimension.
+
+    Shape inference is best-effort: it is only needed to *check* a per-axis
+    scale's claim, and a tensor whose shape stays unknown is refused rather
+    than assumed (``axis_shape_unknown``), so a failed inference costs
+    coverage, never correctness.
+    """
+    try:
+        inferred = onnx.shape_inference.infer_shapes(model, strict_mode=False)
+    except Exception:
+        inferred = model
+    shapes: Dict[str, Tuple[Optional[int], ...]] = {}
+    for init in inferred.graph.initializer:
+        shapes[init.name] = tuple(init.dims)
+    values = (
+        list(inferred.graph.input)
+        + list(inferred.graph.output)
+        + list(inferred.graph.value_info)
+    )
+    for value in values:
+        tensor_type = value.type.tensor_type
+        if not tensor_type.HasField("shape"):
+            continue
+        shapes.setdefault(
+            value.name,
+            tuple(
+                dim.dim_value if dim.HasField("dim_value") else None
+                for dim in tensor_type.shape.dim
+            ),
+        )
+    return shapes
+
+
+# --------------------------------------------------------------------------- #
+# Ingest: detection
+# --------------------------------------------------------------------------- #
+def _check_params(
+    scale_init: Optional[onnx.TensorProto],
+    zp_name: Optional[str],
+    zp_init: Optional[onnx.TensorProto],
+) -> Optional[str]:
+    """The dtype/shape/value checks both QDQ shapes share, as a reason or None."""
+    if scale_init is None:
+        return "scale_not_constant"
+    if scale_init.data_type != onnx.TensorProto.FLOAT:
+        return "unsupported_scale_dtype"
+    scale = onnx.numpy_helper.to_array(scale_init)
+    if not np.all(np.isfinite(scale)) or not np.all(scale > 0):
+        return "non_positive_scale"
+    if zp_name:
+        if zp_init is None:
+            return "zero_point_not_constant"
+        if zp_init.data_type not in _SUPPORTED_ZP_DTYPES:
+            return "unsupported_zero_point_dtype"
+        if tuple(zp_init.dims) != tuple(scale_init.dims):
+            return "zero_point_shape_mismatch"
+    return None
+
+
+def _pair_axis(
+    dq: onnx.NodeProto,
+    q: Optional[onnx.NodeProto],
+    scale: np.ndarray,
+    quantized_name: str,
+    shapes: Dict[str, Tuple[Optional[int], ...]],
+) -> Union[Optional[int], str]:
+    """The pair's quantization axis, or a skip reason.
+
+    Returns ``None`` for a per-tensor (scalar or single-element) scale. For a
+    per-axis one the claim is *checked* against the tensor's own shape rather
+    than trusted: a scale of length C attached to an axis whose extent is not C
+    is a malformed export, and guessing which of the two is right is exactly
+    what this module does not do.
+    """
+    if scale.size == 1:
+        return None
+    axis_attr = _attr(dq, "axis")
+    axis = int(axis_attr.i) if axis_attr is not None else 1
+    if q is not None:
+        q_axis_attr = _attr(q, "axis")
+        q_axis = int(q_axis_attr.i) if q_axis_attr is not None else 1
+        if q_axis != axis:
+            return "mismatched_quantization_params"
+    shape = shapes.get(quantized_name)
+    if shape is None:
+        return "axis_shape_unknown"
+    if axis < 0:
+        axis += len(shape)
+    if axis < 0 or axis >= len(shape):
+        return "axis_shape_mismatch"
+    if shape[axis] is None:
+        return "axis_shape_unknown"
+    if shape[axis] != scale.size:
+        return "axis_shape_mismatch"
+    return axis
+
+
+def _scan_dequantize(
+    dq: onnx.NodeProto,
+    inits: Dict[str, onnx.TensorProto],
+    producers: Dict[str, onnx.NodeProto],
+    uses: Dict[str, int],
+    outputs: Set[str],
+    subgraph_reads: Set[str],
+    shapes: Dict[str, Tuple[Optional[int], ...]],
+) -> Union[QdqAnnotation, SkippedQdq, None]:
+    """One DequantizeLinear node, read as an annotation or a refusal.
+
+    ``None`` means "not a QDQ pattern at all" only in the cases where the node
+    is not a usable DequantizeLinear to begin with; every recognized-but-
+    unusable shape comes back as a :class:`SkippedQdq` rather than being
+    dropped on the floor.
+    """
+    dq_out = dq.output[0]
+    quantized_name = dq.input[0]
+    q = producers.get(quantized_name)
+    if q is not None and q.op_type != "QuantizeLinear":
+        q = None
+    source_is_initializer = quantized_name in inits
+
+    if q is None and not source_is_initializer:
+        return SkippedQdq(dq_out, "dequantize_input_not_recognized", dq_out)
+
+    # The float tensor the pair brackets, and hence the name everything
+    # downstream addresses it by. Shape 3 has no float tensor in the graph at
+    # all -- the dequantized output *is* it -- so it takes that name.
+    tensor_name = q.input[0] if q is not None else dq_out
+
+    if _attr(dq, "block_size") is not None or (
+        q is not None and _attr(q, "block_size") is not None
+    ):
+        return SkippedQdq(tensor_name, "blocked_quantization_unsupported", dq_out)
+    if dq_out in outputs:
+        return SkippedQdq(tensor_name, "dequantize_output_is_graph_output", dq_out)
+    if dq_out in subgraph_reads or tensor_name in subgraph_reads:
+        return SkippedQdq(tensor_name, "referenced_in_subgraph", dq_out)
+
+    scale_name = dq.input[1]
+    zp_name = dq.input[2] if len(dq.input) > 2 and dq.input[2] else None
+    if q is not None:
+        q_zp = q.input[2] if len(q.input) > 2 and q.input[2] else None
+        if len(q.input) < 2 or q.input[1] != scale_name or q_zp != zp_name:
+            return SkippedQdq(tensor_name, "mismatched_quantization_params", dq_out)
+        # Removing the pair removes the integer tensor with it, so anything
+        # else reading it would break.
+        if uses.get(quantized_name, 0) != 1 or quantized_name in outputs:
+            return SkippedQdq(tensor_name, "quantized_tensor_reused", dq_out)
+
+    scale_init = inits.get(scale_name)
+    zp_init = inits.get(zp_name) if zp_name else None
+    reason = _check_params(scale_init, zp_name, zp_init)
+    if reason is not None:
+        return SkippedQdq(tensor_name, reason, dq_out)
+    assert scale_init is not None  # _check_params rejected None already
+    scale = onnx.numpy_helper.to_array(scale_init)
+
+    axis = _pair_axis(dq, q, scale, quantized_name, shapes)
+    if isinstance(axis, str):
+        return SkippedQdq(tensor_name, axis, dq_out)
+
+    if zp_init is not None:
+        zero_point = onnx.numpy_helper.to_array(zp_init)
+        zp_dtype = zp_init.data_type
+    else:
+        # An omitted zero_point is defined to be zero, in the quantized
+        # tensor's own dtype -- which for shape 3 we can read off the stored
+        # codes, and for shapes 1/2 defaults to uint8.
+        zp_dtype = (
+            inits[quantized_name].data_type
+            if source_is_initializer
+            else onnx.TensorProto.UINT8
+        )
+        if zp_dtype not in _SUPPORTED_ZP_DTYPES:
+            return SkippedQdq(tensor_name, "unsupported_zero_point_dtype", dq_out)
+        zero_point = np.zeros(scale.shape, dtype=np.int64)
+
+    is_weight = source_is_initializer or tensor_name in inits
+    return QdqAnnotation(
+        tensor_name=tensor_name,
+        role="weight" if is_weight else "activation",
+        scale=np.asarray(scale, dtype=np.float32),
+        zero_point=np.asarray(zero_point),
+        zero_point_dtype=zp_dtype,
+        axis=axis,
+        scale_name=scale_name,
+        zero_point_name=zp_name,
+        quantize_node=q.output[0] if q is not None else None,
+        dequantize_node=dq_out,
+    )
+
+
+def find_existing_qdq(model: Union[str, onnx.ModelProto]) -> QdqScan:
+    """Detect the QuantizeLinear/DequantizeLinear pairs already in ``model``.
+
+    Three shapes are recognized, which between them cover what QAT exporters
+    and onnxsim's own :func:`onnxsim.quantize_static` emit:
+
+    1. ``X -> QuantizeLinear -> DequantizeLinear -> ...`` where ``X`` is a
+       runtime value -- a *fake-quantized activation*, the learned-scale case
+       this whole module exists for.
+    2. the same, where ``X`` is a float initializer -- a fake-quantized
+       *weight*.
+    3. ``Wq (integer initializer) -> DequantizeLinear -> ...`` with no
+       Quantize -- a weight already stored in its quantized form, which is
+       what ONNX Runtime's quantizer and ``quantize_static`` produce.
+
+    Nothing is modified. The scan is purely informational, which makes it the
+    right entry point for "what did my trainer actually learn?" -- and it is
+    also the first step of :func:`strip_existing_qdq` and
+    :func:`quantize_static_keeping_qdq_scales`, so the three always agree on
+    what counts as a pair.
+
+    :param model: onnx ModelProto object or file path
+    :returns: a :class:`QdqScan` of understood pairs and refused ones
+    """
+    model = _load(model)
+    graph = model.graph
+    inits = {init.name: init for init in graph.initializer}
+    producers = _producers(graph)
+    uses = _use_counts(graph)
+    outputs = {o.name for o in graph.output}
+    subgraph_reads = _subgraph_reads(graph)
+    shapes = _static_shapes(model)
+
+    annotations: List[QdqAnnotation] = []
+    skipped: List[SkippedQdq] = []
+    for dq in graph.node:
+        if dq.op_type != "DequantizeLinear" or len(dq.input) < 2 or not dq.output:
+            continue
+        found = _scan_dequantize(
+            dq, inits, producers, uses, outputs, subgraph_reads, shapes
+        )
+        if isinstance(found, QdqAnnotation):
+            annotations.append(found)
+        elif isinstance(found, SkippedQdq):
+            skipped.append(found)
+    return QdqScan(tuple(annotations), tuple(skipped))
+
+
+# --------------------------------------------------------------------------- #
+# Ingest: canonicalization (removing the pairs)
+# --------------------------------------------------------------------------- #
+def _broadcast_along_axis(
+    vector: np.ndarray, rank: int, axis: Optional[int]
+) -> np.ndarray:
+    """``vector`` reshaped so it broadcasts against a rank-``rank`` tensor along
+    ``axis`` (or unchanged, for a per-tensor scalar).
+    """
+    if axis is None:
+        return vector.reshape(())
+    shape = [1] * rank
+    shape[axis] = vector.size
+    return vector.reshape(shape)
+
+
+def _dequantize(codes: np.ndarray, ann: QdqAnnotation) -> np.ndarray:
+    zero_point = _broadcast_along_axis(
+        np.asarray(ann.zero_point, dtype=np.float64).reshape(-1), codes.ndim, ann.axis
+    )
+    scale = _broadcast_along_axis(
+        np.asarray(ann.scale, dtype=np.float64).reshape(-1), codes.ndim, ann.axis
+    )
+    return ((codes.astype(np.float64) - zero_point) * scale).astype(np.float32)
+
+
+def _strip(
+    model: onnx.ModelProto, annotations: Sequence[QdqAnnotation]
+) -> onnx.ModelProto:
+    """``model`` with each named pair removed and its consumers rewired to the
+    float tensor the pair bracketed.
+
+    The result is an ordinary float graph, which is the only kind the rest of
+    onnxsim's pipeline (``list_quantizable_activations``, ``QuantizeStatic``,
+    the ``passes/``) knows how to reason about. Nothing else in the graph is
+    touched: pairs not named here stay exactly as authored, and the only
+    initializers removed are the ones the removed pairs were the last consumer
+    of.
+    """
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    graph = out.graph
+    inits = {init.name: init for init in graph.initializer}
+    producers = _producers(graph)
+
+    drop_nodes: Set[str] = set()
+    rewire: Dict[str, str] = {}
+    orphan_candidates: Set[str] = set()
+    materialized: List[onnx.TensorProto] = []
+
+    for ann in annotations:
+        dq = producers[ann.dequantize_node]
+        drop_nodes.add(ann.dequantize_node)
+        orphan_candidates.add(ann.scale_name)
+        if ann.zero_point_name:
+            orphan_candidates.add(ann.zero_point_name)
+        if ann.quantize_node is not None:
+            drop_nodes.add(ann.quantize_node)
+            rewire[ann.dequantize_node] = ann.tensor_name
+        else:
+            # Shape 3: the float tensor exists only implicitly, so materialize
+            # it under the dequantized output's own name -- consumers then need
+            # no rewiring at all, and the name the rest of the pipeline sees is
+            # the one the model already used for this value.
+            codes_name = dq.input[0]
+            orphan_candidates.add(codes_name)
+            materialized.append(
+                onnx.numpy_helper.from_array(
+                    _dequantize(onnx.numpy_helper.to_array(inits[codes_name]), ann),
+                    ann.tensor_name,
+                )
+            )
+
+    kept = [
+        node
+        for node in graph.node
+        if not node.output or node.output[0] not in drop_nodes
+    ]
+    del graph.node[:]
+    graph.node.extend(kept)
+    for node in graph.node:
+        for i, name in enumerate(node.input):
+            if name in rewire:
+                node.input[i] = rewire[name]
+
+    graph.initializer.extend(materialized)
+
+    # Only the pairs' own parameter tensors are ever pruned, and only when
+    # nothing at all still reads them -- an initializer that was already unused
+    # before this call is left alone, so canonicalization never has a side
+    # effect the caller did not ask for.
+    still_used: Set[str] = set()
+    for node in graph.node:
+        still_used.update(node.input)
+    for sub in _iter_subgraphs(graph):
+        for node in sub.node:
+            still_used.update(node.input)
+    still_used.update(o.name for o in graph.output)
+    still_used.update(i.name for i in graph.input)
+    orphans = {name for name in orphan_candidates if name not in still_used}
+    if orphans:
+        surviving = [i for i in graph.initializer if i.name not in orphans]
+        del graph.initializer[:]
+        graph.initializer.extend(surviving)
+
+    # value_info describing tensors that no longer exist would otherwise
+    # outlive them and confuse shape inference.
+    gone = drop_nodes | orphans
+    surviving_info = [v for v in graph.value_info if v.name not in gone]
+    del graph.value_info[:]
+    graph.value_info.extend(surviving_info)
+    return out
+
+
+def strip_existing_qdq(
+    model: Union[str, onnx.ModelProto],
+) -> Tuple[onnx.ModelProto, QdqScan]:
+    """Canonicalize ``model`` back to a float graph, returning it and the scan
+    that says what was removed.
+
+    "Canonicalize" rather than "dequantize": for a fake-quant pair the float
+    tensor is already in the graph and the pair is simply deleted, so the
+    result is the *original* float graph, not an approximation of it. Only a
+    weight stored in integer form (scan shape 3) is actually rematerialized,
+    as ``(codes - zero_point) * scale``.
+
+    Useful on its own -- it is how you get a QAT export into any of onnxsim's
+    float-model entry points -- but note that on its own it *discards* the
+    learned parameters, which is the mistake this module exists to prevent.
+    Use :func:`quantize_static_keeping_qdq_scales` to canonicalize and put them
+    back.
+
+    :param model: onnx ModelProto object or file path
+    :returns: ``(float_model, scan)``
+    """
+    model = _load(model)
+    scan = find_existing_qdq(model)
+    return _strip(model, scan.annotations), scan
+
+
+# --------------------------------------------------------------------------- #
+# Ingest: the entry point
+# --------------------------------------------------------------------------- #
+def _range_for(scale: float, zero_point: float, levels: float) -> Tuple[float, float]:
+    """The calibration range whose ``(scale, zero_point)`` is the given one.
+
+    The exact inverse of ``ComputeAsymmetricUint8QuantParams``: that function
+    computes ``scale = (hi - lo) / levels`` and ``zp = round(-lo / scale)``
+    after widening ``[lo, hi]`` to include 0, so ``lo = -zp * scale`` and
+    ``hi = lo + levels * scale`` reproduce it (and the widening is a no-op,
+    since a zero-point inside the code range puts 0 inside the interval by
+    construction). Float32 rounding makes the trip approximate, which is why
+    the caller writes the learned tensors back afterwards; what this only has
+    to get right is making the pass fire and landing in the right ballpark if
+    the write-back is refused.
+    """
+    lo = -zero_point * scale
+    return (lo, lo + levels * scale)
+
+
+def _set_initializer_value(
+    graph: onnx.GraphProto, name: str, value: np.ndarray
+) -> None:
+    """Overwrite initializer ``name``'s payload, keeping its name and dims."""
+    for i, init in enumerate(graph.initializer):
+        if init.name != name:
+            continue
+        replacement = onnx.numpy_helper.from_array(value.reshape(init.dims), name)
+        graph.initializer[i].CopyFrom(replacement)
+        return
+    raise KeyError(name)
+
+
+def _preservable_activation(
+    ann: QdqAnnotation, zp_dtype: int, levels: float
+) -> Optional[str]:
+    """Why this activation annotation cannot be re-emitted, or None."""
+    if ann.axis is not None:
+        return "per_axis_activation_unsupported"
+    if ann.zero_point_dtype != zp_dtype:
+        return "activation_zero_point_dtype_mismatch"
+    zero_point = float(np.asarray(ann.zero_point).reshape(-1)[0])
+    if not 0.0 <= zero_point <= levels:
+        return "activation_zero_point_out_of_range"
+    return None
+
+
+def _writeback_activation(
+    qgraph: onnx.GraphProto,
+    quantize_nodes: Dict[str, List[onnx.NodeProto]],
+    uses: Dict[str, int],
+    ann: QdqAnnotation,
+) -> Optional[str]:
+    """Put ``ann``'s learned scale/zero-point into the emitted QDQ pair(s).
+
+    Plural: the rewrite is per-node, so an activation feeding two quantized
+    nodes comes back bracketed by two independent QDQ pairs with two
+    independent parameter initializers. All of them describe the same tensor
+    and all of them get the same learned values -- writing only one would
+    leave the model quantizing one tensor two different ways.
+
+    Returns a skip reason if a pair the rewrite emitted is not the exclusive
+    owner of its parameter initializers (so overwriting them would reach
+    further than this one tensor), or if none was emitted at all.
+    """
+    nodes = [n for n in quantize_nodes.get(ann.tensor_name, []) if len(n.input) >= 3]
+    if not nodes:
+        return "quantize_node_not_emitted"
+    # The rewrite creates one initializer per quantized tensor and wires it
+    # into exactly the Quantize and the Dequantize of that pair -- two uses.
+    # Anything else means this is not the graph we think it is.
+    for node in nodes:
+        if uses.get(node.input[1], 0) != 2 or uses.get(node.input[2], 0) != 2:
+            return "quantization_params_shared"
+    for node in nodes:
+        scale_name, zp_name = node.input[1], node.input[2]
+        _set_initializer_value(
+            qgraph, scale_name, np.asarray(ann.scale, dtype=np.float32)
+        )
+        zp_init = next(i for i in qgraph.initializer if i.name == zp_name)
+        zp_np = onnx.helper.tensor_dtype_to_np_dtype(zp_init.data_type)
+        _set_initializer_value(
+            qgraph, zp_name, np.asarray(ann.zero_point).astype(zp_np)
+        )
+    return None
+
+
+def _writeback_weight(
+    qgraph: onnx.GraphProto,
+    weight: np.ndarray,
+    wdq: onnx.NodeProto,
+    uses: Dict[str, int],
+    ann: QdqAnnotation,
+) -> Optional[str]:
+    """Put ``ann``'s learned weight scale into the emitted per-channel
+    dequantization, re-deriving the integer codes from it.
+
+    The scale cannot simply be swapped: the codes the rewrite computed are
+    ``round(w / its own scale)``, so a different scale needs different codes or
+    the weight changes value. Both are rewritten together, from the float
+    weight this ingest canonicalized out of the input model -- which is the
+    same float weight the trainer was fake-quantizing, so the result is the
+    quantized weight the trainer was actually training against.
+    """
+    if ann.zero_point_dtype != onnx.TensorProto.INT8:
+        return "weight_dtype_not_int8"
+    if np.any(np.asarray(ann.zero_point) != 0):
+        return "weight_zero_point_not_symmetric"
+    codes_name, scale_name = wdq.input[0], wdq.input[1]
+    if uses.get(codes_name, 0) != 1 or uses.get(scale_name, 0) != 1:
+        return "quantization_params_shared"
+
+    axis_attr = _attr(wdq, "axis")
+    emitted_axis = int(axis_attr.i) if axis_attr is not None else 1
+    emitted = next(i for i in qgraph.initializer if i.name == scale_name)
+    channels = int(np.prod(emitted.dims)) if emitted.dims else 1
+
+    learned = np.asarray(ann.scale, dtype=np.float32).reshape(-1)
+    if ann.axis is None and learned.size == 1:
+        # A per-tensor learned weight scale is coarser than the per-channel
+        # scheme being emitted, but it is what was trained: broadcast it rather
+        # than refuse, so the emitted weight is the one the trainer saw.
+        learned = np.repeat(learned, channels)
+    elif ann.axis != emitted_axis or learned.size != channels:
+        return "weight_scale_shape_mismatch"
+
+    scale = _broadcast_along_axis(learned.astype(np.float64), weight.ndim, emitted_axis)
+    codes = np.clip(np.round(weight.astype(np.float64) / scale), -127, 127)
+    _set_initializer_value(qgraph, codes_name, codes.astype(np.int8))
+    _set_initializer_value(qgraph, scale_name, learned)
+    return None
+
+
+def quantize_static_keeping_qdq_scales(
+    model: Union[str, onnx.ModelProto],
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_calibration_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    method: str = "minmax",
+    scheme: str = "int8",
+) -> QdqIngestResult:
+    """Statically quantize ``model``, **keeping** the quantization parameters it
+    already carries instead of re-deriving them.
+
+    This is the ingest half of ``docs/qat.md``'s "QAT interop". Call it on a
+    model exported from a QAT-trained network:
+    :func:`onnxsim.quantize_static` would observe each activation's min/max
+    over calibration data and compute a fresh ``(scale, zero_point)`` from it,
+    discarding parameters that took a training run to produce -- and a learned
+    scale is usually deliberately *tighter* than the observed range (clipping
+    outliers to spend the codes where the values are), so re-deriving it is a
+    real, silent regression rather than a wash.
+
+    The pipeline is:
+
+    1. :func:`find_existing_qdq` -- read the learned parameters off the graph.
+    2. :func:`strip_existing_qdq` -- canonicalize back to the float graph, but
+       only for the pairs onnxsim's static quantization can re-emit; a pair on
+       a tensor it does not quantize is left in the model exactly as it was.
+    3. calibrate -- but only the tensors that have no usable annotation. When
+       there are none, no calibration runs and ``calibration_data`` is never
+       looked at, so a fully-annotated export needs no data at all.
+    4. quantize -- ordinary ``QuantizeStatic``, so the output is an ordinary
+       onnxsim QDQ model that every downstream pass already understands.
+    5. write the learned tensors back over what step 4 computed, bit-exactly.
+
+    A partially quantized export -- some tensors annotated, some not -- is
+    the normal case rather than an error: annotated tensors keep their learned
+    parameters, the rest are calibrated.
+
+    :param model: onnx ModelProto object or file path
+    :param calibration_data: representative input batches for the tensors that
+            still need calibrating (see :func:`onnxsim.quantize_static`).
+            Ignored, and not generated, when every quantizable tensor is
+            annotated.
+    :param num_calibration_samples: number of random batches to generate when
+            calibration is needed and ``calibration_data`` is not supplied
+    :param seed: seed for that random calibration data
+    :param providers: onnxruntime execution providers to calibrate on
+    :param method: calibration range method for the un-annotated tensors,
+            passed through to :func:`onnxsim.calibrate`
+    :param scheme: ``"int8"`` (uint8 activations, :func:`onnxsim.quantize_static`)
+            or ``"int16"`` (uint16 activations,
+            :func:`onnxsim.quantize_static_int16`). An annotation whose
+            zero-point dtype is not the scheme's is reported and recalibrated
+            rather than reinterpreted.
+    :returns: a :class:`QdqIngestResult` -- the model, plus which tensors kept
+            their learned parameters, which were recalibrated, and which QDQ
+            patterns were refused
+    """
+    if scheme not in _SCHEMES:
+        raise ValueError(
+            f"unknown scheme: {scheme!r} (expected one of {sorted(_SCHEMES)})"
+        )
+    zp_dtype, levels = _SCHEMES[scheme]
+    model = _load(model)
+    scan = find_existing_qdq(model)
+
+    # Which pairs can be re-emitted at all is a property of the *float* graph,
+    # so it takes a throwaway full strip to find out.
+    probe = _infer(_strip(model, scan.annotations))
+    candidates = set(C.list_quantizable_activations(probe.SerializeToString()))
+    quantizable_weights = {
+        node.input[1]
+        for node in probe.graph.node
+        if node.op_type in _QUANTIZED_OPS
+        and len(node.input) >= 2
+        and node.input[0] in candidates
+    }
+
+    keep: List[QdqAnnotation] = []
+    unpreserved: List[SkippedQdq] = []
+    for ann in scan.annotations:
+        reclaimable = (
+            ann.tensor_name in candidates
+            if ann.role == "activation"
+            else ann.tensor_name in quantizable_weights
+        )
+        if reclaimable:
+            keep.append(ann)
+        else:
+            unpreserved.append(
+                SkippedQdq(
+                    ann.tensor_name, "not_a_quantizable_tensor", ann.dequantize_node
+                )
+            )
+    float_model = _infer(_strip(model, keep))
+
+    pinned: Dict[str, QdqAnnotation] = {}
+    for ann in keep:
+        if ann.role != "activation":
+            continue
+        reason = _preservable_activation(ann, zp_dtype, levels)
+        if reason is None:
+            pinned[ann.tensor_name] = ann
+        else:
+            unpreserved.append(SkippedQdq(ann.tensor_name, reason, ann.dequantize_node))
+
+    need_calibration = candidates - set(pinned)
+    ranges: Dict[str, Tuple[float, float]] = {}
+    calibration_ran = bool(need_calibration)
+    if calibration_ran:
+        if calibration_data is None:
+            calibration_data = generate_random_calibration_data(
+                float_model, num_samples=num_calibration_samples, seed=seed
+            )
+        ranges = calibrate(
+            float_model, calibration_data, providers=providers, method=method
+        )
+        # A tensor produced by a DequantizeLinear this module refused to touch
+        # is already quantized; quantizing it again would nest a second QDQ
+        # pair inside the first. The refusal is already in `scan.skipped`.
+        dequantized = {
+            out
+            for node in float_model.graph.node
+            if node.op_type == "DequantizeLinear"
+            for out in node.output
+        }
+        ranges = {k: v for k, v in ranges.items() if k not in dequantized}
+    for name, ann in pinned.items():
+        ranges[name] = _range_for(
+            float(np.asarray(ann.scale).reshape(-1)[0]),
+            float(np.asarray(ann.zero_point).reshape(-1)[0]),
+            levels,
+        )
+
+    quantize = C.quantize_static if scheme == "int8" else C.quantize_static_int16
+    quantized = onnx.load_from_string(quantize(float_model.SerializeToString(), ranges))
+    qgraph = quantized.graph
+    uses = _use_counts(qgraph)
+    producers = _producers(qgraph)
+    quantize_nodes: Dict[str, List[onnx.NodeProto]] = {}
+    for node in qgraph.node:
+        if node.op_type == "QuantizeLinear" and node.input:
+            quantize_nodes.setdefault(node.input[0], []).append(node)
+
+    preserved: List[str] = []
+    for name, ann in pinned.items():
+        reason = _writeback_activation(qgraph, quantize_nodes, uses, ann)
+        if reason is None:
+            preserved.append(name)
+        else:
+            unpreserved.append(SkippedQdq(name, reason, ann.dequantize_node))
+
+    weight_annotations = {a.tensor_name: a for a in keep if a.role == "weight"}
+    if weight_annotations:
+        float_nodes = {
+            node.output[0]: node for node in float_model.graph.node if node.output
+        }
+        float_inits = {i.name: i for i in float_model.graph.initializer}
+        for node in qgraph.node:
+            if node.op_type not in _QUANTIZED_OPS or len(node.input) < 2:
+                continue
+            source = float_nodes.get(node.output[0])
+            if source is None or len(source.input) < 2:
+                continue
+            if source.input[1] not in weight_annotations:
+                continue
+            ann = weight_annotations.pop(source.input[1])
+            wdq = producers.get(node.input[1])
+            if wdq is None or wdq.op_type != "DequantizeLinear":
+                unpreserved.append(
+                    SkippedQdq(
+                        ann.tensor_name,
+                        "quantize_node_not_emitted",
+                        ann.dequantize_node,
+                    )
+                )
+                continue
+            weight = onnx.numpy_helper.to_array(float_inits[ann.tensor_name])
+            reason = _writeback_weight(qgraph, weight, wdq, uses, ann)
+            if reason is None:
+                preserved.append(ann.tensor_name)
+            else:
+                unpreserved.append(
+                    SkippedQdq(ann.tensor_name, reason, ann.dequantize_node)
+                )
+        for ann in weight_annotations.values():
+            unpreserved.append(
+                SkippedQdq(
+                    ann.tensor_name, "quantize_node_not_emitted", ann.dequantize_node
+                )
+            )
+
+    return QdqIngestResult(
+        model=quantized,
+        scan=scan,
+        preserved=tuple(preserved),
+        recalibrated=tuple(sorted(candidates - set(pinned))),
+        unpreserved=tuple(unpreserved),
+        calibration_ran=calibration_ran,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Egress: emit a fake-quant model for an external trainer
+# --------------------------------------------------------------------------- #
+def _set_metadata(model: onnx.ModelProto, key: str, value: str) -> None:
+    """``model.metadata_props[key] = value``, overwriting any existing entry.
+
+    A local copy of ``model_info._set_metadata``'s three lines rather than an
+    import of a private helper; the ``METADATA_PREFIX`` namespace those keys
+    live in *is* imported, so the two stay consistent about where onnxsim's
+    metadata goes.
+    """
+    for entry in model.metadata_props:
+        if entry.key == key:
+            entry.value = value
+            return
+    entry = model.metadata_props.add()
+    entry.key = key
+    entry.value = value
+
+
+def _unique(name: str, taken: Set[str]) -> str:
+    candidate = name
+    suffix = 1
+    while candidate in taken:
+        candidate = f"{name}_{suffix}"
+        suffix += 1
+    taken.add(candidate)
+    return candidate
+
+
+def _rename_initializers(graph: onnx.GraphProto, renames: Dict[str, str]) -> None:
+    for init in graph.initializer:
+        if init.name in renames:
+            init.name = renames[init.name]
+    for node in graph.node:
+        for i, name in enumerate(node.input):
+            if name in renames:
+                node.input[i] = renames[name]
+    surviving = [v for v in graph.value_info if v.name not in renames]
+    del graph.value_info[:]
+    graph.value_info.extend(surviving)
+
+
+def export_fake_quant(
+    model: Union[str, onnx.ModelProto],
+    scheme: str = "int8",
+    calibration_data: Optional[Sequence[Tensors]] = None,
+    num_calibration_samples: int = 8,
+    seed: int = 0,
+    providers: Optional[Sequence[str]] = None,
+    method: str = "minmax",
+    rename_parameters: bool = True,
+) -> FakeQuantExport:
+    """Emit a fake-quant (QDQ) model from a float model, naming the tensors an
+    external trainer should make learnable.
+
+    This is the egress half of ``docs/qat.md``'s "QAT interop", and the other
+    end of :func:`quantize_static_keeping_qdq_scales`. onnxsim picks the scheme
+    and computes a starting point for every quantization parameter by ordinary
+    calibration; the user trains those parameters in whatever framework they
+    already have (LSQ and friends differentiate the fake-quant with respect to
+    its own step size); onnxsim re-imports the trained values through the
+    ingest path. No training happens here -- the output is exactly what
+    :func:`onnxsim.quantize_static` produces, plus stable names and an
+    inventory.
+
+    **How "these are the learnable tensors" is carried.** Both ways, and
+    deliberately:
+
+    - as :attr:`FakeQuantExport.learnable_scales` /
+      ``learnable_zero_points`` -- the authoritative answer, in the obvious
+      form, for a caller that is going to hand the names straight to an
+      optimizer. Scales and zero-points are separate lists because they are
+      not equally trainable: a scale is float32 and a gradient moves it
+      directly, while a zero-point is an integer tensor a trainer must round
+      back into after every step.
+    - as ``metadata_props`` on the model, under
+      :data:`LEARNABLE_SCALES_KEY` / :data:`LEARNABLE_ZERO_POINTS_KEY` (JSON
+      arrays of names, namespaced with ``model_info.METADATA_PREFIX`` like
+      every other key onnxsim writes -- see
+      :func:`onnxsim.model_info.annotate_metadata`, which puts its metrics
+      there under the same prefix). The returned lists die at the end of the
+      process; a QAT round trip does not, because the model is saved to a file
+      and picked up by a training script that never saw this call.
+
+    The metadata is a convenience, never load-bearing: ingest re-derives
+    everything structurally from the graph, so a trainer that rewrites the
+    model (and drops its metadata_props, as most exporters do) still round
+    trips. Do not treat the metadata as a guarantee that a scale was actually
+    trained -- it only records which tensors were *offered*.
+
+    Parameter names are rewritten to ``<tensor>_scale`` / ``<tensor>_zero_point``
+    by default, since the rewrite's own generated names (``_v_5``) tell a user
+    reading the list nothing about which layer they belong to. Pass
+    ``rename_parameters=False`` to keep them.
+
+    :param model: onnx ModelProto object or file path
+    :param scheme: ``"int8"`` (uint8 activations, int8 per-output-channel
+            weights) or ``"int16"`` (uint16 activations, same weights). Both
+            are onnxsim's own static schemes -- see
+            :func:`onnxsim.quantize_static` and
+            :func:`onnxsim.quantize_static_int16`. Per-layer bit widths are not
+            selected here; see ``onnxsim.mixed_precision``.
+    :param calibration_data: representative input batches for the starting
+            point (falls back to random data, as ``quantize_static`` does --
+            fine here, since the values are about to be trained)
+    :param num_calibration_samples: number of random batches when none given
+    :param seed: seed for that random calibration data
+    :param providers: onnxruntime execution providers to calibrate on
+    :param method: calibration range method, passed to :func:`onnxsim.calibrate`
+    :param rename_parameters: rename the emitted scale/zero-point initializers
+            after the tensor they quantize
+    :returns: a :class:`FakeQuantExport`
+    """
+    if scheme not in _SCHEMES:
+        raise ValueError(
+            f"unknown scheme: {scheme!r} (expected one of {sorted(_SCHEMES)})"
+        )
+    model = _infer(_load(model))
+    if calibration_data is None:
+        calibration_data = generate_random_calibration_data(
+            model, num_samples=num_calibration_samples, seed=seed
+        )
+    ranges = calibrate(model, calibration_data, providers=providers, method=method)
+    quantize = C.quantize_static if scheme == "int8" else C.quantize_static_int16
+    quantized = onnx.load_from_string(quantize(model.SerializeToString(), ranges))
+
+    graph = quantized.graph
+    producers = _producers(graph)
+    float_nodes = {node.output[0]: node for node in model.graph.node if node.output}
+    taken = {i.name for i in graph.initializer} | {v.name for v in graph.value_info}
+    taken |= {v.name for v in list(graph.input) + list(graph.output)}
+
+    renames: Dict[str, str] = {}
+    scales: List[str] = []
+    zero_points: List[str] = []
+
+    def register(old: str, preferred: str, into: List[str]) -> None:
+        new = old
+        if rename_parameters:
+            new = _unique(preferred, taken)
+            renames[old] = new
+        into.append(new)
+
+    for node in graph.node:
+        if node.op_type == "QuantizeLinear" and len(node.input) >= 3:
+            register(node.input[1], f"{node.input[0]}_scale", scales)
+            register(node.input[2], f"{node.input[0]}_zero_point", zero_points)
+    for node in graph.node:
+        if node.op_type not in _QUANTIZED_OPS or len(node.input) < 2:
+            continue
+        wdq = producers.get(node.input[1])
+        source = float_nodes.get(node.output[0])
+        if wdq is None or wdq.op_type != "DequantizeLinear" or source is None:
+            continue
+        # The weight's float name in the *input* model -- the emitted int8
+        # codes have a generated name that says nothing about the layer.
+        register(wdq.input[1], f"{source.input[1]}_scale", scales)
+
+    if rename_parameters:
+        _rename_initializers(graph, renames)
+    _set_metadata(quantized, LEARNABLE_SCALES_KEY, json.dumps(scales))
+    _set_metadata(quantized, LEARNABLE_ZERO_POINTS_KEY, json.dumps(zero_points))
+    return FakeQuantExport(quantized, tuple(scales), tuple(zero_points))

--- a/tests/test_qat.py
+++ b/tests/test_qat.py
@@ -16,6 +16,16 @@ Claim 2 is the one with a nuance, and the test that makes it records the
 nuance instead of hiding it: freeing the weights wins where the reconstruction
 problem is *underdetermined*, and loses to AdaRound's smoother relaxation
 where it is not. Both directions are measured below.
+
+The second half of this file covers the whole-model entry points --
+:func:`onnxsim.discover_qat_blocks`, which partitions a model into trainable
+blocks with no caller-named tensors at all, and
+:func:`onnxsim.apply_qat_all_blocks`, which walks them in order. The claim
+there that is genuinely uncertain, and therefore measured rather than
+asserted, is whether feeding each block the *student's* recomputed activation
+beats capturing every block's input once from the teacher; see
+``test_sequential_input_beats_capturing_everything_once`` for the numbers and
+the direction they actually came out in.
 """
 
 import numpy as np
@@ -714,3 +724,373 @@ def test_a_transb_gemm_trains_on_the_other_blocked_axis():
     old, new = _weights_of(quant), _weights_of(tuned)
     assert list(old[scale_name].shape) == list(new[scale_name].shape) == [64, 1]
     assert not np.array_equal(old[codes_name], new[codes_name])
+
+
+def _chain_model(seed=1, depth=4, scale=0.5):
+    """A plain ``MatMul``/``Relu`` chain with no residual anywhere.
+
+    Deliberately the *worst* shape for capture-once block reconstruction:
+    every layer's input is entirely the previous layer's output, so the error
+    each block leaves behind is the error the next block is handed, with
+    nothing (no skip connection carrying a clean copy of the input) to dilute
+    it. ``scale=0.5`` keeps the per-layer quantization error large enough that
+    the compounding is visible above the noise floor.
+    """
+    rng = np.random.default_rng(seed)
+    weights = [
+        (rng.standard_normal((D, D)) * scale).astype(np.float32) for _ in range(depth)
+    ]
+    body = "\n".join(
+        f"  Y{i + 1} = MatMul({'X' if i == 0 else f'A{i}'}, W{i + 1})\n"
+        f"  A{i + 1} = Relu(Y{i + 1})"
+        for i in range(depth - 1)
+    )
+    body += f"\n  Yout = MatMul(A{depth - 1}, W{depth})"
+    return _model(
+        f"""
+        g (float[batch,{D}] X) => (float[batch,{D}] Yout)
+        {{
+        {body}
+        }}
+        """,
+        [_f32(w, f"W{i + 1}") for i, w in enumerate(weights)],
+    )
+
+
+def _run(model, x):
+    session = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return session.run(None, {"X": x})[0].astype(np.float64)
+
+
+def _whole_model_error(candidate, reference, x):
+    """``||float output - quantized output||`` through onnxruntime.
+
+    The end-to-end number, deliberately not the training loop's own loss: a
+    walk that drove every block's *reported* loss down while making the
+    deployed model worse would pass a loss-based assertion and fail this one.
+    """
+    return float(np.linalg.norm(_run(candidate, x) - _run(reference, x)))
+
+
+def _multi_block_model(seed=0):
+    """Two residual Linear+Relu+Linear stages with a ``Sin`` between them.
+
+    Every feature discovery has to handle at once: two blocks' worth of
+    quantized layers, a residual inside each stage (which must *not* be cut
+    through), and one op :mod:`onnxsim.graph_grad` has no gradient rule for
+    (which must become a gap between the blocks rather than a refusal of the
+    whole model).
+    """
+    rng = np.random.default_rng(seed)
+    weights = [(rng.standard_normal((D, D)) * 0.3).astype(np.float32) for _ in range(4)]
+    return _model(
+        f"""
+        g (float[batch,{D}] X) => (float[batch,{D}] Yout)
+        {{
+          Y1 = MatMul(X, W1)
+          A1 = Relu(Y1)
+          Y2 = MatMul(A1, W2)
+          R1 = Add(Y2, X)
+          S = Sin(R1)
+          Y3 = MatMul(S, W3)
+          A3 = Relu(Y3)
+          Y4 = MatMul(A3, W4)
+          Yout = Add(Y4, S)
+        }}
+        """,
+        [_f32(w, f"W{i + 1}") for i, w in enumerate(weights)],
+    )
+
+
+def test_discovery_matches_what_a_caller_would_have_named_by_hand():
+    """The single-block case, pinned against the boundaries every other test
+    in this file passes to :func:`onnxsim.apply_qat` explicitly.
+
+    ``_relu_block_model`` is ``MatMul -> Relu -> MatMul -> Add(residual from
+    X)``. A person names that block ``("X", "Yout")``, and so does discovery
+    -- not because a residual pattern is recognized, but because ``X`` stays
+    live until the residual ``Add`` consumes it, so the graph does not narrow
+    to a single activation anywhere in between. The intermediate tensors
+    ``Y1``/``A1``/``Y2`` are therefore not cut points, and the block is the
+    whole residual stage."""
+    model = _relu_block_model(seed=0)
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+
+    (block,) = onnxsim.discover_qat_blocks(model, quant)
+    assert (block.input_name, block.output_name) == ("X", "Yout")
+    assert block.quantized_outputs == ("Y1", "Y2")
+    assert block.op_types == ("Add", "MatMul", "Relu")
+    assert block.num_nodes == 4
+    # Nothing enters this block sideways: the residual's source *is* the
+    # block input.
+    assert block.external_inputs == ("X",)
+
+
+def test_discovery_routes_around_an_op_it_cannot_differentiate():
+    """A ``Sin`` in the middle becomes a gap between two blocks, not a
+    failure of the model.
+
+    This is the difference between the two entry points, and the reason
+    :func:`onnxsim.apply_qat_all_blocks` exists as its own function:
+    ``apply_qat("X", "Yout")`` on this model raises, correctly, because a
+    caller who names those boundaries is asking for something impossible.
+    Nobody names anything here, so the undifferentiable node is routed around
+    and the eight trainable nodes on either side of it are still trained."""
+    model = _multi_block_model()
+    quant = _quantize_chain_int4(model, {"W1", "W2", "W3", "W4"})
+
+    first, second = onnxsim.discover_qat_blocks(model, quant)
+    assert (first.input_name, first.output_name) == ("X", "R1")
+    assert (second.input_name, second.output_name) == ("S", "Yout")
+    assert first.quantized_outputs == ("Y1", "Y2")
+    assert second.quantized_outputs == ("Y3", "Y4")
+    # The gap really is a gap: the op with no gradient rule is inside neither
+    # block, and every op that is inside one has a rule.
+    for block in (first, second):
+        assert "Sin" not in block.op_types
+        assert set(block.op_types) <= set(graph_grad.SUPPORTED_OPS)
+    # ...and the boundaries a caller would have had to name by hand are
+    # refused outright by the single-block entry point, which is what makes
+    # the gap worth finding rather than a formality.
+    with pytest.raises(graph_grad.UnsupportedOpError, match="Sin"):
+        onnxsim.apply_qat(
+            model,
+            quant,
+            "X",
+            "Yout",
+            calibration_data=[{"X": _correlated_calibration(2)}],
+        )
+
+
+def test_discovery_lets_a_second_graph_input_cross_a_block_boundary():
+    """A mask-shaped second input must not suppress every cut in the graph.
+
+    ``_liveness_cuts`` counts a tensor as blocking a cut because the student
+    would have to recompute it; a graph input is byte-identical in teacher and
+    student, so teacher-forcing it costs nothing and it is exempt. Without
+    that exemption this model -- whose ``M`` spans the middle of the graph --
+    would yield no cuts at all and therefore no blocks."""
+    rng = np.random.default_rng(7)
+    w1 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    w2 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{D}] X, float[batch,{D}] M) => (float[batch,{D}] Yout)
+        {{
+          Y1 = MatMul(X, W1)
+          A1 = Mul(Y1, M)
+          Y2 = MatMul(A1, W2)
+          Yout = Add(Y2, X)
+        }}
+        """,
+        [_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+
+    (block,) = onnxsim.discover_qat_blocks(model, quant)
+    assert (block.input_name, block.output_name) == ("X", "Yout")
+    # ``M`` is teacher-forced into the block alongside the block input, which
+    # is exactly what ``_slice_block`` already does for a sideways tensor.
+    assert block.external_inputs == ("M", "X")
+
+    x = _correlated_calibration(rank=2)
+    m = np.abs(_correlated_calibration(rank=2, seed=11))
+    tuned, results = onnxsim.apply_qat_all_blocks(
+        model, quant, calibration_data=[{"X": x, "M": m}], num_iterations=200
+    )
+    onnx.checker.check_model(tuned)
+    assert [r.trained for r in results] == [True]
+    assert results[0].final_loss < results[0].initial_loss
+
+
+def test_max_layers_per_block_controls_the_granularity_of_the_plan():
+    """A chain with no residuals is a bottleneck at every layer, so the cut
+    structure alone would make each layer its own block and throw away the
+    intra-block error cancellation that block reconstruction is *for*. The
+    merge budget is what recovers it, and it is the only knob."""
+    model = _chain_model(depth=4)
+    quant = _quantize_chain_int4(model, {"W1", "W2", "W3", "W4"})
+
+    def plan(k):
+        return [
+            (b.input_name, b.output_name)
+            for b in onnxsim.discover_qat_blocks(model, quant, max_layers_per_block=k)
+        ]
+
+    assert plan(1) == [("X", "Y1"), ("Y1", "Y2"), ("Y2", "Y3"), ("Y3", "Yout")]
+    assert plan(2) == [("X", "Y2"), ("Y2", "Yout")]
+    assert plan(4) == [("X", "Yout")]
+    # Every layer is covered exactly once, at every granularity.
+    for k in (1, 2, 4):
+        covered = [
+            name
+            for b in onnxsim.discover_qat_blocks(model, quant, max_layers_per_block=k)
+            for name in b.quantized_outputs
+        ]
+        assert covered == ["Y1", "Y2", "Y3", "Yout"]
+
+
+def test_the_walk_improves_the_whole_models_output_error():
+    """The claim the whole feature rests on, measured end to end through
+    onnxruntime rather than through the training loop's own loss.
+
+    Measured on this scenario: round-to-nearest leaves a whole-model output
+    error of ~400 against the float model; the default walk (two blocks of two
+    layers each) takes it to ~200. Every block reports a falling loss, and no
+    block is skipped."""
+    model = _chain_model(seed=1, depth=4)
+    quant = _quantize_chain_int4(model, {"W1", "W2", "W3", "W4"})
+    x = _correlated_calibration(rank=2, num_samples=64)
+
+    tuned, results = onnxsim.apply_qat_all_blocks(
+        model, quant, calibration_data=[{"X": x}], num_iterations=400
+    )
+    onnx.checker.check_model(tuned)
+
+    assert len(results) == 2
+    assert all(r.trained and r.skipped_reason is None for r in results)
+    for r in results:
+        assert len(r.losses) == 400
+        assert r.final_loss < 0.6 * r.initial_loss
+
+    rtn_error = _whole_model_error(quant, model, x)
+    tuned_error = _whole_model_error(tuned, model, x)
+    assert tuned_error < 0.75 * rtn_error
+
+
+def test_sequential_input_beats_capturing_everything_once():
+    """The design decision, measured on a model built to make it matter.
+
+    Both modes aim every block at the *teacher's* output for that block; they
+    differ only in what they feed the block's input. ``sequential=True``
+    re-runs the student after each block, so block *k* sees the activation the
+    deployed model will really hand it -- error and all. ``sequential=False``
+    captures every block's input once from the float model, which is what
+    :mod:`onnxsim.adaround` and :mod:`onnxsim.brecq` do and which assumes
+    every earlier block was reconstructed perfectly.
+
+    ``_chain_model`` has no residual anywhere, so nothing dilutes the error
+    passed from one block to the next, and ``max_layers_per_block=1`` makes
+    the chain four blocks deep -- three chances for the assumption to be
+    wrong.
+
+    **Measured, and the direction is not assumed:** whole-model output error
+    against the float model, seed 1, rank-2 calibration -- round-to-nearest
+    400.3, capture-once 206.2, sequential 168.1. Sequential wins by ~19%. It
+    won on all five seeds tried (0-4), by 14-31%.
+
+    The counter-intuitive part is worth recording: sequential's *reported
+    per-block losses are higher* (block 4: 15.2 -> 7.3 sequential versus
+    12.0 -> 5.0 capture-once), because a block fed a dirtier input is solving
+    a harder reconstruction problem. The block-local loss is simply not the
+    quantity anyone cares about -- the deployed model's output error is, and
+    that is the one measured here."""
+    model = _chain_model(seed=1, depth=4)
+    quant = _quantize_chain_int4(model, {"W1", "W2", "W3", "W4"})
+    x = _correlated_calibration(rank=2, num_samples=64)
+
+    def walk(sequential):
+        tuned, results = onnxsim.apply_qat_all_blocks(
+            model,
+            quant,
+            calibration_data=[{"X": x}],
+            max_layers_per_block=1,
+            sequential=sequential,
+            num_iterations=400,
+        )
+        assert [r.trained for r in results] == [True] * 4
+        return _whole_model_error(tuned, model, x), results
+
+    rtn = _whole_model_error(quant, model, x)
+    sequential_error, sequential_results = walk(True)
+    once_error, once_results = walk(False)
+
+    assert sequential_error < rtn
+    assert once_error < rtn
+    # The two modes really are different computations, not the same one
+    # behind a flag.
+    assert sequential_error != once_error
+    assert sequential_error < once_error
+
+    # The first block's input is the graph input itself, which is identical in
+    # teacher and student, so that block must train identically in both modes
+    # -- the divergence can only start at the second block.
+    assert sequential_results[0].losses == once_results[0].losses
+    assert sequential_results[1].losses != once_results[1].losses
+
+
+def test_a_block_that_cannot_be_trained_is_reported_rather_than_dropped():
+    """Per-block failure must be recoverable *and* visible.
+
+    Discovery only ever proposes blocks it has already validated, so the way
+    to reach this path is to hand in a plan by hand -- which is also the
+    reason ``blocks=`` is part of the signature. Two of the three blocks below
+    are impossible (a slice with no quantized layer; a block output no node
+    produces), and the third is fine. The walk trains the third, records why
+    it refused the other two, and returns a model in which exactly the
+    trainable block moved."""
+    model = _relu_block_model(seed=0)
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+
+    def named(input_name, output_name):
+        return qat.QATBlock(
+            input_name=input_name,
+            output_name=output_name,
+            quantized_outputs=(),
+            external_inputs=(),
+            op_types=(),
+            num_nodes=0,
+        )
+
+    tuned, results = onnxsim.apply_qat_all_blocks(
+        model,
+        quant,
+        blocks=[named("Y1", "A1"), named("X", "Yout"), named("X", "X")],
+        calibration_data=[{"X": _correlated_calibration(rank=2)}],
+        num_iterations=100,
+    )
+    onnx.checker.check_model(tuned)
+
+    assert [r.trained for r in results] == [False, True, False]
+    # Nothing is dropped: every block handed in comes back, in order, with a
+    # reason a human can act on.
+    assert len(results) == 3
+    assert "no quantize_weight_only_int4" in results[0].skipped_reason
+    assert results[1].skipped_reason is None
+    assert "not produced by any node" in results[2].skipped_reason
+    assert results[0].losses == [] and results[2].losses == []
+    assert results[1].final_loss < results[1].initial_loss
+
+    # The trainable block did train, and only its own weights moved.
+    old, new = _weights_of(quant), _weights_of(tuned)
+    changed = {name for name in old if not np.array_equal(old[name], new[name])}
+    assert changed == {_quant_tensors_for(quant, name)[0] for name in ("Y1", "Y2")}
+
+
+def test_the_walk_leaves_a_model_with_no_discoverable_block_untouched():
+    """No blocks is an empty plan and an unchanged model, not an exception.
+    A caller running this over a directory of models needs the no-op case to
+    be quiet."""
+    rng = np.random.default_rng(0)
+    w = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{D}] X) => (float[batch,{D}] Yout)
+        {{
+          Y1 = MatMul(X, W)
+          Yout = Sin(Y1)
+        }}
+        """,
+        [_f32(w, "W")],
+    )
+    # Passing the float model as its own "quantized" counterpart is the
+    # cleanest way to reach this: nothing matches
+    # ``quantize_weight_only_int4``'s scheme, so no span anywhere contains a
+    # layer to train and the plan comes back empty.
+    tuned, results = onnxsim.apply_qat_all_blocks(
+        model, model, calibration_data=[{"X": _correlated_calibration(rank=2)}]
+    )
+    assert results == []
+    assert tuned.SerializeToString() == model.SerializeToString()

--- a/tests/test_qat_interop.py
+++ b/tests/test_qat_interop.py
@@ -1,0 +1,776 @@
+"""Tests for ``onnxsim.qat_interop`` -- the graph-only half of QAT.
+
+The claim under test is narrow and easy to get silently wrong: a QDQ model
+exported from a QAT-trained network carries scales and zero-points that took a
+training run to produce, and ``onnxsim.quantize_static`` would recompute them
+from observed min/max without complaining. So every model built here has
+learned parameters *deliberately far* from what calibration would derive --
+the tests assert both that the learned values come out the other side
+bit-exact and (separately) that plain calibration really would have produced
+something else, which is what makes the first assertion mean anything.
+
+The second theme is refusal: a QDQ pair this module does not fully understand
+must be left alone rather than guessed at, and the caller must be able to find
+out. Each refusal is exercised with a model that triggers exactly it.
+"""
+
+import json
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+import onnxsim
+from onnxsim import qat_interop as qi
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
+
+
+def _u8(value, name):
+    return onnx.numpy_helper.from_array(np.asarray(value, dtype=np.uint8), name)
+
+
+def _i8(value, name):
+    return onnx.numpy_helper.from_array(np.asarray(value, dtype=np.int8), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _check_and_run(model, feeds):
+    """Everything this module produces must both validate and execute."""
+    onnx.checker.check_model(model)
+    outputs = _run(model, feeds)
+    for out in outputs:
+        assert np.all(np.isfinite(out))
+    return outputs
+
+
+def _initializers(model):
+    return {i.name: onnx.numpy_helper.to_array(i) for i in model.graph.initializer}
+
+
+def _activation_params(model, tensor_name):
+    """The (scale, zero_point) the QDQ pair around ``tensor_name`` carries."""
+    inits = _initializers(model)
+    for node in model.graph.node:
+        if node.op_type == "QuantizeLinear" and node.input[0] == tensor_name:
+            return inits[node.input[1]], inits[node.input[2]]
+    raise AssertionError(f"{tensor_name} is not quantized in this model")
+
+
+def _weight_params(model, consumer_output):
+    """The (codes, scale) of the dequantized weight feeding ``consumer_output``."""
+    inits = _initializers(model)
+    producers = {out: node for node in model.graph.node for out in node.output}
+    for node in model.graph.node:
+        if node.output[0] != consumer_output:
+            continue
+        dq = producers[node.input[1]]
+        assert dq.op_type == "DequantizeLinear"
+        return inits[dq.input[0]], inits[dq.input[1]]
+    raise AssertionError(f"no node produces {consumer_output}")
+
+
+# The learned activation quantizer every QAT-style model below carries. It
+# clips hard: over the calibration data used here, min/max calibration derives
+# a scale several times larger (asserted in
+# test_learned_activation_scale_is_not_what_calibration_would_derive), which is
+# the realistic case -- a trained scale buys resolution on the bulk of the
+# distribution by saturating the tails.
+#
+# The exact pair matters, and not only for realism. Ingest hands the C++
+# rewrite a calibration range equivalent to the learned quantizer and then
+# writes the learned tensors back over what the rewrite computed; for many
+# (scale, zero-point) pairs that range round trip happens to be exact in
+# float32 anyway, and a test built on one of those would pass with the
+# write-back deleted. This pair is one the round trip loses (the range-derived
+# scale comes back as 0.011300001), so asserting bit-exactness here actually
+# tests the thing it names.
+LEARNED_SCALE = 0.0113
+LEARNED_ZP = 91
+
+RNG = np.random.default_rng(0)
+W1 = (RNG.standard_normal((4, 6)) * 0.5).astype(np.float32)
+W2 = (RNG.standard_normal((6, 3)) * 0.5).astype(np.float32)
+# Deliberately wide: the observed range is ~40x the learned quantizer's.
+CALIBRATION = [{"X": (RNG.standard_normal((2, 4)) * 4.0).astype(np.float32)}]
+FEEDS = {"X": (RNG.standard_normal((2, 4)) * 0.3).astype(np.float32)}
+
+
+def _float_matmul():
+    return _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          Y = MatMul(X, W1)
+        }
+        """,
+        initializer=[_f32(W1, "W1")],
+    )
+
+
+def _qat_matmul(scale=LEARNED_SCALE, zero_point=LEARNED_ZP):
+    """One MatMul whose activation arrives already fake-quantized."""
+    return _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          Xq = QuantizeLinear(X, x_scale, x_zp)
+          Xdq = DequantizeLinear(Xq, x_scale, x_zp)
+          Y = MatMul(Xdq, W1)
+        }
+        """,
+        initializer=[
+            _f32(W1, "W1"),
+            _f32(scale, "x_scale"),
+            _u8(zero_point, "x_zp"),
+        ],
+    )
+
+
+def _qat_chain():
+    """Two MatMuls, only the first one's activation annotated -- the
+    partially-quantized export a real QAT pipeline produces when only part of
+    the network was wrapped in fake-quant modules.
+    """
+    return _model(
+        """
+        g (float[2, 4] X) => (float[2, 3] Y)
+        {
+          Xq = QuantizeLinear(X, x_scale, x_zp)
+          Xdq = DequantizeLinear(Xq, x_scale, x_zp)
+          H = MatMul(Xdq, W1)
+          Y = MatMul(H, W2)
+        }
+        """,
+        initializer=[
+            _f32(W1, "W1"),
+            _f32(W2, "W2"),
+            _f32(LEARNED_SCALE, "x_scale"),
+            _u8(LEARNED_ZP, "x_zp"),
+        ],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The point of the whole module: learned parameters survive
+# --------------------------------------------------------------------------- #
+def test_learned_activation_scale_is_not_what_calibration_would_derive():
+    # Guards every other assertion in this file: if calibration happened to
+    # land on the learned values, "the learned values survived" would be
+    # vacuous.
+    calibrated = onnxsim.quantize_static(_float_matmul(), calibration_data=CALIBRATION)
+    scale, zero_point = _activation_params(calibrated, "X")
+    assert float(scale) > 3 * LEARNED_SCALE
+    assert int(zero_point) != LEARNED_ZP
+
+
+def test_learned_activation_scale_survives_ingest():
+    result = qi.quantize_static_keeping_qdq_scales(
+        _qat_matmul(), calibration_data=CALIBRATION
+    )
+    assert result.preserved == ("X",)
+    assert result.recalibrated == ()
+    assert result.unpreserved == ()
+    scale, zero_point = _activation_params(result.model, "X")
+    # Bit-exact, not merely close: the value was trained, so re-deriving it
+    # through the calibration-range round trip is not good enough.
+    assert float(scale) == np.float32(LEARNED_SCALE)
+    assert int(zero_point) == LEARNED_ZP
+    _check_and_run(result.model, FEEDS)
+
+
+def test_fully_annotated_model_needs_no_calibration_data():
+    # No `calibration_data`, and none is generated either: every quantizable
+    # tensor already carries a learned quantizer, so there is nothing to
+    # observe. This is the property that makes ingest usable on a model whose
+    # real input data the user does not have.
+    result = qi.quantize_static_keeping_qdq_scales(_qat_matmul())
+    assert result.calibration_ran is False
+    assert result.preserved == ("X",)
+    assert float(_activation_params(result.model, "X")[0]) == np.float32(LEARNED_SCALE)
+
+
+def test_partially_annotated_model_keeps_one_and_calibrates_the_other():
+    result = qi.quantize_static_keeping_qdq_scales(
+        _qat_chain(), calibration_data=CALIBRATION
+    )
+    assert result.calibration_ran is True
+    assert "X" in result.preserved
+    assert result.recalibrated == ("H",)
+
+    scale, zero_point = _activation_params(result.model, "X")
+    assert float(scale) == np.float32(LEARNED_SCALE)
+    assert int(zero_point) == LEARNED_ZP
+    # H had no annotation, so it must have been calibrated the ordinary way --
+    # i.e. it is quantized at all, and not with X's parameters.
+    h_scale, _ = _activation_params(result.model, "H")
+    assert float(h_scale) > 0
+    assert float(h_scale) != float(scale)
+    _check_and_run(result.model, FEEDS)
+
+
+def test_learned_weight_scale_and_codes_survive_ingest():
+    # A per-output-channel weight quantizer trained 20% tighter than
+    # round-to-nearest would pick -- the LSQ-style learned weight scale.
+    learned = (np.abs(W1).max(axis=0) / 127.0 * 0.8).astype(np.float32)
+    model = _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          Xq = QuantizeLinear(X, x_scale, x_zp)
+          Xdq = DequantizeLinear(Xq, x_scale, x_zp)
+          Wq = QuantizeLinear<axis = 1>(W1, w_scale, w_zp)
+          Wdq = DequantizeLinear<axis = 1>(Wq, w_scale, w_zp)
+          Y = MatMul(Xdq, Wdq)
+        }
+        """,
+        initializer=[
+            _f32(W1, "W1"),
+            _f32(LEARNED_SCALE, "x_scale"),
+            _u8(LEARNED_ZP, "x_zp"),
+            _f32(learned, "w_scale"),
+            _i8(np.zeros(6), "w_zp"),
+        ],
+    )
+    result = qi.quantize_static_keeping_qdq_scales(model)
+    assert result.calibration_ran is False
+    assert set(result.preserved) == {"X", "W1"}
+
+    codes, scale = _weight_params(result.model, "Y")
+    assert np.array_equal(scale, learned)
+    # The codes are re-derived from the learned scale rather than kept from
+    # the rewrite's own round-to-nearest scale -- swapping only the scale would
+    # change what the weight dequantizes to.
+    assert np.array_equal(codes, np.clip(np.round(W1 / learned), -127, 127))
+    _check_and_run(result.model, FEEDS)
+
+
+def test_one_activation_feeding_two_layers_gets_both_pairs():
+    # The rewrite is per-node, so a shared activation comes back bracketed by
+    # two independent QDQ pairs with two independent scale initializers.
+    # Writing the learned value into only one of them would leave the model
+    # quantizing a single tensor two different ways.
+    other = (RNG.standard_normal((4, 5)) * 0.5).astype(np.float32)
+    model = _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y, float[2, 5] Z)
+        {
+          Xq = QuantizeLinear(X, x_scale, x_zp)
+          Xdq = DequantizeLinear(Xq, x_scale, x_zp)
+          Y = MatMul(Xdq, W1)
+          Z = MatMul(Xdq, W3)
+        }
+        """,
+        initializer=[
+            _f32(W1, "W1"),
+            _f32(other, "W3"),
+            _f32(LEARNED_SCALE, "x_scale"),
+            _u8(LEARNED_ZP, "x_zp"),
+        ],
+    )
+    result = qi.quantize_static_keeping_qdq_scales(model)
+    assert result.preserved == ("X",)
+    inits = _initializers(result.model)
+    quantizers = [n for n in result.model.graph.node if n.op_type == "QuantizeLinear"]
+    assert len(quantizers) == 2
+    for node in quantizers:
+        assert float(inits[node.input[1]]) == np.float32(LEARNED_SCALE)
+        assert int(inits[node.input[2]]) == LEARNED_ZP
+    _check_and_run(result.model, FEEDS)
+
+
+def test_learned_parameters_survive_on_a_conv():
+    # quantize_static covers Conv as well as MatMul/Gemm, and Conv's weight
+    # puts its output channel on axis 0 rather than 1 -- so the axis agreement
+    # between the learned quantizer and the emitted one is a different case,
+    # not the same one with different numbers.
+    rng = np.random.default_rng(7)
+    weight = (rng.standard_normal((3, 2, 3, 3)) * 0.4).astype(np.float32)
+    learned = (np.abs(weight).max(axis=(1, 2, 3)) / 127.0 * 0.75).astype(np.float32)
+    model = _model(
+        """
+        g (float[1, 2, 5, 5] X) => (float[1, 3, 3, 3] Y)
+        {
+          Xq = QuantizeLinear(X, x_scale, x_zp)
+          Xdq = DequantizeLinear(Xq, x_scale, x_zp)
+          Wq = QuantizeLinear<axis = 0>(K, w_scale, w_zp)
+          Wdq = DequantizeLinear<axis = 0>(Wq, w_scale, w_zp)
+          Y = Conv(Xdq, Wdq)
+        }
+        """,
+        initializer=[
+            _f32(weight, "K"),
+            _f32(LEARNED_SCALE, "x_scale"),
+            _u8(LEARNED_ZP, "x_zp"),
+            _f32(learned, "w_scale"),
+            _i8(np.zeros(3), "w_zp"),
+        ],
+    )
+    result = qi.quantize_static_keeping_qdq_scales(model)
+    assert result.calibration_ran is False
+    assert set(result.preserved) == {"X", "K"}
+    scale, zero_point = _activation_params(result.model, "X")
+    assert float(scale) == np.float32(LEARNED_SCALE)
+    assert int(zero_point) == LEARNED_ZP
+    codes, weight_scale = _weight_params(result.model, "Y")
+    assert np.array_equal(weight_scale, learned)
+    assert np.array_equal(
+        codes,
+        np.clip(np.round(weight / learned.reshape(3, 1, 1, 1)), -127, 127),
+    )
+    _check_and_run(
+        result.model, {"X": rng.standard_normal((1, 2, 5, 5)).astype(np.float32)}
+    )
+
+
+def test_ingest_stays_close_to_the_model_it_ingested():
+    # End-to-end sanity: preserving the learned quantizers should reproduce the
+    # QAT export's own numerics, not merely produce *a* quantized model.
+    model = _qat_matmul()
+    (before,) = _run(model, FEEDS)
+    result = qi.quantize_static_keeping_qdq_scales(model)
+    (after,) = _check_and_run(result.model, FEEDS)
+    assert np.allclose(before, after, atol=2e-2)
+
+
+# --------------------------------------------------------------------------- #
+# Round trip: emit, "train", re-import
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("scheme", ["int8", "int16"])
+def test_round_trip_through_an_external_trainer(scheme):
+    export = qi.export_fake_quant(
+        _float_matmul(), scheme=scheme, calibration_data=CALIBRATION
+    )
+    assert export.learnable_scales == ("X_scale", "W1_scale")
+    assert export.learnable_zero_points == ("X_zero_point",)
+    _check_and_run(export.model, FEEDS)
+
+    # What a trainer does to those tensors: move them. 0.6x is well outside
+    # anything calibration would land on, so a re-derived scale is
+    # distinguishable from a preserved one.
+    trained = onnx.ModelProto()
+    trained.CopyFrom(export.model)
+    wanted = {}
+    for init in trained.graph.initializer:
+        if init.name not in export.learnable_scales:
+            continue
+        moved = (onnx.numpy_helper.to_array(init) * np.float32(0.6)).astype(np.float32)
+        init.CopyFrom(onnx.numpy_helper.from_array(moved, init.name))
+        wanted[init.name] = moved
+
+    result = qi.quantize_static_keeping_qdq_scales(
+        trained, calibration_data=CALIBRATION, scheme=scheme
+    )
+    assert result.calibration_ran is False
+    assert result.unpreserved == ()
+    assert result.scan.skipped == ()
+
+    scale, _ = _activation_params(result.model, "X")
+    assert np.array_equal(scale.reshape(-1), wanted["X_scale"].reshape(-1))
+    _, weight_scale = _weight_params(result.model, "Y")
+    assert np.array_equal(weight_scale, wanted["W1_scale"])
+    _check_and_run(result.model, FEEDS)
+
+
+def test_export_records_learnable_tensors_in_metadata_too():
+    export = qi.export_fake_quant(_float_matmul(), calibration_data=CALIBRATION)
+    props = {p.key: p.value for p in export.model.metadata_props}
+    assert json.loads(props[qi.LEARNABLE_SCALES_KEY]) == list(export.learnable_scales)
+    assert json.loads(props[qi.LEARNABLE_ZERO_POINTS_KEY]) == list(
+        export.learnable_zero_points
+    )
+    # Scales are float and directly trainable; zero-points are integer tensors
+    # a trainer has to round back into, so they are listed apart.
+    inits = _initializers(export.model)
+    for name in export.learnable_scales:
+        assert inits[name].dtype == np.float32
+    for name in export.learnable_zero_points:
+        assert inits[name].dtype in (np.uint8, np.uint16)
+    assert export.learnable_tensors == (
+        export.learnable_scales + export.learnable_zero_points
+    )
+
+
+def test_export_keeps_generated_names_when_asked():
+    export = qi.export_fake_quant(
+        _float_matmul(), calibration_data=CALIBRATION, rename_parameters=False
+    )
+    inits = _initializers(export.model)
+    assert all(name in inits for name in export.learnable_tensors)
+    assert "X_scale" not in inits
+
+
+@pytest.mark.parametrize("bad", ["int4", "fp8", ""])
+def test_unknown_scheme_is_refused(bad):
+    with pytest.raises(ValueError, match="unknown scheme"):
+        qi.export_fake_quant(_float_matmul(), scheme=bad)
+    with pytest.raises(ValueError, match="unknown scheme"):
+        qi.quantize_static_keeping_qdq_scales(_qat_matmul(), scheme=bad)
+
+
+# --------------------------------------------------------------------------- #
+# Canonicalization
+# --------------------------------------------------------------------------- #
+def test_strip_restores_the_float_graph():
+    stripped, scan = qi.strip_existing_qdq(_qat_matmul())
+    assert [a.tensor_name for a in scan.annotations] == ["X"]
+    assert [n.op_type for n in stripped.graph.node] == ["MatMul"]
+    # The pair's own parameters go with it; the float weight stays.
+    names = {i.name for i in stripped.graph.initializer}
+    assert names == {"W1"}
+    _check_and_run(stripped, FEEDS)
+
+
+def test_strip_rematerializes_an_integer_weight():
+    # Scan shape 3: a weight stored in its quantized form with no Quantize in
+    # front of it, which is what quantize_static and ORT's quantizer emit.
+    codes = np.clip(np.round(W1 / 0.01), -127, 127).astype(np.int8)
+    model = _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          Wdq = DequantizeLinear(Wq, w_scale)
+          Y = MatMul(X, Wdq)
+        }
+        """,
+        initializer=[
+            onnx.numpy_helper.from_array(codes, "Wq"),
+            _f32(0.01, "w_scale"),
+        ],
+    )
+    stripped, scan = qi.strip_existing_qdq(model)
+    assert [(a.tensor_name, a.role) for a in scan.annotations] == [("Wdq", "weight")]
+    assert [n.op_type for n in stripped.graph.node] == ["MatMul"]
+    assert np.allclose(_initializers(stripped)["Wdq"], codes.astype(np.float32) * 0.01)
+
+
+def test_strip_leaves_untouched_what_it_refuses():
+    model = _blocked_activation()
+    stripped, scan = qi.strip_existing_qdq(model)
+    assert scan.annotations == ()
+    assert [n.op_type for n in stripped.graph.node] == [
+        n.op_type for n in model.graph.node
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Refusals: each one reported, each one left alone
+# --------------------------------------------------------------------------- #
+def _non_constant_scale():
+    # The scale reaches QuantizeLinear through an Identity, so it is a node
+    # output rather than an initializer: computable, but not readable off the
+    # graph without folding, which this module deliberately will not do.
+    return _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          s = Identity(x_scale)
+          Xq = QuantizeLinear(X, s, x_zp)
+          Xdq = DequantizeLinear(Xq, s, x_zp)
+          Y = MatMul(Xdq, W1)
+        }
+        """,
+        initializer=[_f32(W1, "W1"), _f32(LEARNED_SCALE, "x_scale"), _u8(3, "x_zp")],
+    )
+
+
+def _unexpected_zero_point_dtype():
+    # int4 is a legal QuantizeLinear zero-point type in opset 21 and a
+    # dtype onnxsim's static scheme has no counterpart for. Built with
+    # onnx.helper rather than numpy_helper because a 4-bit tensor has no
+    # plain numpy dtype to build it from.
+    return _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          Xq = QuantizeLinear(X, x_scale, x_zp)
+          Xdq = DequantizeLinear(Xq, x_scale, x_zp)
+          Y = MatMul(Xdq, W1)
+        }
+        """,
+        initializer=[
+            _f32(W1, "W1"),
+            _f32(LEARNED_SCALE, "x_scale"),
+            onnx.helper.make_tensor("x_zp", onnx.TensorProto.INT4, [], [3]),
+        ],
+    )
+
+
+def _axis_shape_mismatch():
+    # A per-channel weight quantizer claiming axis 1 of a [4, 6] weight, with
+    # only 5 scales. One of the two is wrong and there is no way to tell which.
+    return _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          Wq = QuantizeLinear<axis = 1>(W1, w_scale, w_zp)
+          Wdq = DequantizeLinear<axis = 1>(Wq, w_scale, w_zp)
+          Y = MatMul(X, Wdq)
+        }
+        """,
+        initializer=[
+            _f32(W1, "W1"),
+            _f32(np.full(5, 0.01), "w_scale"),
+            _i8(np.zeros(5), "w_zp"),
+        ],
+    )
+
+
+def _blocked_activation():
+    return _model(
+        """
+        g (float[4, 6] X) => (float[4, 3] Y)
+        {
+          Xq = QuantizeLinear<axis = 1, block_size = 3>(X, b_scale, b_zp)
+          Xdq = DequantizeLinear<axis = 1, block_size = 3>(Xq, b_scale, b_zp)
+          Y = MatMul(Xdq, W2)
+        }
+        """,
+        initializer=[
+            _f32(W2, "W2"),
+            _f32(np.full((4, 2), 0.01), "b_scale"),
+            _u8(np.zeros((4, 2)), "b_zp"),
+        ],
+    )
+
+
+def _reused_quantized_tensor():
+    # Xq escapes to a second consumer, so deleting the pair would delete a
+    # tensor something else still reads.
+    return _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y, uint8[2, 4] Z)
+        {
+          Xq = QuantizeLinear(X, x_scale, x_zp)
+          Xdq = DequantizeLinear(Xq, x_scale, x_zp)
+          Z = Identity(Xq)
+          Y = MatMul(Xdq, W1)
+        }
+        """,
+        initializer=[_f32(W1, "W1"), _f32(LEARNED_SCALE, "x_scale"), _u8(3, "x_zp")],
+    )
+
+
+def _dequantized_graph_output():
+    return _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y, float[2, 4] Xdq)
+        {
+          Xq = QuantizeLinear(X, x_scale, x_zp)
+          Xdq = DequantizeLinear(Xq, x_scale, x_zp)
+          Y = MatMul(Xdq, W1)
+        }
+        """,
+        initializer=[_f32(W1, "W1"), _f32(LEARNED_SCALE, "x_scale"), _u8(3, "x_zp")],
+    )
+
+
+def _mismatched_pair():
+    # Quantize and Dequantize disagree about the quantizer: the pair is not a
+    # round trip through one set of parameters, so there is no single
+    # (scale, zero-point) to preserve.
+    return _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          Xq = QuantizeLinear(X, x_scale, x_zp)
+          Xdq = DequantizeLinear(Xq, other_scale, x_zp)
+          Y = MatMul(Xdq, W1)
+        }
+        """,
+        initializer=[
+            _f32(W1, "W1"),
+            _f32(LEARNED_SCALE, "x_scale"),
+            _f32(LEARNED_SCALE * 2, "other_scale"),
+            _u8(3, "x_zp"),
+        ],
+    )
+
+
+def _non_positive_scale():
+    return _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          Xq = QuantizeLinear(X, x_scale, x_zp)
+          Xdq = DequantizeLinear(Xq, x_scale, x_zp)
+          Y = MatMul(Xdq, W1)
+        }
+        """,
+        initializer=[_f32(W1, "W1"), _f32(0.0, "x_scale"), _u8(3, "x_zp")],
+    )
+
+
+REFUSALS = {
+    "scale_not_constant": _non_constant_scale,
+    "unsupported_zero_point_dtype": _unexpected_zero_point_dtype,
+    "axis_shape_mismatch": _axis_shape_mismatch,
+    "blocked_quantization_unsupported": _blocked_activation,
+    "quantized_tensor_reused": _reused_quantized_tensor,
+    "dequantize_output_is_graph_output": _dequantized_graph_output,
+    "mismatched_quantization_params": _mismatched_pair,
+    "non_positive_scale": _non_positive_scale,
+}
+
+
+@pytest.mark.parametrize("reason", sorted(REFUSALS))
+def test_refused_pattern_is_reported_and_left_in_the_graph(reason):
+    model = REFUSALS[reason]()
+    onnx.checker.check_model(model)
+    scan = qi.find_existing_qdq(model)
+    assert scan.annotations == ()
+    assert [s.reason for s in scan.skipped] == [reason]
+    # Every reported reason is a documented one, and its string form says so.
+    assert reason in qi.SKIP_REASONS
+    assert qi.SKIP_REASONS[reason] in str(scan.skipped[0])
+
+    # Refusing means leaving the model's own quantization exactly where it is,
+    # not dropping it: the pair is still there afterwards.
+    result = qi.quantize_static_keeping_qdq_scales(model, num_calibration_samples=2)
+    op_types = [n.op_type for n in result.model.graph.node]
+    assert op_types.count("QuantizeLinear") >= 1
+    assert result.scan.skipped == scan.skipped
+
+
+def test_per_axis_activation_is_understood_but_cannot_be_carried():
+    # Detection succeeds -- the pair is well formed and its axis checks out --
+    # but quantize_static's activation scheme is per-tensor, so the tensor is
+    # recalibrated and the caller is told exactly that.
+    model = _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          Xq = QuantizeLinear<axis = 1>(X, x_scale, x_zp)
+          Xdq = DequantizeLinear<axis = 1>(Xq, x_scale, x_zp)
+          Y = MatMul(Xdq, W1)
+        }
+        """,
+        initializer=[
+            _f32(W1, "W1"),
+            _f32(np.full(4, LEARNED_SCALE), "x_scale"),
+            _u8(np.full(4, LEARNED_ZP), "x_zp"),
+        ],
+    )
+    scan = qi.find_existing_qdq(model)
+    assert [(a.tensor_name, a.axis) for a in scan.annotations] == [("X", 1)]
+
+    result = qi.quantize_static_keeping_qdq_scales(model, calibration_data=CALIBRATION)
+    assert result.preserved == ()
+    assert result.recalibrated == ("X",)
+    assert [(s.tensor_name, s.reason) for s in result.unpreserved] == [
+        ("X", "per_axis_activation_unsupported")
+    ]
+    _check_and_run(result.model, FEEDS)
+
+
+@pytest.mark.parametrize(
+    "zero_point,reason",
+    [
+        (("int8", 5), "weight_zero_point_not_symmetric"),
+        (("uint8", 0), "weight_dtype_not_int8"),
+    ],
+)
+def test_asymmetric_weight_quantizer_is_reported_not_reinterpreted(zero_point, reason):
+    # onnxsim's weight scheme is symmetric int8. A learned weight quantizer
+    # that is not is understood but cannot be re-emitted, so the weight falls
+    # back to onnxsim's own round-to-nearest scale -- and says so.
+    dtype, value = zero_point
+    zp = np.full(6, value, dtype=np.dtype(dtype))
+    model = _model(
+        """
+        g (float[2, 4] X) => (float[2, 6] Y)
+        {
+          Wq = QuantizeLinear<axis = 1>(W1, w_scale, w_zp)
+          Wdq = DequantizeLinear<axis = 1>(Wq, w_scale, w_zp)
+          Y = MatMul(X, Wdq)
+        }
+        """,
+        initializer=[
+            _f32(W1, "W1"),
+            _f32(np.full(6, 0.01), "w_scale"),
+            onnx.numpy_helper.from_array(zp, "w_zp"),
+        ],
+    )
+    onnx.checker.check_model(model)
+    result = qi.quantize_static_keeping_qdq_scales(model, calibration_data=CALIBRATION)
+    assert result.preserved == ()
+    assert [(s.tensor_name, s.reason) for s in result.unpreserved] == [("W1", reason)]
+    _, scale = _weight_params(result.model, "Y")
+    assert not np.allclose(scale, 0.01)
+    _check_and_run(result.model, FEEDS)
+
+
+def test_qdq_on_a_tensor_onnxsim_does_not_quantize_is_left_alone():
+    # A fake-quantized Add output: a real QAT export annotates far more
+    # tensors than onnxsim's static quantization has a place for. The pair
+    # stays in the graph untouched, and the reason says why.
+    model = _model(
+        """
+        g (float[2, 4] X) => (float[2, 4] Y)
+        {
+          H = Add(X, X)
+          Hq = QuantizeLinear(H, x_scale, x_zp)
+          Hdq = DequantizeLinear(Hq, x_scale, x_zp)
+          Y = Relu(Hdq)
+        }
+        """,
+        initializer=[_f32(LEARNED_SCALE, "x_scale"), _u8(LEARNED_ZP, "x_zp")],
+    )
+    scan = qi.find_existing_qdq(model)
+    assert [a.tensor_name for a in scan.annotations] == ["H"]
+
+    result = qi.quantize_static_keeping_qdq_scales(model, calibration_data=CALIBRATION)
+    assert result.preserved == ()
+    assert [(s.tensor_name, s.reason) for s in result.unpreserved] == [
+        ("H", "not_a_quantizable_tensor")
+    ]
+    assert [n.op_type for n in result.model.graph.node] == [
+        n.op_type for n in model.graph.node
+    ]
+    scale, zero_point = _activation_params(result.model, "H")
+    assert float(scale) == np.float32(LEARNED_SCALE)
+    assert int(zero_point) == LEARNED_ZP
+    _check_and_run(result.model, FEEDS)
+
+
+def test_every_reported_reason_is_documented():
+    # A reason with no entry in SKIP_REASONS would render as a KeyError in
+    # SkippedQdq.__str__ the first time a user printed it.
+    models = [factory() for factory in REFUSALS.values()] + [
+        _qat_matmul(),
+        _qat_chain(),
+        _axis_shape_mismatch(),
+    ]
+    seen = set()
+    for model in models:
+        result = qi.quantize_static_keeping_qdq_scales(model, num_calibration_samples=2)
+        seen.update(s.reason for s in result.scan.skipped)
+        seen.update(s.reason for s in result.unpreserved)
+    assert seen
+    assert seen <= set(qi.SKIP_REASONS)


### PR DESCRIPTION
Follow-up to #1221. Closes two of the items that PR listed as still open, and implements `docs/qat.md`'s stage 4.

## Block discovery, and a sequential walk over the plan

`apply_qat` trained one caller-named block per call, inheriting `brecq`'s contract. `discover_qat_blocks` now plans the whole model without the caller naming a tensor, and `apply_qat_all_blocks` trains that plan in order.

**Boundary discovery is a liveness argument, not a pattern match.** Walk the nodes in topological order and cut wherever exactly one tensor is live across the gap, since a slice bounded that way is self-contained — which is exactly the property the block slicer needs of its boundaries. The consequence is that residual connections *place* the boundaries instead of defeating them: inside `y = f(x) + x` the skip tensor is live alongside every intermediate, so the first cut after `x` is the residual `Add`'s own output — a ResNet BasicBlock or transformer sub-layer boundary, derived rather than special-cased.

Initializers and non-primary graph inputs are excluded from the live set: a mask or position-id input is byte-identical in teacher and student, so teacher-forcing it is exact, and letting it span the graph would suppress every cut. A span containing an op `graph_grad` cannot differentiate becomes a *gap between blocks* rather than a failure of the whole model, and spans merge until `max_layers_per_block` quantized layers accumulate — without merging, a residual-free MLP gives one block per layer and loses all intra-block error cancellation. Every proposed pair is validated by actually constructing the block plan, so discovery cannot disagree with `apply_qat` about what is legal.

**The walk defaults to sequential**: each block's target is the teacher's output, but its input is recaptured from the student after the previous blocks were tuned, so a block corrects the error its predecessors leave rather than assuming they were perfect. That differs from `adaround`/`brecq`, which capture everything once from the float model and never re-run the student. Whole-model output error against the float model on a 4-layer chain:

| | error |
| --- | --- |
| round-to-nearest | 400.3 |
| capture once | 206.2 |
| **sequential (default)** | **168.1** |

Sequential won on all five seeds tried, by 14–31%. The counter-intuitive part, recorded in the docstring and the test: sequential's *per-block reported losses are higher*, because a dirtier input is a harder reconstruction problem. The block-local loss is not the quantity that matters.

A block that cannot be trained is reported with its reason rather than silently skipped. `apply_qat`'s signature and behaviour are unchanged — its body is now the three internals the walk reuses, and its 14 existing tests pass untouched.

## `qat_interop.py` — keeping the scales a QAT export learned

`docs/qat.md`'s deliverable A, the half of QAT that needs no training at all.

A learned scale is usually deliberately *tighter* than the observed min/max — clipping outliers to spend the codes where the values are — so `quantize_static` re-deriving it from calibration is a silent regression, not a wash. `quantize_static_keeping_qdq_scales` reads the parameters a QAT export already carries, canonicalizes back to float only the pairs onnxsim can re-emit, calibrates **only** the tensors with no usable annotation (a fully annotated export needs no calibration data at all), runs the ordinary `QuantizeStatic` rewrite, then writes the learned values back bit-exactly — re-deriving a weight's integer codes from its learned scale, since swapping the scale alone would change what the weight dequantizes to.

Three QDQ shapes are recognized: fake-quant on an activation, fake-quant on a float weight, and a weight already stored quantized. Refusal is a documented table (`SKIP_REASONS`) and a refused pair is left in the graph **exactly as authored**, never dropped: a non-constant or non-finite scale, an unexpected zero-point dtype, a Q/DQ pair disagreeing about scale/zp/axis, blocked quantization, a per-axis scale whose length contradicts the axis it claims. Cases that are understood but cannot be carried through onnxsim's own scheme are reported separately rather than silently downgraded.

`export_fake_quant` closes the round trip, naming the initializers a trainer should make learnable — split into float scales (directly differentiable) and integer zero-points (a trainer must round back into them). The names are returned *and* stamped into `metadata_props`, since a round trip goes through a saved file and a training script that never saw the call, but the metadata is non-load-bearing: ingest re-derives everything structurally.

## Tests

190 pass across the QAT files. Two in the interop set are worth calling out, because they are where this kind of work goes vacuous: the learned constants are chosen so the calibration round trip is *deliberately not* float32-exact (many pairs happen to be, and a test built on one would pass with the write-back deleted), and the write-back is mutation-checked by stubbing it out — six tests catch that.

`ruff` clean, `mypy` at the repo's pre-existing 34-error baseline.

## Still open

Real data via `load_huggingface_calibration_data`, a `QuantizationConfig` flag, an end-to-end pass against the model's own output (a block is always the unit of optimization), minibatching, activation quantization, and stage 3 of `docs/qat.md` — the browser fine-tuning panel, now the only unimplemented stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_