### PR TITLE
mcode: read 98.5% of resnet18d's convolution weights with no vendor tools

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3685,35 +3685,78 @@ which is exact for every measured channel -- `o = 8` lands at 72, `o = 16` at
 plane pairs also separate by `+288` rather than staying 36 apart, and that
 placement rule is not yet pinned down.
 
-**Where that leaves resnet18d.** Its 22 convolutions are 2-D with 3 to 512
-channels, so every one of them sits past the shapes confirmed above. A search
-over plausible strides for its *first* convolution reaches only 0.43
-correlation, so we cannot currently locate, read or generate resnet18d's
-weights. The block-size arithmetic does line up -- summing the predicted
-per-layer blocks gives 11,208,960 bytes against an actual `npu_params` of
-11,855,108, within 5.8% -- which says the tiling family is right and the
-addressing constants for large channel counts are what is missing.
+**This has since been carried through to resnet18d** -- see the next section.
+The addressing constants for large channel counts turned out to be two
+things: a shape-scaled unit and a cap.
 
 The honest budget for resnet18d today:
 
 | part | size | status |
 | --- | --- | --- |
-| weight table | 11,855,108 B (242x the mcode) | layout not yet decoded at these shapes |
+| weight table | 11,855,108 B (242x the mcode) | 98.5% of conv weights addressable |
 | mcode stream | 48,320 B | 98.92% explained, round-trips byte-exactly |
 | framing bytes | 28,552 B (59.1% of stream) | emitted from the grammar |
 | value bytes | 19,235 B (39.8%) | 3.81% have a confirmed meaning |
 | header + tail | 760 B | rules known |
 
 So on resnet18d specifically: we can decode and reproduce its instruction
-stream exactly, we understand under 4% of its operand values, and its weight
-table -- 242 times the size of everything else -- is not yet addressable. The
-method that cracked the smaller shapes is unchanged and keeps working; what
-it needs is the same single-weight sweep run at 64, 128, 256 and 512
-channels.
+stream exactly, we can locate and read 98.5% of its convolution weights, and
+we understand under 4% of its operand values.
 
 Tests: `test_conv2d_weights_are_int8_split_across_four_bit_planes` (Docker)
 and `test_conv2d_weights_can_be_rewritten_without_pulsar2` (Docker and
 device).
+
+### Reading a real network's weights: 98.5% of resnet18d
+
+The sweep that finishes this is cheaper than it looks, because **the address
+is linear in the bits of the channel indices**. For the 32-channel case
+`base(1) + base(2) + base(4) + base(8) + base(16)` sums exactly to
+`base(31)`, so one build per *bit* suffices where one per channel would be
+hopeless. Fifteen builds characterise a shape.
+
+**Two constants, both shape-dependent.** Probing 8, 32 and 64 channels gives
+the same table twice over:
+
+    A = 18 * min(Cin, 128)      output-channel unit
+    P =  9 * min(Cin, 128)      separation between the two plane pairs
+
+and the full 2-D address is
+
+    addr(o,i,kh,kw) = A*(o%8) + 72*((o>>3)&1) + 8*A*(o>>4)
+                    + 4*(K - 1 - (K_w*kh + kw))
+                    + (i%16)//4 + 144*(i>>4)
+    planes at 0, 36, P, P+36;  bits 2*(i%4), planes 3,2,1,0 most significant first
+
+Output-channel bit 3 always costs 72 bytes while bits 0-2 cost `A` and bits 4
+and up cost `8A`: an interleave, not a stride. With no fitting at all this
+reconstructs a compiled 64x64x3x3 table at 0.99997.
+
+**The cap is the part that unlocks a real network.** `min(Cin, 128)` says a
+convolution wider than 128 input channels is *split into slices*. Until that
+was applied, resnet18d's 256- and 512-channel layers read as noise (0.36);
+with it, `(256,256,3,3)` and `(512,256,3,3)` both locate at 0.9999.
+
+**And one measurement trap worth recording.** Scoring a match by pooling
+output channels reads about 0.9 even when the addressing is perfectly right,
+because every output channel carries its own quantisation scale. Scored *per
+channel* the same layers read 0.9999. A 0.9 that should be 0.9999 looks like
+a nearly-correct layout and invites fiddling with the formula; it was
+actually a wrong metric.
+
+**The result on resnet18d:** 18 of 22 convolutions located and read from an
+11.9 MB table with nothing but each layer's shape and a search for its base
+offset -- **98.5% of its convolution weights**. The blocks are contiguous and
+in graph order, with regular deltas (37,376 bytes between 64-channel layers,
+148,480 between 128-channel ones).
+
+The four that resist are the three 1x1 convolutions (0.62-0.74, and a sweep
+over input-group strides does not improve them) and the 3-channel stem
+(0.92-0.93, clustered around one base, so the signal is there but the padding
+of a 3-channel input is not yet right). Together they are 1.5% of the
+weights.
+
+Test: `test_resnet18d_conv_weights_are_addressable` (Docker, no device).
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4038,13 +4038,103 @@ _WBT2D_PLANE = 36
 _WBT2D_PLANES = (3, 2, 1, 0)  # most significant first
 
 
-def _weight2d_offset(o, i, kh, kw, kernel):
-    """`(byte offset of plane 0, bit shift)` for a 2-D weight."""
+# The shape-parameterised form, recovered by probing one build per index bit
+# (the address is *linear* in the bits of the channel indices, so a bit costs
+# one build rather than a channel costing one). Both units scale with the
+# input channel count and cap at 128: a wider convolution is split into
+# 128-channel slices. See the README's "Reading a real network's weights".
+_WBT2D_UNIT_CAP = 128
+
+
+def _wbt2d_unit(cin):
+    return min(cin, _WBT2D_UNIT_CAP)
+
+
+def _wbt2d_planes(cin):
+    """Byte offsets of the four 2-bit planes, relative to plane 0."""
+    pair = 9 * _wbt2d_unit(cin)
+    return (0, _WBT2D_PLANE, pair, pair + _WBT2D_PLANE)
+
+
+def _weight2d_offset(o, i, kh, kw, kernel, cin=None):
+    """`(byte offset of plane 0, bit shift)` for a 2-D weight.
+
+    `cin` selects the shape-dependent output unit `A = 18 * min(cin, 128)`;
+    omitting it keeps the 8-channel constant the first experiments used.
+    Output-channel bit 3 always costs 72 bytes, bits 0-2 cost `A` each and
+    bits 4 and up cost `8A` -- a bit-interleave, not a stride.
+    """
     flat = kernel * kh + kw
+    kernel_part = 4 * (kernel * kernel - 1 - flat)
+    if cin is None:
+        return _WBT2D_O_STRIDE * o + kernel_part + i // 4, 2 * (i % 4)
+    a = 18 * _wbt2d_unit(cin)
     return (
-        _WBT2D_O_STRIDE * o + 4 * (kernel * kernel - 1 - flat) + i // 4,
-        2 * (i % 4),
-    )
+        a * (o % 8)
+        + 72 * ((o >> 3) & 1)
+        + 8 * a * (o >> 4)
+        + kernel_part
+        + (i % 16) // 4
+        + 144 * (i >> 4)
+    ), 2 * (i % 4)
+
+
+def _read_weight2d_code_at(wbt, base, o, i, kh, kw, kernel, cin):
+    """One INT8 code from a real network's weight block at `base`."""
+    off, shift = _weight2d_offset(o, i, kh, kw, kernel, cin)
+    value = 0
+    for plane in _WBT2D_PLANES:
+        value = (value << 2) | (
+            (wbt[base + off + _wbt2d_planes(cin)[plane]] >> shift) & 0x3
+        )
+    return value
+
+
+def _locate_conv_weights(wbt, weights, step=8, samples=200):
+    """Find a convolution's weight block in a whole network's table, by
+    correlating a *single* output channel -- each channel carries its own
+    quantisation scale, so pooling channels hides the match behind those
+    scales (it reads about 0.9 instead of 0.9999).
+
+    Returns `(best correlation, base offset)`.
+    """
+    cin, kernel = weights.shape[1], weights.shape[2]
+    slice_in = min(cin, _WBT2D_UNIT_CAP)
+    rng = np.random.RandomState(1)
+    count = min(samples, slice_in * kernel * kernel)
+    picks = [
+        (int(rng.randint(slice_in)), int(rng.randint(kernel)), int(rng.randint(kernel)))
+        for _ in range(count)
+    ]
+    target = np.array([weights[0, i, kh, kw] for (i, kh, kw) in picks], dtype=float)
+    rel, shifts = [], []
+    for i, kh, kw in picks:
+        off, shift = _weight2d_offset(0, i, kh, kw, kernel, cin)
+        rel.append(off)
+        shifts.append(shift)
+    rel = np.array(rel)
+    shifts = np.array(shifts)
+    planes = _wbt2d_planes(cin)
+    limit = len(wbt) - int(rel.max()) - max(planes) - 4
+    best = (-2.0, None)
+    centred = target - target.mean()
+    for start in range(0, max(limit, 1), 4096 * 16):
+        bases = np.arange(start, min(start + 4096 * 16, limit), step)
+        if not len(bases):
+            break
+        index = bases[:, None] + rel[None, :]
+        value = np.zeros(index.shape, np.int32)
+        for plane in _WBT2D_PLANES:
+            value = (value << 2) | ((wbt[index + planes[plane]] >> shifts) & 0x3)
+        codes = value.astype(float) - 128
+        codes -= codes.mean(1, keepdims=True)
+        denom = np.sqrt((codes**2).sum(1) * (centred**2).sum())
+        with np.errstate(invalid="ignore", divide="ignore"):
+            corr = np.abs((codes * centred).sum(1) / denom)
+        pick = int(np.nanargmax(corr))
+        if corr[pick] > best[0]:
+            best = (float(corr[pick]), int(bases[pick]))
+    return best
 
 
 def _read_weight2d_code(wbt, o, i, kh, kw, kernel):
@@ -4061,6 +4151,61 @@ def _write_weight2d_code(wbt, o, i, kh, kw, kernel, code):
         bits = (code >> (2 * (len(_WBT2D_PLANES) - 1 - n))) & 0x3
         at = off + _WBT2D_PLANE * plane
         wbt[at] = (wbt[at] & ~(0x3 << shift) & 0xFF) | (bits << shift)
+
+
+def test_resnet18d_conv_weights_are_addressable(tmp_path):
+    """Confirmed real (see the README's "Reading a real network's weights"
+    section): the shape-parameterised 2-D layout locates and reads the
+    convolution weights of a *real* network -- resnet18d, 22 convolutions
+    from 3 to 512 channels in an 11.9 MB weight table -- with nothing but the
+    layer's shape and a search for its base offset.
+
+    The two things that made this work are worth keeping. The output unit
+    `A = 18 * min(cin, 128)` caps: a convolution wider than 128 input
+    channels is split into slices, which is why 256- and 512-channel layers
+    read as noise until the cap is applied. And the match must be scored
+    *per output channel*, because each channel carries its own quantisation
+    scale -- pooling channels reads about 0.9 where the true figure is
+    0.9999. Needs Docker, no device.
+    """
+    # `_build_real_resnet18d` imports convert_onnxmodelzoo, which is what puts
+    # model_zoo on sys.path -- so the build has to come first.
+    path, _, _ = _build_real_resnet18d(str(tmp_path))
+    import model_zoo
+
+    compiled = onnx.load(path)
+    wbt = np.frombuffer(
+        next(i for i in compiled.graph.initializer if i.name == "npu_params").raw_data,
+        dtype=np.uint8,
+    )
+    source = onnx.load(model_zoo.fetch_model("resnet18d_Opset18"))
+    inits = {i.name: i for i in source.graph.initializer}
+
+    # One layer per distinct shape family, including a 256-channel one that
+    # only reads correctly once the 128 cap is applied.
+    for name in ("onnx::Conv_217", "onnx::Conv_223", "onnx::Conv_253"):
+        weights = numpy_helper.to_array(inits[name]).astype(float)
+        correlation, base = _locate_conv_weights(wbt, weights)
+        assert correlation > 0.99, (name, weights.shape, correlation)
+
+        # Read the located block back and check a whole output channel.
+        cin, kernel = weights.shape[1], weights.shape[2]
+        codes = np.array(
+            [
+                [
+                    [
+                        _read_weight2d_code_at(wbt, base, 0, i, kh, kw, kernel, cin)
+                        for kw in range(kernel)
+                    ]
+                    for kh in range(kernel)
+                ]
+                for i in range(min(cin, _WBT2D_UNIT_CAP))
+            ],
+            dtype=float,
+        )
+        truth = weights[0, : min(cin, _WBT2D_UNIT_CAP)]
+        channel = abs(np.corrcoef(truth.ravel(), (codes - 128).ravel())[0, 1])
+        assert channel > 0.999, (name, channel)
 
 
 def test_conv2d_weights_are_int8_split_across_four_bit_planes(tmp_path):


### PR DESCRIPTION
The weight layout stopped at the shapes it had been probed on. Two facts carry it to a real network.

### One build per bit, not per channel

The address is **linear in the bits** of the channel indices -- for 32 channels `base(1)+base(2)+base(4)+base(8)+base(16)` sums exactly to `base(31)`. So fifteen builds characterise a shape where one build per channel would be hopeless.

Probing 8, 32 and 64 channels gives two shape-scaled constants:

```
A = 18 * min(Cin, 128)   output-channel unit
P =  9 * min(Cin, 128)   plane-pair separation

addr(o,i,kh,kw) = A*(o%8) + 72*((o>>3)&1) + 8*A*(o>>4)
                + 4*(K - 1 - (K_w*kh + kw))
                + (i%16)//4 + 144*(i>>4)
planes at 0, 36, P, P+36; bits 2*(i%4), planes 3,2,1,0 most significant first
```

Output-channel bit 3 always costs 72 bytes while bits 0-2 cost `A` and bits 4 and up cost `8A` -- an interleave, not a stride. With no fitting at all this reconstructs a compiled 64x64x3x3 table at **0.99997**.

### The cap is what unlocks a real network

`min(Cin, 128)` says a convolution wider than 128 input channels is **split into slices**. Without it resnet18d's 256- and 512-channel layers read as noise (0.36); with it `(256,256,3,3)` and `(512,256,3,3)` both locate at **0.9999**.

### A measurement trap, recorded because it cost time

Scoring a match by pooling output channels reads about **0.9 even when the addressing is exactly right**, because every output channel carries its own quantisation scale. Scored per channel the same layers read 0.9999. A 0.9 looks like a nearly-correct formula and invites fiddling with it; it was a wrong metric.

### Result

**18 of 22 convolutions located and read** from an 11.9 MB weight table using nothing but each layer's shape and a search for its base offset -- **98.5% of resnet18d's convolution weights**. The blocks are contiguous and in graph order, with regular deltas (37,376 bytes between 64-channel layers, 148,480 between 128-channel ones).

The four that resist are the three 1x1 convolutions (0.62-0.74; a sweep over input-group strides does not improve them) and the 3-channel stem (0.92-0.93, clustered around one base, so the signal is there but the padding of a narrow input is not yet right). Together they are 1.5% of the weights.

resnet18d now stands at: instruction stream reproduced byte-exactly, 98.5% of weights addressable, under 4% of operand values understood.

### Test

`test_resnet18d_conv_weights_are_addressable` (Docker, no device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS