### PR TITLE
Stop block fine-tuning from filling a pruned model in, and let the browser do it at all

### DIFF
--- a/README.md
+++ b/README.md
@@ -1432,10 +1432,19 @@ strictly better. What it cannot do is what a block buys: it declines a layer
 pruned on its input and output channels at once, and a per-layer least-squares
 fit cannot let two layers with a nonlinearity between them trade error off
 against each other. `apply_block_finetune` is the general, slower,
-weaker-guarantee alternative for those cases. It also has no sparsity mask
-anywhere in the step graph, so it *fills in* the zeros of an unstructured
-(magnitude-pruned) model: measured on a two-layer block at 50% sparsity, 128
-zeros per weight before and 0 after.
+weaker-guarantee alternative for those cases.
+
+By default it *fills in* the zeros of an unstructured (magnitude-pruned)
+model, since nothing masks the optimizer: measured on a two-layer block at 50%
+sparsity, 128 zeros per weight before and 0 after, while the loss fell five
+orders of magnitude. Pass `preserve_sparsity=True` to hold every element that
+starts at zero at zero -- exactly, via one `Mul` on the gradient, which also
+keeps Adam's moments at zero. It costs accuracy, because half the parameters
+are pinned (held-out error 0.241 before, 0.191 with the zeros kept, 0.000 for
+the unconstrained run that hands back a dense model), and it is opt-in because
+only the caller knows whether a zero is a pruned weight or just a small one.
+`apply_qat` takes the same flag, where the erosion is gradual with the
+learning rate rather than immediate.
 
 ### Running AdaRound, AdaQuant and AutoRound on an accelerator
 

--- a/docs/qat.md
+++ b/docs/qat.md
@@ -421,13 +421,40 @@ alternative for those cases -- and, unlike a numpy solve, it is a step graph,
 so `step_providers=` reaches the same accelerators the rest of this note is
 about. It is a fallback, not a replacement.
 
-Note also what it does *not* preserve: the optimizer updates every element of
-a trained weight, with no sparsity mask anywhere in the step graph. On a
-magnitude-pruned (unstructured) model that is fatal to the thing that was
-bought -- measured on a two-layer block at 50% sparsity, 128 zeros per weight
-before and **0 after**, while the block's loss fell 0.140 -> 5.3e-06.
-Fine-tuning a model whose value is its zeros needs a masked optimizer this
-does not have.
+### Preserving a pruned model's zeros
+
+By default the optimizer updates every element of a trained weight, so on a
+magnitude-pruned (unstructured) model it *fills the zeros back in* -- measured
+on a two-layer block at 50% sparsity, 128 zeros per weight before and **0
+after**, while the block's loss fell 0.140 -> 5.3e-06. Every signal a caller
+looks at says that run went well, which is what makes it dangerous rather than
+merely wrong.
+
+`preserve_sparsity=True` zeroes the weight gradient wherever the master weight
+started at zero. One `Mul` per trained layer is enough to hold those elements
+at zero *exactly*, not approximately: with a gradient of 0 every step, Adam's
+`m` and `v` stay 0, its step is `lr * 0 / (sqrt(0) + eps)` -- exactly 0 -- and
+the parameter never moves. No clean-up pass, and no drift in between. It is
+opt-in because "this element is zero" and "this element was pruned away" are
+the same bit pattern, and only the caller knows which they meant. Structured
+pruning needs nothing here: the channel is gone from the tensor rather than
+zeroed inside it.
+
+It costs what it must. Half the free parameters are pinned, so the block
+cannot fit the reference as closely -- on the model above, held-out error
+0.241 before, **0.191** with the zeros kept, against 0.000 for the
+unconstrained run that returns a dense model. The unconstrained number is
+lower and is not the model that was asked for.
+
+**Under `apply_qat` the same flag applies, and there the failure it prevents
+is intermittent rather than total** -- which is worse. A weight must drift half
+a quantization step before `round(w / s)` reports anything but 0, so at the
+default learning rate of 1e-4 a short run moves no code off zero and the
+problem is invisible. It is invisible, not absent: on the same weight at 300
+iterations, the count of pruned zeros returning as nonzero codes was 6 at lr
+1e-3, 38 at 1e-2 and 177 at 5e-2. A sparsity that erodes with the learning
+rate and the budget is a worse way to lose it than losing it outright. With
+the flag on it is 0 at every rate.
 
 ### Measured, and the measurement is the point
 

--- a/docs/qat.md
+++ b/docs/qat.md
@@ -489,6 +489,27 @@ reading is intuition rather than a bound -- there is a nonlinearity in the
 middle of the block and two weights are trained jointly -- but the direction
 was the same everywhere it was measured.
 
+And `num_iterations` interacts with it, in opposite directions either side of
+the cliff. Held-out error ratio, 4 seeds, same model and learning rate:
+
+| rows | 25 iters | 50 | 100 | 300 |
+| --- | --- | --- | --- | --- |
+| 16 | 0.60-0.70 | 0.59-0.70 | 0.59-0.72 | 0.62-0.76 |
+| 256 | 0.30-0.34 | 0.14-0.18 | 0.03-0.07 | 0.000-0.002 |
+
+With enough rows, longer is monotonically better -- 300 iterations won on
+every seed. With too few, it is monotonically *worse* past a knee somewhere
+around 25-100: the training loss keeps falling three or four orders of
+magnitude while the held-out error climbs, which is textbook overfitting and
+is the same thing the table above measures from the other side.
+
+So `num_iterations` is the regularizer here, and the default of 1000 is aimed
+at the well-fed case. But note the sizes before reaching for it: stopping
+early at 16 rows buys perhaps 3-9% relative, where going to 256 rows buys
+99.8%. Early stopping is worth doing and is not a substitute for data, which
+is why no regularization parameter was added -- one would look like a fix for
+a problem it barely moves.
+
 Two things follow, and they belong in any use of this. First, `num_samples`
 defaults to 8 *batches* of random data, so the row count is 8 times the
 model's own batch dimension: for a model with a small batch dimension that is

--- a/onnxsim/qat.py
+++ b/onnxsim/qat.py
@@ -1088,6 +1088,7 @@ def _build_step_graph(
     batch: Optional[_Minibatch] = None,
     learn_activation_scales: bool = False,
     fake_quant: bool = True,
+    preserve_sparsity: bool = False,
 ) -> qat_graph.StepGraph:
     """The whole loop as one graph: fake-quant forward, block forward,
     reconstruction loss, backward, Adam.
@@ -1114,6 +1115,13 @@ def _build_step_graph(
     student are different models: the student is the pruned, simplified or
     otherwise altered one, and the block is trained to reproduce what the
     original produced at that point.
+
+    ``preserve_sparsity`` adds one ``Mul`` per trained layer, zeroing the
+    weight gradient wherever the master weight started at zero. That is enough
+    to hold those elements at zero exactly, rather than merely near it: with a
+    gradient of 0 every step, Adam's ``m`` and ``v`` stay 0, its step is
+    ``lr * 0 / (sqrt(0) + eps)`` -- exactly 0 -- and the parameter never moves.
+    No clean-up pass at the end, and no drift in between.
 
     ``externals`` and ``block_output_shape`` are always the *whole*
     calibration set's arrays and shape. With ``batch`` set they become the
@@ -1273,6 +1281,12 @@ def _build_step_graph(
         # gradient, with no scale factor anywhere. Without a fake-quant there
         # is no clipping range and no estimator: ``g`` is already dL/dw.
         w_grad = g if ste_mask is None else b.mul(g, ste_mask)
+        if preserve_sparsity:
+            # The zeros the optimizer *started* from, held there. Emitted per
+            # layer rather than hoisted, so the mask sits next to the gradient
+            # it applies to and the builder's name counter stays a function of
+            # emission order.
+            w_grad = b.mul(w_grad, b.const((t.w_init != 0).astype(np.float32), "keep"))
         t.w_next, t.m_next, t.v_next = qat_graph.adam_update(
             b,
             t.w_input,
@@ -1587,6 +1601,7 @@ def _train_block(
     learn_activation_scales: bool = False,
     activation_learning_rate: float = 1e-2,
     fake_quant: bool = True,
+    preserve_sparsity: bool = False,
 ) -> onnx.ModelProto:
     """Runs the whole optimization for one already-planned, already-captured
     block and returns ``quantized_model`` with that block's initializers
@@ -1642,6 +1657,7 @@ def _train_block(
         batch,
         learn_activation_scales,
         fake_quant,
+        preserve_sparsity,
     )
 
     # The whole set is the constant either way; with a minibatch it is bound
@@ -1851,6 +1867,7 @@ def apply_qat(
     step_providers: Optional[Sequence[backend.Provider]] = None,
     losses: Optional[List[float]] = None,
     fake_quant: bool = True,
+    preserve_sparsity: bool = False,
 ) -> onnx.ModelProto:
     """Fine-tunes one block's quantized weights (and, opted in, its activation
     quantizers) against the float model's own
@@ -2078,6 +2095,30 @@ def apply_qat(
     :param losses: when given, the reconstruction loss is appended to it once
             per step -- the cheapest way to see whether a block actually
             trained, and what the tests here assert on.
+    :param preserve_sparsity: hold every weight element that starts at zero
+            at zero for the whole run. Off by default, and it is the caller's
+            call rather than a detected one, because "this element is zero" and
+            "this element was pruned away" are the same bit pattern and only
+            the caller knows which they meant.
+
+            **Turn it on for an unstructured-pruned model.** Nothing else in
+            the step graph masks the optimizer, so without it a pruned zero
+            gets a gradient like any other element and leaves zero on the very
+            first step: measured at 50% sparsity, 128 zeros per weight before
+            and none after, while the loss fell five orders of magnitude. Every
+            signal a caller would look at says that run went well, which is
+            what makes it worth a parameter rather than a note.
+
+            Structured pruning needs nothing here -- there the channel is gone
+            from the tensor rather than zeroed inside it.
+
+            The mask is the zero pattern of the weight the optimizer *starts*
+            from, which is the master weight's seed: the student's own weight
+            when fine-tuning, and the float model's when quantizing (so for
+            QAT over a pruned model, prune first and pass the pruned model as
+            ``float_model``, which is the ordinary order anyway). Elements it
+            holds are held exactly, not approximately -- see
+            :func:`_build_step_graph` for why one ``Mul`` is enough.
     :param fake_quant: with ``False``, drop the fake-quantizer and train the
             *second model's own float weights* directly. Everything else --
             the teacher, the reconstruction loss, the backward, Adam, the
@@ -2150,6 +2191,7 @@ def apply_qat(
         step_providers=step_providers,
         losses=losses,
         fake_quant=fake_quant,
+        preserve_sparsity=preserve_sparsity,
     )
 
 
@@ -2523,6 +2565,7 @@ def apply_qat_all_blocks(
     providers: Optional[Sequence[backend.Provider]] = None,
     step_providers: Optional[Sequence[backend.Provider]] = None,
     fake_quant: bool = True,
+    preserve_sparsity: bool = False,
 ) -> Tuple[onnx.ModelProto, List[QATBlockResult]]:
     """Trains every block :func:`discover_qat_blocks` finds, in graph order --
     :func:`apply_qat` lifted from one caller-named block to the whole model.
@@ -2737,6 +2780,7 @@ def apply_qat_all_blocks(
                 step_providers=step_providers,
                 losses=result.losses,
                 fake_quant=fake_quant,
+                preserve_sparsity=preserve_sparsity,
             )
         except (ValueError, graph_grad.UnsupportedOpError) as error:
             # A step graph that was half-built cannot have touched ``tuned``
@@ -2766,6 +2810,7 @@ def apply_block_finetune(
     providers: Optional[Sequence[backend.Provider]] = None,
     step_providers: Optional[Sequence[backend.Provider]] = None,
     losses: Optional[List[float]] = None,
+    preserve_sparsity: bool = False,
 ) -> onnx.ModelProto:
     """Fine-tunes one block's float weights against a *reference* model's own
     output for that block -- :func:`apply_qat` with the quantizer taken out of
@@ -2864,6 +2909,30 @@ def apply_block_finetune(
             optimization itself on
     :param losses: when given, the reconstruction loss is appended once per
             step
+    :param preserve_sparsity: hold every weight element that starts at zero
+            at zero for the whole run. Off by default, and it is the caller's
+            call rather than a detected one, because "this element is zero" and
+            "this element was pruned away" are the same bit pattern and only
+            the caller knows which they meant.
+
+            **Turn it on for an unstructured-pruned model.** Nothing else in
+            the step graph masks the optimizer, so without it a pruned zero
+            gets a gradient like any other element and leaves zero on the very
+            first step: measured at 50% sparsity, 128 zeros per weight before
+            and none after, while the loss fell five orders of magnitude. Every
+            signal a caller would look at says that run went well, which is
+            what makes it worth a parameter rather than a note.
+
+            Structured pruning needs nothing here -- there the channel is gone
+            from the tensor rather than zeroed inside it.
+
+            The mask is the zero pattern of the weight the optimizer *starts*
+            from, which is the master weight's seed: the student's own weight
+            when fine-tuning, and the float model's when quantizing (so for
+            QAT over a pruned model, prune first and pass the pruned model as
+            ``float_model``, which is the ordinary order anyway). Elements it
+            holds are held exactly, not approximately -- see
+            :func:`_build_step_graph` for why one ``Mul`` is enough.
     :returns: ``model`` with the block's weight initializers rewritten. Every
             other byte is untouched.
     :raises ValueError: if the block cannot be discovered, is not closed at
@@ -2890,6 +2959,7 @@ def apply_block_finetune(
         step_providers=step_providers,
         losses=losses,
         fake_quant=False,
+        preserve_sparsity=preserve_sparsity,
     )
 
 
@@ -2910,6 +2980,7 @@ def apply_block_finetune_all_blocks(
     max_layers_per_block: int = 2,
     providers: Optional[Sequence[backend.Provider]] = None,
     step_providers: Optional[Sequence[backend.Provider]] = None,
+    preserve_sparsity: bool = False,
 ) -> Tuple[onnx.ModelProto, List[QATBlockResult]]:
     """:func:`apply_block_finetune` lifted to the whole model, exactly as
     :func:`apply_qat_all_blocks` lifts :func:`apply_qat`.
@@ -2948,4 +3019,5 @@ def apply_block_finetune_all_blocks(
         providers=providers,
         step_providers=step_providers,
         fake_quant=False,
+        preserve_sparsity=preserve_sparsity,
     )

--- a/onnxsim/qat_entry.cpp
+++ b/onnxsim/qat_entry.cpp
@@ -303,6 +303,13 @@ struct QuantizedLayer {
   float n_max = 0.0f;
   bool packed_int4 = false;
   ActQuant act;
+  // Whether the step graph fake-quantizes this layer's weight on the way into
+  // the block -- qat.py's _QuantizedLayer.fake_quant. False is FromFloat's
+  // third scheme: the block reads the master weight directly, the
+  // straight-through estimator has nothing to pass through, and the write-back
+  // stores fp32 rather than codes. Every field above describing the quantizer
+  // is then unread; see FromFloat for the values they carry instead.
+  bool fake_quant = true;
 };
 
 // adaround.py's _find_int4_matmul_candidates, already turned into the
@@ -484,12 +491,88 @@ std::vector<QuantizedLayer> FindStaticLayers(
   return layers;
 }
 
-// qat.py's _find_layers. The two finders are mutually exclusive by
+// A plain, unquantized MatMul/Gemm -- qat.py's _from_float, the scheme that
+// makes this a fine-tuner rather than only a quantizer.
+//
+// Everything downstream is already written against "a master weight the block
+// reads and an optimizer updates"; quantization is what sits *between* those
+// two, and QuantizedLayer::fake_quant is the switch that removes it. So this
+// only says which weight is trainable and where it is written back -- which,
+// with no code array in the picture, is the weight initializer itself.
+//
+// The quantizer fields are unread here, and are filled in with values chosen
+// to *break* rather than to look plausible, exactly as the Python's are: a
+// block_size of 0 makes the write-back's block indexing degenerate and
+// n_min == n_max == 0 makes a fake-quant forward produce all zeros. A
+// neutral-looking block_size of 1 with a unit scale would instead round the
+// weights to integers and train on quietly, which is the failure mode worth
+// ruling out: it is wrong, and it looks like a model that merely trained
+// badly.
+QuantizedLayer FromFloat(const onnx::NodeProto& node,
+                         const onnx::TensorProto& w_init) {
+  QuantizedLayer layer;
+  layer.output_name = node.output(0);
+  layer.float_node = node;
+  layer.w_float_init = w_init;
+  // There is no separate code array: the tensor trained and the tensor written
+  // back are the same one.
+  layer.wq_name = w_init.name();
+  layer.ws_name = "";
+  layer.scale_dims = Shape{1, 1};
+  layer.scale_2d = {0.0f};
+  layer.axis = 0;
+  layer.block_size = 0;
+  layer.n_min = 0.0f;
+  layer.n_max = 0.0f;
+  layer.packed_int4 = false;
+  layer.fake_quant = false;
+  return layer;
+}
+
+// qat.py's _find_float_layers: every plain MatMul/Gemm in `model` whose weight
+// is a 2-D fp32 initializer.
+//
+// Scanned out of the *student* rather than the teacher, unlike the two
+// quantized schemes, and that is the substantive difference between
+// fine-tuning and QAT rather than an implementation detail. QAT seeds its
+// master weights from the teacher because the student's weights are a lossy
+// encoding of them. Fine-tuning has no such relationship: the student's
+// weights are the starting point precisely because they are *not* the
+// teacher's -- they were pruned, or simplified, or already tuned -- and
+// re-seeding from the teacher would throw that away before the first step.
+//
+// Rank-2 and fp32 are required for the same reason the other two schemes
+// require them: the loop carries the weight as a 2-D fp32 state tensor, and a
+// layer this does not recognize is simply not trained.
+std::vector<QuantizedLayer> FindFloatLayers(const onnx::ModelProto& model) {
+  const auto initializers = InitializerIndex(model.graph());
+  std::vector<QuantizedLayer> layers;
+  for (const onnx::NodeProto& node : model.graph().node()) {
+    if ((node.op_type() != "MatMul" && node.op_type() != "Gemm") ||
+        node.input_size() < 2) {
+      continue;
+    }
+    if (node.output_size() == 0 || node.output(0).empty()) continue;
+    const onnx::TensorProto* w_init = Lookup(initializers, node.input(1));
+    if (w_init == nullptr) continue;
+    if (w_init->data_type() != onnx::TensorProto::FLOAT ||
+        w_init->dims_size() != 2) {
+      continue;
+    }
+    layers.push_back(FromFloat(node, *w_init));
+  }
+  return layers;
+}
+
+// qat.py's _find_layers. The two quantized finders are mutually exclusive by
 // construction, so this selects rather than merges; which one is selected is
-// the single decision learn_activation_scales makes.
+// the single decision learn_activation_scales makes. fake_quant=false selects
+// neither: it is the third scheme, in which there is nothing quantized to look
+// for and the trainable layers are just the student's own float ones.
 std::vector<QuantizedLayer> FindLayers(const onnx::ModelProto& float_model,
                                        const onnx::ModelProto& quantized_model,
-                                       bool activation_quant) {
+                                       bool activation_quant, bool fake_quant) {
+  if (!fake_quant) return FindFloatLayers(quantized_model);
   return activation_quant ? FindStaticLayers(float_model, quantized_model)
                           : FindInt4Layers(float_model, quantized_model);
 }
@@ -1004,9 +1087,17 @@ std::string NoLayersMessage(const onnx::ModelProto& float_model,
                             const onnx::ModelProto& quantized_model,
                             const std::string& block_input_name,
                             const std::string& block_output_name,
-                            bool learn_activation_scales) {
+                            bool learn_activation_scales, bool fake_quant) {
   const std::string where = "the block between " + Quoted(block_input_name) +
                             " and " + Quoted(block_output_name);
+  if (!fake_quant) {
+    return where +
+           " contains no MatMul/Gemm with a 2-D fp32 weight initializer to "
+           "fine-tune (fake_quant=False trains the model's own float weights, "
+           "so a layer whose weight is computed rather than stored, or stored "
+           "at some other rank or dtype, has nothing for the optimizer to "
+           "hold)";
+  }
   if (learn_activation_scales) {
     if (!FindInt4Layers(float_model, quantized_model).empty()) {
       return "learn_activation_scales targets onnxsim.quantize_static's QDQ "
@@ -1034,6 +1125,30 @@ std::string NoLayersMessage(const onnx::ModelProto& float_model,
   return message;
 }
 
+// qat.py's _refuse_quantizer_flags_without_fake_quant. fake_quant=false and
+// the two scale flags are a contradiction, not a combination: both flags name
+// a parameter of a quantizer, and with the fake-quant gone there is no
+// quantizer for them to name. Silently ignoring them would be the worse
+// failure of the two available -- a caller who asked to learn scales and got a
+// model whose scales are exactly as they were has no way to tell that from a
+// run in which learning them did not help.
+void RefuseQuantizerFlagsWithoutFakeQuant(bool fake_quant, bool learn_scales,
+                                          bool learn_activation_scales) {
+  if (fake_quant) return;
+  std::string asked;
+  if (learn_scales) asked = "learn_scales";
+  if (learn_activation_scales) {
+    if (!asked.empty()) asked += " and ";
+    asked += "learn_activation_scales";
+  }
+  if (asked.empty()) return;
+  throw std::invalid_argument(
+      asked +
+      " cannot be used with fake_quant=False: both train a quantizer's "
+      "parameters, and fake_quant=False is the mode with no quantizer in it. "
+      "Fine-tuning trains the weights themselves.");
+}
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -1046,6 +1161,8 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
                               const std::string& block_input_name,
                               const std::string& block_output_name,
                               int64_t num_rows, const QatOptions& options) {
+  RefuseQuantizerFlagsWithoutFakeQuant(options.fake_quant, options.learn_scales,
+                                       options.learn_activation_scales);
   if (num_rows < 1) {
     throw std::invalid_argument("num_rows must be at least 1, got " +
                                 std::to_string(num_rows));
@@ -1072,16 +1189,17 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
     }
   }
   std::vector<QuantizedLayer> candidates;
-  for (QuantizedLayer& layer : FindLayers(float_model, quantized_model,
-                                          options.learn_activation_scales)) {
+  for (QuantizedLayer& layer :
+       FindLayers(float_model, quantized_model, options.learn_activation_scales,
+                  options.fake_quant)) {
     if (slice_outputs.count(layer.output_name) != 0) {
       candidates.push_back(std::move(layer));
     }
   }
   if (candidates.empty()) {
-    throw std::invalid_argument(
-        NoLayersMessage(float_model, quantized_model, block_input_name,
-                        block_output_name, options.learn_activation_scales));
+    throw std::invalid_argument(NoLayersMessage(
+        float_model, quantized_model, block_input_name, block_output_name,
+        options.learn_activation_scales, options.fake_quant));
   }
 
   // --- shapes ------------------------------------------------------------
@@ -1156,7 +1274,16 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
 
   // --- _build_step_graph -------------------------------------------------
   GraphBuilder b(kPrefix);
-  for (const onnx::TensorProto& t : float_model.graph().initializer()) {
+  // The block's *untrained* constants -- a LayerNorm's scale and bias, a
+  // Gemm's C -- come from whichever model the trained weights came from, and
+  // for the same reason. Under QAT that is the teacher, whose weights the
+  // student encodes. Under fine-tuning it is the student, because the student
+  // is a different model and quietly substituting the teacher's constants into
+  // it would train the block to compensate for a substitution the deployed
+  // model does not make. qat.py's constant_source.
+  const onnx::ModelProto& constant_source =
+      options.fake_quant ? float_model : quantized_model;
+  for (const onnx::TensorProto& t : constant_source.graph().initializer()) {
     if (used.count(t.name()) != 0 &&
         trained_weight_names.count(t.name()) == 0) {
       b.initializer().push_back(t);
@@ -1202,14 +1329,40 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
   // 1. Fake-quantize each trained master weight into the tensor name the
   //    block's own node already reads, so the block's nodes need no rewriting
   //    at all -- the weight initializer simply became a computed value.
+  //    `fq` is meaningful only when this layer has a fake-quant; step 5
+  //    branches on `fake_quant` exactly where qat.py branches on its `active`
+  //    slot being None.
   struct PerLayer {
     Trained* t;
+    // The tensor this layer's gradient arrives on: the block's own weight
+    // name, or -- with no fake-quant between them -- the master weight itself.
     std::string weight_name;
     std::string scale_full;
     FakeQuant fq;
+    bool fake_quant = true;
   };
   std::vector<PerLayer> per_layer;
+  // Block tensor name -> what the block's own node should read instead. Only
+  // fake_quant=false puts anything here: the master weight is substituted for
+  // the weight initializer by *renaming one input*, rather than by emitting an
+  // Identity, because Identity is not in EpFriendlyOps -- a node whose whole
+  // job is to copy a tensor is a node an execution provider would have to
+  // implement for no reason.
+  std::map<std::string, std::string> weight_rewrites;
+  ShapeMap weight_shapes;
   for (Trained& t : trained) {
+    if (!t.candidate->fake_quant) {
+      const std::string weight_name = t.candidate->float_node.input(1);
+      weight_rewrites[weight_name] = t.w_input;
+      // The master weight is now a differentiated *leaf* of the block rather
+      // than a value computed inside it, so the backward needs its shape the
+      // way it needs the block's own tensors'.
+      weight_shapes[t.w_input] = t.w_shape;
+      // No quantizer, so no straight-through mask: step 5 uses the raw
+      // gradient.
+      per_layer.push_back({&t, t.w_input, "", FakeQuant(), false});
+      continue;
+    }
     const int64_t block_size = t.candidate->block_size;
     const std::string scale =
         t.scale_input.empty() ? b.Const(t.scale_init, t.scale_shape, "scale")
@@ -1219,7 +1372,7 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
     const std::string weight_name = t.candidate->float_node.input(1);
     const FakeQuant fq = EmitFakeQuant(b, t.w_input, scale_full, weight_name,
                                        t.candidate->n_min, t.candidate->n_max);
-    per_layer.push_back({&t, weight_name, scale_full, fq});
+    per_layer.push_back({&t, weight_name, scale_full, fq, true});
   }
 
   // 2. The block itself, node for node as the float graph wrote it -- except
@@ -1227,6 +1380,8 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
   //    fake-quantized copy of its own input instead of the raw tensor. Only
   //    that one node is rewritten (one input name), so the quantizer lands on
   //    the *edge* the deployed QDQ pair occupies rather than on the tensor.
+  //    With no fake-quant, one more input name is rewritten per trained
+  //    layer: the weight the block reads becomes the master weight.
   ShapeMap act_shapes;
   std::map<std::string, Trained*> quantized_input;
   for (Trained& t : trained) {
@@ -1258,6 +1413,10 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
       act_shapes.insert(emitted.shapes.begin(), emitted.shapes.end());
       node.set_input(0, emitted.xdq);
     }
+    for (int i = 0; i < node.input_size(); ++i) {
+      const auto rewrite = weight_rewrites.find(node.input(i));
+      if (rewrite != weight_rewrites.end()) node.set_input(i, rewrite->second);
+    }
     forward.push_back(node);
     differentiated.push_back(node);
   }
@@ -1280,6 +1439,8 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
   //    fake-quant chain.
   ShapeMap all_shapes = shapes;
   for (const auto& entry : act_shapes) all_shapes[entry.first] = entry.second;
+  for (const auto& entry : weight_shapes)
+    all_shapes[entry.first] = entry.second;
   std::vector<std::string> targets;
   for (const PerLayer& layer : per_layer) targets.push_back(layer.weight_name);
   for (const Trained& t : trained) {
@@ -1310,8 +1471,9 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
     // STE: d(w_hat)/d(w) is 1 inside the clipping range and 0 outside. The
     // scale cancels -- w_hat = round(w/s)*s -- which is why a straight-through
     // weight gradient is just the masked output gradient, with no scale factor
-    // anywhere.
-    const std::string masked = b.Mul(g, layer.fq.active);
+    // anywhere. Without a fake-quant there is no clipping range and no
+    // estimator: `g` is already dL/dw.
+    const std::string masked = layer.fake_quant ? b.Mul(g, layer.fq.active) : g;
     const AdamOutputs w_step =
         AdamUpdate(b, t.w_input, masked, t.m_input, t.v_input, lr,
                    "m_correction", "v_correction");
@@ -1459,6 +1621,7 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
     layer.packed_int4 = t.candidate->packed_int4;
     layer.frozen_weight_scale = MakeFloatTensor(
         t.candidate->ws_name, t.scale_shape, t.candidate->scale_2d);
+    layer.fake_quant = t.candidate->fake_quant;
     plan.layers.push_back(std::move(layer));
   }
   return plan;
@@ -1485,6 +1648,9 @@ onnx::ModelProto WriteBackQatState(
   // first so a layer naming an initializer the model does not have is a
   // no-op rather than a partial rewrite, exactly as the Python's dict lookup
   // over the initializer list is.
+  // Keyed by initializer, and already built as the tensor that replaces it:
+  // fp32, under the layer's own name, with the dims the plan carries.
+  std::map<std::string, onnx::TensorProto> new_weights;
   std::map<std::string, std::vector<int8_t>> new_codes;
   std::map<std::string, std::vector<double>> new_scales;
   std::map<std::string, double> new_act_scales;
@@ -1493,6 +1659,23 @@ onnx::ModelProto WriteBackQatState(
   for (const QatTrainedLayer& layer : plan.layers) {
     const std::vector<double> w =
         TensorValues(state_of(layer.weight_state_input));
+    if (!layer.fake_quant) {
+      // Nothing to project back onto: the master weight *is* what the model
+      // stores, so the write-back is the identity that the two quantized
+      // schemes' rounding and clipping stand in for.
+      if (static_cast<int64_t>(w.size()) != ElementCount(layer.weight_dims)) {
+        throw std::invalid_argument(
+            "the trained weight " + Quoted(layer.weight_state_input) + " has " +
+            std::to_string(w.size()) + " elements, expected " +
+            std::to_string(ElementCount(layer.weight_dims)));
+      }
+      std::vector<float> values;
+      values.reserve(w.size());
+      for (double v : w) values.push_back(static_cast<float>(v));
+      new_weights[layer.codes_initializer] =
+          MakeFloatTensor(layer.codes_initializer, layer.weight_dims, values);
+      continue;
+    }
     const std::vector<double> scale =
         layer.weight_scale_state_input.empty()
             ? TensorValues(layer.frozen_weight_scale)
@@ -1559,6 +1742,15 @@ onnx::ModelProto WriteBackQatState(
   onnx::ModelProto tuned = quantized_model;
   for (onnx::TensorProto& initializer :
        *tuned.mutable_graph()->mutable_initializer()) {
+    const auto weight = new_weights.find(initializer.name());
+    if (weight != new_weights.end()) {
+      // The tensor the loop trained, stored as itself. The initializer is
+      // replaced wholesale rather than patched -- numpy_helper.from_array's
+      // own rewrite in the Python -- so a weight the model happened to store
+      // some other way (in float_data, say) comes out canonical raw fp32.
+      initializer = weight->second;
+      continue;
+    }
     const auto codes = new_codes.find(initializer.name());
     if (codes != new_codes.end()) {
       if (initializer.data_type() == onnx::TensorProto::INT4) {

--- a/onnxsim/qat_entry.cpp
+++ b/onnxsim/qat_entry.cpp
@@ -1473,7 +1473,18 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
     // weight gradient is just the masked output gradient, with no scale factor
     // anywhere. Without a fake-quant there is no clipping range and no
     // estimator: `g` is already dL/dw.
-    const std::string masked = layer.fake_quant ? b.Mul(g, layer.fq.active) : g;
+    std::string masked = layer.fake_quant ? b.Mul(g, layer.fq.active) : g;
+    if (options.preserve_sparsity) {
+      // The zeros the optimizer *started* from, held there. The constant is
+      // built and then multiplied, in that order, because qat.py evaluates
+      // b.const(...) before the b.mul(...) that consumes it and the builder's
+      // name counter is a function of emission order.
+      std::vector<float> keep(t.w_init.size(), 1.0f);
+      for (size_t i = 0; i < t.w_init.size(); ++i) {
+        if (t.w_init[i] == 0.0f) keep[i] = 0.0f;
+      }
+      masked = b.Mul(masked, b.Const(keep, t.w_shape, "keep"));
+    }
     const AdamOutputs w_step =
         AdamUpdate(b, t.w_input, masked, t.m_input, t.v_input, lr,
                    "m_correction", "v_correction");

--- a/onnxsim/qat_entry.h
+++ b/onnxsim/qat_entry.h
@@ -54,6 +54,19 @@
 struct QatOptions {
   bool learn_scales = false;
   bool learn_activation_scales = false;
+  // With false, drop the fake-quantizer and train the *second model's own
+  // float weights* directly -- apply_block_finetune rather than apply_qat.
+  // Everything else here (the teacher, the reconstruction loss, the backward,
+  // Adam, the minibatch) is unchanged, so this is the same block-wise,
+  // label-free distillation with the quantizer taken out of the middle: plain
+  // fine-tuning. The trainable layers stop being the quantized ones and become
+  // the *quantized_model* argument's own MatMul/Gemms whose weight is a 2-D
+  // fp32 initializer -- scanned out of the student, and seeded from the
+  // student, because its weights are the starting point precisely by *not*
+  // being the teacher's (they were pruned, or simplified, or already tuned).
+  // Incompatible with the two flags above, which have no scales to learn:
+  // asking for either alongside this is refused rather than ignored.
+  bool fake_quant = true;
   // Rows per optimizer step. 0 means full batch, which is the default and the
   // only mode with no per-step input beyond the scalars.
   int64_t batch_size = 0;
@@ -93,6 +106,11 @@ struct QatCapture {
 // *is* a block-wise scale whose block spans the whole reduction axis, so INT4's
 // 32-element blocks and INT8's per-channel scales are both just
 // (block_axis, block_size, grid), and the write-back needs no special case.
+//
+// The third scheme -- QatOptions::fake_quant off -- normalizes away
+// differently: see `fake_quant` below. There is nothing between the master
+// weight and the stored tensor there, so the trained tensor *is* the stored
+// tensor, and every field describing a quantizer is unread.
 struct QatTrainedLayer {
   // Loop state inputs. The last three are empty when not trained.
   std::string weight_state_input;
@@ -101,6 +119,9 @@ struct QatTrainedLayer {
   std::string act_zero_point_state_input;
 
   // Initializers in the quantized model these write back into.
+  // `codes_initializer` names the weight initializer itself when `fake_quant`
+  // is off, since then the write-back stores the trained fp32 tensor rather
+  // than codes derived from it.
   std::string codes_initializer;
   std::string weight_scale_initializer;
   std::string act_scale_initializer;
@@ -119,6 +140,16 @@ struct QatTrainedLayer {
   // The weight scale as the model currently stores it. Needed to re-derive
   // codes when learn_scales is off, since then no state tensor carries it.
   onnx::TensorProto frozen_weight_scale;
+  // QatOptions::fake_quant, carried per layer because it is what the
+  // write-back branches on. With it false there is no quantizer between the
+  // master weight and what the model stores, so WriteBackQatState writes
+  // `weight_state_input`'s final value straight back as a FLOAT initializer
+  // named `codes_initializer`: no rounding, no clipping to a code grid, and no
+  // scale -- the trained tensor is the stored tensor. Every quantizer field
+  // above is then unread, and carries a value chosen to fail loudly rather
+  // than plausibly if some future caller reads one anyway (a `block_size` of
+  // 0, an empty code grid), exactly as qat.py's _from_float does.
+  bool fake_quant = true;
 };
 
 // Everything needed to run the loop and then write its result back.
@@ -139,6 +170,10 @@ struct QatStepPlan {
   // Seeding from the float weight rather than the quantized one is what makes
   // step 0 reproduce round-to-nearest exactly, so every later step is a
   // measured improvement on it rather than on an arbitrary re-initialization.
+  // With QatOptions::fake_quant off the seed is the *student's* own weight
+  // instead, and for the same kind of reason: there is no encoding to invert,
+  // and the student's weights are the starting point precisely by not being
+  // the teacher's.
   std::vector<onnx::TensorProto> initial_state;
   // The minibatch row index input, when batch_size > 0. Empty otherwise.
   // It is rank-1 int64 and is the only non-float input a step graph ever has.
@@ -163,6 +198,10 @@ struct QatStepPlan {
 // slice contains no layer of the scheme `options` selects -- including the
 // case where the caller asked for activation training over a weight-only
 // model, which is a scheme error rather than a boundary error and says so.
+// `options.fake_quant` off with either scale flag on is refused the same way,
+// and for the same reason it is refused rather than ignored in the Python:
+// both flags name a parameter of a quantizer, and that is the mode with no
+// quantizer in it.
 QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
                               const onnx::ModelProto& quantized_model,
                               const std::string& block_input_name,
@@ -181,7 +220,10 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
 // rounded and clipped to the grid, the activation scale taken out of log
 // space, the zero-point rounded onto uint8's integer grid -- for the reason
 // qat.py does them here too: the optimizer needs those parameters continuous,
-// and the model can only hold what it can hold.
+// and the model can only hold what it can hold. A layer trained with
+// `fake_quant` off has no such projection to make: its trained master weight
+// is written back verbatim as a FLOAT initializer, which is the identity the
+// two quantized schemes' rounding and clipping stand in for.
 onnx::ModelProto WriteBackQatState(
     const onnx::ModelProto& quantized_model, const QatStepPlan& plan,
     const std::map<std::string, onnx::TensorProto>& final_state);

--- a/onnxsim/qat_entry.h
+++ b/onnxsim/qat_entry.h
@@ -67,6 +67,20 @@ struct QatOptions {
   // Incompatible with the two flags above, which have no scales to learn:
   // asking for either alongside this is refused rather than ignored.
   bool fake_quant = true;
+  // Hold every weight element that starts at zero at zero for the whole run --
+  // qat.py's preserve_sparsity. Off by default, and the caller's call rather
+  // than a detected one, because "this element is zero" and "this element was
+  // pruned away" are the same bit pattern and only the caller knows which they
+  // meant. Turn it on for an unstructured-pruned model: without it a pruned
+  // zero gets a gradient like any other element and leaves zero on the very
+  // first step, while the loss falls by orders of magnitude, so every signal a
+  // caller would look at says the run went well. Structured pruning needs
+  // nothing here -- the channel is gone from the tensor rather than zeroed
+  // inside it. The mask is the zero pattern of the master weight's seed, and
+  // one Mul on the gradient holds those elements at zero *exactly*: with a
+  // gradient of 0 every step Adam's m and v stay 0 and its step is
+  // lr * 0 / (sqrt(0) + eps), which is 0.
+  bool preserve_sparsity = false;
   // Rows per optimizer step. 0 means full batch, which is the default and the
   // only mode with no per-step input beyond the scalars.
   int64_t batch_size = 0;

--- a/onnxsim/qat_entry_test.cpp
+++ b/onnxsim/qat_entry_test.cpp
@@ -845,6 +845,103 @@ void UntrainedBlockConstantsComeFromTheStudentWhenFineTuning() {
 // With no quantizer between the master weight and what the model stores, the
 // trained tensor *is* the stored tensor: the write-back is the identity that
 // the two quantized schemes' rounding and clipping stand in for.
+// A student whose weights carry real zeros, for preserve_sparsity. Every
+// other element is zeroed, so the mask is neither all-ones nor all-zeros and a
+// port that built it from the wrong tensor -- or inverted it -- fails rather
+// than coincidentally agreeing.
+onnx::ModelProto SparseStudent() {
+  onnx::ModelProto model = FineTuneModel(kStudentWeight, kStudentNorm);
+  for (onnx::TensorProto& t : *model.mutable_graph()->mutable_initializer()) {
+    if (t.name() != "W1" && t.name() != "W2") continue;
+    std::vector<float> values = FloatsOf(t);
+    for (size_t i = 0; i < values.size(); i += 2) values[i] = 0.0f;
+    const std::vector<int64_t> dims(t.dims().begin(), t.dims().end());
+    t = FloatTensor(t.name(), dims, values);
+  }
+  return model;
+}
+
+void PreserveSparsityPinsTheStartingZerosAndNothingElse() {
+  const onnx::ModelProto teacher = FineTuneModel(kTeacherWeight, kTeacherNorm);
+  const onnx::ModelProto student = SparseStudent();
+
+  QatOptions plain;
+  plain.fake_quant = false;
+  QatOptions kept = plain;
+  kept.preserve_sparsity = true;
+
+  const QatStepPlan a =
+      BuildQatStepGraph(teacher, student, "X", "Y", kRows, plain);
+  const QatStepPlan b =
+      BuildQatStepGraph(teacher, student, "X", "Y", kRows, kept);
+  CheckModel(b.step_graph, "the sparsity-preserving step graph");
+
+  // One Mul per trained layer and nothing else: the mask is applied to the
+  // gradient, not bolted on as a separate clean-up.
+  std::map<std::string, int64_t> before, after;
+  for (const onnx::NodeProto& n : a.step_graph.graph().node())
+    before[n.op_type()]++;
+  for (const onnx::NodeProto& n : b.step_graph.graph().node())
+    after[n.op_type()]++;
+  CheckEqual(after["Mul"] - before["Mul"], 2,
+             "preserve_sparsity costs one Mul per trained layer");
+  for (const auto& entry : after) {
+    if (entry.first == "Mul") continue;
+    CheckEqual(
+        entry.second, before[entry.first],
+        "preserve_sparsity changes no operator but Mul (" + entry.first + ")");
+  }
+
+  // The mask is the seed's zero pattern, element for element.
+  const onnx::TensorProto* w1 = FindInitializer(student, "W1");
+  Check(w1 != nullptr, "the sparse student has a W1 to mask");
+  const std::vector<float> seed = FloatsOf(*w1);
+  const onnx::TensorProto* mask = nullptr;
+  for (const onnx::TensorProto& t : b.step_graph.graph().initializer()) {
+    if (t.name().find("keep") != std::string::npos &&
+        FloatsOf(t).size() == seed.size()) {
+      mask = &t;
+      break;
+    }
+  }
+  Check(mask != nullptr, "the step graph carries a mask constant");
+  if (mask != nullptr) {
+    const std::vector<float> values = FloatsOf(*mask);
+    CheckEqual(static_cast<int64_t>(values.size()),
+               static_cast<int64_t>(seed.size()), "the mask covers the weight");
+    for (size_t i = 0; i < seed.size(); ++i) {
+      Check(values[i] == (seed[i] == 0.0f ? 0.0f : 1.0f),
+            "the mask is 0 exactly where the seed weight is 0");
+    }
+
+    // An op count cannot tell a gradient mask from a mask on the updated
+    // weight -- both are one Mul. Where the product *goes* can: a masked
+    // gradient feeds Adam's two moment updates, so it has several consumers
+    // and is not itself a state output, whereas a masked weight would be the
+    // state output and feed nothing.
+    std::string product;
+    for (const onnx::NodeProto& n : b.step_graph.graph().node()) {
+      for (int i = 0; i < n.input_size(); ++i) {
+        if (n.input(i) == mask->name()) product = n.output(0);
+      }
+    }
+    Check(!product.empty(), "the mask is consumed by a node");
+    int64_t consumers = 0;
+    for (const onnx::NodeProto& n : b.step_graph.graph().node()) {
+      for (int i = 0; i < n.input_size(); ++i) {
+        if (n.input(i) == product) consumers++;
+      }
+    }
+    Check(consumers >= 2,
+          "the masked gradient feeds Adam's moments rather than being a "
+          "finished parameter");
+    for (const onnx::ValueInfoProto& out : b.step_graph.graph().output()) {
+      Check(out.name() != product,
+            "the masked value is a gradient, not a state output");
+    }
+  }
+}
+
 void FineTunedWeightsAreWrittenBackAsFloatUnderTheirOwnName() {
   QatOptions options;
   options.fake_quant = false;
@@ -1049,6 +1146,7 @@ int main() {
   TrainingActivationQuantizersPlansBothOfTheirParameters();
   ADeeperBlockTrainsEveryLayerAndCapturesTheResidual();
   AFloatBlockFineTunesWithNoQuantizerInTheStepGraph();
+  PreserveSparsityPinsTheStartingZerosAndNothingElse();
   UntrainedBlockConstantsComeFromTheStudentWhenFineTuning();
   FineTunedWeightsAreWrittenBackAsFloatUnderTheirOwnName();
   TheScaleFlagsAreRefusedRatherThanIgnoredWithoutFakeQuant();

--- a/onnxsim/qat_entry_test.cpp
+++ b/onnxsim/qat_entry_test.cpp
@@ -315,6 +315,44 @@ onnx::ModelProto DeepInt4QuantizedModel() {
   return model;
 }
 
+// The fine-tuning pair -- QatOptions::fake_quant off. Nothing here is
+// quantized: this scheme trains the *student's* own float weights against the
+// teacher's activation, so the two models being different weights over one
+// topology is the whole thing there is to learn. Two MatMuls make the block
+// two trained layers; the LayerNormalization between them carries the
+// untrained constants (its scale and bias) whose source is the one
+// substantive decision this scheme makes, so the two models give them
+// different values too.
+onnx::ModelProto FineTuneModel(float weight, float norm) {
+  onnx::ModelProto model;
+  onnx::GraphProto* graph = model.mutable_graph();
+  graph->set_name("finetune");
+  AddBatchedInput(graph, "X", kK);
+  AddOutput(graph, "Y", kN);
+  *graph->add_node() = MakeNode("MatMul", {"X", "W1"}, {"H"});
+  *graph->add_node() = MakeNode("LayerNormalization", {"H", "LnS", "LnB"},
+                                {"Nrm"}, {{"axis", -1}});
+  *graph->add_node() = MakeNode("MatMul", {"Nrm", "W2"}, {"Y"});
+  *graph->add_initializer() =
+      FloatTensor("W1", {kK, kK}, std::vector<float>(kK * kK, weight));
+  *graph->add_initializer() =
+      FloatTensor("LnS", {kK}, std::vector<float>(kK, norm));
+  *graph->add_initializer() =
+      FloatTensor("LnB", {kK}, std::vector<float>(kK, -norm));
+  *graph->add_initializer() =
+      FloatTensor("W2", {kK, kN}, std::vector<float>(kK * kN, weight));
+  Finish(&model);
+  return model;
+}
+
+// The teacher's weights, which fine-tuning must never read: it trains the
+// student, and re-seeding from the teacher would throw away whatever change
+// (a pruning, a simplification, an earlier tuning) made the two differ.
+constexpr float kTeacherWeight = 0.25f;
+constexpr float kTeacherNorm = 1.5f;
+constexpr float kStudentWeight = 0.5f;
+constexpr float kStudentNorm = 2.5f;
+
 std::set<std::string> InputNames(const onnx::ModelProto& model) {
   std::set<std::string> names;
   for (const onnx::ValueInfoProto& v : model.graph().input()) {
@@ -696,6 +734,215 @@ void ADeeperBlockTrainsEveryLayerAndCapturesTheResidual() {
   // whose ops happen to be inside it.
 }
 
+// fake_quant off is the same loop with the quantizer taken out of the middle:
+// the block reads the master weight itself, so there is nothing to
+// fake-quantize and nothing for a straight-through estimator to pass through.
+// The operators that make up the weight fake-quant are therefore the ones that
+// must be *absent* -- a port that emitted them anyway would round the trained
+// weights to a grid nobody asked for and train on quietly.
+void AFloatBlockFineTunesWithNoQuantizerInTheStepGraph() {
+  QatOptions options;
+  options.fake_quant = false;
+  const QatStepPlan plan = BuildQatStepGraph(
+      FineTuneModel(kTeacherWeight, kTeacherNorm),
+      FineTuneModel(kStudentWeight, kStudentNorm), "X", "Y", kRows, options);
+  CheckModel(plan.step_graph, "the fine-tuning step graph");
+  CheckEqual(static_cast<int64_t>(plan.layers.size()), 2,
+             "both of the student's float MatMuls are trained");
+  CheckEqual(plan.layers[0].codes_initializer, "W1",
+             "a fine-tuned layer writes back into the weight itself");
+  CheckEqual(plan.layers[1].codes_initializer, "W2",
+             "the second layer follows it in graph order");
+  Check(!plan.layers[0].fake_quant,
+        "the write-back is told there is no quantizer to invert");
+  CheckEqual(plan.layers[0].block_size, 0,
+             "the unread block size is the value that breaks rather than the "
+             "one that looks plausible");
+  CheckEqual(plan.layers[0].weight_scale_initializer, "",
+             "there is no scale initializer to write back into");
+
+  // Three state tensors per layer and one learning rate, exactly as the
+  // weight-only quantized path: the optimizer half is untouched.
+  CheckEqual(static_cast<int64_t>(plan.state.size()), 6,
+             "w, m and v for each of the two trained weights");
+  CheckEqual(plan.state[0].first, "qat__w0", "the master weight is state 0");
+  CheckEqual(plan.layers[1].weight_state_input, "qat__w1",
+             "the layers are numbered from zero in the order they were found");
+  CheckEqual(static_cast<int64_t>(plan.scalars.size()), 3,
+             "one learning rate and Adam's two bias corrections");
+  CheckEqual(static_cast<int64_t>(plan.captures.size()), 2,
+             "the block's input and its teacher");
+  CheckEqual(plan.captures[0].source_tensor, "X",
+             "the block input is captured from the float model");
+  CheckEqual(plan.captures[1].step_graph_input, "qat__teacher",
+             "the teacher is bound under the private name the loss reads");
+  Check(plan.captures[1].is_teacher, "the reconstruction target is flagged");
+
+  const std::set<std::string> ops = OpTypes(plan.step_graph);
+  for (const std::string& op : {"Sign", "Abs", "Clip", "Round"}) {
+    Check(ops.count(op) == 0,
+          "the fine-tuning step graph emits " + op +
+              ", which only a weight fake-quant would need");
+  }
+
+  // The block's node reads the master weight by *name*: the substitution is a
+  // renamed input rather than an Identity, since a node whose whole job is to
+  // copy a tensor is a node an execution provider would have to implement for
+  // no reason.
+  Check(FindInitializer(plan.step_graph, "W1") == nullptr,
+        "the trained weight is not an initializer of the step graph");
+  bool reads_master = false;
+  for (const onnx::NodeProto& node : plan.step_graph.graph().node()) {
+    if (node.op_type() == "MatMul" && node.input_size() > 1 &&
+        node.input(1) == "qat__w0" && node.output(0) == "H") {
+      reads_master = true;
+    }
+  }
+  Check(reads_master, "the block's own MatMul reads the master weight");
+  Check(ops.count("Identity") == 0,
+        "the substitution renames an input rather than emitting an Identity");
+}
+
+// Which model the block's *untrained* constants come from is a semantic
+// decision, not a detail. Under QAT it is the teacher, whose weights the
+// student encodes; under fine-tuning it is the student, because the student is
+// a different model and quietly substituting the teacher's constants into it
+// would train the block to compensate for a substitution the deployed model
+// does not make.
+void UntrainedBlockConstantsComeFromTheStudentWhenFineTuning() {
+  QatOptions options;
+  options.fake_quant = false;
+  const QatStepPlan plan = BuildQatStepGraph(
+      FineTuneModel(kTeacherWeight, kTeacherNorm),
+      FineTuneModel(kStudentWeight, kStudentNorm), "X", "Y", kRows, options);
+  for (const auto& entry :
+       {std::make_pair(std::string("LnS"), kStudentNorm),
+        std::make_pair(std::string("LnB"), -kStudentNorm)}) {
+    const onnx::TensorProto* constant =
+        FindInitializer(plan.step_graph, entry.first);
+    Check(constant != nullptr,
+          "the LayerNorm's " + entry.first + " is a step-graph initializer");
+    if (constant == nullptr) continue;
+    const std::vector<float> values = FloatsOf(*constant);
+    Check(values == std::vector<float>(kK, entry.second),
+          "the LayerNorm's " + entry.first +
+              " is the student's own, not the teacher's");
+  }
+
+  // And the master weight is seeded from the student too, for the same
+  // reason: its weights are the starting point precisely by not being the
+  // teacher's.
+  const std::map<std::string, onnx::TensorProto> state =
+      AsStateMap(plan.initial_state);
+  const auto w = state.find("qat__w0");
+  Check(w != state.end(), "the master weight is seeded");
+  if (w != state.end()) {
+    Check(FloatsOf(w->second) == std::vector<float>(kK * kK, kStudentWeight),
+          "fine-tuning starts from the student's own weight");
+  }
+}
+
+// With no quantizer between the master weight and what the model stores, the
+// trained tensor *is* the stored tensor: the write-back is the identity that
+// the two quantized schemes' rounding and clipping stand in for.
+void FineTunedWeightsAreWrittenBackAsFloatUnderTheirOwnName() {
+  QatOptions options;
+  options.fake_quant = false;
+  const onnx::ModelProto student = FineTuneModel(kStudentWeight, kStudentNorm);
+  const QatStepPlan plan =
+      BuildQatStepGraph(FineTuneModel(kTeacherWeight, kTeacherNorm), student,
+                        "X", "Y", kRows, options);
+
+  // A "trained" state that is not the warm start, so the write-back is
+  // visible: the whole point is that these values reach the model unrounded.
+  std::map<std::string, onnx::TensorProto> final_state =
+      AsStateMap(plan.initial_state);
+  final_state["qat__w0"] =
+      FloatTensor("qat__w0", {kK, kK}, std::vector<float>(kK * kK, 0.1234f));
+  const onnx::ModelProto tuned = WriteBackQatState(student, plan, final_state);
+
+  const onnx::TensorProto* w1 = FindInitializer(tuned, "W1");
+  Check(w1 != nullptr, "the weight initializer survives the write-back");
+  if (w1 != nullptr) {
+    CheckEqual(static_cast<int64_t>(w1->data_type()),
+               static_cast<int64_t>(onnx::TensorProto::FLOAT),
+               "a fine-tuned weight is written back as fp32");
+    Check(std::vector<int64_t>(w1->dims().begin(), w1->dims().end()) ==
+              std::vector<int64_t>({kK, kK}),
+          "it keeps the weight's storage layout");
+    Check(FloatsOf(*w1) == std::vector<float>(kK * kK, 0.1234f),
+          "the trained tensor is stored verbatim -- no rounding, no grid");
+  }
+  // The second layer was fed its warm start, so it comes back as it went in.
+  const onnx::TensorProto* w2 = FindInitializer(tuned, "W2");
+  Check(w2 != nullptr &&
+            FloatsOf(*w2) == std::vector<float>(kK * kN, kStudentWeight),
+        "an untrained-away weight is written back unchanged");
+  // Nothing else in the model was touched: there is no scale and no code
+  // array for this scheme to rewrite.
+  const onnx::TensorProto* norm_before = FindInitializer(student, "LnS");
+  const onnx::TensorProto* norm_after = FindInitializer(tuned, "LnS");
+  Check(norm_before != nullptr && norm_after != nullptr &&
+            norm_before->SerializeAsString() == norm_after->SerializeAsString(),
+        "the block's untrained constants are left byte-identical");
+}
+
+// The two scale flags each name a parameter of a quantizer, and fake_quant off
+// is the mode with no quantizer in it. Ignoring them would be the worse
+// failure of the two available: a caller who asked to learn scales and got a
+// model whose scales are exactly as they were has no way to tell that from a
+// run in which learning them did not help.
+void TheScaleFlagsAreRefusedRatherThanIgnoredWithoutFakeQuant() {
+  const onnx::ModelProto teacher = FineTuneModel(kTeacherWeight, kTeacherNorm);
+  const onnx::ModelProto student = FineTuneModel(kStudentWeight, kStudentNorm);
+  CheckThrows<std::invalid_argument>(
+      [&] {
+        QatOptions options;
+        options.fake_quant = false;
+        options.learn_scales = true;
+        BuildQatStepGraph(teacher, student, "X", "Y", kRows, options);
+      },
+      "learn_scales cannot be used with fake_quant=False",
+      "learn_scales without a fake-quant is refused");
+  CheckThrows<std::invalid_argument>(
+      [&] {
+        QatOptions options;
+        options.fake_quant = false;
+        options.learn_activation_scales = true;
+        BuildQatStepGraph(teacher, student, "X", "Y", kRows, options);
+      },
+      "learn_activation_scales cannot be used with fake_quant=False",
+      "learn_activation_scales without a fake-quant is refused");
+  CheckThrows<std::invalid_argument>(
+      [&] {
+        QatOptions options;
+        options.fake_quant = false;
+        options.learn_scales = true;
+        options.learn_activation_scales = true;
+        BuildQatStepGraph(teacher, student, "X", "Y", kRows, options);
+      },
+      "learn_scales and learn_activation_scales cannot be used",
+      "both flags at once are named together");
+}
+
+// A block with nothing to fine-tune is refused in terms of *this* scheme: the
+// caller's model has no MatMul/Gemm whose weight is a stored 2-D fp32 tensor,
+// which is a different problem from having no quantized layer and reads as
+// one.
+void ABlockWithNoFloatWeightToFineTuneIsRefusedInThoseTerms() {
+  QatOptions options;
+  options.fake_quant = false;
+  CheckThrows<std::invalid_argument>(
+      [&] {
+        // The INT4 student's MatMul reads a DequantizeLinear's output, not an
+        // initializer, so there is no stored weight for the optimizer to hold.
+        BuildQatStepGraph(FloatModel(), Int4QuantizedModel(), "X", "Y", kRows,
+                          options);
+      },
+      "contains no MatMul/Gemm with a 2-D fp32 weight initializer to fine-tune",
+      "a block with no stored float weight is refused in the scheme's terms");
+}
+
 // A node with no gradient rule must be refused by op type, before any of the
 // expensive work -- and the message must name both the offender and the
 // supported set, or the caller has to go read graph_grad to find out what to
@@ -801,6 +1048,11 @@ int main() {
   AMinibatchedBlockGathersItsRowsOutOfResidentTables();
   TrainingActivationQuantizersPlansBothOfTheirParameters();
   ADeeperBlockTrainsEveryLayerAndCapturesTheResidual();
+  AFloatBlockFineTunesWithNoQuantizerInTheStepGraph();
+  UntrainedBlockConstantsComeFromTheStudentWhenFineTuning();
+  FineTunedWeightsAreWrittenBackAsFloatUnderTheirOwnName();
+  TheScaleFlagsAreRefusedRatherThanIgnoredWithoutFakeQuant();
+  ABlockWithNoFloatWeightToFineTuneIsRefusedInThoseTerms();
   ABlockContainingAnUndifferentiableOpIsRefusedByOpType();
   ABlockWithNoQuantizedLayerIsRefused();
   EachSchemeMismatchIsNamedRatherThanReportedAsABoundaryError();

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -1149,15 +1149,26 @@ em::val onnxsim_quantize_qoperator(const std::string &data, em::val names_ary,
 
 // QatOptions as a plain JS object with named fields:
 //
-//   { learnScales, learnActivationScales, batchSize, batchSeed, shuffle }
+//   { learnScales, learnActivationScales, fakeQuant, batchSize, batchSeed,
+//     shuffle }
 //
-// Named fields rather than five positional arguments because they are
+// Named fields rather than six positional arguments because they are
 // independent knobs that each already have a default: an absent (or
 // null/undefined) field keeps QatOptions' own, so `{}` means "full batch,
 // train the weights only" -- apply_qat's default -- and a caller that wants
 // one knob writes one field. `batchSize`/`batchSeed` arrive as JS numbers
 // (doubles) and are truncated to the int64 fields they feed; nothing here is
 // large enough for that to lose anything.
+//
+// `fakeQuant: false` is the one field that changes what the two model
+// arguments mean rather than adding a knob: the quantizer comes out of the
+// middle and the second model's own float MatMul/Gemm weights are trained
+// against the first model's activations -- apply_block_finetune, so the page
+// can fine-tune a pruned or otherwise altered model and not only quantize
+// one. It cannot be combined with either scale flag (there is no quantizer
+// left for them to name); BuildQatStepGraph refuses that pairing and the
+// binding returns null with the reason on the console, as it does for every
+// other refusal.
 QatOptions QatOptionsFromVal(em::val options) {
   QatOptions out;
   if (options.isUndefined() || options.isNull())
@@ -1174,6 +1185,7 @@ QatOptions QatOptionsFromVal(em::val options) {
   };
   read_bool("learnScales", out.learn_scales);
   read_bool("learnActivationScales", out.learn_activation_scales);
+  read_bool("fakeQuant", out.fake_quant);
   read_int("batchSize", out.batch_size);
   read_int("batchSeed", out.batch_seed);
   read_bool("shuffle", out.shuffle);

--- a/scripts/convertmodel/interface.cpp
+++ b/scripts/convertmodel/interface.cpp
@@ -1149,10 +1149,10 @@ em::val onnxsim_quantize_qoperator(const std::string &data, em::val names_ary,
 
 // QatOptions as a plain JS object with named fields:
 //
-//   { learnScales, learnActivationScales, fakeQuant, batchSize, batchSeed,
-//     shuffle }
+//   { learnScales, learnActivationScales, fakeQuant, preserveSparsity,
+//     batchSize, batchSeed, shuffle }
 //
-// Named fields rather than six positional arguments because they are
+// Named fields rather than seven positional arguments because they are
 // independent knobs that each already have a default: an absent (or
 // null/undefined) field keeps QatOptions' own, so `{}` means "full batch,
 // train the weights only" -- apply_qat's default -- and a caller that wants
@@ -1186,6 +1186,7 @@ QatOptions QatOptionsFromVal(em::val options) {
   read_bool("learnScales", out.learn_scales);
   read_bool("learnActivationScales", out.learn_activation_scales);
   read_bool("fakeQuant", out.fake_quant);
+  read_bool("preserveSparsity", out.preserve_sparsity);
   read_int("batchSize", out.batch_size);
   read_int("batchSeed", out.batch_seed);
   read_bool("shuffle", out.shuffle);

--- a/scripts/convertmodel/test/qat_step_graph.test.mjs
+++ b/scripts/convertmodel/test/qat_step_graph.test.mjs
@@ -43,6 +43,7 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { fields, decode } from "../macs.mjs";
 import { readShapes } from "../shapes.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -126,6 +127,27 @@ function copyBytes(view) {
 
 function names(valueInfos) {
   return valueInfos.map((v) => v.name);
+}
+
+// The op types of a model's nodes, read straight out of the bytes with the
+// same dependency-free wire reader shapes.mjs uses (ModelProto.graph = 7,
+// GraphProto.node = 1, NodeProto.op_type = 4). A substring search over the
+// model bytes would do for a name as long as "DequantizeLinear", but not for
+// the three-letter op names below -- "Abs" would match three bytes of a
+// weight as happily as an op type.
+function opTypes(modelBytes) {
+  const buf = modelBytes instanceof Uint8Array ? modelBytes : new Uint8Array(modelBytes);
+  const ops = new Set();
+  for (const model of fields(buf)) {
+    if (model.field !== 7 || model.wire !== 2) continue;
+    for (const graph of fields(model.bytes)) {
+      if (graph.field !== 1 || graph.wire !== 2) continue;
+      for (const node of fields(graph.bytes)) {
+        if (node.field === 4 && node.wire === 2) ops.add(decode(node.bytes));
+      }
+    }
+  }
+  return ops;
 }
 
 // ---------------------------------------------------------------------------
@@ -343,6 +365,60 @@ async function main() {
       assert.notEqual(capture.input, capture.source);
       assert.equal(capture.dims[0], NUM_ROWS);
     }
+  });
+
+  // --- the fine-tuning variant ----------------------------------------------
+  //
+  // fakeQuant:false takes the quantizer out of the middle and trains the
+  // *second* model's own float weights, so the student here is the float model
+  // rather than the quantized one -- the quantized model's MatMul reads a
+  // DequantizeLinear's output, not a stored weight, and would have nothing to
+  // fine-tune. Both models being the same one makes for a zero loss and
+  // nothing to learn, which is fine: what is under test is the graph the
+  // builder returns, and the numerics belong to the python tests.
+  await check("fakeQuant:false builds a step graph with no fake-quant in it", () => {
+    const tuned = runtime.onnxsim_qat_build_step_graph(
+      floatModel,
+      floatModel,
+      "X",
+      "Y",
+      NUM_ROWS,
+      { fakeQuant: false },
+    );
+    assert.ok(tuned, "onnxsim_qat_build_step_graph returned null for fakeQuant:false");
+    const graph = copyBytes(tuned.stepGraph);
+    const tunedState = tuned.state.map((s) => ({ input: s.input, output: s.output }));
+    const tunedScalars = [...tuned.scalars];
+    const tunedInputs = new Set(names(readShapes(graph).inputs));
+    runtime.onnxsim_qat_release_plan(tuned.planHandle);
+
+    assert.equal(tunedState.length, 3, "one weight plus Adam's two moments");
+    assert.equal(tunedScalars.length, 3, "no scale learning rate to feed");
+    for (const { input } of tunedState) {
+      assert.ok(tunedInputs.has(input), `state input '${input}' is not a graph input`);
+    }
+    // The weight fake-quant is Abs/Sign (GraphBuilder's RoundToNearest) and
+    // Clip; none of the three has any other reason to be in this graph, so
+    // their absence is what "the quantizer is gone" looks like from out here.
+    const ops = opTypes(graph);
+    assert.ok(ops.size > 0, "no nodes -- the step graph bytes did not parse");
+    for (const op of ["Abs", "Sign", "Clip", "Round"]) {
+      assert.ok(!ops.has(op), `the fine-tuning step graph contains a ${op}`);
+    }
+    assert.ok(ops.has("MatMul"), "the block's own node is still there");
+  });
+
+  await check("fakeQuant:false refuses the two scale flags rather than ignoring them", () => {
+    // Both name a parameter of a quantizer, and this is the mode with no
+    // quantizer in it. BuildQatStepGraph throws; the binding turns that into
+    // null with the reason on the console.
+    assert.equal(
+      runtime.onnxsim_qat_build_step_graph(floatModel, floatModel, "X", "Y", NUM_ROWS, {
+        fakeQuant: false,
+        learnScales: true,
+      }),
+      null,
+    );
   });
 
   // --- refusals -------------------------------------------------------------

--- a/tests/test_block_finetune.py
+++ b/tests/test_block_finetune.py
@@ -553,23 +553,23 @@ def test_the_whole_model_walk_recovers_a_damaged_model():
     assert _held_out_error(tuned, reference, held_out) < before / 2
 
 
-def test_unstructured_sparsity_is_not_preserved():
-    """A known gap, pinned so that closing it is a visible change.
+def test_unstructured_sparsity_is_not_preserved_by_default():
+    """The default fills a pruned model's zeros back in, and says so.
 
-    Nothing in the step graph masks the optimizer: Adam updates every element
-    of a trained weight, so an element pruning set to zero gets a gradient
-    like any other and leaves zero on the first step. For a model whose value
-    *is* its zeros -- an unstructured magnitude-pruned one -- that destroys
-    what was bought, and it does so while the loss falls by orders of
+    Nothing in the step graph masks the optimizer unless asked: Adam updates
+    every element of a trained weight, so an element pruning set to zero gets
+    a gradient like any other and leaves zero on the first step. For a model
+    whose value *is* its zeros -- an unstructured magnitude-pruned one -- that
+    destroys what was bought, and it does so while the loss falls by orders of
     magnitude, which is exactly the shape of failure that goes unnoticed.
 
-    Structured pruning is unaffected, because there the channel is gone from
-    the tensor rather than zeroed inside it.
+    ``preserve_sparsity=True`` is the fix and the test next door measures it.
+    The default stays off because "this element is zero" and "this element was
+    pruned away" are the same bit pattern, and only the caller knows which
+    they meant -- so this test pins the default rather than deprecating it.
 
-    This asserts the current behaviour rather than the desired one. A masked
-    optimizer would be a real feature and would make this test fail, which is
-    the point of writing it down: the assertion below is the specification of
-    what such a change would have to alter.
+    Structured pruning is unaffected either way, because there the channel is
+    gone from the tensor rather than zeroed inside it.
     """
     rng = np.random.default_rng(12)
     w1 = rng.normal(0, 0.3, (D, D)).astype(np.float32)
@@ -600,3 +600,171 @@ def test_unstructured_sparsity_is_not_preserved():
     assert losses[-1] < losses[0] / 100
     assert (_init(tuned, "W1") == 0).sum() == 0
     assert (_init(tuned, "W2") == 0).sum() == 0
+
+
+def _pruned_pair(rng, sparsity=0.5):
+    """A dense reference and an unstructured magnitude-pruned copy of it."""
+    weights = [rng.normal(0, 0.3, (D, D)).astype(np.float32) for _ in range(2)]
+
+    def pruned(w):
+        w = w.copy()
+        w[np.abs(w) < np.quantile(np.abs(w), sparsity)] = 0.0
+        return w
+
+    sparse = [pruned(w) for w in weights]
+    return _mlp(*weights), _mlp(*sparse), sparse
+
+
+def test_preserve_sparsity_holds_every_pruned_zero_exactly():
+    """The fix, and the reason one ``Mul`` is enough.
+
+    With the gradient zeroed wherever the master weight started at zero,
+    Adam's ``m`` and ``v`` stay 0 for those elements, its step is
+    ``lr * 0 / (sqrt(0) + eps)`` -- exactly 0 -- and the parameter never
+    moves. So the assertion is equality with zero rather than a tolerance:
+    "held near zero" would be a different, weaker feature, and a model whose
+    zeros became 1e-20 is a dense model as far as any sparse kernel is
+    concerned.
+
+    The whole zero *pattern* is compared, not just the count, because a run
+    that zeroed some other element to compensate would keep the count and be
+    entirely wrong.
+    """
+    rng = np.random.default_rng(21)
+    reference, student, sparse = _pruned_pair(rng)
+
+    tuned = onnxsim.apply_block_finetune(
+        reference,
+        student,
+        "X",
+        "Y",
+        calibration_data=_data(rng, batches=32),
+        num_iterations=300,
+        learning_rate=2e-2,
+        preserve_sparsity=True,
+    )
+
+    for name, before in zip(("W1", "W2"), sparse):
+        after = _init(tuned, name)
+        assert np.array_equal(after == 0, before == 0)
+        assert (after == 0).sum() == D * D // 2
+        # ...and the surviving weights did move, or the mask would have been
+        # a very thorough way of doing nothing.
+        assert not np.array_equal(after, before)
+
+
+def test_preserve_sparsity_still_recovers_error_while_staying_sparse():
+    """What the option is actually worth, measured against both alternatives.
+
+    Preserving the zeros costs reconstruction quality -- half the free
+    parameters are held at zero, so the block cannot fit the dense reference
+    and its loss plateaus far above the unconstrained run's. That is the
+    trade, and the number worth having is whether what remains still beats
+    doing nothing. It does, on a held-out input.
+
+    The unconstrained run is measured alongside precisely so the comparison is
+    not flattering by omission: it reaches a lower error, and it gets there by
+    returning a dense model, which is not the model that was asked for.
+    """
+    rng = np.random.default_rng(22)
+    reference, student, _ = _pruned_pair(rng)
+    data = _data(rng, batches=32)
+    held_out = _data(rng, batches=8)
+    before = _held_out_error(student, reference, held_out)
+
+    def run(preserve):
+        return onnxsim.apply_block_finetune(
+            reference,
+            student,
+            "X",
+            "Y",
+            calibration_data=data,
+            num_iterations=300,
+            learning_rate=2e-2,
+            preserve_sparsity=preserve,
+        )
+
+    sparse_tuned = run(True)
+    dense_tuned = run(False)
+
+    sparse_error = _held_out_error(sparse_tuned, reference, held_out)
+    dense_error = _held_out_error(dense_tuned, reference, held_out)
+
+    assert sparse_error < before * 0.9
+    # The dense run wins on error and loses the sparsity. Both halves are
+    # asserted so neither can quietly stop being true.
+    assert dense_error < sparse_error
+    assert (_init(dense_tuned, "W1") == 0).sum() == 0
+    assert (_init(sparse_tuned, "W1") == 0).sum() == D * D // 2
+
+
+def test_preserve_sparsity_costs_exactly_one_multiply_per_layer():
+    """The mechanism, pinned at the graph level.
+
+    A mask applied by writing zeros back after each step, or by a clean-up
+    pass at the end, would satisfy the tests above and be a different thing:
+    the weight would move and be moved back, its Adam moments would fill with
+    garbage, and the moments are state the loop carries. This asserts the
+    cheap version -- one extra ``Mul`` per trained layer, on the gradient --
+    which is what keeps the moments at zero too.
+    """
+    rng = np.random.default_rng(23)
+    reference, student, _ = _pruned_pair(rng)
+    data = _data(rng, batches=1)
+
+    def step_graph(preserve):
+        plan = qat._plan_block(reference, student, "X", "Y", False, False)
+        captured = qat._capture(
+            reference, sorted(set(plan.externals) | {plan.output_name}), data, None
+        )
+        externals = {name: captured[name] for name in plan.externals}
+        trained = qat._plan_trained(plan.candidates, False, False)
+        shapes = qat._block_shapes(
+            reference,
+            plan.nodes,
+            externals,
+            plan.output_name,
+            captured[plan.output_name],
+        )
+        return qat._build_step_graph(
+            trained,
+            plan.nodes,
+            shapes,
+            [],
+            externals,
+            plan.output_name,
+            list(captured[plan.output_name].shape),
+            False,
+            None,
+            False,
+            False,
+            preserve,
+        )
+
+    def counts(graph):
+        ops: dict = {}
+        for node in graph.model.graph.node:
+            ops[node.op_type] = ops.get(node.op_type, 0) + 1
+        return ops
+
+    plain_graph, masked_graph = step_graph(False), step_graph(True)
+    plain, masked = counts(plain_graph), counts(masked_graph)
+    assert masked["Mul"] - plain["Mul"] == 2  # two trained layers
+    assert {op: n for op, n in masked.items() if op != "Mul"} == {
+        op: n for op, n in plain.items() if op != "Mul"
+    }
+
+    # An op count alone cannot tell a gradient mask from a mask on the
+    # *updated weight* -- both are one Mul. What separates them is where the
+    # result goes: a masked gradient feeds Adam's two moment updates, so it
+    # has several consumers and is not itself a state output, whereas a masked
+    # weight would be the state output and feed nothing.
+    graph = masked_graph.model.graph
+    keep = [t.name for t in graph.initializer if "keep" in t.name]
+    assert len(keep) == 2
+    outputs = {o.name for o in graph.output}
+    for name in keep:
+        product = next(node.output[0] for node in graph.node if name in node.input)
+        consumers = [node for node in graph.node if product in node.input]
+        assert product not in outputs
+        assert len(consumers) >= 2

--- a/tests/test_qat.py
+++ b/tests/test_qat.py
@@ -2221,3 +2221,69 @@ def test_many_calibration_batches_are_all_used_not_just_the_first(monkeypatch):
     assert any(
         not np.array_equal(old[name], new[name]) for name in old if name in new
     ), "no initializer changed, so the run trained nothing"
+
+
+def test_preserve_sparsity_holds_a_pruned_models_zero_codes():
+    """``preserve_sparsity`` under the quantized path, where the failure it
+    prevents is intermittent rather than total.
+
+    Fine-tuning destroys an unstructured-pruned model's zeros on the first
+    step, because nothing rounds the weight back (see
+    ``tests/test_block_finetune.py``). Quantization hides that: a weight has
+    to drift half a quantization step before ``round(w / s)`` reports anything
+    but 0, so at ``apply_qat``'s default learning rate of 1e-4 a short run
+    moves no code off zero at all and the problem is invisible.
+
+    It is invisible, not absent. Measured on this model at 300 iterations, the
+    number of pruned zeros that came back as nonzero codes was 6 at lr 1e-3,
+    38 at 1e-2 and 177 at 5e-2 -- a sparsity that erodes with the learning
+    rate and the budget, which is a worse way to lose it than losing it
+    outright. With the flag on it is 0 at every rate.
+
+    The mask is the zero pattern of the master weight's seed, and under QAT
+    that seed is ``float_model``'s weight -- so this is the ordinary order of
+    operations (prune, then quantize the pruned model) rather than a special
+    case.
+    """
+    rng = np.random.default_rng(5)
+    weight = rng.normal(0, 0.3, (D, D)).astype(np.float32)
+    weight[np.abs(weight) < np.quantile(np.abs(weight), 0.5)] = 0.0
+    zeros = weight == 0
+
+    model = _model(
+        f"""
+        g (float[8,{D}] X) => (float[8,{D}] Y) {{
+          H = MatMul(X, W1)
+          Y = Relu(H)
+        }}
+        """,
+        [_f32(weight, "W1")],
+    )
+    quant = _quantize_chain_int4(model, {"W1"})
+    data = [{"X": rng.normal(0, 1, (8, D)).astype(np.float32)} for _ in range(4)]
+
+    def codes(tuned):
+        packed = next(
+            t
+            for t in tuned.graph.initializer
+            if t.data_type in (onnx.TensorProto.INT4, onnx.TensorProto.INT8)
+        )
+        return onnx.numpy_helper.to_array(packed)
+
+    def run(preserve):
+        return onnxsim.apply_qat(
+            model,
+            quant,
+            "X",
+            "Y",
+            calibration_data=data,
+            num_iterations=300,
+            learning_rate=1e-2,
+            preserve_sparsity=preserve,
+        )
+
+    # The learning rate is deliberately well above the default: at 1e-4 this
+    # test would pass with the feature removed, which would make it a test of
+    # nothing.
+    assert (zeros & (codes(run(False)) != 0)).sum() > 0
+    assert (zeros & (codes(run(True)) != 0)).sum() == 0


### PR DESCRIPTION
Follow-up to #1237, closing the two gaps it shipped with.

## 1. `preserve_sparsity` — the fix for a failure that looked like success

#1237 documented that block fine-tuning destroys an unstructured-pruned model's zeros, and pinned it with a test that asserted the broken behaviour. This fixes it.

Nothing in the step graph masks the optimizer unless asked, so a pruned zero gets a gradient like any other element and leaves zero on the very first step. `preserve_sparsity=True` zeroes the weight gradient wherever the master weight started at zero. **One `Mul` per trained layer holds those elements at zero exactly, not approximately**: with a gradient of 0 every step, Adam's `m` and `v` stay 0, its step is `lr * 0 / (sqrt(0) + eps)` — exactly 0 — and the parameter never moves. No clean-up pass, no drift in between, and the moments stay clean too, which a mask applied to the *updated weight* would not manage.

Measured on a two-layer block at 50% sparsity:

| | zeros kept | held-out error |
| --- | --- | --- |
| untuned | 128/128 | 0.241 |
| default | **0/128** | 0.000 |
| `preserve_sparsity=True` | **128/128** | 0.191 |

The default's lower error comes with a dense model, which is not the model that was asked for. Both halves are asserted so neither can quietly stop being true.

It is opt-in: "this element is zero" and "this element was pruned away" are the same bit pattern, and only the caller knows which they meant. The mask is the zero pattern of the master weight's *seed* — the student's own weight when fine-tuning, the float model's when quantizing, which for QAT over a pruned model is the ordinary order of operations anyway.

**Under `apply_qat` the same flag applies, and there the failure it prevents is intermittent rather than total — which is worse.** A weight must drift half a quantization step before `round(w / s)` reports anything but 0, so at the default learning rate of 1e-4 a short run moves no code off zero and the problem is invisible. Invisible, not absent: at 300 iterations on one weight, pruned zeros returning as nonzero codes numbered 6 at lr 1e-3, 38 at 1e-2 and 177 at 5e-2. A sparsity that erodes with the learning rate and the budget is a worse way to lose it than losing it outright. Zero at every rate with the flag on. That test deliberately runs well above the default rate, because at the default it would pass with the feature deleted.

## 2. The browser can fine-tune, not only quantize

`qat.py` grew `fake_quant=False` in #1237 and the C++ entry point did not, so the WASM build could quantize a model in the page but not fine-tune one. Ported: `QatOptions::fake_quant`, a float scheme scanned out of the student, the weight-input rewrite in place of the fake-quant emission, and a write-back that stores the trained fp32 tensor rather than codes derived from it. `preserve_sparsity` went across too — otherwise the browser could fine-tune a pruned model and hand back a dense one, the exact failure the flag exists to prevent, reachable only from the half a caller cannot see into.

The two student-rather-than-teacher decisions carry over intact, because they are the semantics rather than an implementation detail: trainable layers are scanned from the student and seeded from it, and the block's untrained constants come from it too. `QatTrainedLayer` gained an explicit `fake_quant` field rather than keying the write-back off a `block_size == 0` sentinel — those sentinels exist to fail loudly if a quantizer field is ever read when it should not be, and branching on one would have made the load-bearing path depend on exactly the value that is meant to be nonsense.

## Investigated and deliberately *not* fixed

#1237 also measured that generalization is dominated by calibration-set size. I was going to add a regularizer — `apply_pruning_finetune` has `reg_param`, so the precedent existed — and measured first. The damage at 16 rows **is** genuine overfitting (held-out error bottoms at 25–100 iterations then climbs, on every seed), so a regularizer would help. By about 0.60 → 0.59, where going from 16 to 256 rows gives 0.001.

A knob that looks like a fix for a problem it barely touches is worse than no knob. Documented the real interaction instead: `num_iterations` **is** the regularizer here, its default of 1000 is aimed at the well-fed case, and with too few rows longer is monotonically *worse* — the opposite of the well-fed case, where 300 iterations won on every seed.

## Verification

- **3917 Python tests pass**, 218 skipped (eight files excluded needing `torch`/`timm`, not installed here; pre-existing).
- **All four C++ tests pass**; `clang-format --Werror`, `ruff check`, `ruff format --check` clean; `mypy` clean on every touched file.
- Merged current `master` in; no conflicts, and everything re-verified on the merged tree.

### The parity check, and why its controls matter more than its result

C++/Python emission parity was checked by differential comparison — a dumper linked against the real library against a script driving `qat.py`'s own planner — on fixtures whose student weights carry real zeros, so the mask is neither all-ones nor all-zeros. Full-batch and minibatched runs both diff identical, and the mask constant's bytes were confirmed to interleave `0.0f` and `1.0f` rather than being uniform.

**Two earlier attempts at that comparison passed for reasons that had nothing to do with the code**, and both would have let me claim verification I had not done:

1. The link line uses build-dir-relative paths; run from elsewhere the dumper never built, so `diff` compared against a **missing file** and reported no differences.
2. `--target onnxsim` names the *binary*, not the library (`onnxsim_bin` sets `OUTPUT_NAME onnxsim`), so the rebuild silently failed and the comparison used a stale binary.

A green comparison that cannot go red is worth nothing. With the harness fixed and explicit failure checks, the controls discriminate: ignoring the flag differs in 110 lines, and an extra `Mul` that shifts the name counter differs in 114.

### Mutation-tested

Every new test was checked against the mutation it exists to catch. The one worth naming: an operator count **cannot** tell a gradient mask from a mask on the updated weight — both are one `Mul`. Both the Python and C++ tests therefore assert where the product *goes*: a masked gradient feeds Adam's two moment updates, so it has several consumers and is not a state output, whereas a masked weight would be the state output and feed nothing. That variant fails only that assertion, in both languages.

**Not verified:** `scripts/convertmodel/interface.cpp` compiles only under Emscripten and there is no `emcc` here. The change is two `read_bool` calls inside an existing function with no new embind registration, so the argument-dependent-lookup trap that broke `deploy` on #1237 does not apply — but CI's deploy job is still the first real compile. The `.mjs` test's new cases have likewise never executed against a real wasm module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_