### PR TITLE
Make the big-endian job run on the code it tests

### DIFF
--- a/.github/workflows/big-endian.yml
+++ b/.github/workflows/big-endian.yml
@@ -16,6 +16,15 @@ name: Big Endian
 # caught by the weekly run rather than at review time -- the trade that keeps
 # this off the critical path of ordinary PRs. To make it stricter, widen the
 # paths filter below to "onnxsim/**".
+#
+# **The filter has to keep step with what the job runs.** ctest here executes
+# every test CMake registers, and build_s390x_extension.sh builds 25 of them
+# specifically because they read or write raw_data. For a long time this list
+# named exactly one of those 25, so a change to (say) qat_entry.cpp -- which
+# reads float weights out of raw_data and packs INT4 codes back into it -- did
+# not run the job that tests it, and merged verified only by the following
+# Monday. Adding a test target there is therefore half the job: its source
+# belongs here too, or the coverage is nominal.
 
 on:
   schedule:
@@ -30,6 +39,51 @@ on:
       # The other file that reads raw_data (IntTensorToSymTensor, IsAllZeroTensor).
       - "onnxsim/onnxsim.cpp"
       - "onnxsim/onnxsim.h"
+      # Tensor bytes in and out of TensorPool, including its content hash.
+      - "onnxsim/tensor_pool.cpp"
+      - "onnxsim/tensor_pool.h"
+      - "onnxsim/tensor_pool_dtype.h"
+      - "onnxsim/tensor_pool_hash.cpp"
+      - "onnxsim/tensor_pool_hash.h"
+      - "onnxsim/tensor_pool_gguf.cpp"
+      - "onnxsim/tensor_pool_bridge.h"
+      - "onnxsim/tensor_pool_gguf_bridge.h"
+      # These two have no source of their own -- they cover the headers above
+      # -- but a test that picks up a host-order assumption reports a false
+      # pass, so editing one alone should still run here.
+      - "onnxsim/tensor_pool_archive_test.cpp"
+      - "onnxsim/read_gguf_metadata_test.cpp"
+      # The GGUF/GGML decoders: a decoded value is real numeric output rather
+      # than bytes copied through, so a host-order assumption changes results
+      # rather than merely scrambling a blob.
+      - "onnxsim/gguf_dtype.h"
+      - "onnxsim/ggml_kquant.h"
+      - "onnxsim/ggml_legacy_quant.h"
+      - "onnxsim/ggml_mxfp4.h"
+      # ReadFloatTensorFlat and GetTensorFloatData, which decode weight tensors.
+      - "onnxsim/precision_estimator.cpp"
+      - "onnxsim/precision_estimator.h"
+      - "onnxsim/xnnpack_codegen.cpp"
+      - "onnxsim/xnnpack_codegen.h"
+      # The step-graph emitters. GraphBuilder::Const *writes* raw_data and
+      # qat_entry reads weights and scales back out of it, so a big-endian run
+      # exercises both directions.
+      - "onnxsim/graph_grad.cpp"
+      - "onnxsim/graph_grad.h"
+      - "onnxsim/qat_graph_builder.cpp"
+      - "onnxsim/qat_graph_builder.h"
+      - "onnxsim/qat_entry.cpp"
+      - "onnxsim/qat_entry.h"
+      # The sharpest check in the tree, and the reason its four files are
+      # listed rather than just the C++: the fixture is generated on a
+      # little-endian host and both emitters are compared against it, so it
+      # fails if either side of the round trip picks up a host-order
+      # assumption. qat_graph.py and the generator decide what the fixture
+      # says; test_qat_parity.py runs here too.
+      - "onnxsim/qat_graph_parity_test.cpp"
+      - "onnxsim/qat_parity_fixtures.txt"
+      - "onnxsim/qat_graph.py"
+      - "scripts/make_qat_parity_fixtures.py"
       # The harness, so changes to it are validated before they are relied on.
       - "scripts/cross/bootstrap_s390x_rootfs.sh"
       - "scripts/cross/build_s390x_extension.sh"

--- a/scripts/cross/build_s390x_extension.sh
+++ b/scripts/cross/build_s390x_extension.sh
@@ -257,6 +257,12 @@ cmake --build "${BUILD_DIR}" --target sym_expr_test model_metrics_test \
 # both directions. It was also, briefly, the worked example of the trap
 # described above -- added to CMakeLists.txt, left off this list, and so an
 # instant "Failed 0.00 sec" rather than a test that did not run.
+#
+# Adding a target here is half the job. The workflow that runs this script is
+# path-filtered, so a test built here whose source is not listed in
+# .github/workflows/big-endian.yml never runs on a pull request that changes
+# it -- it waits for the Monday schedule. Both lists have to move together:
+# add the target here, add its source there.
 cmake --build "${BUILD_DIR}" --target tensor_pool_bridge_test \
   tensor_pool_gguf_bridge_test tensor_pool_archive_test \
   precision_estimator_test contrib_schemas_moe_test xnnpack_codegen_test \


### PR DESCRIPTION
The s390x job builds **25** test targets, chosen in `build_s390x_extension.sh`'s own comments because they read or write `raw_data`. Its `pull_request` paths filter named the source of exactly **one** of them.

So the job that exists to catch host-order assumptions did not run on pull requests that changed the code making them. It waited for the Monday schedule, while its green tick on the PRs it *did* run on made the coverage look complete.

## This is not hypothetical

- **#1239** changed 229 lines of `qat_entry.cpp` — which reads float weights and scales out of `raw_data` and packs INT4 codes back into it two to a byte — and merged with the big-endian job never running.
- **#1237** triggered it only by incidentally touching `CMakeLists.txt`. Its own commit message observed that the workflow is path-filtered, without drawing the conclusion.

I have dispatched the workflow manually against `master` to verify the code that merged unverified; that run is separate from this PR.

## What changes

The filter now names the sources behind **19 of the 25**, by the criterion the workflow itself states:

- tensor bytes through `TensorPool` and its content hash
- the GGUF/GGML decoders — a decoded value is numeric output, not bytes copied through, so a host-order assumption changes results rather than merely scrambling a blob
- the two weight-tensor readers (`ReadFloatTensorFlat`, `GetTensorFloatData`)
- the step-graph emitters — `GraphBuilder::Const` *writes* `raw_data` and `qat_entry` reads it back, so a big-endian run exercises both directions
- the parity fixture together with both emitters compared against it. That fixture is generated on a little-endian host, which makes the pair the sharpest byte-order check in the tree — it fails if either side of the round trip picks up a host-order assumption. Its four files are listed, including the Python, because `test_qat_parity.py` runs there too.

**The other six stay non-triggering deliberately**, because they are not this job's subject. `sym_expr`, `sym_value_eval`, `sym_shape_infer`, `model_metrics`, `memory_planning` and `contrib_schemas_moe` are on the build list, in that script's own words, "because they are cheap and exercise the same cross-built toolchain". Widening to `onnxsim/**` would sweep them in and put 40–50 minutes on every C++ pull request — the trade this filter exists to avoid. It stays available and stays documented.

## Keeping the two lists in step

The root cause is that the build list and the trigger list are maintained separately and silently drifted apart. `build_s390x_extension.sh` now says so where the target list is: adding a target there is half the job, and its source belongs in the filter or the coverage is nominal.

## Verification

- Both lists parsed programmatically and cross-checked rather than eyeballed: coverage goes from **1/25 to 19/25**, and the six exclusions are enumerated and match the build script's own stated rationale.
- YAML parses; `bash -n` clean on the script.
- This PR touches two files already in the filter, so the s390x job runs on it — **the fix is gated by the thing it fixes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_