### PR TITLE
mcode: the weight layout tiles, a second packing for 2-D convs, and resnet18d's real budget

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3654,6 +3654,67 @@ Tests: `test_conv_weights_are_int8_split_across_two_nibble_planes` (Docker)
 and `test_conv_weights_can_be_rewritten_without_pulsar2` (Docker and device)
 in `tests/test_axera_mcode_structure.py`.
 
+### A second packing, and how far generation reaches on resnet18d
+
+The weight layout above was found on 1-D convolutions. A real CNN is built
+from 2-D ones, so the obvious question is whether the same formula reads
+resnet18d. It does not, and the reason is worth recording: **the packing is a
+property of the convolution's shape, not of the format.**
+
+**2-D convolutions bit-slice differently.** The same INT8 codes are stored as
+*four* 2-bit planes 36 bytes apart rather than two 4-bit ones, four input
+channels share a byte instead of two, and the kernel is laid out in reverse:
+
+    offset(o, i, kh, kw) = 144*o + 4*(K - 1 - (kw + K_w*kh)) + i//4
+    bits  = 2 bits at 2*(i % 4), across planes 3, 2, 1, 0 most significant first
+
+Confirmed at `cin = cout = 8, 3x3`, where it reconstructs a compiled table at
+0.99998 and predicts `(7,7,2,2)` at byte 1009 exactly. **Confirmed on the
+device too**: rewriting a 2-D convolution's weights by hand gives 0.99982
+against the new weights' CPU reference versus 0.99988 for pulsar2's own
+build, with both cross-controls at zero.
+
+**At 32 channels the 2-D case adds two more levels.** Input channels group 16
+at a time (`+144` per group), and the output channel is addressed through a
+*bit-interleave* rather than a stride:
+
+    base(o) = 576*(o % 8) + 72*((o // 8) % 2) + 4608*(o // 16)
+
+which is exact for every measured channel -- `o = 8` lands at 72, `o = 16` at
+4608, `o = 31` at 8712 -- and predicts the compiled table's total size. The
+plane pairs also separate by `+288` rather than staying 36 apart, and that
+placement rule is not yet pinned down.
+
+**Where that leaves resnet18d.** Its 22 convolutions are 2-D with 3 to 512
+channels, so every one of them sits past the shapes confirmed above. A search
+over plausible strides for its *first* convolution reaches only 0.43
+correlation, so we cannot currently locate, read or generate resnet18d's
+weights. The block-size arithmetic does line up -- summing the predicted
+per-layer blocks gives 11,208,960 bytes against an actual `npu_params` of
+11,855,108, within 5.8% -- which says the tiling family is right and the
+addressing constants for large channel counts are what is missing.
+
+The honest budget for resnet18d today:
+
+| part | size | status |
+| --- | --- | --- |
+| weight table | 11,855,108 B (242x the mcode) | layout not yet decoded at these shapes |
+| mcode stream | 48,320 B | 98.92% explained, round-trips byte-exactly |
+| framing bytes | 28,552 B (59.1% of stream) | emitted from the grammar |
+| value bytes | 19,235 B (39.8%) | 3.81% have a confirmed meaning |
+| header + tail | 760 B | rules known |
+
+So on resnet18d specifically: we can decode and reproduce its instruction
+stream exactly, we understand under 4% of its operand values, and its weight
+table -- 242 times the size of everything else -- is not yet addressable. The
+method that cracked the smaller shapes is unchanged and keeps working; what
+it needs is the same single-weight sweep run at 64, 128, 256 and 512
+channels.
+
+Tests: `test_conv2d_weights_are_int8_split_across_four_bit_planes` (Docker)
+and `test_conv2d_weights_can_be_rewritten_without_pulsar2` (Docker and
+device).
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3569,14 +3569,29 @@ whose weights are all zero, then compile the same convolution with a *single*
 non-zero weight at a known `(o, i, k)`, and see which byte changes. Repeated
 over nine positions this gives the addressing exactly rather than by fitting.
 
-**The layout.** Weights live in the `npu_params` initializer at
+**The layout.** Weights live in the `npu_params` initializer. A slot index
+walks one output channel's weights, and both that index and the output
+channel are *tiled*:
 
-    offset(o, i, k) = 72*o + (Cin/2)*k + i//2,   nibble = i % 2
+    s      = (Cin/2)*k + i//2          slot within an output channel
+    chunk  = s // 36,  within = s % 36
+    group  = o // 16,  member = o % 16
+    groups = ceil(Cout/16),  chunks = ceil((Cin/2)*K / 36)
 
-with a *second* plane 36 bytes further on. Predictions from the first few
-positions land exactly: `(3,5,1)` at byte 222 and `(7,7,2)` at byte 515.
+    low  = 72*groups*chunks*member + 72*(group + groups*chunk) + within
+    high = low + 36,   nibble = i % 2
+
 Two input channels share a byte, which is what first looked like 4-bit
-weights.
+weights. The tiling is the part guessing would miss: a channel's weights are
+*not* contiguous once either dimension overflows its tile. At 8 channels
+neither does, and the formula collapses to `72*o + (Cin/2)*k + i//2`; at 32
+channels both do, and weight `(0,8,2)` jumps from a predicted byte 36 to 144
+while output channel 16 lands at byte 72 rather than after channel 15.
+
+Across both shapes the formula predicts **35 of 35** measured spike offsets
+exactly -- `(3,5,1)` at 222, `(7,7,2)` at 515, `(31,31,2)` at 4547 -- and it
+reconstructs a full 32x32x3 weight tensor from a compiled table at a
+per-channel correlation of 0.99998.
 
 **They are not 4-bit.** Combining the planes as `high*16 + low` gives INT8
 with zero point 128, and the arithmetic closes exactly:
@@ -3604,12 +3619,16 @@ least squares from a compiled reference reproduces pulsar2's own codes for
 compiled convolution and replacing its weights by hand -- no vendor compiler
 anywhere in the loop -- the NPU then computes the *new* convolution:
 
-| run | vs CPU reference | correlation |
-| --- | --- | --- |
-| pulsar2's own build | its own weights | 0.99992 |
-| our patched table | the **new** weights | 0.99987 |
-| our patched table | the old weights | 0.319 |
-| pulsar2's own build | the new weights | 0.320 |
+| shape | run | vs CPU reference | correlation |
+| --- | --- | --- | --- |
+| 8 ch | pulsar2's own build | its own weights | 0.99992 |
+| 8 ch | our patched table | the **new** weights | 0.99987 |
+| 8 ch | our patched table | the old weights | 0.319 |
+| 8 ch | pulsar2's own build | the new weights | 0.320 |
+| 32 ch | pulsar2's own build | its own weights | 0.99981 |
+| 32 ch | our patched table | the **new** weights | 0.99972 |
+| 32 ch | our patched table | the old weights | 0.052 |
+| 32 ch | pulsar2's own build | the new weights | 0.052 |
 
 The two cross-controls are the point. The patched model stops matching the
 old weights and the untouched model does not match the new ones, so the
@@ -3623,11 +3642,13 @@ activation scales too, and those are calibrated from the weights, so changing
 a channel's dynamic range invalidates the scale the table already holds.
 Rewriting weights freely needs the scale rewritten with them.
 
-And the addressing is confirmed for `Cin` up to 16, not beyond. The plane is
-36 bytes and a channel's weights occupy `(Cin/2)*K` of it, which fits at
-`Cin = 16, K = 3` (24 bytes) and overflows at `Cin = 32` (48). A search over
-strides finds no simple affine layout for 32 or 64 channels, so larger
-convolutions must tile, and how they tile is open.
+And the addressing is confirmed at 8, 16 and 32 channels with `K = 3`. The
+tiling constants (a 36-byte plane, 72-byte pairs, output groups of 16) are
+read off those shapes rather than derived, so a shape that overflows some
+*other* limit -- many chunks, a large kernel, 64 channels and up -- may well
+expose another level of tiling. A stride search alone never found this
+structure; the single-weight builds did, and the same method extends to any
+shape worth confirming.
 
 Tests: `test_conv_weights_are_int8_split_across_two_nibble_planes` (Docker)
 and `test_conv_weights_can_be_rewritten_without_pulsar2` (Docker and device)

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -3857,13 +3857,12 @@ def _build_single_op_axmodel(work_dir, tag, model):
     """Compile a one-op model for real and return the `.axmodel` path."""
     os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
     os.makedirs(os.path.join(work_dir, "config"), exist_ok=True)
-    cin = model.graph.input[0].type.tensor_type.shape.dim[1].dim_value
     onnx.save(model, os.path.join(work_dir, f"{tag}.onnx"))
-    length = model.graph.input[0].type.tensor_type.shape.dim[2].dim_value
+    shape = [d.dim_value for d in model.graph.input[0].type.tensor_type.shape.dim]
     rng = np.random.RandomState(1)
     pulsar2_docker.make_numpy_calibration_tar(
         os.path.join(work_dir, "dataset", f"{tag}.tar"),
-        [rng.randn(1, cin, length).astype(np.float32) for _ in range(4)],
+        [rng.randn(*shape).astype(np.float32) for _ in range(4)],
     )
     with open(os.path.join(work_dir, "config", f"{tag}.json"), "w") as f:
         json.dump(
@@ -4000,6 +3999,199 @@ def _effective_slopes(weights, codes):
         nz = np.abs(w) > 0
         slopes[o] = np.sum(w[nz] * q[nz]) / np.sum(w[nz] ** 2)
     return slopes
+
+
+def _one_conv2d_model(cin, cout, hw=16, kernel=3, weights=None):
+    """A single same-padded 2-D convolution -- the shape a real CNN is built
+    from, and a different weight packing from the 1-D case."""
+    rng = np.random.RandomState(0)
+    shape = (cout, cin, kernel, kernel)
+    values = (rng.randn(*shape) * 0.05) if weights is None else weights
+    weight = numpy_helper.from_array(np.asarray(values, dtype=np.float32), "w")
+    node = helper.make_node(
+        "Conv",
+        ["x", "w"],
+        ["y"],
+        name="conv",
+        kernel_shape=[kernel, kernel],
+        pads=[kernel // 2] * 4,
+    )
+    graph = helper.make_graph(
+        [node],
+        "one_conv2d",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, cin, hw, hw])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, cout, hw, hw])],
+        [weight],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    return model
+
+
+# A 2-D convolution packs its weights differently from a 1-D one: four 2-bit
+# planes rather than two 4-bit ones, four input channels to a byte, and the
+# kernel stored in reverse. Confirmed at `cin = cout = 8, 3x3`. See the
+# README's "A second packing" section.
+_WBT2D_O_STRIDE = 144
+_WBT2D_PLANE = 36
+_WBT2D_PLANES = (3, 2, 1, 0)  # most significant first
+
+
+def _weight2d_offset(o, i, kh, kw, kernel):
+    """`(byte offset of plane 0, bit shift)` for a 2-D weight."""
+    flat = kernel * kh + kw
+    return (
+        _WBT2D_O_STRIDE * o + 4 * (kernel * kernel - 1 - flat) + i // 4,
+        2 * (i % 4),
+    )
+
+
+def _read_weight2d_code(wbt, o, i, kh, kw, kernel):
+    off, shift = _weight2d_offset(o, i, kh, kw, kernel)
+    value = 0
+    for plane in _WBT2D_PLANES:
+        value = (value << 2) | ((wbt[off + _WBT2D_PLANE * plane] >> shift) & 0x3)
+    return value
+
+
+def _write_weight2d_code(wbt, o, i, kh, kw, kernel, code):
+    off, shift = _weight2d_offset(o, i, kh, kw, kernel)
+    for n, plane in enumerate(_WBT2D_PLANES):
+        bits = (code >> (2 * (len(_WBT2D_PLANES) - 1 - n))) & 0x3
+        at = off + _WBT2D_PLANE * plane
+        wbt[at] = (wbt[at] & ~(0x3 << shift) & 0xFF) | (bits << shift)
+
+
+def test_conv2d_weights_are_int8_split_across_four_bit_planes(tmp_path):
+    """Confirmed real (see the README's "A second packing" section): a *2-D*
+    convolution stores the same INT8 weights in a different shape -- four
+    2-bit planes 36 bytes apart rather than two 4-bit ones, four input
+    channels to a byte, and the kernel laid out in reverse, so `(kh, kw)`
+    counts *down* from the end of the block.
+
+    The packing is not a property of the format but of the convolution: the
+    1-D and 2-D cases here hold identical INT8 codes in different bit
+    layouts. A generator therefore needs the shape, not just the weights.
+    Needs Docker, no device.
+    """
+    cin = cout = 8
+    kernel, hw = 3, 16
+    zero = tmp_path / "zero"
+    zero.mkdir()
+    base = _wbt_of(
+        _build_single_op_axmodel(
+            str(zero),
+            "m",
+            _one_conv2d_model(
+                cin, cout, hw, kernel, weights=np.zeros((cout, cin, kernel, kernel))
+            ),
+        )
+    )
+    for o, i, kh, kw in [
+        (0, 0, 0, 0),
+        (0, 0, 0, 1),
+        (0, 0, 1, 0),
+        (0, 1, 0, 0),
+        (7, 7, 2, 2),
+    ]:
+        w = np.zeros((cout, cin, kernel, kernel))
+        w[o, i, kh, kw] = 0.5
+        work = tmp_path / f"s{o}{i}{kh}{kw}"
+        work.mkdir()
+        spike = _wbt_of(
+            _build_single_op_axmodel(
+                str(work), "m", _one_conv2d_model(cin, cout, hw, kernel, weights=w)
+            )
+        )
+        moved = [j for j in range(min(len(base), len(spike))) if base[j] != spike[j]]
+        off, shift = _weight2d_offset(o, i, kh, kw, kernel)
+        for plane in _WBT2D_PLANES:
+            at = off + _WBT2D_PLANE * plane
+            assert at in moved, (o, i, kh, kw, at, moved[:6])
+            # A full-scale weight saturates its two bits in every plane.
+            assert (spike[at] >> shift) & 0x3 == 0x3, (o, i, kh, kw, plane)
+
+
+def test_conv2d_weights_can_be_rewritten_without_pulsar2(tmp_path):
+    """Confirmed on the AX650N: the 2-D packing is understood well enough to
+    rewrite a real 2-D convolution's weights by hand, and the device then
+    computes the new convolution. Same permutation trick and same two
+    cross-controls as the 1-D case. Needs Docker and a device.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device")
+    ort = pytest.importorskip("onnxruntime")
+    cin = cout = 8
+    kernel, hw = 3, 16
+    rng = np.random.RandomState(0)
+    w_old = (rng.randn(cout, cin, kernel, kernel) * 0.1).astype(np.float32)
+    w_new = w_old[:, rng.permutation(cin), :, :].copy()
+
+    work = tmp_path / "work"
+    work.mkdir()
+    axmodel = _build_single_op_axmodel(
+        str(work), "m", _one_conv2d_model(cin, cout, hw, kernel, weights=w_old)
+    )
+    compiled = onnx.load(axmodel)
+    init = next(i for i in compiled.graph.initializer if i.name == "npu_params")
+    wbt = bytearray(init.raw_data)
+    codes = np.array(
+        [
+            [
+                [
+                    [
+                        _read_weight2d_code(wbt, o, i, kh, kw, kernel)
+                        for kw in range(kernel)
+                    ]
+                    for kh in range(kernel)
+                ]
+                for i in range(cin)
+            ]
+            for o in range(cout)
+        ],
+        dtype=float,
+    )
+    slopes = _effective_slopes(
+        w_old.astype(float).reshape(cout, -1, 1), codes.reshape(cout, -1, 1)
+    )
+    retargeted = np.clip(
+        np.round(w_new.astype(float) * slopes[:, None, None, None]) + 128, 0, 255
+    ).astype(int)
+    for o in range(cout):
+        for i in range(cin):
+            for kh in range(kernel):
+                for kw in range(kernel):
+                    _write_weight2d_code(
+                        wbt, o, i, kh, kw, kernel, int(retargeted[o, i, kh, kw])
+                    )
+    init.raw_data = bytes(wbt)
+    patched = str(work / "patched.axmodel")
+    onnx.save(compiled, patched)
+
+    x = rng.randn(1, cin, hw, hw).astype(np.float32)
+
+    def reference(weights):
+        ref = _one_conv2d_model(cin, cout, hw, kernel, weights=weights)
+        path = str(work / "ref.onnx")
+        onnx.save(ref, path)
+        session = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
+        return np.asarray(session.run(None, {"x": x})[0]).ravel()
+
+    def on_device(path):
+        result = pulsar2_docker.run_on_device_with_inputs(
+            path, {"x": x.tobytes()}, timeout=300
+        )
+        assert not result.error, result.error
+        return np.frombuffer(result.outputs[0], dtype=np.float32).ravel()
+
+    ref_old, ref_new = reference(w_old), reference(w_new)
+    npu_old, npu_new = on_device(axmodel), on_device(patched)
+    corr = lambda a, b: float(np.corrcoef(a, b)[0, 1])  # noqa: E731
+    assert corr(npu_old, ref_old) > 0.99, corr(npu_old, ref_old)
+    assert corr(npu_new, ref_new) > 0.99, corr(npu_new, ref_new)
+    assert corr(npu_new, ref_old) < 0.9, corr(npu_new, ref_old)
+    assert corr(npu_old, ref_new) < 0.9, corr(npu_old, ref_new)
 
 
 def test_conv_weights_are_int8_split_across_two_nibble_planes(tmp_path):

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -3915,10 +3915,17 @@ def _operands(mcode, verb, field, bank):
 
 # The weight table's layout for a convolution, confirmed by placing a single
 # non-zero weight at known positions and seeing which byte moved. See the
-# README's "Generating a weight table" section. `k_stride` is `cin // 2`;
-# these two are fixed for the channel counts this was confirmed at.
-_WBT_O_STRIDE = 72
+# README's "Generating a weight table" section.
+#
+# Weights are INT8 (zero point 128) split across two 36-byte nibble planes,
+# the high plane `_WBT_PLANE_GAP` bytes after the low one. Two input channels
+# share a byte. Output channels are grouped 16 at a time and slots are chunked
+# 36 at a time, and those groups and chunks interleave in 72-byte pairs -- so
+# a channel's weights are not contiguous once either dimension overflows.
+_WBT_PLANE = 36
 _WBT_PLANE_GAP = 36
+_WBT_PAIR = 72
+_WBT_O_GROUP = 16
 
 
 def _wbt_of(axmodel_path):
@@ -3929,10 +3936,25 @@ def _wbt_of(axmodel_path):
     )
 
 
-def _weight_offset(o, i, k, cin):
+def _weight_offset(o, i, k, cin, cout, kernel):
     """`(byte offset, nibble shift)` of weight `(o, i, k)`'s low-nibble plane.
-    The high nibble lives `_WBT_PLANE_GAP` bytes further on."""
-    return _WBT_O_STRIDE * o + (cin // 2) * k + i // 2, (4 if i % 2 else 0)
+    The high nibble lives `_WBT_PLANE_GAP` bytes further on.
+
+    Slot `s` walks the weights of one output channel; it is chunked into
+    36-byte planes, and output channels are grouped 16 at a time. Both the
+    group and the chunk index select which 72-byte pair the plane lands in.
+    """
+    s = (cin // 2) * k + i // 2
+    chunk, within = divmod(s, _WBT_PLANE)
+    group, member = divmod(o, _WBT_O_GROUP)
+    groups = -(-cout // _WBT_O_GROUP)
+    chunks = -(-((cin // 2) * kernel) // _WBT_PLANE)
+    low = (
+        _WBT_PAIR * groups * chunks * member
+        + _WBT_PAIR * (group + groups * chunk)
+        + within
+    )
+    return low, (4 if i % 2 else 0)
 
 
 def _read_weight_codes(wbt, shape):
@@ -3942,7 +3964,7 @@ def _read_weight_codes(wbt, shape):
     for o in range(cout):
         for i in range(cin):
             for k in range(kernel):
-                off, sh = _weight_offset(o, i, k, cin)
+                off, sh = _weight_offset(o, i, k, cin, cout, kernel)
                 lo = (wbt[off] >> sh) & 0xF
                 hi = (wbt[off + _WBT_PLANE_GAP] >> sh) & 0xF
                 codes[o, i, k] = (hi << 4) | lo
@@ -3956,7 +3978,7 @@ def _write_weight_codes(wbt, codes):
     for o in range(cout):
         for i in range(cin):
             for k in range(kernel):
-                off, sh = _weight_offset(o, i, k, cin)
+                off, sh = _weight_offset(o, i, k, cin, cout, kernel)
                 value = int(codes[o, i, k]) & 0xFF
                 out[off] = (out[off] & ~(0xF << sh) & 0xFF) | ((value & 0xF) << sh)
                 high = off + _WBT_PLANE_GAP
@@ -3991,35 +4013,48 @@ def test_conv_weights_are_int8_split_across_two_nibble_planes(tmp_path):
     `_weight_offset()` predicts, in the nibble `i % 2` selects. Needs Docker,
     no device.
     """
-    cin = cout = 8
     kernel, length = 3, 32
-    zero = tmp_path / "zero"
-    zero.mkdir()
-    base = _wbt_of(
-        _build_single_op_axmodel(
-            str(zero),
-            "m",
-            _one_conv_model(
-                cin, cout, length, kernel, weights=np.zeros((cout, cin, kernel))
-            ),
-        )
-    )
-    for o, i, k in [(0, 0, 0), (0, 1, 0), (0, 2, 0), (0, 0, 1), (3, 5, 1), (7, 7, 2)]:
-        w = np.zeros((cout, cin, kernel))
-        w[o, i, k] = 0.5
-        work = tmp_path / f"s{o}{i}{k}"
-        work.mkdir()
-        spike = _wbt_of(
+    # 8 channels needs neither an output group nor a slot chunk; 32 needs
+    # both, so `(0,8,2)` spills to the next chunk and `(16,0,0)` to the next
+    # output group. Those are the cases a naive contiguous layout gets wrong.
+    for cin, positions in (
+        (8, [(0, 0, 0), (0, 1, 0), (0, 2, 0), (0, 0, 1), (3, 5, 1), (7, 7, 2)]),
+        (32, [(0, 0, 0), (0, 8, 2), (16, 0, 0), (31, 31, 2)]),
+    ):
+        cout = cin
+        zero = tmp_path / f"zero{cin}"
+        zero.mkdir()
+        base = _wbt_of(
             _build_single_op_axmodel(
-                str(work), "m", _one_conv_model(cin, cout, length, kernel, weights=w)
+                str(zero),
+                "m",
+                _one_conv_model(
+                    cin, cout, length, kernel, weights=np.zeros((cout, cin, kernel))
+                ),
             )
         )
-        moved = [j for j in range(min(len(base), len(spike))) if base[j] != spike[j]]
-        low, shift = _weight_offset(o, i, k, cin)
-        assert low in moved, (o, i, k, low, moved[:8])
-        assert low + _WBT_PLANE_GAP in moved, (o, i, k, moved[:8])
-        # A weight at full scale saturates its nibble in both planes.
-        assert (spike[low] >> shift) & 0xF == 0xF, (o, i, k, spike[low])
+        for o, i, k in positions:
+            w = np.zeros((cout, cin, kernel))
+            w[o, i, k] = 0.5
+            work = tmp_path / f"s{cin}_{o}_{i}_{k}"
+            work.mkdir()
+            spike = _wbt_of(
+                _build_single_op_axmodel(
+                    str(work),
+                    "m",
+                    _one_conv_model(cin, cout, length, kernel, weights=w),
+                )
+            )
+            moved = [
+                j for j in range(min(len(base), len(spike))) if base[j] != spike[j]
+            ]
+            low, shift = _weight_offset(o, i, k, cin, cout, kernel)
+            assert low in moved, (cin, o, i, k, low, moved[:8])
+            assert low + _WBT_PLANE_GAP in moved, (cin, o, i, k, moved[:8])
+            # A weight at full scale saturates its nibble in both planes, and
+            # an all-zero table reads as the zero point in the high plane.
+            assert (spike[low] >> shift) & 0xF == 0xF, (cin, o, i, k, spike[low])
+            assert (base[low + _WBT_PLANE_GAP] >> shift) & 0xF == 0x8, (cin, o, i, k)
 
 
 def test_conv_weights_can_be_rewritten_without_pulsar2(tmp_path):
@@ -4037,8 +4072,15 @@ def test_conv_weights_can_be_rewritten_without_pulsar2(tmp_path):
     if not pulsar2_docker.axcl_available():
         pytest.skip("no AXCL device")
     ort = pytest.importorskip("onnxruntime")
-    cin = cout = 8
+    for channels in (8, 32):
+        _check_weight_retargeting(tmp_path / f"c{channels}", ort, channels)
+
+
+def _check_weight_retargeting(tmp_path, ort, channels):
+    """One shape's worth of `test_conv_weights_can_be_rewritten_without_pulsar2`."""
+    cin = cout = channels
     kernel, length = 3, 32
+    tmp_path.mkdir()
     rng = np.random.RandomState(0)
     w_old = (rng.randn(cout, cin, kernel) * 0.1).astype(np.float32)
     w_new = w_old[:, rng.permutation(cin), :].copy()


### PR DESCRIPTION
Two commits continuing the weight-table generator work.

## 1. The layout tiles (confirmed at 32 channels, on device)

The earlier finding stopped at `Cin <= 16` because a 36-byte plane holds `(Cin/2)*K`, which overflows at 32, and a stride search found no affine layout beyond it. Single-weight builds found the structure the search could not: **both the slot index and the output channel are tiled.**

```
s      = (Cin/2)*k + i//2
chunk  = s // 36,  within = s % 36
group  = o // 16,  member = o % 16
low    = 72*groups*chunks*member + 72*(group + groups*chunk) + within
high   = low + 36,  nibble = i % 2
```

A channel's weights are **not contiguous** once either dimension overflows. At 32 channels weight `(0,8,2)` jumps from a naively predicted byte 36 to 144, and output channel 16 lands at byte 72 rather than after channel 15.

The formula predicts **35 of 35** measured spike offsets exactly across both shapes -- `(3,5,1)` at 222, `(7,7,2)` at 515, `(31,31,2)` at 4547 -- and reconstructs a full 32x32x3 tensor at 0.99998.

On the AX650N at 32 channels: patching by hand computes the new convolution at **0.99972** versus 0.99981 for pulsar2's own build, both cross-controls at 0.05.

## 2. A second packing for 2-D convolutions

The layout above was found on 1-D convolutions. A real CNN is built from 2-D ones, and they do **not** share a packing -- the packing is a property of the convolution's shape, not of the format.

A 2-D conv stores the same INT8 codes as **four 2-bit planes** 36 bytes apart rather than two 4-bit ones, four input channels to a byte, and the kernel **reversed**:

```
offset(o,i,kh,kw) = 144*o + 4*(K-1-(kw + K_w*kh)) + i//4
2 bits at 2*(i%4), planes 3,2,1,0 most significant first
```

Confirmed at `cin=cout=8, 3x3`: reconstructs at 0.99998, predicts `(7,7,2,2)` at byte 1009 exactly, and on device a hand-rewritten 2-D table computes the new convolution at **0.99982** versus 0.99988 for pulsar2's own build, both cross-controls at zero.

At 32 channels the 2-D case adds input-channel groups of 16 (`+144` each) and addresses the output channel through a *bit-interleave* rather than a stride, `base(o) = 576*(o%8) + 72*((o//8)%2) + 4608*(o//16)`, exact for every measured channel. The plane-pair placement at that size is not yet pinned down.

## 3. Where that leaves resnet18d

Its 22 convolutions are 2-D with 3 to 512 channels, so every one sits past the confirmed shapes. A stride search on its first convolution reaches only 0.43, so we cannot yet locate or generate its weights. The block-size arithmetic does line up -- 11,208,960 predicted against an actual 11,855,108, within 5.8% -- so the tiling family is right and the large-channel addressing constants are what is missing.

Measured budget:

| part | size | status |
| --- | --- | --- |
| weight table | 11,855,108 B (242x the mcode) | not yet addressable |
| mcode stream | 48,320 B | 98.92% explained, byte-exact round trip |
| framing bytes | 28,552 B (59.1%) | emitted from the grammar |
| value bytes | 19,235 B (39.8%) | 3.81% have a confirmed meaning |
| header + tail | 760 B | rules known |

## Tests

Four weight-table tests, two on device:

- `test_conv_weights_are_int8_split_across_two_nibble_planes` (now 8 and 32 channels)
- `test_conv_weights_can_be_rewritten_without_pulsar2` (now 8 and 32 channels)
- `test_conv2d_weights_are_int8_split_across_four_bit_planes`
- `test_conv2d_weights_can_be_rewritten_without_pulsar2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS