### PR TITLE
axera: prefill cannot be timed on this stack -- and the matmul measurement that stands in for it

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4078,6 +4078,56 @@ groups, of which these layer files have none.
 Test: `test_llm_build_offers_an_int4_weight_path_the_cnn_path_lacks`
 (Docker, no device).
 
+### Prefill: why it cannot be timed directly, and what stands in for it
+
+Decode measures memory. Prefill is the compute-bound half of an LLM, and it
+is what a 43.2 TOPS INT4 rating would have to be claiming. It cannot be timed
+on this stack, and the reasons are worth recording so nobody repeats the
+attempt.
+
+**The two halves are both in the file.** An `llm_build` layer `.axmodel`
+holds *two independent* `neu mode` nodes: `subgraph_npu_0` takes
+`K_cache, V_cache, indices, input, mask` (decode) and `subgraph_npu_1` takes
+the same names suffixed `_1` (prefill). Neither consumes the other's output.
+
+**`axcl_run_model` always runs the first one.** Its `--group` flag indexes
+*shape* groups, of which these files have none -- asking for group 0 or 1
+both return "Selected shape group index {n vs. 0} is out of range". Feeding
+only the `_1` inputs fails; feeding all ten runs decode and reports decode's
+latency. There is no other runner: `/usr/bin/axcl/` ships `axcl_run_model`,
+`axcl_demo` and hardware samples, nothing LLM-specific.
+
+**Editing the wrapper does not redirect it.** Deleting the decode node makes
+the model fail to load, while an unmodified load-and-re-save runs fine
+(9.268 ms against 9.182 ms), so the surgery is the cause, not the round trip.
+Renaming so prefill becomes `subgraph_npu_0` gets past loading and then fails
+at "Feed stimulus failed" -- the runtime takes its input specification from
+the compiled blob, not from the ONNX names, so the wrapper cannot choose
+which subgraph runs.
+
+**And a prefill-only build is not on offer.** `llm_build --kv_cache_len 0`
+fails in the frontend with degenerate RoPE parameters (`shape (0, 64)`).
+
+**What stands in for it: the arithmetic prefill is made of.** A prefill step
+is dominated by large matrix multiplications, and those compile through the
+ordinary path:
+
+| matmul stack | GMAC | min ms | TOPS |
+| --- | --- | --- | --- |
+| S=128, 4096x11008, 4 layers | 46.2 | 16.21 | 5.70 |
+| S=512, 2048x5632, 6 layers | 70.9 | 19.01 | 7.46 |
+
+So transformer-shaped INT8 arithmetic sustains **5.7 to 7.5 TOPS**, against
+10.13 for convolution. Longer sequences do better, which is the same tiling
+story as the CNN measurements: 128 rows do not fill the engine as well as 512.
+
+That puts a bound on the INT4 claim rather than testing it. Prefill
+arithmetic on this card runs at roughly 6-7 TOPS in INT8; for INT4 to reach
+43.2 it would have to be six times faster than INT8 matmul measured here,
+where the decode measurements show INT4 buying 1.56x. The rating is not
+verifiable on this toolchain, and nothing measured here suggests it is
+reachable.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3971,6 +3971,31 @@ build config's `weight_data_type` for convolution accepts only `S8` or
 `FP32`, and `pulsar2 build --help` offers no 4-bit flag either. There is a
 4-bit path, but it is in the other pipeline -- see the next section.
 
+**Against the compiler's own cycle model.** Building with `profile=True`
+gives a modelled critical path, and a per-op profile in which convolutions
+are **98.9%** of the modelled cycles -- so the benchmark really is measuring
+arithmetic and not plumbing. Dividing that cycle count by the measured time
+gives an implied clock:
+
+| graph | max_cycle | min ms | implied MHz | MAC/cycle |
+| --- | --- | --- | --- | --- |
+| 1024ch 16x16 | 3,905,355 | 4.12 | 949 | 4,949 |
+| 512ch 32x32 | 3,704,778 | 4.30 | 862 | 5,217 |
+| 256ch 64x64 | 3,831,460 | 4.49 | 854 | 5,044 |
+
+**MAC-per-cycle is stable at about 5,000** across the three cores (roughly
+1,650 each), which is the more meaningful figure -- it is a property of the
+engine, not of the graph. The implied clock is *not* stable: 854 to 949 MHz.
+Since the clock cannot actually vary by 11% between two runs a minute apart,
+what that spread measures is the cycle model being optimistic by up to ~10%
+on some shapes -- stalls it does not account for. The best-matching graph is
+also the fastest one, which is consistent with that reading rather than with
+a variable clock.
+
+So the honest summary is: the engine sustains ~5,000 MAC/cycle at somewhere
+around 0.95 GHz, 9-10 TOPS is what that product comes to, and the compiler's
+cycle estimate is a good predictor to within about 10%.
+
 Test: `test_int8_throughput_reaches_a_useful_fraction_of_the_rating` (Docker
 and device). Its floor of 5 TOPS sits between a healthy NPU3 run and the
 ~3 TOPS a single-core or fallback build produces, so it doubles as a health
@@ -4012,6 +4037,36 @@ token of pure overhead, so this model cannot exceed roughly 80 tokens/s on
 this card no matter how the weights are quantised. INT4 pays off on a model
 whose per-layer weights are large enough for streaming to dominate that fixed
 cost -- which a 135M model's 3.5 MB per layer is not.
+
+**So the next test is a model built to make it pay.** A synthetic
+Llama-shaped checkpoint at 4096 hidden and 11008 intermediate -- **177 M
+parameters per layer**, fifty times SmolLM2's -- puts weight streaming firmly
+in charge:
+
+| weights | per layer | decode/layer | implied GB/s |
+| --- | --- | --- | --- |
+| `s4` | 100.5 MB | 5.91 ms | 17.0 |
+| `s8` | 195.6 MB | 9.20 ms | 21.3 |
+
+**INT4 now buys 1.56x**, against 1.10x on the small model, and the weight
+saving reaches 1.95x once layers are large enough that non-weight structure
+stops diluting it. The benefit scales with per-layer weight size exactly as
+the overhead argument predicts, and 1.56x of a theoretical 2x says roughly a
+third of a decode step is still something other than streaming weights.
+
+Effective weight-streaming bandwidth lands around **21 GB/s** at `s8`.
+
+**One caveat on the earlier model, stated plainly:** fitting
+`time = overhead + bytes / bandwidth` to the large model gives a fixed
+overhead of 2.6 ms per layer, not the 0.40 ms the small model gave. A
+genuinely fixed cost cannot do that, so that two-parameter fit describes each
+model at its own scale and should not be extrapolated between them. What does
+survive across both is the direction and its size: halving the weights buys
+almost nothing when layers are small and about 1.56x when they are large.
+
+For deployment arithmetic: at 9.20 ms per layer, a 32-layer model of this
+width would take 294 ms per token at `s8` and 189 ms at `s4` -- roughly 3.4
+against 5.3 tokens/s.
 
 **And the 43.2 TOPS INT4 rating stays unverified.** It is a compute-throughput
 claim, and the decode path cannot demonstrate it: a decode step is about

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3966,15 +3966,62 @@ The 8x8 collapse is the sharpest result: the same arithmetic runs 3.1x slower
 purely because the spatial dimension no longer covers the tiles the engine
 works in -- which is the same 32-wide tiling the `b0.03` operand counts.
 
-**The 43.2 TOPS INT4 figure is not reachable through this compiler.** The
+**The 43.2 TOPS INT4 figure is not reachable through *this* path.** The
 build config's `weight_data_type` for convolution accepts only `S8` or
-`FP32`; there is no 4-bit weight option in this Pulsar2 version, whatever the
-silicon can do.
+`FP32`, and `pulsar2 build --help` offers no 4-bit flag either. There is a
+4-bit path, but it is in the other pipeline -- see the next section.
 
 Test: `test_int8_throughput_reaches_a_useful_fraction_of_the_rating` (Docker
 and device). Its floor of 5 TOPS sits between a healthy NPU3 run and the
 ~3 TOPS a single-core or fallback build produces, so it doubles as a health
 check for a card that has quietly dropped to one core.
+
+### Where the INT4 path actually is
+
+Searching for 4-bit support the way the LLM pipeline does it finds it
+immediately, and in only one of the two pipelines:
+
+| pipeline | weight types offered |
+| --- | --- |
+| `pulsar2 build` (CNNs, everything above) | `S8`, `FP32` |
+| `pulsar2 llm_build` (transformers) | `fp16`, `bf16`, `fp32`, `s8`, **`s4`**, `fp8_e5m2`, `fp8_e4m3` |
+
+So the toolchain does have INT4 weights -- and FP8 in two flavours -- but only
+for the LLM path. `pulsar2 build` has no 4-bit option at all, neither in its
+config schema nor on its command line.
+
+**It builds, and it is much smaller.** SmolLM2-135M compiled three ways, same
+prefill length and KV cache, measured on the AX650N:
+
+| weights | total | per layer | decode/layer | tokens/s |
+| --- | --- | --- | --- | --- |
+| `s4` | 98.2 MB | 2.30 MB | 0.441 ms | 75.6 |
+| `s8` | 152.7 MB | 4.12 MB | 0.485 ms | 68.7 |
+| `fp16` | 253.4 MB | 7.47 MB | 0.639 ms | 52.2 |
+
+**But at this size the win is memory, not speed.** Going from `s8` to `s4`
+cuts the model 1.56x and buys only 1.10x on decode. The reason is visible in
+the three points: fitting `time = overhead + bytes / bandwidth` gives a fixed
+**per-layer overhead of about 0.40 ms** against roughly 0.09 ms of weight
+streaming at `s8`. Overhead dominates by four to one, so halving the weights
+barely moves the total. The same fit predicts the `fp16` measurement to
+within 10%, which is about as much as a two-parameter model of this deserves.
+
+That also sets a ceiling worth knowing: 0.40 ms x 30 layers is 12 ms per
+token of pure overhead, so this model cannot exceed roughly 80 tokens/s on
+this card no matter how the weights are quantised. INT4 pays off on a model
+whose per-layer weights are large enough for streaming to dominate that fixed
+cost -- which a 135M model's 3.5 MB per layer is not.
+
+**And the 43.2 TOPS INT4 rating stays unverified.** It is a compute-throughput
+claim, and the decode path cannot demonstrate it: a decode step is about
+4.5 MMAC per layer, some 0.02 TOPS, so it is latency-bound by three orders of
+magnitude. Showing it would need the prefill subgraph in isolation, and
+`axcl_run_model` will not select it -- its `--group` flag indexes shape
+groups, of which these layer files have none.
+
+Test: `test_llm_build_offers_an_int4_weight_path_the_cnn_path_lacks`
+(Docker, no device).
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3914,6 +3914,68 @@ Tests: `test_spatial_extent_lives_in_three_bits_of_b0_03` and
 `test_the_spatial_field_follows_the_innermost_dimension_in_2d` (Docker, no
 device).
 
+### What the card actually does: 10.13 TOPS against a 10.8 TOPS rating
+
+Everything above is about *what* the hardware runs. This is about how fast.
+The graphs are deliberately the most compute-dense thing that will compile --
+stacks of identical same-padded convolutions, nothing else attached -- and
+accuracy is irrelevant to the measurement. Throughput is
+`2 * MACs / latency`, with the MAC count taken from the compiler's own
+`build_context.json` rather than recomputed.
+
+**Peak measured: 10.13 TOPS INT8**, which is **93.8%** of Axera's 10.8
+TOPS "from NPU alone" figure and 56% of the 18 TOPS INT8 headline. The curve
+flattens there:
+
+| graph | GMAC | min ms | TOPS |
+| --- | --- | --- | --- |
+| 1024ch 16x16 3x3, 8 layers | 19.3 | 4.13 | 9.37 |
+| 1024ch 16x16 3x3, 16 layers | 38.7 | 7.82 | 9.89 |
+| 1024ch 16x16 3x3, **24 layers** | 58.0 | 11.45 | **10.13** |
+| 1024ch 32x32 3x3, 8 layers | 77.3 | 15.35 | 10.07 |
+| 512ch 48x48 3x3, 12 layers | 65.2 | 13.04 | 10.01 |
+
+Depth is what buys the last 8%: identical arithmetic at 8, 16 and 24 layers
+gives 9.37, 9.89 and 10.13, so a fixed per-inference overhead of roughly
+0.3 ms is being amortised.
+
+**The cores scale almost linearly.** The same graph under each `npu_mode`:
+
+| mode | min ms | TOPS | relative |
+| --- | --- | --- | --- |
+| NPU1 | 11.49 | 3.37 | 1.00 |
+| NPU2 | 6.03 | 6.41 | 1.90 |
+| NPU3 | 4.09 | 9.45 | 2.80 |
+
+`NPU4` and `NPU5` exist in the toolchain's `NPUMode` enum but are rejected on
+this target, so three cores is the ceiling here.
+
+**Shape matters more than size.** All the 3x3 rows above are the *same* 19.3
+GMAC of arithmetic, and they differ by a factor of three depending on how it
+is shaped:
+
+| shape | TOPS | why |
+| --- | --- | --- |
+| 1024ch, 16x16 | 9.37 | best of the set |
+| 256ch, 64x64 | 8.47 | |
+| 128ch, 128x128 | 7.75 | |
+| 2048ch, **8x8** | 2.99 | spatial extent too small to fill the array |
+| 512ch 32x32, 1x1 kernel | 6.19 | nine times fewer MACs per weight byte |
+
+The 8x8 collapse is the sharpest result: the same arithmetic runs 3.1x slower
+purely because the spatial dimension no longer covers the tiles the engine
+works in -- which is the same 32-wide tiling the `b0.03` operand counts.
+
+**The 43.2 TOPS INT4 figure is not reachable through this compiler.** The
+build config's `weight_data_type` for convolution accepts only `S8` or
+`FP32`; there is no 4-bit weight option in this Pulsar2 version, whatever the
+silicon can do.
+
+Test: `test_int8_throughput_reaches_a_useful_fraction_of_the_rating` (Docker
+and device). Its floor of 5 TOPS sits between a healthy NPU3 run and the
+~3 TOPS a single-core or fallback build produces, so it doubles as a health
+check for a card that has quietly dropped to one core.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4656,6 +4656,111 @@ def test_the_spatial_field_follows_the_innermost_dimension_in_2d(tmp_path):
     assert field_for(32, kernel=3) == (32 + 2 - 1) // 32
 
 
+def _conv_stack_model(channels, hw, kernel, layers):
+    """A stack of identical same-padded convolutions -- arithmetic with as
+    little else attached as possible, for a throughput measurement."""
+    rng = np.random.RandomState(0)
+    nodes, inits = [], []
+    current = "x"
+    for i in range(layers):
+        name = f"w{i}"
+        inits.append(
+            numpy_helper.from_array(
+                (rng.randn(channels, channels, kernel, kernel) * 0.02).astype(
+                    np.float32
+                ),
+                name,
+            )
+        )
+        nodes.append(
+            helper.make_node(
+                "Conv",
+                [current, name],
+                [f"h{i}"],
+                name=f"c{i}",
+                kernel_shape=[kernel, kernel],
+                pads=[kernel // 2] * 4,
+            )
+        )
+        current = f"h{i}"
+    shape = [1, channels, hw, hw]
+    graph = helper.make_graph(
+        nodes,
+        "stack",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, shape)],
+        [helper.make_tensor_value_info(current, TensorProto.FLOAT, shape)],
+        inits,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_int8_throughput_reaches_a_useful_fraction_of_the_rating(tmp_path):
+    """Confirmed on the AX650N (see the README's "What the card actually
+    does" section): a compute-dense INT8 convolution stack sustains several
+    TOPS, well above what a misconfigured build would produce.
+
+    This is a hardware health check as much as a performance claim. A card
+    pinned to one NPU core, or a build that quietly fell back, lands around
+    3 TOPS; the floor here sits between the two so either failure shows up.
+    The peak actually measured was 10.13 TOPS against Axera's 10.8 TOPS
+    "NPU alone" INT8 figure. Needs Docker and a device.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device")
+    channels, hw, kernel, layers = 512, 32, 3, 8
+    work = tmp_path / "work"
+    work.mkdir()
+    os.makedirs(work / "dataset", exist_ok=True)
+    os.makedirs(work / "config", exist_ok=True)
+    model = _conv_stack_model(channels, hw, kernel, layers)
+    onnx.save(model, str(work / "m.onnx"))
+    rng = np.random.RandomState(1)
+    pulsar2_docker.make_numpy_calibration_tar(
+        str(work / "dataset" / "m.tar"),
+        [rng.randn(1, channels, hw, hw).astype(np.float32) for _ in range(2)],
+    )
+    with open(work / "config" / "m.json", "w") as f:
+        json.dump(
+            {
+                "model_type": "ONNX",
+                "npu_mode": "NPU3",
+                "quant": {
+                    "input_configs": [
+                        {
+                            "tensor_name": "x",
+                            "calibration_dataset": "./dataset/m.tar",
+                            "calibration_format": "Numpy",
+                            "calibration_size": 2,
+                        }
+                    ],
+                    "calibration_method": "MinMax",
+                    "precision_analysis": False,
+                },
+                "compiler": {"check": 0},
+            },
+            f,
+        )
+    result = pulsar2_docker.build(
+        str(work), "m.onnx", "out", config_path="config/m.json", timeout=3000
+    )
+    assert result.success, result.error
+
+    with open(work / "out" / "build_context.json") as f:
+        macs = json.load(f)["macs"]
+    # The compiler's own MAC count must match the arithmetic in the graph.
+    assert macs == channels * channels * kernel * kernel * hw * hw * layers, macs
+
+    stats = pulsar2_docker.run_on_device(
+        str(work / "out" / "compiled.axmodel"), repeat=20, warmup=5, timeout=900
+    )
+    assert not stats.get("error"), stats.get("error")
+    tops = 2 * macs / (stats["min_ms"] * 1e-3) / 1e12
+    assert tops > 5.0, (tops, stats)
+
+
 def test_single_conv_program_encodes_its_output_channel_count(tmp_path):
     """Confirmed real (see the README's "The first operand with a known
     meaning" section): in a program holding exactly one convolution, the

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -11,9 +11,11 @@ Needs a loaded `pulsar2:*` Docker image -- skip-guarded like
 tests/test_pulsar2_hf_to_axmodel.py.
 """
 
+import glob
 import json
 import os
 import re
+import shutil
 import struct
 import sys
 import tempfile
@@ -4759,6 +4761,45 @@ def test_int8_throughput_reaches_a_useful_fraction_of_the_rating(tmp_path):
     assert not stats.get("error"), stats.get("error")
     tops = 2 * macs / (stats["min_ms"] * 1e-3) / 1e12
     assert tops > 5.0, (tops, stats)
+
+
+def test_llm_build_offers_an_int4_weight_path_the_cnn_path_lacks(tmp_path):
+    """Confirmed real (see the README's "Where the INT4 path actually is"
+    section): `pulsar2 llm_build` accepts `-w s4`, and the resulting model is
+    substantially smaller than the `s8` build of the same checkpoint.
+
+    This is the only 4-bit route in the toolchain. `pulsar2 build` -- the CNN
+    path everything else here uses -- has no 4-bit option at all: its
+    `weight_data_type` for convolution accepts only `S8` and `FP32`, and
+    there is no command-line flag either. Needs Docker, no device.
+    """
+    ckpt = _cached_hf_checkpoint("HuggingFaceTB/SmolLM2-135M")
+    if ckpt is None:
+        pytest.skip("HuggingFaceTB/SmolLM2-135M is not in the local HuggingFace cache")
+    work = tmp_path / "work"
+    work.mkdir()
+    shutil.copytree(ckpt, work / "SmolLM2-135M", symlinks=False)
+
+    sizes = {}
+    for weight_type in ("s8", "s4"):
+        result = pulsar2_docker.llm_build(
+            str(work),
+            "SmolLM2-135M",
+            f"out_{weight_type}",
+            weight_type=weight_type,
+            prefill_len=512,
+            kv_cache_len=1023,
+            parallel=8,
+        )
+        assert result.success, (weight_type, getattr(result, "error", None))
+        files = sorted(glob.glob(str(work / f"out_{weight_type}" / "*.axmodel")))
+        assert files, weight_type
+        sizes[weight_type] = sum(os.path.getsize(f) for f in files)
+
+    # 4-bit weights are the bulk of the saving, but a layer file also carries
+    # non-weight structure, so the ratio lands well short of 2x.
+    ratio = sizes["s8"] / sizes["s4"]
+    assert 1.3 < ratio < 2.0, (ratio, sizes)
 
 
 def test_single_conv_program_encodes_its_output_channel_count(tmp_path):


### PR DESCRIPTION
Decode measures memory. **Prefill** is the compute-bound half of an LLM, and it is what a 43.2 TOPS INT4 rating would have to be claiming. Four routes were tried and all close, so the reasons are recorded rather than left for someone to repeat.

### The two halves are both in the file

An `llm_build` layer `.axmodel` holds **two independent** `neu mode` nodes: `subgraph_npu_0` takes `K_cache, V_cache, indices, input, mask` (decode) and `subgraph_npu_1` takes the same names suffixed `_1` (prefill). Neither consumes the other's output.

### Why each route closes

1. **`axcl_run_model` always runs the first subgraph.** Its `--group` flag indexes *shape* groups, of which these files have none -- group 0 and group 1 both return "Selected shape group index {n vs. 0} is out of range". Feeding only the `_1` inputs fails; feeding all ten runs decode and reports decode's latency. `/usr/bin/axcl/` ships `axcl_run_model`, `axcl_demo` and hardware samples -- nothing LLM-specific.
2. **Deleting the decode node breaks loading.** An unmodified load-and-re-save runs fine (9.268 ms against 9.182 ms), so the surgery is the cause, not the round trip.
3. **Renaming prefill to `subgraph_npu_0` gets past loading and fails at "Feed stimulus failed".** The runtime takes its input specification from the compiled blob, not from the ONNX names, so the wrapper cannot choose which subgraph runs.
4. **A prefill-only build is not on offer.** `llm_build --kv_cache_len 0` fails in the frontend with degenerate RoPE parameters (`shape (0, 64)`).

### What stands in for it

A prefill step is dominated by large matrix multiplications, and those compile through the ordinary path:

| matmul stack | GMAC | min ms | TOPS |
| --- | --- | --- | --- |
| S=128, 4096x11008, 4 layers | 46.2 | 16.21 | 5.70 |
| S=512, 2048x5632, 6 layers | 70.9 | 19.01 | 7.46 |

Transformer-shaped INT8 arithmetic sustains **5.7 to 7.5 TOPS**, against 10.13 for convolution. Longer sequences do better, which is the same tiling story as the CNN measurements -- 128 rows do not fill the engine as well as 512 do.

### What that says about the INT4 rating

This **bounds** the claim rather than testing it. Prefill arithmetic on this card runs at roughly 6-7 TOPS in INT8; for INT4 to reach 43.2 it would have to be six times faster than the INT8 matmul measured here, in a regime where the decode measurements (#1242) show INT4 buying 1.56x.

The rating is not verifiable on this toolchain, and nothing measured here suggests it is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS