### PR TITLE
mcode: the same register carries two different spatial rules

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3829,7 +3829,41 @@ So the operand budget moves from one confirmed field to two, and there is now
 a repeatable procedure for the rest: sweep, align by signature, split into
 moving bitfields, fit, and discard whatever a held-out configuration refutes.
 
-Test: `test_spatial_extent_lives_in_three_bits_of_b0_03` (Docker, no device).
+**Scaling the procedure up says the remaining operands are mostly not shape
+functions at all.** A larger sweep -- 28 training builds varying `Cin`,
+`Cout`, length, kernel, dilation *and* stride, against six held-out
+combinations -- finds 28 operand slots that move. Fitting each moving
+bitfield against nineteen derived quantities a convolution engine plausibly
+holds (raw parameters, padding, dilated kernel extent, output length, and
+each of those in 4- or 16-element tiles, plus `Cin*k`, `Cin*L`, `Cout*Lout`),
+allowing any one- or two-term exact affine combination, yields exactly **one**
+field that also survives the held-out set: the same `length/16 - 1`.
+
+That is a strong negative, and it points somewhere specific. Of the 28 moving
+slots, **25 carry values above 4096** and only 3 are small enough to be
+counts. Large, shape-sensitive, not affine in any shape quantity -- that is
+what an *allocator output* looks like. The compiler is choosing buffer
+addresses, and an address depends on the order and size of every prior
+allocation, not on the current layer's shape alone.
+
+One more measurement supports the reading: **no slot moves with dilation
+unless it also moves with a size parameter.** Dilation changes no tensor
+size, so a register that tracked dilation alone would have to be a genuine
+configuration field; there is not one. Every dilation-sensitive operand is
+sensitive to sizes too, consistent with dilation changing what gets buffered
+rather than being programmed directly.
+
+For a generator this reframes the remaining work. It is not "decode 154 more
+constants". Most of those operands cannot be computed from a layer's shape at
+all -- they require reproducing the compiler's allocator, which is a
+different and much larger problem than the weight table turned out to be.
+
+Test: `test_spatial_extent_lives_in_three_bits_of_b0_03` (Docker, no device)
+covers the confirmed field and its four invariances. The wider
+characterisation above -- the 28 moving slots, the 25 address-like values, the
+absence of a dilation-only register -- comes from the 34-build sweep in this
+session's notes rather than from a regression test; it is a measurement of
+this toolchain version, not an invariant worth 34 Docker builds per CI run.
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3865,6 +3865,55 @@ absence of a dilation-only register -- comes from the 34-build sweep in this
 session's notes rather than from a regression test; it is a measurement of
 this toolchain version, not an invariant worth 34 Docker builds per CI run.
 
+### The same register, two spatial rules
+
+Running the same procedure over *2-D* convolutions -- 23 training builds
+sweeping `Cin`, `Cout`, height, width and kernel, against four held-out
+combinations -- first produced two apparent survivors, and both were wrong.
+Catching them sharpened the method.
+
+**A held-out set only falsifies what it actually varies.** The two candidates
+were quadratic in the kernel size, fitted to the three kernel values in the
+sweep with three free parameters -- exact by construction. The held-out
+configurations reused those same three kernel values, so they could not
+refute a kernel-only model. Extrapolating one to `k = 7` predicts **-9** for
+a two-bit field; the measured value is 0. A held-out set has to contain
+unseen *values* of whatever a candidate depends on, not merely unseen
+combinations.
+
+**What the register actually holds in 2-D.** The same `a1 b0.03` bits 4 to 6
+carry
+
+    floor((W + 2*pad - 1) / 32)
+
+the index of the last 32-wide tile of the *padded* width. Confirmed in
+**32 of 32** configurations, including four widths never swept. It follows
+the innermost dimension only: sweeping the height from 16 to 80 does not move
+it at all.
+
+**And it is not the 1-D rule.** For a 1-D convolution the same bits hold
+`floor((L - 1) / 16)` -- a 16-wide tile over the *unpadded* length. Two
+differences, both real:
+
+| | tile | padding |
+| --- | --- | --- |
+| 1-D | 16 | unpadded (`k` does not move it) |
+| 2-D | 32 | padded (`k` moves it) |
+
+The padding difference is visible only at an exact multiple of the tile,
+where a 1x1 and a 3x3 kernel disagree by one -- which is exactly the single
+configuration that a `floor(W/32)` reading gets wrong (31 of 32).
+
+So a register's meaning is not fixed by its address: this one is spatial in
+both layouts, but *what* it measures and *how* it tiles depend on the
+convolution's dimensionality. That is the same lesson the weight table
+taught -- the shape picks the encoding -- now showing up in the instruction
+stream.
+
+Tests: `test_spatial_extent_lives_in_three_bits_of_b0_03` and
+`test_the_spatial_field_follows_the_innermost_dimension_in_2d` (Docker, no
+device).
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4609,6 +4609,53 @@ def test_spatial_extent_lives_in_three_bits_of_b0_03(tmp_path):
         assert field_for(**overrides) == reference, overrides
 
 
+def test_the_spatial_field_follows_the_innermost_dimension_in_2d(tmp_path):
+    """Confirmed real (see the README's "The same register, two spatial
+    rules" section): in a *2-D* convolution the same `a1 b0.03` bits 4 to 6
+    hold
+
+        floor((W + 2*pad - 1) / 32)
+
+    -- the index of the last 32-wide tile of the *padded* width. It follows
+    the innermost dimension only: sweeping the height from 16 to 80 does not
+    move it at all.
+
+    Two details separate this from the 1-D rule for the same register, and
+    both are the kind of thing a single formula would paper over: the tile is
+    32 wide rather than 16, and the width is padded where the 1-D length is
+    not -- which is visible only at an exact multiple of the tile, where a
+    1x1 and a 3x3 kernel disagree. Needs Docker, no device.
+    """
+    cin = cout = 32
+    height = 32
+
+    seen = []
+
+    def field_for(width, kernel=3, h=height):
+        seen.append(1)
+        work = tmp_path / f"w{width}k{kernel}h{h}_{len(seen)}"
+        work.mkdir()
+        model = _one_conv2d_model(cin, cout, max(h, width), kernel)
+        # `_one_conv2d_model` is square; build the rectangle by hand.
+        model.graph.input[0].type.tensor_type.shape.dim[2].dim_value = h
+        model.graph.input[0].type.tensor_type.shape.dim[3].dim_value = width
+        model.graph.output[0].type.tensor_type.shape.dim[2].dim_value = h
+        model.graph.output[0].type.tensor_type.shape.dim[3].dim_value = width
+        mcode = _build_single_op(str(work), "m", model)
+        return _operand_field(mcode, 0xA1, 0xB0, 0x03, 4, 6)
+
+    for width in (32, 64, 96):
+        assert field_for(width) == (width + 2 - 1) // 32, width
+
+    # The height does not move it.
+    assert field_for(64, h=16) == field_for(64, h=80), "height must not matter"
+
+    # At an exact multiple of the tile the padding shows: a 1x1 kernel pads
+    # nothing and lands one tile lower than a 3x3.
+    assert field_for(32, kernel=1) == (32 - 1) // 32
+    assert field_for(32, kernel=3) == (32 + 2 - 1) // 32
+
+
 def test_single_conv_program_encodes_its_output_channel_count(tmp_path):
     """Confirmed real (see the README's "The first operand with a known
     meaning" section): in a program holding exactly one convolution, the

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4586,9 +4586,8 @@ def test_spatial_extent_lives_in_three_bits_of_b0_03(tmp_path):
 
     def field_for(**overrides):
         cfg = dict(base, **overrides)
-        work = tmp_path / "_".join(
-            f"{k}{v}" for k, v in sorted(overrides.items()) or [("base", 0)]
-        )
+        name = "_".join(f"{k}{v}" for k, v in sorted(overrides.items())) or "base"
+        work = tmp_path / name
         work.mkdir()
         model = _one_conv_model(
             cfg["cin"],


### PR DESCRIPTION
Running the operand-discovery procedure over **2-D** convolutions -- 23 training builds sweeping `Cin`, `Cout`, height, width and kernel, against four held-out combinations.

### First, two false positives, and what they taught

The run produced two apparent survivors. Both were wrong, and catching them sharpened the method:

> **A held-out set only falsifies what it actually varies.**

Both candidates were quadratic in kernel size, fitted to the sweep's three kernel values with three free parameters -- exact by construction. The held-out configurations reused those same three kernel values, so they could not refute a kernel-only model. Extrapolating one to `k = 7` predicts **-9** for a two-bit field; the measured value is **0**.

A held-out set must contain unseen *values* of whatever a candidate depends on, not merely unseen combinations. That is now recorded in the README alongside the procedure.

### What the register actually holds in 2-D

The same `a1 b0.03` bits 4 to 6 carry

```
floor((W + 2*pad - 1) / 32)
```

the index of the last 32-wide tile of the **padded** width. Confirmed in **32 of 32** configurations, including four widths never swept. It follows the innermost dimension only -- sweeping the height from 16 to 80 does not move it at all.

### And it is not the 1-D rule

For a 1-D convolution the same bits hold `floor((L - 1) / 16)`: a 16-wide tile over the **unpadded** length.

| | tile | padding |
| --- | --- | --- |
| 1-D | 16 | unpadded (`k` does not move it) |
| 2-D | 32 | padded (`k` moves it) |

The padding difference is visible only at an exact multiple of the tile, where a 1x1 and a 3x3 kernel disagree by one -- which is exactly the single configuration a simpler `floor(W/32)` reading gets wrong (31 of 32).

### The point

A register's meaning is **not fixed by its address**. This one is spatial in both layouts, but *what* it measures and *how* it tiles depend on the convolution's dimensionality. That is the same lesson the weight table taught -- the shape picks the encoding -- now showing up in the instruction stream, and it means a generator must dispatch on shape there too.

### Tests

- `test_spatial_extent_lives_in_three_bits_of_b0_03` (1-D rule and its four invariances)
- `test_the_spatial_field_follows_the_innermost_dimension_in_2d` (2-D rule, height invariance, and the padding difference at an exact tile multiple)

Both Docker, no device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS