### PR TITLE
mixed_precision: rank layers by a per-channel Hessian-diagonal saliency

### DIFF
--- a/onnxsim/mixed_precision.py
+++ b/onnxsim/mixed_precision.py
@@ -21,21 +21,36 @@ sensitive layers, block-wise INT8), choosing which one each layer gets
 from a data-driven **sensitivity score**, then reusing existing
 graph-construction machinery for both.
 
-**The sensitivity score.** For a layer with weight ``W`` and calibration
-activation ``X``, this asks "how much would this layer's *output* change
-if ``W`` were quantized to INT4?" -- not just "how big is the raw
-quantization error", which ignores that a layer whose input is typically
-tiny barely matters even with a large per-weight error. Concretely:
+**The sensitivity score.** For a layer with weight ``W`` ([N, K]) and
+calibration activation ``X`` ([rows, K]), this asks "how much would this
+layer's *output* change if ``W`` were quantized to INT4?" -- not just "how
+big is the raw quantization error", which ignores that some input channels
+barely matter (tiny or rarely-large activation) even if their own weight
+column has a large per-element error. Concretely, per input channel ``k``:
 
-    mse = mean((W - INT4_dequant(W))^2)     -- INT4's own reconstruction error
-    sensitivity = mse * mean(X^2)           -- scaled by typical input magnitude
+    diag_h[k] = mean_rows(X[:, k] ** 2)          -- diag(X^T X) / rows
+    e[n, k]   = W[n, k] - INT4_dequant(W)[n, k]  -- INT4's own reconstruction error
+    sensitivity = mean_n( sum_k diag_h[k] * e[n, k] ** 2 )
 
-``mean(X^2)`` is the same per-layer activation-energy signal
-:mod:`onnxsim.duquant`'s own sensitivity ranking is built on (there,
-per-channel; here, a single per-layer scalar, since the decision being
-made -- INT4 vs INT8 -- is per-layer, not per-channel). Layers are ranked
-by this score; the top ``high_bits_fraction`` (by count, most sensitive
-first) get block-wise INT8 (:func:`onnxsim.quantize_weight_only_int8_block`'s
+``diag_h`` is the diagonal of the same per-layer reconstruction-error
+Hessian ``H = X^T X`` that :mod:`onnxsim.gptq` builds and inverts for a
+different purpose (correcting *which* integer each weight rounds to, given
+its neighbors, via ``H^{-1}``) -- here only the cheap diagonal is needed,
+since the decision being made (INT4 vs INT8) is per-layer, not per-weight,
+so there's nothing to gain from the off-diagonal (cross-channel) terms
+GPTQ's own correction relies on. ``sensitivity`` is thus the diagonal
+(channel-independent) approximation of the true curvature-weighted error
+``e @ H @ e^T`` -- an Optimal-Brain-Damage-style saliency, ``O(N*K)`` and
+needing no matrix inversion, unlike GPTQ/OBQ's exact per-weight version.
+It improves on a plain ``mean((W - INT4_dequant(W))^2) * mean(X^2)`` scalar
+product (this module's original scheme) exactly when a layer's
+quantization error is concentrated in the *same* channels its activation
+energy is concentrated in -- an outlier channel that is both large-valued
+and strongly activated, exactly the case mixed precision exists to catch --
+since that scalar product averages error and energy independently and so
+can't see that correlation. Layers are ranked by this score; the top
+``high_bits_fraction`` (by count, most sensitive first) get block-wise INT8
+(:func:`onnxsim.quantize_weight_only_int8_block`'s
 own granularity, reimplemented locally here since that function quantizes
 a whole model uniformly and can't be dispatched per-layer); every other
 layer gets ordinary block-wise INT4
@@ -62,7 +77,12 @@ from onnxsim import backend
 # `sys.modules` by the time this module is loaded as part of `import onnxsim`.
 from onnxsim.accuracy import AccuracyDropReport, measure_accuracy_drop
 from onnxsim.adaround import _pack_int4
-from onnxsim.bias_correction import _add_probe_outputs, _all_names, _unique_name
+from onnxsim.bias_correction import (
+    _activation_rows,
+    _add_probe_outputs,
+    _all_names,
+    _unique_name,
+)
 from onnxsim.calibration import Tensors, generate_random_calibration_data
 from onnxsim.omniquant import _quantize_blockwise_int4_with_clip
 from onnxsim.quip_sharp import _match_matmul_like
@@ -111,8 +131,8 @@ def apply_mixed_precision_quantization(
     :param model: the original (unquantized) onnx ModelProto or file path
     :param calibration_data: representative input batches (each a
             ``{input_name: np.ndarray}`` dict matching ``model``'s graph
-            inputs) used to measure each layer's own typical activation
-            magnitude -- see :func:`onnxsim.generate_random_calibration_data`
+            inputs) used to measure each layer's own per-input-channel
+            activation energy -- see :func:`onnxsim.generate_random_calibration_data`
             (the default when omitted) and
             :func:`onnxsim.load_huggingface_calibration_data` (real data,
             a more representative ranking than random input)
@@ -181,26 +201,33 @@ def apply_mixed_precision_quantization(
 
     probe_names = sorted({x_name for _, x_name, _, _, _ in candidates})
     probe_model = _add_probe_outputs(model, probe_names)
-    mean_x_sq: Dict[str, float] = {}
-    counts: Dict[str, int] = {}
+    # diag_h[name]: per-input-channel mean(X^2) -- diag(X^T X) / rows, the
+    # diagonal of the same reconstruction-error Hessian onnxsim.gptq builds
+    # (see module docstring). Accumulated across batches before dividing by
+    # the total row count, exactly like onnxsim.gptq's own H = X^T X.
+    diag_h_sum: Dict[str, np.ndarray] = {}
+    diag_h_rows: Dict[str, int] = {}
     for batch in calibration_data:
         result = backend.run_model(probe_model, batch, providers=providers)
         for name in probe_names:
             x = np.asarray(result[name], dtype=np.float64)
-            total = float(np.sum(x**2))
-            mean_x_sq[name] = mean_x_sq.get(name, 0.0) + total
-            counts[name] = counts.get(name, 0) + x.size
+            for x_rows in _activation_rows([x]):
+                diag_h_sum[name] = diag_h_sum.get(name, 0.0) + np.sum(
+                    x_rows**2, axis=0
+                )
+                diag_h_rows[name] = diag_h_rows.get(name, 0) + x_rows.shape[0]
 
-    for name in list(mean_x_sq):
-        if counts[name] > 0:
-            mean_x_sq[name] /= counts[name]
+    diag_h: Dict[str, np.ndarray] = {
+        name: total / diag_h_rows[name]
+        for name, total in diag_h_sum.items()
+        if diag_h_rows[name] > 0
+    }
 
-    # Sensitivity per candidate: how much INT4 quantization error this
-    # layer's weight would have, scaled by that layer's own typical
-    # (calibration) input magnitude -- see module docstring.
+    # Sensitivity per candidate: an Optimal-Brain-Damage-style,
+    # curvature-weighted INT4 reconstruction error -- see module docstring.
     sensitivities: List[Optional[float]] = []
     for node, x_name, w_name, bias_name, weight_transposed in candidates:
-        if x_name not in mean_x_sq:
+        if x_name not in diag_h:
             sensitivities.append(None)
             continue
         w_init = initializer_map[w_name]
@@ -211,8 +238,8 @@ def apply_mixed_precision_quantization(
         )
         scale_full = np.repeat(scale_blocks_nk, block_size, axis=1)
         dequant_nk = codes_nk * scale_full
-        mse = float(np.mean((w_nk - dequant_nk) ** 2))
-        sensitivities.append(mse * mean_x_sq[x_name])
+        err_sq_nk = (w_nk - dequant_nk) ** 2
+        sensitivities.append(float(np.mean(err_sq_nk @ diag_h[x_name])))
 
     eligible_idx = [i for i, s in enumerate(sensitivities) if s is not None]
     eligible_idx.sort(key=lambda i: sensitivities[i] or 0.0, reverse=True)

--- a/tests/test_mixed_precision.py
+++ b/tests/test_mixed_precision.py
@@ -151,6 +151,83 @@ def test_mixed_precision_declines_below_opset21():
     assert result.SerializeToString() == model.SerializeToString()
 
 
+def _two_independent_layer_model(K=8, N=4, block_size=4, seed=0):
+    # Two UNCHAINED MatMuls sharing the exact same weight values (so their
+    # raw INT4 quantization MSE is identical), each block_size-wide K split
+    # into a "noisy" block (large-magnitude weights -> large absolute
+    # per-block quantization error) and a "quiet" block (tiny weights ->
+    # tiny error). This isolates a case a single-scalar
+    # `mse * mean(activation^2)` sensitivity score (this module's original
+    # heuristic) cannot distinguish -- both layers have the same overall MSE
+    # -- from the per-input-channel Hessian-diagonal score, which can: see
+    # test_mixed_precision_prefers_layer_whose_error_and_activation_energy_coincide.
+    rng = np.random.default_rng(seed)
+    assert K % block_size == 0 and K // block_size == 2  # exactly one noisy, one quiet block
+    w = np.concatenate(
+        [
+            rng.standard_normal((N, block_size)) * 1.0,  # noisy block (cols 0:block_size)
+            rng.standard_normal((N, block_size)) * 0.02,  # quiet block
+        ],
+        axis=1,
+    ).T.astype(np.float32)  # [K, N], transB=0 layout
+    nodes = [
+        onnx.helper.make_node("MatMul", ["Xp", "W"], ["Yp"]),
+        onnx.helper.make_node("MatMul", ["Xq", "W"], ["Yq"]),
+    ]
+    return _model(
+        nodes,
+        [_vi("Xp", ["batch", K]), _vi("Xq", ["batch", K])],
+        [_vi("Yp", ["batch", N]), _vi("Yq", ["batch", N])],
+        [_f32(w, "W")],
+    )
+
+
+def test_mixed_precision_prefers_layer_whose_error_and_activation_energy_coincide():
+    # Both MatMuls use the identical weight `W` above (identical MSE either
+    # way), so a sensitivity score built from one scalar mean(activation^2)
+    # per layer cannot tell them apart *if* their overall activation energy
+    # also happens to match -- exactly arranged here (`xp`/`xq` are the same
+    # values with their two blocks swapped, so both layers see the same
+    # total sum(activation^2)). The per-input-channel Hessian-diagonal score
+    # (this module's current scheme) can still tell them apart: "p"'s large
+    # activations land on the noisy (high quantization error) block, "q"'s
+    # land on the quiet block, so "p" is the genuinely more sensitive layer
+    # and must be the one promoted to INT8.
+    K, N, block_size = 8, 4, 4
+    model = _two_independent_layer_model(K=K, N=N, block_size=block_size, seed=11)
+
+    rng = np.random.default_rng(12)
+    noisy_block = rng.standard_normal((6, block_size)) * 5.0
+    quiet_block = rng.standard_normal((6, block_size)) * 0.02
+    xp = np.concatenate([noisy_block, quiet_block], axis=1).astype(np.float32)
+    xq = np.concatenate([quiet_block, noisy_block], axis=1).astype(np.float32)
+    # The two layers' overall activation energy is identical by construction
+    # (same blocks, swapped) -- the old single-scalar heuristic would have
+    # tied them.
+    assert np.isclose(np.sum(xp**2), np.sum(xq**2))
+
+    q = onnxsim.apply_mixed_precision_quantization(
+        model,
+        calibration_data=[{"Xp": xp, "Xq": xq}],
+        high_bits_fraction=0.5,  # exactly one of the two layers gets INT8
+        block_size=block_size,
+    )
+    # Both candidates quantize the same initializer name ("W"), so identify
+    # each new MatMul's own codes by tracing its input back to Xp/Xq instead
+    # of by initializer name.
+    matmuls = [n for n in q.graph.node if n.op_type == "MatMul"]
+    dequant_of = {n.output[0]: n for n in q.graph.node if n.op_type == "DequantizeLinear"}
+    codes_dtype_by_input = {}
+    for mm in matmuls:
+        x_name, w_dequant_name = mm.input
+        dq = dequant_of[w_dequant_name]
+        codes_init = next(t for t in q.graph.initializer if t.name == dq.input[0])
+        codes_dtype_by_input[x_name] = codes_init.data_type
+
+    assert codes_dtype_by_input["Xp"] == onnx.TensorProto.INT8
+    assert codes_dtype_by_input["Xq"] == onnx.TensorProto.INT4
+
+
 # --------------------------------------------------------------------------- #
 # search_mixed_precision_for_budget
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Replace the mse * mean(X^2) scalar-product sensitivity score with a
diagonal-Hessian-weighted one: diag_h[k] = mean(X[:,k]^2) (the same
diag(X^T X) term onnxsim.gptq already computes, just not inverted),
weighting each input channel's own INT4 reconstruction error by how
strongly that channel is actually activated. This distinguishes layers
the old scalar score could only tie -- e.g. two layers with identical
weight-quantization MSE and identical overall activation energy, but
where the error and the energy concentrate in different channels.

Adds a regression test constructing exactly that tie case and asserting
the layer whose error and activation energy coincide gets promoted to
INT8 instead of the other one.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01191kynr9LZrZ5amohqeFf8