### PR TITLE
mcode: all 22 of resnet18d's convolutions -- the weight table has three layouts

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3693,21 +3693,21 @@ The honest budget for resnet18d today:
 
 | part | size | status |
 | --- | --- | --- |
-| weight table | 11,855,108 B (242x the mcode) | 98.5% of conv weights addressable |
+| weight table | 11,855,108 B (242x the mcode) | 100% of conv weights addressable |
 | mcode stream | 48,320 B | 98.92% explained, round-trips byte-exactly |
 | framing bytes | 28,552 B (59.1% of stream) | emitted from the grammar |
 | value bytes | 19,235 B (39.8%) | 3.81% have a confirmed meaning |
 | header + tail | 760 B | rules known |
 
 So on resnet18d specifically: we can decode and reproduce its instruction
-stream exactly, we can locate and read 98.5% of its convolution weights, and
+stream exactly, we can locate and read *all* of its convolution weights, and
 we understand under 4% of its operand values.
 
 Tests: `test_conv2d_weights_are_int8_split_across_four_bit_planes` (Docker)
 and `test_conv2d_weights_can_be_rewritten_without_pulsar2` (Docker and
 device).
 
-### Reading a real network's weights: 98.5% of resnet18d
+### Reading a real network's weights: all of resnet18d
 
 The sweep that finishes this is cheaper than it looks, because **the address
 is linear in the bits of the channel indices**. For the 32-channel case
@@ -3750,13 +3750,39 @@ offset -- **98.5% of its convolution weights**. The blocks are contiguous and
 in graph order, with regular deltas (37,376 bytes between 64-channel layers,
 148,480 between 128-channel ones).
 
-The four that resist are the three 1x1 convolutions (0.62-0.74, and a sweep
-over input-group strides does not improve them) and the 3-channel stem
-(0.92-0.93, clustered around one base, so the signal is there but the padding
-of a 3-channel input is not yet right). Together they are 1.5% of the
-weights.
+**The last four needed two more packings, and they are not variations -- they
+are different formats.** Neither the 1x1 convolutions nor the 3-channel stem
+bit-slices at all; both store plain INT8 bytes.
 
-Test: `test_resnet18d_conv_weights_are_addressable` (Docker, no device).
+A **1x1 convolution** stores one byte per weight, chunking the input channels
+36 at a time with the next chunk 144 bytes on:
+
+    addr(o,i) = U*((o>>1)&15) + 144*(i//36) + 36*(o&1) + 72*((o>>5)&1) + (i%36)
+    U = 144 * ceil(Cin/36)
+
+A **narrow input** -- the 3-channel stem -- also stores plain bytes, with the
+kernel *row* fastest and the output channel on a flat 36-byte stride:
+
+    addr(o,i,kh,kw) = 36*o + 12*kw + 3*i + kh
+
+Both were found the same way, but with *dense* probe models: a nearly-empty
+weight tensor gets compressed, so flipping one weight's sign inside an
+otherwise dense tensor is what keeps the diff to a single byte. That is worth
+remembering -- an earlier 256-channel probe produced a 37 KB table where the
+weights alone should have taken 590 KB, and the sparsity was the reason.
+
+**resnet18d is now fully covered: 22 of 22 convolutions, 100% of its
+convolution weights.** The stem sits at base 0 and reads at correlation
+1.0000; the three 1x1 layers read at 1.0000; the eighteen bit-sliced layers at
+0.9998 or better.
+
+So the weight table does not have *a* layout. It has at least three, and the
+convolution's shape picks one -- narrow input, 1x1 kernel, or anything wider.
+A generator has to dispatch on shape, which is exactly what
+`_conv_channel0_addresses()` does.
+
+Test: `test_resnet18d_conv_weights_are_addressable` (Docker, no device),
+which locates every one of the 22 layers.
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3685,35 +3685,78 @@ which is exact for every measured channel -- `o = 8` lands at 72, `o = 16` at
 plane pairs also separate by `+288` rather than staying 36 apart, and that
 placement rule is not yet pinned down.
 
-**Where that leaves resnet18d.** Its 22 convolutions are 2-D with 3 to 512
-channels, so every one of them sits past the shapes confirmed above. A search
-over plausible strides for its *first* convolution reaches only 0.43
-correlation, so we cannot currently locate, read or generate resnet18d's
-weights. The block-size arithmetic does line up -- summing the predicted
-per-layer blocks gives 11,208,960 bytes against an actual `npu_params` of
-11,855,108, within 5.8% -- which says the tiling family is right and the
-addressing constants for large channel counts are what is missing.
+**This has since been carried through to resnet18d** -- see the next section.
+The addressing constants for large channel counts turned out to be two
+things: a shape-scaled unit and a cap.
 
 The honest budget for resnet18d today:
 
 | part | size | status |
 | --- | --- | --- |
-| weight table | 11,855,108 B (242x the mcode) | layout not yet decoded at these shapes |
+| weight table | 11,855,108 B (242x the mcode) | 98.5% of conv weights addressable |
 | mcode stream | 48,320 B | 98.92% explained, round-trips byte-exactly |
 | framing bytes | 28,552 B (59.1% of stream) | emitted from the grammar |
 | value bytes | 19,235 B (39.8%) | 3.81% have a confirmed meaning |
 | header + tail | 760 B | rules known |
 
 So on resnet18d specifically: we can decode and reproduce its instruction
-stream exactly, we understand under 4% of its operand values, and its weight
-table -- 242 times the size of everything else -- is not yet addressable. The
-method that cracked the smaller shapes is unchanged and keeps working; what
-it needs is the same single-weight sweep run at 64, 128, 256 and 512
-channels.
+stream exactly, we can locate and read 98.5% of its convolution weights, and
+we understand under 4% of its operand values.
 
 Tests: `test_conv2d_weights_are_int8_split_across_four_bit_planes` (Docker)
 and `test_conv2d_weights_can_be_rewritten_without_pulsar2` (Docker and
 device).
+
+### Reading a real network's weights: 98.5% of resnet18d
+
+The sweep that finishes this is cheaper than it looks, because **the address
+is linear in the bits of the channel indices**. For the 32-channel case
+`base(1) + base(2) + base(4) + base(8) + base(16)` sums exactly to
+`base(31)`, so one build per *bit* suffices where one per channel would be
+hopeless. Fifteen builds characterise a shape.
+
+**Two constants, both shape-dependent.** Probing 8, 32 and 64 channels gives
+the same table twice over:
+
+    A = 18 * min(Cin, 128)      output-channel unit
+    P =  9 * min(Cin, 128)      separation between the two plane pairs
+
+and the full 2-D address is
+
+    addr(o,i,kh,kw) = A*(o%8) + 72*((o>>3)&1) + 8*A*(o>>4)
+                    + 4*(K - 1 - (K_w*kh + kw))
+                    + (i%16)//4 + 144*(i>>4)
+    planes at 0, 36, P, P+36;  bits 2*(i%4), planes 3,2,1,0 most significant first
+
+Output-channel bit 3 always costs 72 bytes while bits 0-2 cost `A` and bits 4
+and up cost `8A`: an interleave, not a stride. With no fitting at all this
+reconstructs a compiled 64x64x3x3 table at 0.99997.
+
+**The cap is the part that unlocks a real network.** `min(Cin, 128)` says a
+convolution wider than 128 input channels is *split into slices*. Until that
+was applied, resnet18d's 256- and 512-channel layers read as noise (0.36);
+with it, `(256,256,3,3)` and `(512,256,3,3)` both locate at 0.9999.
+
+**And one measurement trap worth recording.** Scoring a match by pooling
+output channels reads about 0.9 even when the addressing is perfectly right,
+because every output channel carries its own quantisation scale. Scored *per
+channel* the same layers read 0.9999. A 0.9 that should be 0.9999 looks like
+a nearly-correct layout and invites fiddling with the formula; it was
+actually a wrong metric.
+
+**The result on resnet18d:** 18 of 22 convolutions located and read from an
+11.9 MB table with nothing but each layer's shape and a search for its base
+offset -- **98.5% of its convolution weights**. The blocks are contiguous and
+in graph order, with regular deltas (37,376 bytes between 64-channel layers,
+148,480 between 128-channel ones).
+
+The four that resist are the three 1x1 convolutions (0.62-0.74, and a sweep
+over input-group strides does not improve them) and the 3-channel stem
+(0.92-0.93, clustered around one base, so the signal is there but the padding
+of a 3-channel input is not yet right). Together they are 1.5% of the
+weights.
+
+Test: `test_resnet18d_conv_weights_are_addressable` (Docker, no device).
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4090,6 +4090,84 @@ def _read_weight2d_code_at(wbt, base, o, i, kh, kw, kernel, cin):
     return value
 
 
+def _conv_channel0_addresses(shape):
+    """Where output channel 0's weights live, relative to a layer's base, as
+    `(offsets, shifts or None, plane offsets)`.
+
+    Three packings, chosen by shape -- this is the whole point: the format
+    does not have *a* weight layout, the convolution's shape picks one.
+
+    * a narrow input (under four channels) stores plain INT8 bytes with the
+      kernel row fastest: `3*i + kh + 12*kw`;
+    * a 1x1 convolution stores plain INT8 bytes too, but chunks the input
+      channels 36 at a time with the next chunk 144 bytes on;
+    * anything wider bit-slices into four 2-bit planes (`_weight2d_offset`).
+    """
+    cin, kernel = shape[1], shape[2]
+    if cin < 4:
+        offsets, picks = [], []
+        for i in range(cin):
+            for kh in range(kernel):
+                for kw in range(kernel):
+                    offsets.append(3 * i + kh + 12 * kw)
+                    picks.append((i, kh, kw))
+        return np.array(offsets), None, (0,), picks
+    if kernel == 1:
+        offsets = [144 * (i // 36) + (i % 36) for i in range(cin)]
+        return np.array(offsets), None, (0,), [(i, 0, 0) for i in range(cin)]
+    slice_in = min(cin, _WBT2D_UNIT_CAP)
+    offsets, shifts, picks = [], [], []
+    for i in range(slice_in):
+        for kh in range(kernel):
+            for kw in range(kernel):
+                off, shift = _weight2d_offset(0, i, kh, kw, kernel, cin)
+                offsets.append(off)
+                shifts.append(shift)
+                picks.append((i, kh, kw))
+    return np.array(offsets), np.array(shifts), _wbt2d_planes(cin), picks
+
+
+def _locate_conv_weights_any(wbt, weights, step=4, samples=120):
+    """Locate any convolution's weight block, dispatching on its shape.
+    Scored on a single output channel, since each carries its own scale.
+
+    Every block observed so far starts on a 4-byte boundary, which is what
+    makes a whole-table scan affordable: at `step=1` this search over
+    resnet18d's 22 layers does not finish in a useful time.
+    """
+    offsets, shifts, planes, picks = _conv_channel0_addresses(weights.shape)
+    if len(picks) > samples:
+        keep = np.random.RandomState(1).choice(len(picks), samples, replace=False)
+        offsets = offsets[keep]
+        picks = [picks[k] for k in keep]
+        if shifts is not None:
+            shifts = shifts[keep]
+    target = np.array([weights[0, i, kh, kw] for (i, kh, kw) in picks], dtype=float)
+    centred = target - target.mean()
+    limit = len(wbt) - int(offsets.max()) - max(planes) - 4
+    best = (-2.0, None)
+    for start in range(0, max(limit, 1), 4096 * 32):
+        bases = np.arange(start, min(start + 4096 * 32, limit), step)
+        if not len(bases):
+            break
+        index = bases[:, None] + offsets[None, :]
+        if shifts is None:
+            codes = wbt[index].astype(float) - 128
+        else:
+            value = np.zeros(index.shape, np.int32)
+            for plane in _WBT2D_PLANES:
+                value = (value << 2) | ((wbt[index + planes[plane]] >> shifts) & 0x3)
+            codes = value.astype(float) - 128
+        codes = codes - codes.mean(1, keepdims=True)
+        denom = np.sqrt((codes**2).sum(1) * (centred**2).sum())
+        with np.errstate(invalid="ignore", divide="ignore"):
+            corr = np.abs((codes * centred).sum(1) / denom)
+        pick = int(np.nanargmax(corr))
+        if corr[pick] > best[0]:
+            best = (float(corr[pick]), int(bases[pick]))
+    return best
+
+
 def _locate_conv_weights(wbt, weights, step=8, samples=200):
     """Find a convolution's weight block in a whole network's table, by
     correlating a *single* output channel -- each channel carries its own
@@ -4181,8 +4259,21 @@ def test_resnet18d_conv_weights_are_addressable(tmp_path):
     source = onnx.load(model_zoo.fetch_model("resnet18d_Opset18"))
     inits = {i.name: i for i in source.graph.initializer}
 
-    # One layer per distinct shape family, including a 256-channel one that
-    # only reads correctly once the 128 cap is applied.
+    # Every convolution in the network, all three packings.
+    convs = [
+        n.input[1]
+        for n in source.graph.node
+        if n.op_type == "Conv" and len(n.input) > 1 and n.input[1] in inits
+    ]
+    assert len(convs) == 22, len(convs)
+    located = 0
+    for name in convs:
+        weights = numpy_helper.to_array(inits[name]).astype(float)
+        correlation, base = _locate_conv_weights_any(wbt, weights)
+        assert correlation > 0.99, (name, weights.shape, correlation)
+        located += 1
+    assert located == 22, located
+
     for name in ("onnx::Conv_217", "onnx::Conv_223", "onnx::Conv_253"):
         weights = numpy_helper.to_array(inits[name]).astype(float)
         correlation, base = _locate_conv_weights(wbt, weights)

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4038,13 +4038,103 @@ _WBT2D_PLANE = 36
 _WBT2D_PLANES = (3, 2, 1, 0)  # most significant first
 
 
-def _weight2d_offset(o, i, kh, kw, kernel):
-    """`(byte offset of plane 0, bit shift)` for a 2-D weight."""
+# The shape-parameterised form, recovered by probing one build per index bit
+# (the address is *linear* in the bits of the channel indices, so a bit costs
+# one build rather than a channel costing one). Both units scale with the
+# input channel count and cap at 128: a wider convolution is split into
+# 128-channel slices. See the README's "Reading a real network's weights".
+_WBT2D_UNIT_CAP = 128
+
+
+def _wbt2d_unit(cin):
+    return min(cin, _WBT2D_UNIT_CAP)
+
+
+def _wbt2d_planes(cin):
+    """Byte offsets of the four 2-bit planes, relative to plane 0."""
+    pair = 9 * _wbt2d_unit(cin)
+    return (0, _WBT2D_PLANE, pair, pair + _WBT2D_PLANE)
+
+
+def _weight2d_offset(o, i, kh, kw, kernel, cin=None):
+    """`(byte offset of plane 0, bit shift)` for a 2-D weight.
+
+    `cin` selects the shape-dependent output unit `A = 18 * min(cin, 128)`;
+    omitting it keeps the 8-channel constant the first experiments used.
+    Output-channel bit 3 always costs 72 bytes, bits 0-2 cost `A` each and
+    bits 4 and up cost `8A` -- a bit-interleave, not a stride.
+    """
     flat = kernel * kh + kw
+    kernel_part = 4 * (kernel * kernel - 1 - flat)
+    if cin is None:
+        return _WBT2D_O_STRIDE * o + kernel_part + i // 4, 2 * (i % 4)
+    a = 18 * _wbt2d_unit(cin)
     return (
-        _WBT2D_O_STRIDE * o + 4 * (kernel * kernel - 1 - flat) + i // 4,
-        2 * (i % 4),
-    )
+        a * (o % 8)
+        + 72 * ((o >> 3) & 1)
+        + 8 * a * (o >> 4)
+        + kernel_part
+        + (i % 16) // 4
+        + 144 * (i >> 4)
+    ), 2 * (i % 4)
+
+
+def _read_weight2d_code_at(wbt, base, o, i, kh, kw, kernel, cin):
+    """One INT8 code from a real network's weight block at `base`."""
+    off, shift = _weight2d_offset(o, i, kh, kw, kernel, cin)
+    value = 0
+    for plane in _WBT2D_PLANES:
+        value = (value << 2) | (
+            (wbt[base + off + _wbt2d_planes(cin)[plane]] >> shift) & 0x3
+        )
+    return value
+
+
+def _locate_conv_weights(wbt, weights, step=8, samples=200):
+    """Find a convolution's weight block in a whole network's table, by
+    correlating a *single* output channel -- each channel carries its own
+    quantisation scale, so pooling channels hides the match behind those
+    scales (it reads about 0.9 instead of 0.9999).
+
+    Returns `(best correlation, base offset)`.
+    """
+    cin, kernel = weights.shape[1], weights.shape[2]
+    slice_in = min(cin, _WBT2D_UNIT_CAP)
+    rng = np.random.RandomState(1)
+    count = min(samples, slice_in * kernel * kernel)
+    picks = [
+        (int(rng.randint(slice_in)), int(rng.randint(kernel)), int(rng.randint(kernel)))
+        for _ in range(count)
+    ]
+    target = np.array([weights[0, i, kh, kw] for (i, kh, kw) in picks], dtype=float)
+    rel, shifts = [], []
+    for i, kh, kw in picks:
+        off, shift = _weight2d_offset(0, i, kh, kw, kernel, cin)
+        rel.append(off)
+        shifts.append(shift)
+    rel = np.array(rel)
+    shifts = np.array(shifts)
+    planes = _wbt2d_planes(cin)
+    limit = len(wbt) - int(rel.max()) - max(planes) - 4
+    best = (-2.0, None)
+    centred = target - target.mean()
+    for start in range(0, max(limit, 1), 4096 * 16):
+        bases = np.arange(start, min(start + 4096 * 16, limit), step)
+        if not len(bases):
+            break
+        index = bases[:, None] + rel[None, :]
+        value = np.zeros(index.shape, np.int32)
+        for plane in _WBT2D_PLANES:
+            value = (value << 2) | ((wbt[index + planes[plane]] >> shifts) & 0x3)
+        codes = value.astype(float) - 128
+        codes -= codes.mean(1, keepdims=True)
+        denom = np.sqrt((codes**2).sum(1) * (centred**2).sum())
+        with np.errstate(invalid="ignore", divide="ignore"):
+            corr = np.abs((codes * centred).sum(1) / denom)
+        pick = int(np.nanargmax(corr))
+        if corr[pick] > best[0]:
+            best = (float(corr[pick]), int(bases[pick]))
+    return best
 
 
 def _read_weight2d_code(wbt, o, i, kh, kw, kernel):
@@ -4061,6 +4151,61 @@ def _write_weight2d_code(wbt, o, i, kh, kw, kernel, code):
         bits = (code >> (2 * (len(_WBT2D_PLANES) - 1 - n))) & 0x3
         at = off + _WBT2D_PLANE * plane
         wbt[at] = (wbt[at] & ~(0x3 << shift) & 0xFF) | (bits << shift)
+
+
+def test_resnet18d_conv_weights_are_addressable(tmp_path):
+    """Confirmed real (see the README's "Reading a real network's weights"
+    section): the shape-parameterised 2-D layout locates and reads the
+    convolution weights of a *real* network -- resnet18d, 22 convolutions
+    from 3 to 512 channels in an 11.9 MB weight table -- with nothing but the
+    layer's shape and a search for its base offset.
+
+    The two things that made this work are worth keeping. The output unit
+    `A = 18 * min(cin, 128)` caps: a convolution wider than 128 input
+    channels is split into slices, which is why 256- and 512-channel layers
+    read as noise until the cap is applied. And the match must be scored
+    *per output channel*, because each channel carries its own quantisation
+    scale -- pooling channels reads about 0.9 where the true figure is
+    0.9999. Needs Docker, no device.
+    """
+    # `_build_real_resnet18d` imports convert_onnxmodelzoo, which is what puts
+    # model_zoo on sys.path -- so the build has to come first.
+    path, _, _ = _build_real_resnet18d(str(tmp_path))
+    import model_zoo
+
+    compiled = onnx.load(path)
+    wbt = np.frombuffer(
+        next(i for i in compiled.graph.initializer if i.name == "npu_params").raw_data,
+        dtype=np.uint8,
+    )
+    source = onnx.load(model_zoo.fetch_model("resnet18d_Opset18"))
+    inits = {i.name: i for i in source.graph.initializer}
+
+    # One layer per distinct shape family, including a 256-channel one that
+    # only reads correctly once the 128 cap is applied.
+    for name in ("onnx::Conv_217", "onnx::Conv_223", "onnx::Conv_253"):
+        weights = numpy_helper.to_array(inits[name]).astype(float)
+        correlation, base = _locate_conv_weights(wbt, weights)
+        assert correlation > 0.99, (name, weights.shape, correlation)
+
+        # Read the located block back and check a whole output channel.
+        cin, kernel = weights.shape[1], weights.shape[2]
+        codes = np.array(
+            [
+                [
+                    [
+                        _read_weight2d_code_at(wbt, base, 0, i, kh, kw, kernel, cin)
+                        for kw in range(kernel)
+                    ]
+                    for kh in range(kernel)
+                ]
+                for i in range(min(cin, _WBT2D_UNIT_CAP))
+            ],
+            dtype=float,
+        )
+        truth = weights[0, : min(cin, _WBT2D_UNIT_CAP)]
+        channel = abs(np.corrcoef(truth.ravel(), (codes - 128).ravel())[0, 1])
+        assert channel > 0.999, (name, channel)
 
 
 def test_conv2d_weights_are_int8_split_across_four_bit_planes(tmp_path):


### PR DESCRIPTION
Follow-up to #1228, which reached 18 of 22 layers. The last four needed two more packings -- and they are not variations of the bit-sliced one. **Neither the 1x1 convolutions nor the 3-channel stem bit-slices at all**; both store plain INT8 bytes.

### 1x1 convolutions

One byte per weight, chunking input channels 36 at a time with the next chunk 144 bytes on:

```
addr(o,i) = U*((o>>1)&15) + 144*(i//36) + 36*(o&1) + 72*((o>>5)&1) + (i%36)
U = 144 * ceil(Cin/36)
```

### A narrow input (the 3-channel stem)

Plain bytes again, with the kernel *row* fastest and a flat 36-byte output stride:

```
addr(o,i,kh,kw) = 36*o + 12*kw + 3*i + kh
```

### Both needed dense probe models

A nearly-empty weight tensor gets **compressed** -- an earlier 256-channel probe produced a 37 KB table where the weights alone should have taken 590 KB. The fix is to flip one weight's sign inside an otherwise dense tensor, which keeps the diff to a single byte. Worth remembering for any future probe.

### Result

**resnet18d is fully covered: 22 of 22 convolutions, 100% of its convolution weights.** The stem sits at base 0 and reads at correlation 1.0000, the three 1x1 layers at 1.0000, and the eighteen bit-sliced layers at 0.9998 or better.

So the weight table does not have *a* layout. It has at least three, and the convolution's shape picks one -- narrow input, 1x1 kernel, or anything wider. A generator has to dispatch on shape, which is what `_conv_channel0_addresses()` does.

resnet18d now stands at: instruction stream reproduced byte-exactly, **all** convolution weights locatable and readable, and under 4% of operand values understood.

### Note on the search

It runs at step 4 -- every block observed starts on a 4-byte boundary, and at step 1 a whole-table scan across 22 layers does not finish in a useful time. The test takes about two minutes.

### Test

`test_resnet18d_conv_weights_are_addressable` now locates every one of the 22 layers (Docker, no device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS