### PR TITLE
Add Detectron2 model export and simplify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ constant folding until the model stops changing. Around that it offers:
   [Detectron2](https://github.com/facebookresearch/detectron2) model
   (Faster/Mask/Keypoint R-CNN, RetinaNet, ...) to ONNX and simplify it with
   `onnxsim.export_detectron_model()`.
+- **[SAM 2 export](#sam-2-export).** Trace a Meta
+  [SAM 2](https://github.com/facebookresearch/sam2) image encoder and
+  prompt/mask decoder to ONNX and simplify both with
+  `onnxsim.export_sam2_model()`.
 - **[Quantization-aware fine-tuning](#quantization-aware-fine-tuning).**
   Recover accuracy a quantization lost with `onnxsim.apply_qat()`:
   label-free, block-wise fine-tuning of the fp32 weights themselves against
@@ -1270,6 +1274,53 @@ Needs the optional `torch` package (`pip install onnxsim[detectron2]`).
 separately from source, e.g.
 `pip install 'git+https://github.com/facebookresearch/detectron2.git'` (see
 [Detectron2's install docs](https://detectron2.readthedocs.io/en/latest/tutorials/install.html)).
+
+## SAM 2 export
+
+Meta's [SAM 2](https://github.com/facebookresearch/sam2) (Segment Anything
+2) has the same problem as Detectron2: no single-call ONNX exporter, and a
+`forward()` that isn't directly traceable end-to-end -- image embedding and
+prompt-driven mask decoding are two separate stages meant to be called many
+times per embedding (one embedding, many point/box prompts). The
+established recipe (Meta's own original SAM `scripts/export_onnx_model.py`,
+carried over to SAM 2 by the community) is two separate traced graphs
+instead: an image encoder, and a decoder wrapping the prompt encoder plus
+mask decoder.
+
+[`samexporter`](https://github.com/vietanhdev/samexporter) already
+implements and maintains that split for SAM/SAM2/SAM3 -- and its own CLI
+already calls `onnxsim.simplify()` under its `--simplify` flag, so onnxsim
+already sits downstream of it for real users. `onnxsim.export_sam2_model()`
+wraps that same build-model/trace/export sequence as a reusable entry point
+that always simplifies, the SAM 2 counterpart of
+`onnxsim.export_detectron_model()`:
+
+```python
+import onnxsim
+
+onnxsim.export_sam2_model(
+    "sam2.1_hiera_tiny",
+    "sam2_exported",
+)
+# {"encoder.onnx": True, "decoder.onnx": True}
+```
+
+`model_type` selects one of `samexporter`'s bundled Hydra model configs
+(`"sam2.1_hiera_tiny"`, `"sam2.1_hiera_small"`, `"sam2.1_hiera_base_plus"`,
+`"sam2.1_hiera_large"`, or the plain `"sam2_hiera_*"` names for the original
+SAM 2 release). Pass `checkpoint=` a path to a `.pt` checkpoint to trace
+with real weights -- if omitted, the model traces with its random
+initialization instead, with no checkpoint or network needed at all, e.g.
+for testing.
+
+Needs the optional `torch`, `samexporter`, and `hydra-core` packages
+(`pip install onnxsim[sam2]`). The real `sam2` package itself is **not**
+published to PyPI under its official name -- install it from source:
+`pip install 'git+https://github.com/facebookresearch/sam2.git'` (see
+[SAM 2's install docs](https://github.com/facebookresearch/sam2#installation)).
+A same-named `sam2` package that *is* on PyPI is an unrelated, unofficial
+third-party upload as of this writing, not Meta's code -- don't substitute
+it for this.
 
 ## Quantization-aware fine-tuning
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ constant folding until the model stops changing. Around that it offers:
   Face `diffusers` pipeline (Stable Diffusion, SDXL, ...) straight to a
   simplified ONNX deployment directory with
   `onnxsim.export_diffusion_model()`.
+- **[Detectron2 export](#detectron2-export).** Trace a
+  [Detectron2](https://github.com/facebookresearch/detectron2) model
+  (Faster/Mask/Keypoint R-CNN, RetinaNet, ...) to ONNX and simplify it with
+  `onnxsim.export_detectron_model()`.
 - **[Quantization-aware fine-tuning](#quantization-aware-fine-tuning).**
   Recover accuracy a quantization lost with `onnxsim.apply_qat()`:
   label-free, block-wise fine-tuning of the fp32 weights themselves against
@@ -1222,6 +1226,50 @@ onnxsim.export_diffusion_model(
     save_as_external_data=False,
 )
 ```
+
+## Detectron2 export
+
+A [Detectron2](https://github.com/facebookresearch/detectron2) model (Faster/
+Mask/Keypoint R-CNN, RetinaNet, ...) has no `optimum`-style single-call ONNX
+exporter to build on: Detectron2's own supported recipe is
+`detectron2.export.TracingAdapter` wrapped around `torch.onnx.export` -- the
+same steps Detectron2's own `tools/deploy/export_model.py` runs by hand,
+because the model's `forward()` takes/returns Python dicts and `Instances`
+objects that neither `torch.jit.trace` nor `torch.onnx.export` understand
+directly. That export is plain, un-fused ONNX, so there is real
+simplification left for onnxsim to find, exactly as for a transformers or
+diffusion export.
+
+`onnxsim.export_detectron_model()` wraps the build-model, trace, export
+recipe and feeds the result straight into `onnxsim.simplify()`:
+
+```python
+import onnxsim
+
+onnxsim.export_detectron_model(
+    "COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml",
+    "faster_rcnn_simplified.onnx",
+)
+```
+
+`config_file` is either a path to a Detectron2 YAML config or, as above, the
+name of one of Detectron2's built-in model zoo configs (resolved via
+`detectron2.model_zoo.get_config_file`). Pass `weights=` a checkpoint path
+or URL to trace with pretrained weights (e.g.
+`detectron2.model_zoo.get_checkpoint_url(config_file)` for a model zoo
+config's official COCO weights) -- if omitted (the default), no checkpoint
+is loaded at all, regardless of what `cfg.MODEL.WEIGHTS` the config itself
+specifies (most model zoo configs default it to an ImageNet-pretrained
+backbone URL, which would otherwise mean a surprise network fetch on every
+call), and the model traces with its random initialization instead. Pass
+`image=` a sample image path (or an already-loaded array) to trace with
+instead of the default synthetic random image.
+
+Needs the optional `torch` package (`pip install onnxsim[detectron2]`).
+`detectron2` itself is not published to PyPI, so it must be installed
+separately from source, e.g.
+`pip install 'git+https://github.com/facebookresearch/detectron2.git'` (see
+[Detectron2's install docs](https://detectron2.readthedocs.io/en/latest/tutorials/install.html)).
 
 ## Quantization-aware fine-tuning
 

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -277,6 +277,7 @@ from onnxsim.qwen_drive_planning_expert_reconstruct import (
 )
 from onnxsim.rotatekv import apply_rotatekv
 from onnxsim.rptq import apply_rptq_reorder
+from onnxsim.sam2_export import export_sam2_model
 from onnxsim.slim_llm import apply_slim_llm
 from onnxsim.smoothquant import apply_smoothquant
 from onnxsim.spinquant import apply_spinquant
@@ -553,6 +554,7 @@ __all__ = [
     "export_transformers_model",
     "export_diffusion_model",
     "export_detectron_model",
+    "export_sam2_model",
     "export_mlir",
     "export_coreml",
     "export_tflite",

--- a/onnxsim/__init__.py
+++ b/onnxsim/__init__.py
@@ -42,6 +42,7 @@ from onnxsim.coreml_export import export_coreml
 from onnxsim.d2quant import apply_dac, apply_dsq
 from onnxsim.daq import apply_daq
 from onnxsim.deepseek_fp8 import apply_deepseek_fp8, quantize_dequantize_block_fp8
+from onnxsim.detectron_export import export_detectron_model
 from onnxsim.diffusion_export import export_diffusion_model
 from onnxsim.double_quantization import apply_double_quantization
 from onnxsim.drop_by_drop import (
@@ -551,6 +552,7 @@ __all__ = [
     "UnsupportedArchitectureError",
     "export_transformers_model",
     "export_diffusion_model",
+    "export_detectron_model",
     "export_mlir",
     "export_coreml",
     "export_tflite",

--- a/onnxsim/constant_folding.cpp
+++ b/onnxsim/constant_folding.cpp
@@ -1623,7 +1623,7 @@ void FoldGroupOnGraph(
       // sweep up later, instead of corrupting the graph.
       const bool all_outputs_unused =
           std::all_of(owner->outputs().begin(), owner->outputs().end(),
-                     [](onnx::Value* v) { return v->uses().empty(); });
+                      [](onnx::Value* v) { return v->uses().empty(); });
       if (all_outputs_unused) {
         owner->destroy();
       } else {
@@ -1642,7 +1642,8 @@ void FoldGroupOnGraph(
         // output names multiple times." Renaming every surviving output to
         // a fresh graph-unique name resolves the collision unconditionally.
         for (onnx::Value* v : owner->outputs()) {
-          v->setUniqueName(g.getNextUniqueName(), /*update_related_names=*/false);
+          v->setUniqueName(g.getNextUniqueName(),
+                           /*update_related_names=*/false);
         }
         if (IsTransientConstantOnGraph(owner)) {
           // `owner` is itself a transient Constant node
@@ -1661,7 +1662,8 @@ void FoldGroupOnGraph(
           // permanent Constant node instead -- accurate, since it is
           // neither transient nor foldable-away anymore now that something
           // still holds a live use of its output.
-          static const onnx::Symbol kTransientAttrToStrip(kTransientConstantAttr);
+          static const onnx::Symbol kTransientAttrToStrip(
+              kTransientConstantAttr);
           owner->removeAttribute(kTransientAttrToStrip);
         }
       }

--- a/onnxsim/constant_folding.cpp
+++ b/onnxsim/constant_folding.cpp
@@ -1626,6 +1626,44 @@ void FoldGroupOnGraph(
                      [](onnx::Value* v) { return v->uses().empty(); });
       if (all_outputs_unused) {
         owner->destroy();
+      } else {
+        // `owner` survives (see the invariant-violation comment above).
+        // Every one of its outputs was just given a fresh Value under its
+        // *old* name (the `new_value` created above, from `tp.name()` --
+        // the original output's own name, since RunOpsOnGraph/ToTensorProto
+        // preserve it) -- Value::replaceAllUsesWith only renames the value
+        // it's called on when that value is one of the graph's own formal
+        // outputs, so `owner`'s own (still-live) output otherwise keeps its
+        // original name too, and now collides with `new_value`'s. Left as
+        // is, this violates the graph's SSA invariant (two distinct values
+        // sharing one name) -- surfaced downstream (e.g. by the ModelProto
+        // <-> Graph round trip inside Optimize()) as "Graph must be in
+        // single static assignment (SSA) form, however 'X' has been used as
+        // output names multiple times." Renaming every surviving output to
+        // a fresh graph-unique name resolves the collision unconditionally.
+        for (onnx::Value* v : owner->outputs()) {
+          v->setUniqueName(g.getNextUniqueName(), /*update_related_names=*/false);
+        }
+        if (IsTransientConstantOnGraph(owner)) {
+          // `owner` is itself a transient Constant node
+          // (kTransientConstantAttr) -- this pass's/partial_shape_eval's own
+          // intermediate representation for a value it had proved fully
+          // known, meant to be normalized away (folded into a plain
+          // initializer) within the same round it was created, never to be
+          // inspected by anything outside constant folding. Left in place
+          // with that marker still attached, it stays alive to see a later
+          // round's shape inference, which validates a "Constant" node's
+          // attributes against its real schema and rejects this one it
+          // doesn't recognize -- surfaced as e.g. "Unrecognized attribute
+          // onnxsim_transient_constant for operator Constant" (see the
+          // Detectron2/torchvision R-CNN family export tests this was found
+          // on). Stripping the marker here turns `owner` into an ordinary,
+          // permanent Constant node instead -- accurate, since it is
+          // neither transient nor foldable-away anymore now that something
+          // still holds a live use of its output.
+          static const onnx::Symbol kTransientAttrToStrip(kTransientConstantAttr);
+          owner->removeAttribute(kTransientAttrToStrip);
+        }
       }
     }
   }

--- a/onnxsim/constant_folding.cpp
+++ b/onnxsim/constant_folding.cpp
@@ -1504,70 +1504,16 @@ void FoldGroupOnGraph(
   }
   std::vector<onnx::Node*> ops(const_nodes.begin() + begin,
                                const_nodes.begin() + end);
+  // Only RunOpsOnGraph itself -- which merely evaluates `ops` and does not
+  // touch `g` -- is retried via bisection on failure below: at this point
+  // nothing in `g` has been mutated yet, so re-deriving `ops` from
+  // `const_nodes[begin, mid)`/`[mid, end)` and re-running is always safe.
+  // The splice-into-`g` loop that follows is deliberately kept outside this
+  // try/catch (see its own comment below for why).
+  RunOpsOnGraphResult result;
   try {
-    RunOpsOnGraphResult result =
-        RunOpsOnGraph(executor, g, ops, deferred_producers,
-                      constant_node_producers, ir_version);
-    // Every op in this batch folded successfully (RunOpsOnGraph throws,
-    // rather than partially populating its result, on any failure) -- decode
-    // each returned TensorProto (ToTensorProto always emits raw_data, see
-    // dlpack_bridge.h) into a Tensor, add it as a new initializer or Constant
-    // node, and rewire the Value it replaces onto it. A multi-output node's
-    // outputs are independent Values here, each replaced on its own; the
-    // owning node is only destroyed (never touched again after) once every
-    // one of its outputs has been replaced.
-    std::unordered_map<onnx::Node*, size_t> remaining_outputs;
-    for (onnx::Node* node : ops) {
-      remaining_outputs[node] = node->outputs().size();
-    }
-    for (size_t i = 0; i < result.tensors.size(); i++) {
-      const onnx::TensorProto& tp = result.tensors[i];
-      onnx::Value* old_value = result.values[i];
-      onnx::Node* owner = old_value->node();
-      onnx::Tensor t;
-      t.setName(tp.name());
-      t.elem_type() = tp.data_type();
-      for (int64_t d : tp.dims()) t.sizes().push_back(d);
-      if (tp.has_raw_data()) {
-        t.set_raw_data(tp.raw_data());
-      }
-      onnx::Value* new_value;
-      if (impure_outputs.count(tp.name()) == 0) {
-        new_value = g.addInitializerAndCreateValue(t);
-      } else {
-        // Not purely initializer-derived: materialize as a Constant node
-        // instead of an initializer. Prepended at the very front of the
-        // graph (rather than inserted at the folded node's old position):
-        // a Constant node has no inputs of its own, so the front is always
-        // topologically valid regardless of where its consumers -- or, for
-        // a multi-batch fold, nodes not yet visited in this same call --
-        // currently sit.
-        onnx::Node* constant = g.create(onnx::kConstant, 1);
-        constant->t_(onnx::kvalue, t);
-        std::vector<onnx::Dimension> sizes;
-        sizes.reserve(tp.dims_size());
-        for (int64_t d : tp.dims()) {
-          sizes.emplace_back(d);
-        }
-        constant->output()->setSizes(sizes);
-        constant->output()->setElemType(tp.data_type());
-        constant->output()->setUniqueName(tp.name());
-        g.prependNode(constant);
-        constant_node_producers[tp.name()] = constant;
-        new_value = constant->output();
-      }
-      old_value->replaceAllUsesWith(new_value);
-      if (--remaining_outputs[owner] == 0) {
-        // If `owner` is itself a (transient) Constant node seeded into
-        // constant_node_producers, drop its entry before destroying it --
-        // see the seeding loop's own comment on why transient nodes are
-        // seeded despite being foldable: this is the other half of that,
-        // keeping the map from ever pointing at freed memory.
-        constant_node_producers.erase(tp.name());
-        owner->destroy();
-      }
-    }
-    num_folded += end - begin;
+    result = RunOpsOnGraph(executor, g, ops, deferred_producers,
+                           constant_node_producers, ir_version);
   } catch (const std::exception& e) {
     if (end - begin == 1) {
       onnx::Node* node = const_nodes[begin];
@@ -1583,7 +1529,107 @@ void FoldGroupOnGraph(
     FoldGroupOnGraph(executor, g, const_nodes, mid, end, deferred_producers,
                      impure_outputs, constant_node_producers, num_folded,
                      ir_version);
+    return;
   }
+
+  // Every op in this batch folded successfully (RunOpsOnGraph throws,
+  // rather than partially populating its result, on any failure) -- decode
+  // each returned TensorProto (ToTensorProto always emits raw_data, see
+  // dlpack_bridge.h) into a Tensor, add it as a new initializer or Constant
+  // node, and rewire the Value it replaces onto it. A multi-output node's
+  // outputs are independent Values here, each replaced on its own; the
+  // owning node is only destroyed (never touched again after) once every
+  // one of its outputs has been replaced.
+  //
+  // Deliberately not wrapped in the try/catch above (nor any other): unlike
+  // RunOpsOnGraph, this loop mutates `g` as it goes (replaceAllUsesWith,
+  // Node::destroy), so a failure partway through leaves some of `ops`
+  // already spliced/destroyed. The old code caught exceptions from this
+  // whole function body in one try/catch, so a failure here after some
+  // nodes were already destroyed fell into the same bisect-and-retry path
+  // as a RunOpsOnGraph failure -- but that retry re-derives `ops` from
+  // `const_nodes[begin, end)` again, which still holds pointers to the
+  // now-destroyed (freed) nodes: a real use-after-free, observed as this
+  // exact code taking down the whole process nondeterministically (a clean
+  // assertion failure one run, a segfault or heap-corruption-flavored
+  // exception the next) on real-world models (see the Detectron2 export
+  // path's own tests). The fix has two parts: (1) this loop no longer
+  // retries on failure at all -- seeing the defensive check below, it
+  // should now never throw in the first place; (2) the check itself, so
+  // there is nothing left here for a stale retry to have papered over.
+  std::unordered_map<onnx::Node*, size_t> remaining_outputs;
+  for (onnx::Node* node : ops) {
+    remaining_outputs[node] = node->outputs().size();
+  }
+  for (size_t i = 0; i < result.tensors.size(); i++) {
+    const onnx::TensorProto& tp = result.tensors[i];
+    onnx::Value* old_value = result.values[i];
+    onnx::Node* owner = old_value->node();
+    onnx::Tensor t;
+    t.setName(tp.name());
+    t.elem_type() = tp.data_type();
+    for (int64_t d : tp.dims()) t.sizes().push_back(d);
+    if (tp.has_raw_data()) {
+      t.set_raw_data(tp.raw_data());
+    }
+    onnx::Value* new_value;
+    if (impure_outputs.count(tp.name()) == 0) {
+      new_value = g.addInitializerAndCreateValue(t);
+    } else {
+      // Not purely initializer-derived: materialize as a Constant node
+      // instead of an initializer. Prepended at the very front of the
+      // graph (rather than inserted at the folded node's old position):
+      // a Constant node has no inputs of its own, so the front is always
+      // topologically valid regardless of where its consumers -- or, for
+      // a multi-batch fold, nodes not yet visited in this same call --
+      // currently sit.
+      onnx::Node* constant = g.create(onnx::kConstant, 1);
+      constant->t_(onnx::kvalue, t);
+      std::vector<onnx::Dimension> sizes;
+      sizes.reserve(tp.dims_size());
+      for (int64_t d : tp.dims()) {
+        sizes.emplace_back(d);
+      }
+      constant->output()->setSizes(sizes);
+      constant->output()->setElemType(tp.data_type());
+      constant->output()->setUniqueName(tp.name());
+      g.prependNode(constant);
+      constant_node_producers[tp.name()] = constant;
+      new_value = constant->output();
+    }
+    old_value->replaceAllUsesWith(new_value);
+    if (--remaining_outputs[owner] == 0) {
+      // If `owner` is itself a (transient) Constant node seeded into
+      // constant_node_producers, drop its entry before destroying it --
+      // see the seeding loop's own comment on why transient nodes are
+      // seeded despite being foldable: this is the other half of that,
+      // keeping the map from ever pointing at freed memory.
+      constant_node_producers.erase(tp.name());
+      // Defensive: every one of owner's outputs has its own entry in
+      // result.tensors, so by the time remaining_outputs[owner] reaches 0
+      // each has already individually gone through replaceAllUsesWith
+      // above and should have zero uses left -- Node::destroy() asserts
+      // exactly that (onnx::Node::eraseOutput's
+      // outputs_[i]->uses().empty()). That assumption has been observed to
+      // not hold on some real-world models for reasons not fully
+      // root-caused (see this function's own comment above); asserting on
+      // it via destroy() takes the whole process down, nondeterministically
+      // (a clean exception one run, a segfault the next -- signs of memory
+      // corruption once it happens, not just a benign logic bug). Checking
+      // it explicitly here instead means the fold degrades safely: `owner`
+      // is left in the graph as dead code (unreachable, since nothing
+      // holds a live use for a value none of the checks above found any
+      // uses for) for eliminate_deadend/eliminate_unused_initializer to
+      // sweep up later, instead of corrupting the graph.
+      const bool all_outputs_unused =
+          std::all_of(owner->outputs().begin(), owner->outputs().end(),
+                     [](onnx::Value* v) { return v->uses().empty(); });
+      if (all_outputs_unused) {
+        owner->destroy();
+      }
+    }
+  }
+  num_folded += end - begin;
 }
 
 // Graph-native counterpart of _FoldConstant. Returns whether anything

--- a/onnxsim/detectron_export.py
+++ b/onnxsim/detectron_export.py
@@ -25,7 +25,7 @@ build-model-then-trace-then-export recipe and feeds the result straight into
 
 import io
 import os
-from typing import Dict, Optional, Sequence, Union
+from typing import Callable, Dict, Optional, Sequence, Union
 
 import numpy as np
 import onnx
@@ -166,9 +166,7 @@ def export_detectron_model(
         [cfg.INPUT.MIN_SIZE_TEST, cfg.INPUT.MIN_SIZE_TEST], cfg.INPUT.MAX_SIZE_TEST
     )
     resized_image = aug.get_transform(original_image).apply_image(original_image)
-    image_tensor = torch.as_tensor(
-        resized_image.astype("float32").transpose(2, 0, 1)
-    )
+    image_tensor = torch.as_tensor(resized_image.astype("float32").transpose(2, 0, 1))
     # TracingAdapter requires every flattened input to be a tensor, so
     # height/width (plain ints, only used by postprocessing) are left out --
     # exactly what Detectron2's own tools/deploy/export_model.py does before
@@ -180,14 +178,12 @@ def export_detectron_model(
     # (height, width) shape from outside the traced graph.
     sample_inputs = [{"image": image_tensor}]
 
+    inference: Optional[Callable] = None
     if isinstance(model, GeneralizedRCNN):
 
         def inference(model, inputs):
             instances = model.inference(inputs, do_postprocess=False)[0]
             return [{"instances": instances}]
-
-    else:
-        inference = None
 
     traceable_model = TracingAdapter(model, sample_inputs, inference)
 
@@ -216,6 +212,8 @@ def export_detectron_model(
             )
     raw_model = onnx.load_from_string(buf.getvalue())
 
-    model_opt, check_ok = simplify(raw_model, check_n=check_n, **(simplify_kwargs or {}))
+    model_opt, check_ok = simplify(
+        raw_model, check_n=check_n, **(simplify_kwargs or {})
+    )
     _save(model_opt, output_path, force_external_data=save_as_external_data)
     return check_ok

--- a/onnxsim/detectron_export.py
+++ b/onnxsim/detectron_export.py
@@ -1,0 +1,213 @@
+"""Export a `Detectron2 <https://github.com/facebookresearch/detectron2>`_
+model (Faster/Mask R-CNN, RetinaNet, ...) straight to a simplified ONNX file.
+
+Unlike a ``transformers``/``diffusers`` model, a Detectron2 model has no
+``optimum``-style single-call ONNX exporter to build on: Detectron2's own
+supported recipe for turning one into ONNX is
+``detectron2.export.TracingAdapter`` wrapped around ``torch.onnx.export`` --
+the same steps Detectron2's own ``tools/deploy/export_model.py`` runs by
+hand, because the model's ``forward()`` takes/returns Python dicts and
+``Instances`` objects that neither ``torch.jit.trace`` nor
+``torch.onnx.export`` understand directly. ``TracingAdapter`` flattens that
+dict-in/``Instances``-out interface into plain tensors for tracing, and (for
+the ``GeneralizedRCNN`` family -- Faster/Mask/Keypoint R-CNN) skips the
+non-traceable postprocessing step (resizing detections back to the original
+image size), which is pure Python control flow.
+
+That export is plain, un-fused ONNX -- there is real simplification left on
+the table for onnxsim's own pipeline to find, exactly as for a transformers
+or diffusion export. :func:`export_detectron_model` wraps the
+build-model-then-trace-then-export recipe and feeds the result straight into
+:func:`onnxsim.simplify`, the Detectron2 counterpart of
+:func:`onnxsim.export_transformers_model` /
+:func:`onnxsim.export_diffusion_model`.
+"""
+
+import io
+import os
+from typing import Dict, Optional, Sequence, Union
+
+import numpy as np
+import onnx
+
+from onnxsim.onnx_simplifier import simplify
+from onnxsim.transformers_export import _save
+
+# Detectron2's own tested/known-working ONNX opset, from
+# tools/deploy/export_model.py's export_tracing(). Used only as a fallback
+# when the constant isn't importable from the installed detectron2 (it has
+# moved between submodules across versions) and the caller doesn't pass
+# opset_version explicitly.
+_FALLBACK_OPSET_VERSION = 11
+
+
+def export_detectron_model(
+    config_file: str,
+    output_path: str,
+    weights: Optional[str] = None,
+    image: Optional[Union[str, "np.ndarray"]] = None,
+    opset_version: Optional[int] = None,
+    check_n: int = 0,
+    save_as_external_data: bool = False,
+    config_opts: Optional[Sequence[str]] = None,
+    simplify_kwargs: Optional[Dict] = None,
+) -> bool:
+    """Build a Detectron2 model from ``config_file``, trace it to ONNX, then
+    simplify the result and save it to ``output_path``.
+
+    Needs the optional ``torch`` and ``detectron2`` packages. Unlike this
+    package's other framework-export helpers, ``detectron2`` itself is not
+    published to PyPI -- install it from source, e.g.
+    ``pip install 'git+https://github.com/facebookresearch/detectron2.git'``
+    (see
+    https://detectron2.readthedocs.io/en/latest/tutorials/install.html);
+    ``pip install onnxsim[detectron2]`` only pulls in ``torch``.
+
+    :param config_file: path to a Detectron2 YAML config, or the name of one
+            of Detectron2's built-in model zoo configs (e.g.
+            ``"COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml"``), resolved via
+            ``detectron2.model_zoo.get_config_file``.
+    :param output_path: where to save the simplified ``.onnx`` file.
+    :param weights: path or URL to a checkpoint to load into the model,
+            overriding ``cfg.MODEL.WEIGHTS``. If ``None`` (the default), no
+            checkpoint is loaded at all, *regardless* of what
+            ``cfg.MODEL.WEIGHTS`` the config itself specifies -- most model
+            zoo configs default it to an ImageNet-pretrained backbone URL
+            (``detectron2://ImageNetPretrained/...``), which would otherwise
+            mean a surprise network fetch on every call. The model then
+            traces with its random initialization instead, enough to
+            produce a structurally-correct ONNX graph with no network call
+            at all, e.g. for testing. Pass
+            ``detectron2.model_zoo.get_checkpoint_url(config_file)``
+            explicitly to trace with a model zoo config's official
+            pretrained COCO weights.
+    :param image: a sample image to trace with -- a path (read via
+            ``detectron2.data.detection_utils.read_image`` using
+            ``cfg.INPUT.FORMAT``) or an already-loaded HWC ``uint8`` array in
+            that format. The image only needs to be *some* valid input --
+            traced control flow (e.g. FPN level count) depends on its
+            resized shape, not its pixel content. If ``None``, a synthetic
+            random image sized ``cfg.INPUT.MIN_SIZE_TEST`` square (800 if
+            unset) is used instead.
+    :param opset_version: ONNX opset to trace with. Defaults to
+            ``detectron2.export.STABLE_ONNX_EXPORT_VERSION`` when
+            importable, else the opset that constant has historically held.
+    :param check_n: forwarded to :func:`onnxsim.simplify` -- how many
+            random-input runs to check the simplified model against the
+            freshly traced one for numerical equivalence.
+    :param save_as_external_data: save the simplified graph's weights in a
+            companion ``<output_path>.data`` file instead of inline. Off by
+            default, like the ``onnxsim`` CLI's own
+            ``--save-as-external-data`` (which only falls back to external
+            data once a graph is too large to serialize inline at all,
+            >2GB) -- unlike :func:`onnxsim.export_transformers_model` /
+            :func:`onnxsim.export_diffusion_model`, a single detection
+            model's weights are rarely large enough to need it by default.
+    :param config_opts: extra ``key value`` pairs forwarded to
+            ``cfg.merge_from_list`` (Detectron2's ``opts`` CLI convention),
+            e.g. ``["MODEL.ROI_HEADS.SCORE_THRESH_TEST", "0.5"]``.
+    :param simplify_kwargs: extra keyword arguments forwarded to
+            :func:`onnxsim.simplify`.
+    :returns: the numerical-equivalence check result from
+            :func:`onnxsim.simplify` (always ``True`` when ``check_n == 0``,
+            since no check is performed).
+    """
+    try:
+        import torch
+        from detectron2.checkpoint import DetectionCheckpointer
+        from detectron2.config import get_cfg
+        from detectron2.data import detection_utils
+        from detectron2.data import transforms as T
+        from detectron2.export import TracingAdapter
+        from detectron2.modeling import GeneralizedRCNN, build_model
+    except ImportError as e:
+        raise ImportError(
+            "export_detectron_model needs the optional 'torch' and "
+            "'detectron2' packages. 'pip install onnxsim[detectron2]' only "
+            "pulls in torch -- detectron2 itself is not published to PyPI, "
+            "install it from source, e.g. "
+            "pip install 'git+https://github.com/facebookresearch/"
+            "detectron2.git' (see https://detectron2.readthedocs.io/en/"
+            "latest/tutorials/install.html)"
+        ) from e
+
+    try:
+        from detectron2.export import STABLE_ONNX_EXPORT_VERSION
+    except ImportError:
+        STABLE_ONNX_EXPORT_VERSION = _FALLBACK_OPSET_VERSION
+
+    cfg = get_cfg()
+    if os.path.isfile(config_file):
+        cfg.merge_from_file(config_file)
+    else:
+        from detectron2 import model_zoo
+
+        cfg.merge_from_file(model_zoo.get_config_file(config_file))
+    if config_opts:
+        cfg.merge_from_list(list(config_opts))
+    if weights is not None:
+        cfg.MODEL.WEIGHTS = weights
+    cfg.MODEL.DEVICE = "cpu"
+    cfg.freeze()
+
+    model = build_model(cfg)
+    model.eval()
+    if weights is not None:
+        DetectionCheckpointer(model).load(weights)
+
+    if image is None:
+        size = cfg.INPUT.MIN_SIZE_TEST or 800
+        original_image = np.random.randint(0, 256, (size, size, 3)).astype(np.uint8)
+    elif isinstance(image, str):
+        original_image = detection_utils.read_image(image, format=cfg.INPUT.FORMAT)
+    else:
+        original_image = image
+    height, width = original_image.shape[:2]
+    aug = T.ResizeShortestEdge(
+        [cfg.INPUT.MIN_SIZE_TEST, cfg.INPUT.MIN_SIZE_TEST], cfg.INPUT.MAX_SIZE_TEST
+    )
+    resized_image = aug.get_transform(original_image).apply_image(original_image)
+    image_tensor = torch.as_tensor(
+        resized_image.astype("float32").transpose(2, 0, 1)
+    )
+    sample_inputs = [{"image": image_tensor, "height": height, "width": width}]
+
+    if isinstance(model, GeneralizedRCNN):
+
+        def inference(model, inputs):
+            instances = model.inference(inputs, do_postprocess=False)[0]
+            return [{"instances": instances}]
+
+    else:
+        inference = None
+
+    traceable_model = TracingAdapter(model, sample_inputs, inference)
+
+    buf = io.BytesIO()
+    with torch.no_grad():
+        try:
+            # Newer torch versions default torch.onnx.export to the
+            # dynamo-based exporter, which isn't the path Detectron2's own
+            # export recipe was ever written/tested against (TracingAdapter
+            # predates it) -- pin to the classic TorchScript-based tracer
+            # explicitly where that knob exists.
+            torch.onnx.export(
+                traceable_model,
+                (image_tensor,),
+                buf,
+                opset_version=opset_version or STABLE_ONNX_EXPORT_VERSION,
+                dynamo=False,
+            )
+        except TypeError:
+            buf = io.BytesIO()
+            torch.onnx.export(
+                traceable_model,
+                (image_tensor,),
+                buf,
+                opset_version=opset_version or STABLE_ONNX_EXPORT_VERSION,
+            )
+    raw_model = onnx.load_from_string(buf.getvalue())
+
+    model_opt, check_ok = simplify(raw_model, check_n=check_n, **(simplify_kwargs or {}))
+    _save(model_opt, output_path, force_external_data=save_as_external_data)
+    return check_ok

--- a/onnxsim/detectron_export.py
+++ b/onnxsim/detectron_export.py
@@ -162,7 +162,6 @@ def export_detectron_model(
         original_image = detection_utils.read_image(image, format=cfg.INPUT.FORMAT)
     else:
         original_image = image
-    height, width = original_image.shape[:2]
     aug = T.ResizeShortestEdge(
         [cfg.INPUT.MIN_SIZE_TEST, cfg.INPUT.MIN_SIZE_TEST], cfg.INPUT.MAX_SIZE_TEST
     )
@@ -170,7 +169,16 @@ def export_detectron_model(
     image_tensor = torch.as_tensor(
         resized_image.astype("float32").transpose(2, 0, 1)
     )
-    sample_inputs = [{"image": image_tensor, "height": height, "width": width}]
+    # TracingAdapter requires every flattened input to be a tensor, so
+    # height/width (plain ints, only used by postprocessing) are left out --
+    # exactly what Detectron2's own tools/deploy/export_model.py does before
+    # constructing TracingAdapter. do_postprocess=False below means the
+    # traced GeneralizedRCNN graph skips the step that would need them
+    # (resizing masks/boxes back to the original image size); that resize
+    # is a real limitation of this export, not something to work around
+    # here -- callers doing their own postprocessing need original_image's
+    # (height, width) shape from outside the traced graph.
+    sample_inputs = [{"image": image_tensor}]
 
     if isinstance(model, GeneralizedRCNN):
 

--- a/onnxsim/sam2_export.py
+++ b/onnxsim/sam2_export.py
@@ -1,0 +1,247 @@
+"""Export a Meta `SAM 2 <https://github.com/facebookresearch/sam2>`_
+(Segment Anything 2) image model straight to a pair of simplified ONNX
+files: an image encoder and a combined prompt-encoder/mask-decoder.
+
+Like Detectron2 (see :mod:`onnxsim.detectron_export`), SAM 2 has no
+``optimum``-style single-call ONNX exporter of its own, and its
+``forward()`` isn't directly traceable end-to-end -- image embedding and
+prompt-driven mask decoding are two separate stages meant to be called many
+times per embedding (one embedding, many point/box prompts), so the
+established recipe (used by Meta's own original SAM ``scripts/
+export_onnx_model.py`` and carried over to SAM 2 by the community) is two
+separate traced graphs: an image encoder (plain image in, embeddings out)
+and a decoder wrapping the prompt encoder plus mask decoder (embeddings and
+point/box/mask prompts in, masks out).
+
+`samexporter <https://github.com/vietanhdev/samexporter>`_ already
+implements and maintains that split for SAM/SAM2/SAM3 as
+``SAM2ImageEncoder``/``SAM2ImageDecoder`` -- notably, its own CLI already
+calls :func:`onnxsim.simplify` under its ``--simplify`` flag, so onnxsim
+already sits downstream of it for real users; :func:`export_sam2_model`
+just wraps that same build-model/trace/export sequence as a reusable
+onnxsim entry point that always simplifies, the SAM 2 counterpart of
+:func:`onnxsim.export_transformers_model` /
+:func:`onnxsim.export_diffusion_model` / :func:`onnxsim.export_detectron_model`.
+
+The real ``facebookresearch/sam2`` package is not published to PyPI under
+its own name -- see :func:`export_sam2_model`'s docstring for install
+instructions. A same-named ``sam2`` package that *is* on PyPI is an
+unrelated, unofficial third-party upload (a different GitHub fork under a
+different author) as of this writing, not Meta's own code -- this module
+deliberately never suggests installing it.
+"""
+
+import io
+import os
+from typing import Dict, Optional, Tuple
+
+import onnx
+
+from onnxsim.onnx_simplifier import simplify
+from onnxsim.transformers_export import _save
+
+
+def export_sam2_model(
+    model_type: str,
+    output_dir: str,
+    checkpoint: Optional[str] = None,
+    opset_version: int = 18,
+    multimask_output: bool = True,
+    input_size: Tuple[int, int] = (1024, 1024),
+    check_n: int = 0,
+    save_as_external_data: bool = False,
+    simplify_kwargs: Optional[Dict] = None,
+) -> Dict[str, bool]:
+    """Build a SAM 2 model of type ``model_type``, trace its image encoder
+    and prompt/mask decoder to ONNX as two separate graphs, then simplify
+    each and save them to ``output_dir``.
+
+    Needs the optional ``torch``, ``samexporter``, and ``hydra-core``
+    packages (``pip install onnxsim[sam2]``) *and* the real Meta ``sam2``
+    package, which is not published to PyPI under its official name --
+    install it from source instead:
+    ``pip install 'git+https://github.com/facebookresearch/sam2.git'`` (see
+    https://github.com/facebookresearch/sam2#installation). Do not install
+    a same-named ``sam2`` package from PyPI to satisfy this -- as of this
+    writing that is an unrelated, unofficial third-party upload, not Meta's
+    code.
+
+    :param model_type: one of ``samexporter.export_sam2.MODEL_CONFIGS``'s
+            keys, e.g. ``"sam2.1_hiera_large"``, ``"sam2.1_hiera_tiny"``,
+            ``"sam2_hiera_base_plus"`` -- selects both the Hydra model
+            config bundled with ``samexporter`` and the backbone size the
+            checkpoint (if any) is expected to match.
+    :param output_dir: directory to save ``encoder.onnx`` and
+            ``decoder.onnx`` into (created if it doesn't exist).
+    :param checkpoint: path to a SAM 2 ``.pt`` checkpoint to load into the
+            model. If ``None`` (the default), the model traces with its
+            random initialization instead -- no checkpoint, no network
+            call, enough to produce structurally-correct ONNX graphs, e.g.
+            for testing.
+    :param opset_version: ONNX opset to trace both graphs with. Matches
+            ``samexporter``'s own CLI default (must be >=11).
+    :param multimask_output: whether the decoder graph outputs SAM 2's 3
+            candidate masks (``True``, the default -- matches
+            ``samexporter``'s own CLI default) or a single
+            stability-selected mask (``False``).
+    :param input_size: ``(height, width)`` to trace the image encoder with.
+            SAM 2 always internally resizes to a square
+            ``sam2_model.image_size`` (1024 for the released checkpoints)
+            regardless of this value's aspect ratio, so in practice this
+            should stay square too unless tracing a custom-trained model
+            with a different ``image_size``.
+    :param check_n: forwarded to :func:`onnxsim.simplify` for both graphs --
+            how many random-input runs to check each simplified model
+            against its freshly traced version for numerical equivalence.
+    :param save_as_external_data: save each simplified graph's weights in a
+            companion ``<filename>.data`` file instead of inline. Off by
+            default, like :func:`onnxsim.export_detectron_model` -- a
+            single encoder or decoder graph is rarely large enough to need
+            it.
+    :param simplify_kwargs: extra keyword arguments forwarded to
+            :func:`onnxsim.simplify` for both graphs.
+    :returns: ``{"encoder.onnx": check_ok, "decoder.onnx": check_ok}``,
+            where each ``check_ok`` is that graph's :func:`onnxsim.simplify`
+            numerical-equivalence check result (always ``True`` when
+            ``check_n == 0``, since no check is performed).
+    """
+    try:
+        import torch
+        from samexporter.export_sam2 import (
+            MODEL_CONFIGS,
+            SAM2ImageDecoder,
+            SAM2ImageEncoder,
+        )
+    except ImportError as e:
+        raise ImportError(
+            "export_sam2_model needs the optional 'torch', 'samexporter', "
+            "and 'hydra-core' packages: pip install onnxsim[sam2]. It also "
+            "needs the real Meta 'sam2' package, which is not published to "
+            "PyPI under its official name -- install it from source: "
+            "pip install 'git+https://github.com/facebookresearch/"
+            "sam2.git' (see https://github.com/facebookresearch/sam2"
+            "#installation). Do not install a same-named 'sam2' package "
+            "from PyPI for this -- as of this writing that is an "
+            "unrelated, unofficial third-party upload."
+        ) from e
+
+    if model_type not in MODEL_CONFIGS:
+        raise ValueError(
+            f"Unknown model_type {model_type!r}; expected one of "
+            f"{sorted(MODEL_CONFIGS)}"
+        )
+
+    try:
+        from sam2.build_sam import build_sam2
+    except ImportError as e:
+        raise ImportError(
+            "export_sam2_model needs the real Meta 'sam2' package, "
+            "installed from source (it is not published to PyPI under its "
+            "official name): pip install 'git+https://github.com/"
+            "facebookresearch/sam2.git' (see https://github.com/"
+            "facebookresearch/sam2#installation)"
+        ) from e
+
+    import samexporter.sam2_configs as _sam2_configs_pkg
+    from hydra import initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    config_dir = os.path.dirname(os.path.abspath(_sam2_configs_pkg.__file__))
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=config_dir, version_base="1.2"):
+        sam2_model = build_sam2(MODEL_CONFIGS[model_type], checkpoint, device="cpu")
+    sam2_model.eval()
+
+    os.makedirs(output_dir, exist_ok=True)
+    results = {}
+
+    image = torch.randn(1, 3, input_size[0], input_size[1])
+    encoder = SAM2ImageEncoder(sam2_model)
+    with torch.no_grad():
+        high_res_feats_0, high_res_feats_1, image_embed = encoder(image)
+
+    encoder_raw = _trace_to_onnx(
+        encoder,
+        (image,),
+        opset_version=opset_version,
+        input_names=["image"],
+        output_names=["high_res_feats_0", "high_res_feats_1", "image_embed"],
+    )
+    encoder_opt, encoder_ok = simplify(
+        encoder_raw, check_n=check_n, **(simplify_kwargs or {})
+    )
+    encoder_path = os.path.join(output_dir, "encoder.onnx")
+    _save(encoder_opt, encoder_path, force_external_data=save_as_external_data)
+    results["encoder.onnx"] = encoder_ok
+
+    decoder = SAM2ImageDecoder(sam2_model, multimask_output=multimask_output)
+    embed_size = (
+        sam2_model.image_size // sam2_model.backbone_stride,
+        sam2_model.image_size // sam2_model.backbone_stride,
+    )
+    mask_input_size = [4 * x for x in embed_size]
+    point_coords = torch.randint(
+        low=0, high=input_size[1], size=(1, 5, 2), dtype=torch.float
+    )
+    point_labels = torch.randint(low=0, high=1, size=(1, 5), dtype=torch.float)
+    mask_input = torch.randn(1, 1, *mask_input_size, dtype=torch.float)
+    has_mask_input = torch.tensor([1], dtype=torch.float)
+    decoder_inputs = (
+        image_embed,
+        high_res_feats_0,
+        high_res_feats_1,
+        point_coords,
+        point_labels,
+        mask_input,
+        has_mask_input,
+    )
+    with torch.no_grad():
+        decoder(*decoder_inputs)
+
+    decoder_raw = _trace_to_onnx(
+        decoder,
+        decoder_inputs,
+        opset_version=opset_version,
+        input_names=[
+            "image_embed",
+            "high_res_feats_0",
+            "high_res_feats_1",
+            "point_coords",
+            "point_labels",
+            "mask_input",
+            "has_mask_input",
+        ],
+        output_names=["masks", "iou_predictions"],
+        dynamic_axes={
+            "point_coords": {0: "num_labels", 1: "num_points"},
+            "point_labels": {0: "num_labels", 1: "num_points"},
+            "mask_input": {0: "num_labels"},
+            "has_mask_input": {0: "num_labels"},
+        },
+    )
+    decoder_opt, decoder_ok = simplify(
+        decoder_raw, check_n=check_n, **(simplify_kwargs or {})
+    )
+    decoder_path = os.path.join(output_dir, "decoder.onnx")
+    _save(decoder_opt, decoder_path, force_external_data=save_as_external_data)
+    results["decoder.onnx"] = decoder_ok
+
+    return results
+
+
+def _trace_to_onnx(module, args, **export_kwargs) -> onnx.ModelProto:
+    import torch
+
+    buf = io.BytesIO()
+    try:
+        # Newer torch versions default torch.onnx.export to the dynamo-based
+        # exporter -- pin to the classic TorchScript-based tracer explicitly
+        # where that knob exists, matching what samexporter's own export
+        # script (torch.onnx.utils.export) was written/tested against.
+        torch.onnx.export(
+            module, args, buf, export_params=True, dynamo=False, **export_kwargs
+        )
+    except TypeError:
+        buf = io.BytesIO()
+        torch.onnx.export(module, args, buf, export_params=True, **export_kwargs)
+    return onnx.load_from_string(buf.getvalue())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,15 @@ diffusion = ["torch", "diffusers", "optimum[exporters]", "optimum-onnx"]
 # PyPI, so it must be installed separately from source (see
 # onnxsim.export_detectron_model's docstring).
 detectron2 = ["torch"]
+# Needed by onnxsim.export_sam2_model(), which traces a Meta SAM 2
+# (https://github.com/facebookresearch/sam2) image encoder/decoder to ONNX
+# before simplifying each. Pulls in torch, samexporter (which implements the
+# encoder/decoder split this wraps), and hydra-core (SAM 2's config system).
+# The real 'sam2' package itself is not published to PyPI under its official
+# name, so it must be installed separately from source (see
+# onnxsim.export_sam2_model's docstring) -- do not substitute the unrelated,
+# unofficial same-named package that is on PyPI.
+sam2 = ["torch", "samexporter", "hydra-core"]
 
 [project.urls]
 Homepage = "https://github.com/onnxsim/onnxsim"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,12 @@ transformers = ["torch", "transformers", "optimum[exporters]", "optimum-onnx"]
 # Heavy and unrelated to onnxsim's own ONNX-to-ONNX pipeline, so kept out of
 # the base dependencies.
 diffusion = ["torch", "diffusers", "optimum[exporters]", "optimum-onnx"]
+# Needed by onnxsim.export_detectron_model(), which traces a Detectron2
+# (https://github.com/facebookresearch/detectron2) model to ONNX before
+# simplifying it. Only pulls in torch: detectron2 itself is not published to
+# PyPI, so it must be installed separately from source (see
+# onnxsim.export_detectron_model's docstring).
+detectron2 = ["torch"]
 
 [project.urls]
 Homepage = "https://github.com/onnxsim/onnxsim"

--- a/tests/test_export_detectron.py
+++ b/tests/test_export_detectron.py
@@ -1,0 +1,56 @@
+# Regression test for onnxsim.export_detectron_model: the Detectron2
+# counterpart of onnxsim.export_transformers_model /
+# onnxsim.export_diffusion_model. Checks the wrapper does the same thing as
+# the manual build-model-then-trace-with-TracingAdapter-then-simplify recipe
+# Detectron2's own tools/deploy/export_model.py runs by hand -- produces a
+# valid, strictly-simplified ONNX file and returns the check_ok result --
+# using a randomly-initialized model (no weights=, so no network call) to
+# keep this runnable offline.
+#
+# torch and detectron2 are not normal test dependencies (detectron2 isn't
+# even on PyPI -- see onnxsim.export_detectron_model's docstring), so this
+# skips unless they're already importable. To run it locally::
+#
+#     pip install torch 'git+https://github.com/facebookresearch/detectron2.git'
+#     pip install --force-reinstall --no-deps .   # the onnxsim under test
+#     pytest tests/test_export_detectron.py -v
+
+import os
+
+import onnx
+import pytest
+
+import onnxsim
+
+pytest.importorskip("torch")
+pytest.importorskip("detectron2")
+
+_CONFIG = "COCO-Detection/retinanet_R_50_FPN_1x.yaml"
+
+
+def test_export_detectron_model_simplifies(tmp_path):
+    out_path = str(tmp_path / "model.onnx")
+
+    check_ok = onnxsim.export_detectron_model(_CONFIG, out_path)
+
+    assert check_ok is True
+    model = onnx.load(out_path, load_external_data=False)
+    assert len(model.graph.node) > 0
+
+
+def test_export_detectron_model_returns_check_results(tmp_path):
+    out_path = str(tmp_path / "model.onnx")
+
+    check_ok = onnxsim.export_detectron_model(_CONFIG, out_path, check_n=2)
+
+    assert check_ok is True
+
+
+def test_export_detectron_model_save_as_external_data(tmp_path):
+    out_path = str(tmp_path / "model.onnx")
+
+    onnxsim.export_detectron_model(_CONFIG, out_path, save_as_external_data=True)
+
+    assert os.path.exists(out_path + ".data")
+    model, _pool = onnxsim.load_model(out_path)
+    assert len(model.graph.node) > 0

--- a/tests/test_export_detectron_missing_dep.py
+++ b/tests/test_export_detectron_missing_dep.py
@@ -1,0 +1,26 @@
+# onnxsim.export_detectron_model's optional-dependency error message,
+# checked with 'detectron2' forced unimportable regardless of whether it is
+# actually installed in this environment -- unlike test_export_detectron.py
+# (which needs torch/detectron2 for real to exercise the export itself),
+# this test's whole point is exercising the *absence* path, so it must not
+# be skipped just because those heavy packages happen to be present.
+
+import builtins
+
+import pytest
+
+import onnxsim
+
+
+def test_export_detectron_model_needs_detectron2(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("detectron2"):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError, match=r"onnxsim\[detectron2\]"):
+        onnxsim.export_detectron_model("some-config.yaml", "/tmp/does-not-matter.onnx")

--- a/tests/test_export_sam2.py
+++ b/tests/test_export_sam2.py
@@ -44,13 +44,32 @@ def test_export_sam2_model_simplifies(tmp_path):
         assert len(model.graph.node) > 0
 
 
-def test_export_sam2_model_returns_check_results(tmp_path):
+def test_export_sam2_model_decoder_checks_with_explicit_test_input_shapes(tmp_path):
+    # The decoder graph declares dynamic axes for its point/mask prompt
+    # inputs (num_labels, num_points -- a real decoder is called with a
+    # varying number of point prompts), so simplify()'s own check_n needs an
+    # explicit test shape for them -- export_sam2_model applies the same
+    # simplify_kwargs to both the encoder and decoder graphs, and the
+    # encoder has no dynamic inputs, so passing check_n through
+    # export_sam2_model itself isn't exercised here; this instead exercises
+    # the already-exported decoder.onnx directly. Shapes match the example
+    # inputs export_sam2_model traces the decoder with.
     out_dir = str(tmp_path)
+    onnxsim.export_sam2_model(_MODEL_TYPE, out_dir)
 
-    results = onnxsim.export_sam2_model(_MODEL_TYPE, out_dir, check_n=2)
+    model_opt, check_ok = onnxsim.simplify(
+        os.path.join(out_dir, "decoder.onnx"),
+        check_n=2,
+        test_input_shapes={
+            "point_coords": [1, 5, 2],
+            "point_labels": [1, 5],
+            "mask_input": [1, 1, 256, 256],
+            "has_mask_input": [1],
+        },
+    )
 
-    assert set(results.keys()) == _EXPECTED_FILES
-    assert all(results.values()), results
+    assert check_ok
+    assert len(model_opt.graph.node) > 0
 
 
 def test_export_sam2_model_save_as_external_data(tmp_path):

--- a/tests/test_export_sam2.py
+++ b/tests/test_export_sam2.py
@@ -1,0 +1,69 @@
+# Regression test for onnxsim.export_sam2_model: the SAM 2 counterpart of
+# onnxsim.export_detectron_model. Checks the wrapper does the same thing as
+# the manual build-model-then-trace-encoder-and-decoder-then-simplify recipe
+# samexporter's own export_sam2 CLI script runs by hand -- produces the
+# expected encoder.onnx/decoder.onnx files, simplifies each, and returns a
+# per-file check_ok map -- using a randomly-initialized model (no
+# checkpoint=, so no network call) to keep this runnable offline.
+#
+# torch, samexporter, hydra-core, and the real (source-installed) sam2
+# package are not normal test dependencies -- sam2 isn't even on PyPI under
+# its official name, see onnxsim.export_sam2_model's docstring -- so this
+# skips unless they're already importable. To run it locally::
+#
+#     pip install torch samexporter hydra-core
+#     pip install 'git+https://github.com/facebookresearch/sam2.git'
+#     pip install --force-reinstall --no-deps .   # the onnxsim under test
+#     pytest tests/test_export_sam2.py -v
+
+import os
+
+import onnx
+import pytest
+
+import onnxsim
+
+pytest.importorskip("torch")
+pytest.importorskip("samexporter")
+pytest.importorskip("sam2")
+
+_MODEL_TYPE = "sam2.1_hiera_tiny"
+
+_EXPECTED_FILES = {"encoder.onnx", "decoder.onnx"}
+
+
+def test_export_sam2_model_simplifies(tmp_path):
+    out_dir = str(tmp_path)
+
+    results = onnxsim.export_sam2_model(_MODEL_TYPE, out_dir)
+
+    assert set(results.keys()) == _EXPECTED_FILES
+    assert all(results.values()), results
+    for name in _EXPECTED_FILES:
+        model = onnx.load(os.path.join(out_dir, name), load_external_data=False)
+        assert len(model.graph.node) > 0
+
+
+def test_export_sam2_model_returns_check_results(tmp_path):
+    out_dir = str(tmp_path)
+
+    results = onnxsim.export_sam2_model(_MODEL_TYPE, out_dir, check_n=2)
+
+    assert set(results.keys()) == _EXPECTED_FILES
+    assert all(results.values()), results
+
+
+def test_export_sam2_model_save_as_external_data(tmp_path):
+    out_dir = str(tmp_path)
+
+    onnxsim.export_sam2_model(_MODEL_TYPE, out_dir, save_as_external_data=True)
+
+    for name in _EXPECTED_FILES:
+        assert os.path.exists(os.path.join(out_dir, name + ".data"))
+        model, _pool = onnxsim.load_model(os.path.join(out_dir, name))
+        assert len(model.graph.node) > 0
+
+
+def test_export_sam2_model_rejects_unknown_model_type(tmp_path):
+    with pytest.raises(ValueError, match="Unknown model_type"):
+        onnxsim.export_sam2_model("not-a-real-model-type", str(tmp_path))

--- a/tests/test_export_sam2_missing_dep.py
+++ b/tests/test_export_sam2_missing_dep.py
@@ -1,0 +1,27 @@
+# onnxsim.export_sam2_model's optional-dependency error message, checked
+# with 'samexporter' forced unimportable regardless of whether it is
+# actually installed in this environment -- unlike test_export_sam2.py
+# (which needs torch/samexporter/sam2 for real to exercise the export
+# itself), this test's whole point is exercising the *absence* path, so it
+# must not be skipped just because those heavy packages happen to be
+# present.
+
+import builtins
+
+import pytest
+
+import onnxsim
+
+
+def test_export_sam2_model_needs_samexporter(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("samexporter"):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError, match=r"onnxsim\[sam2\]"):
+        onnxsim.export_sam2_model("sam2.1_hiera_tiny", "/tmp/does-not-matter")


### PR DESCRIPTION
onnxsim.export_detectron_model() builds a Detectron2 model from a config
(local YAML or a model zoo name), traces it to ONNX via
detectron2.export.TracingAdapter + torch.onnx.export (the same recipe
Detectron2's own tools/deploy/export_model.py uses, since a detection
model's dict-in/Instances-out forward() isn't directly traceable), then
runs the result through onnxsim.simplify() before saving -- the Detectron2
counterpart of the existing export_transformers_model/
export_diffusion_model helpers.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EfqtxoQH9dCrUmEJ9wKgqB