### PR TITLE
Fine-tune in the browser: stage 3 of docs/qat.md

### DIFF
--- a/docs/qat.md
+++ b/docs/qat.md
@@ -1,14 +1,14 @@
 # Delivering QAT in onnxsim: a design note
 
-**Status: design note, with stages 0-2 and 4 implemented.**
+**Status: design note, all five stages implemented.**
 `onnxsim/qat_graph.py`, `onnxsim/graph_grad.py`, `onnxsim/qat.py`
 (`apply_qat`, `apply_qat_all_blocks`, and the `apply_block_finetune` pair the
-same machinery becomes with the quantizer removed), `onnxsim/qat_interop.py`
-and the converter page's calibration-provider picker have all landed; the
-browser fine-tuning panel (stage 3) has not (see "Staging" below). This note
-answers "how *could* we deliver quantization-aware training as an onnxsim
-feature, and can the training math run on WebGPU or an NPU?" and records the
-shape of the work so the question doesn't have to be re-derived. `docs/nncf-comparison-future-work.md`
+same machinery becomes with the quantizer removed), `onnxsim/qat_interop.py`,
+and the converter page's calibration-provider picker and fine-tuning panel
+have all landed. This note answers "how *could* we deliver quantization-aware
+training as an onnxsim feature, and can the training math run on WebGPU or an
+NPU?" and records the shape of the work so the question doesn't have to be
+re-derived. `docs/nncf-comparison-future-work.md`
 currently lists QAT as out of scope ("QAT needs a training loop with a
 framework-native model"); this note revisits that on the narrower reading
 below, and leaves the broader one (task loss, labels, epochs) exactly as
@@ -329,10 +329,36 @@ Each stage is independently shippable and independently useful.
    outside, training and improving the model while silently using a fraction
    of the data the caller paid to download -- so a test asserts the step
    graph's teacher constant carries every row. That closes this stage.
-3. **Browser QAT panel.** A "fine-tune" panel in the converter page: data
-   from `hf_datasets.mjs`, execution from `ort_executor.mjs` on WebGPU, a
-   loss curve, and `quantize_metrics.mjs` for the before/after. Client-side
-   QAT with no server is something none of the comparable tools offer.
+3. **Browser QAT panel -- done**, as `scripts/convertmodel/qat_ui.mjs` over
+   `qat_finetune.mjs` and `qat_blocks.mjs`, driving the three wasm bindings
+   `interface.cpp` exposes. Two things in the sketch above did not survive
+   contact with the loop, and both are worth recording.
+
+   **`ort_executor.mjs` is the wrong runner for this.** Its `makeOrtRunner`
+   creates a session per call and passes tensors positionally as one packed
+   blob -- exactly right for the constant-folding trampoline it was written
+   for, and exactly wrong for a training loop, which needs one session held
+   across every step and binds inputs by name. The panel opens an
+   onnxruntime-web session directly, as `quantize_calibration.mjs` does, on
+   whatever `providersForEp` returns.
+
+   **The minibatch row stream cannot be bit-compatible with Python.**
+   `qat_graph.minibatch_indices` draws each epoch's permutation from
+   `np.random.default_rng([seed, epoch])` -- numpy's PCG64, which a browser
+   cannot regenerate. The port keeps every property the docstring argues for
+   (a permutation per epoch from `(seed, epoch)` alone, a straddling batch
+   completed from the front of the next epoch, the whole stream a pure
+   function of `t`) but not the sequence, so the same seed picks different,
+   equally valid batches. This is the one deliberate gap in Python/browser
+   parity, and it is confined to *which rows* a step sees: the emitted step
+   graph stays byte-identical, which is what `qat_parity_fixtures.txt` pins.
+
+   The panel captures every block's activations from the float model, which
+   is the capture-once walk rather than `apply_qat_all_blocks`' sequential
+   one -- the weaker of the two by this note's own measurements (206.2
+   against 168.1 above). `QatCapture` carries no "recapture this from the
+   student" flag, so doing better needs a change to the plan rather than to
+   the panel; it is flagged in `qat_ui.mjs` rather than quietly left out.
 4. **QAT interop (A) -- done.** `onnxsim/qat_interop.py`.
    `quantize_static_keeping_qdq_scales` reads the parameters a QAT export
    already carries, canonicalizes back to float only the pairs onnxsim can

--- a/onnxsim/qat_entry.h
+++ b/onnxsim/qat_entry.h
@@ -84,7 +84,17 @@ struct QatOptions {
   // Rows per optimizer step. 0 means full batch, which is the default and the
   // only mode with no per-step input beyond the scalars.
   int64_t batch_size = 0;
-  // Only consulted when batch_size > 0; matches minibatch_indices' own seed.
+  // Only consulted when batch_size > 0. It plays minibatch_indices' role --
+  // the per-epoch permutation is a function of (batch_seed, epoch) alone, so
+  // an interrupted run resumes on the same schedule -- but it does *not*
+  // reproduce that function's output, and no caller of this header can.
+  // minibatch_indices draws from np.random.default_rng([seed, epoch]), i.e.
+  // numpy's PCG64, which a browser has no way to regenerate. So the same seed
+  // picks different, equally valid batches here than in Python. That is the
+  // one place the Python and this port are deliberately not bit-comparable,
+  // and it is confined to *which rows* a step sees rather than to any emitted
+  // graph -- the step graph itself stays byte-identical, which is what
+  // qat_parity_fixtures.txt pins.
   int64_t batch_seed = 0;
   bool shuffle = true;
 };
@@ -172,8 +182,18 @@ struct QatStepPlan {
   // Input name -> the output carrying its next value. This is what makes the
   // loop a ping-pong of two buffers rather than a rebuild per step.
   std::vector<std::pair<std::string, std::string>> state;
-  // Scalar float inputs supplied fresh each step: the learning rates and Adam's
-  // two bias-correction factors. AdamBiasCorrections computes the latter.
+  // Scalar float inputs supplied fresh each step, by name, because feeding the
+  // right count of values in the wrong order is silent -- every one of them is
+  // a bare float and nothing downstream can tell a weight learning rate from an
+  // activation one:
+  //   "qat__lr"        the master weights' Adam learning rate
+  //   "m_correction"   Adam's first-moment bias correction, 1/(1 - beta1^(t+1))
+  //   "v_correction"   ... and its second, 1/(1 - beta2^(t+1))
+  //   "qat__lr_scale"  present only with learn_scales
+  //   "qat__lr_act"    present only with learn_activation_scales
+  // AdamBiasCorrections computes the two corrections. apply_qat decays each
+  // learning rate linearly (lr * (1 - t/num_iterations)) when lr_decay is on;
+  // that schedule is the caller's to reproduce, since nothing here sees t.
   std::vector<std::string> scalars;
   // The scalar output carrying this step's loss. Empty if none.
   std::string loss_name;

--- a/scripts/convertmodel/index.html
+++ b/scripts/convertmodel/index.html
@@ -40,6 +40,7 @@
             <a href="#sec-parse">Parse graph</a>
             <a href="#sec-convert">Convert</a>
             <a href="#sec-quantize">Quantize</a>
+            <a href="#sec-qat">Fine-tune</a>
             <a href="#sec-visualize">Netron</a>
             <a href="#sec-dims">Dynamic dims</a>
             <a href="#sec-console">Console</a>
@@ -444,6 +445,111 @@ agraph (float[N] X) =&gt; (float[N] Y) {
         </div>
         <script type="module" src="./quantize_ui.mjs"></script>
         <script type="module" src="./quantize_risk_estimate.mjs"></script>
+        <h2 id="sec-qat">Fine-tune a quantized model (QAT)</h2>
+        <div class="tool-panel">
+            <p class="tool-note">
+                Recovers some of the accuracy quantization cost, by
+                <b>training</b> the quantized model -- in your browser, with no
+                server and no labels. The float model is the <b>teacher</b>, the
+                quantized one is the <b>student</b>, and each block's weights are
+                optimized by Adam so the student reproduces the teacher's own
+                activations at that block's output. This is
+                <code>onnxsim.apply_qat</code>, reachable without Python: the
+                WebAssembly module emits one optimizer step as a plain ONNX
+                inference graph (a hand-derived backward pass is just dataflow --
+                no autograd, no training runtime) and
+                <a href="https://github.com/microsoft/onnxruntime" target="_blank" rel="noopener">onnxruntime-web</a>
+                runs that graph in a loop, so the whole training step reaches
+                WebGPU (and WebNN) through the same execution providers the
+                inference panel uses. See
+                <a href="https://github.com/onnxsim/onnxsim/blob/master/docs/qat.md" target="_blank" rel="noopener">docs/qat.md</a>.
+            </p>
+            <p class="tool-note">
+                <b>What it can and cannot do.</b> The objective is
+                "reproduce what the teacher produced", so it cannot exceed the
+                float model and it is not a way to train on new data or a new
+                task -- it fixes a model something else made worse. With
+                <b>fine-tune only</b> below, the quantizer comes out of the
+                middle and the student's own float weights are trained instead
+                (<code>apply_block_finetune</code>), which is for a pruned or
+                otherwise altered model; the two models have to differ, or there
+                is nothing to learn. Training runs on a handful of calibration
+                rows, so treat the result as a demonstration of the machinery
+                rather than a production tuning run.
+            </p>
+            <div>
+                <label for="qat-teacher">teacher (float)</label>
+                <select id="qat-teacher">
+                    <option value="original" selected>original (uploaded)</option>
+                    <option value="converted">onnxsim-simplified (Convert section)</option>
+                </select>
+                <label for="qat-student">student (trained)</label>
+                <select id="qat-student">
+                    <option value="quantized" selected>quantized (Quantize panel output)</option>
+                    <option value="converted">onnxsim-simplified (Convert section)</option>
+                    <option value="original">original (uploaded)</option>
+                </select>
+            </div>
+            <div>
+                <label for="qat-block-input" title="Leave both blank to discover blocks automatically: the graph is cut wherever exactly one activation is live, which is the boundary a self-contained slice needs.">block input tensor</label>
+                <input type="text" id="qat-block-input" placeholder="(auto-discover)" style="width: 12em;">
+                <label for="qat-block-output">block output tensor</label>
+                <input type="text" id="qat-block-output" placeholder="(auto-discover)" style="width: 12em;">
+                <label for="qat-max-layers" title="How many weight-bearing layers to merge into one block before closing it. 1 gives per-layer blocks; larger blocks let layers inside one cancel each other's quantization error.">layers per block</label>
+                <input type="number" id="qat-max-layers" value="2" min="1" max="16" step="1" style="width: 4em;">
+            </div>
+            <div>
+                <label for="qat-rows" title="Calibration rows captured from the teacher and held resident for the whole loop.">calibration rows</label>
+                <input type="number" id="qat-rows" value="8" min="1" max="128" step="1" style="width: 4em;">
+                <label for="qat-fill" title="'sample data' fetches a fresh real image (frgfm/imagenette) or sentence (stanfordnlp/sst2) from Hugging Face per row; the synthetic fills are seeded, so every row is identical.">calibration data</label>
+                <select id="qat-fill">
+                    <option value="sample" selected>sample data (Hugging Face image/text)</option>
+                    <option value="random">random (deterministic)</option>
+                    <option value="ones">ones</option>
+                    <option value="zeros">zeros</option>
+                </select>
+                <label for="qat-steps">steps per block</label>
+                <input type="number" id="qat-steps" value="200" min="1" max="20000" step="1" style="width: 5em;">
+                <label for="qat-lr">learning rate</label>
+                <input type="text" id="qat-lr" value="1e-4" style="width: 5em;">
+                <label for="qat-batch-size" title="Rows per optimizer step. 0 (or the full row count) trains full batch, the only mode with no per-step input beyond the scalars.">minibatch</label>
+                <input type="number" id="qat-batch-size" value="0" min="0" max="128" step="1" style="width: 4em;">
+                <label for="qat-batch-seed">seed</label>
+                <input type="number" id="qat-batch-seed" value="0" min="0" step="1" style="width: 4em;">
+            </div>
+            <div>
+                <label for="qat-ep" title="Which execution provider runs the training loop and the teacher captures. The loop is hundreds of forward+backward passes over one block, which is what makes an accelerator worth using here; every accelerated choice falls back to WASM.">execution provider</label>
+                <select id="qat-ep">
+                    <option value="webgpu" selected>WebGPU (fallback to WASM)</option>
+                    <option value="wasm">WASM</option>
+                    <option value="webnn-gpu">WebNN · GPU (fallback to WASM)</option>
+                    <option value="webnn-npu">WebNN · NPU (fallback to WASM)</option>
+                    <option value="webnn-cpu">WebNN · CPU (fallback to WASM)</option>
+                </select>
+            </div>
+            <div>
+                <input type="checkbox" id="qat-lr-decay" checked>
+                <label for="qat-lr-decay" title="Decays every learning rate linearly to zero across the run (apply_qat's lr_decay, on by default there too).">learning-rate decay</label>
+                <input type="checkbox" id="qat-learn-scales">
+                <label for="qat-learn-scales" title="Also train each block's weight quantization scale, LSQ-style (apply_qat's learn_scales).">learn weight scales</label>
+                <input type="checkbox" id="qat-learn-act-scales">
+                <label for="qat-learn-act-scales" title="Train the activation quantizers too. This selects the Static (QDQ) scheme rather than adding a knob: a weight-only model has no activation quantizer to train, and asking for the wrong pairing is refused rather than ignored.">learn activation scales (Static/QDQ models)</label>
+                <input type="checkbox" id="qat-preserve-sparsity">
+                <label for="qat-preserve-sparsity" title="Holds every weight element that starts at zero at zero for the whole run. Turn this on for an unstructured-pruned model: without it a pruned zero gets a gradient like any other element and leaves zero on the first step, while every signal you would look at says the run went well.">preserve sparsity (pruned models)</label>
+                <input type="checkbox" id="qat-finetune-only">
+                <label for="qat-finetune-only" title="Drops the fake-quantizer and trains the student's own float MatMul/Gemm weights against the teacher (apply_block_finetune). Incompatible with the two scale options, which name a parameter of a quantizer.">fine-tune only (no fake-quant)</label>
+                <input type="checkbox" id="qat-metrics-toggle" checked>
+                <label for="qat-metrics-toggle" title="After training, run the float, the quantized and the tuned model on the same random input through onnxruntime-web and report both drifts -- relative L2 error and SQNR, the same metric the Quantize panel reports.">report before/after quality</label>
+            </div>
+            <div class="debug-actions">
+                <button id="qat-button" type="button">Fine-tune</button>
+                <button id="qat-download" type="button" style="display: none;">download model ↓</button>
+                <span id="qat-status" class="tool-note"></span>
+            </div>
+            <div id="qat-curve" style="display: none; margin-top: 0.4em;"></div>
+            <div id="qat-metrics" style="display: none; margin-top: 0.4em;"></div>
+        </div>
+        <script type="module" src="./qat_ui.mjs"></script>
         <h2 id="sec-visualize">Visualize with Netron (before / after)</h2>
         <p>
             Renders the model graph with a self-hosted

--- a/scripts/convertmodel/package.json
+++ b/scripts/convertmodel/package.json
@@ -29,8 +29,11 @@
     "test:classify": "node test/classify_output.test.mjs",
     "test:quantize-risk": "node test/quantize_risk_estimate.test.mjs",
     "test:quantize-cal": "node test/quantize_calibration.test.mjs",
+    "test:qat-blocks": "node test/qat_blocks.test.mjs",
+    "test:qat-finetune": "node test/qat_finetune.test.mjs",
+    "test:qat-loop": "node test/qat_loop_ort.test.mjs",
     "test:stepgraph": "node test/step_graph_ep.test.mjs",
-    "test:all": "npm run test:netron && npm run test:trace && npm run test:node-reduction && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:hftoken && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:ortlog && npm run test:cdn && npm run test:fill && npm run test:tokenize && npm run test:hfdata && npm run test:sample && npm run test:classify && npm run test:quantize-risk && npm run test:quantize-cal && npm run test:inference && npm run test:compare && npm run test:stepgraph",
+    "test:all": "npm run test:netron && npm run test:trace && npm run test:node-reduction && npm run test:macs && npm run test:shapes && npm run test:hf && npm run test:hftoken && npm run test:xet && npm run test:issue && npm run test:versions && npm run test:backend && npm run test:query && npm run test:webnn && npm run test:ortlog && npm run test:cdn && npm run test:fill && npm run test:tokenize && npm run test:hfdata && npm run test:sample && npm run test:classify && npm run test:quantize-risk && npm run test:quantize-cal && npm run test:qat-blocks && npm run test:qat-finetune && npm run test:qat-loop && npm run test:inference && npm run test:compare && npm run test:stepgraph",
     "coverage": "c8 npm run test:all"
   },
   "dependencies": {

--- a/scripts/convertmodel/qat_blocks.mjs
+++ b/scripts/convertmodel/qat_blocks.mjs
@@ -1,0 +1,271 @@
+// Block discovery for the converter page's "Fine-tune (QAT)" panel.
+//
+// onnxsim_qat_build_step_graph names a block the way onnxsim.apply_qat does:
+// by two tensor names, its input and its output. A user can type them, but on
+// a real model nobody knows them offhand -- so this module proposes them,
+// porting onnxsim/qat.py's discover_qat_blocks (_liveness_cuts /
+// _primary_graph_input and the span walk over them) to JavaScript, reading the
+// model bytes directly with the same dependency-free protobuf wire reader
+// macs.mjs and shapes.mjs already share.
+//
+// It is a liveness argument rather than a pattern match, and that is the whole
+// substance: walk the nodes in graph order tracking which activations are
+// live at each gap, and cut wherever exactly one is. A slice bounded that way
+// is self-contained, so it can be lifted out and differentiated on its own --
+// which means residual connections *place* the boundaries instead of defeating
+// them (inside `y = f(x) + x` the skip tensor is live alongside every
+// intermediate, so the first cut after `x` is the residual Add's own output).
+// qat.py's own docstrings carry the full argument; this is the port, not a
+// second derivation of it.
+//
+// **Where this port is deliberately weaker than the Python.** Python closes a
+// block after `max_layers_per_block` *quantized* layers, which it knows from
+// qat.py's _find_layers matching the float model's layers against the
+// quantized model's. There is no binding for that -- the wasm module exposes
+// BuildQatStepGraph and WriteBackQatState and nothing else of qat.py -- so a
+// "layer" here is a float-side weight-bearing op instead: a MatMul/Gemm/Conv
+// with a constant (initializer) weight, which is the population every
+// quantizer in onnxsim draws its layers from. The two agree except at the
+// margins each scheme adds (quantize_weight_only_int4 skips a MatMul whose
+// reduction axis is not a multiple of 32, say), so a proposal can occasionally
+// merge one span too few or too many. That costs block granularity, not
+// correctness: BuildQatStepGraph refuses a block with no layer of the
+// requested scheme in it, loudly, and the panel reports the refusal and moves
+// to the next block.
+//
+// Field numbers below are from onnx.proto:
+//   ModelProto     graph = 7
+//   GraphProto     node = 1, initializer = 5, input = 11, output = 12
+//   NodeProto      input = 1, output = 2, name = 3, op_type = 4
+//   TensorProto    name = 8
+//   ValueInfoProto name = 1
+
+import { fields, decode } from "./macs.mjs";
+
+// onnxsim.graph_grad.SUPPORTED_OPS -- the op types build_backward has a
+// gradient rule for, and therefore the only ops a block may contain. It tracks
+// graph_grad.py's _RULES table and graph_grad.cpp's Rules(), which are the same
+// table on both sides. A span containing anything else is a gap between blocks
+// rather than a failed model, which is what makes whole-model discovery usable
+// at all.
+//
+// This is a pre-filter, not the authority: BuildQatStepGraph checks the real
+// table and refuses a block whose ops it cannot differentiate, naming them. So
+// a list that lags a newly added rule costs block granularity (that op becomes
+// a gap), and a list that runs ahead of one costs a proposed block that is then
+// refused and skipped with its reason -- neither trains anything wrongly.
+export const DIFFERENTIABLE_OPS = new Set([
+  "Add",
+  "Clip",
+  "Div",
+  "Erf",
+  "Exp",
+  "Gemm",
+  "Identity",
+  "LayerNormalization",
+  "MatMul",
+  "Mul",
+  "Neg",
+  "ReduceMean",
+  "ReduceSum",
+  "Relu",
+  "Reshape",
+  "Sigmoid",
+  "Softmax",
+  "Sqrt",
+  "Sub",
+  "Tanh",
+  "Transpose",
+]);
+
+// The ops onnxsim's quantizers turn into quantized layers -- see the header
+// note on why this stands in for qat.py's _find_layers here.
+const WEIGHTED_OPS = new Set(["MatMul", "Gemm", "Conv"]);
+
+function parseNode(buf) {
+  const input = [];
+  const output = [];
+  let name = "";
+  let opType = "";
+  for (const f of fields(buf)) {
+    if (f.field === 1 && f.wire === 2) input.push(decode(f.bytes));
+    else if (f.field === 2 && f.wire === 2) output.push(decode(f.bytes));
+    else if (f.field === 3 && f.wire === 2) name = decode(f.bytes);
+    else if (f.field === 4 && f.wire === 2) opType = decode(f.bytes);
+  }
+  return { name, opType, input, output };
+}
+
+// The `name` field of a ValueInfoProto (field 1) or a TensorProto (field 8) --
+// the only field either is read for here.
+function parseName(buf, field) {
+  for (const f of fields(buf)) {
+    if (f.field === field && f.wire === 2) return decode(f.bytes);
+  }
+  return "";
+}
+
+function parseGraph(buf) {
+  const nodes = [];
+  const initializers = [];
+  const inputs = [];
+  const outputs = [];
+  for (const f of fields(buf)) {
+    if (f.wire !== 2) continue;
+    if (f.field === 1) nodes.push(parseNode(f.bytes));
+    else if (f.field === 5) initializers.push(parseName(f.bytes, 8));
+    else if (f.field === 11) inputs.push(parseName(f.bytes, 1));
+    else if (f.field === 12) outputs.push(parseName(f.bytes, 1));
+  }
+  return { nodes, initializers, inputs, outputs };
+}
+
+// Read the pieces of a model's graph block discovery needs: its nodes in graph
+// (topological) order with their input/output tensor names, and the three name
+// sets that decide what counts as an activation. Returns
+// { nodes: [{ name, opType, input, output }], initializers, inputs, outputs }.
+export function readGraph(modelBytes) {
+  const buf = modelBytes instanceof Uint8Array ? modelBytes : new Uint8Array(modelBytes);
+  let graph = { nodes: [], initializers: [], inputs: [], outputs: [] };
+  for (const f of fields(buf)) {
+    if (f.field === 7 && f.wire === 2) graph = parseGraph(f.bytes);
+  }
+  return graph;
+}
+
+// The graph input the most nodes depend on -- the main activation path, and a
+// heuristic named as one (qat.py's _primary_graph_input). Models with several
+// inputs almost always have one carrying activations and the others carrying
+// masks or ids, and "reaches the most nodes" separates those without depending
+// on naming conventions. Ties go to the earlier graph input. Getting it wrong
+// costs block granularity, not correctness: every non-chosen input is
+// teacher-forced exactly.
+export function primaryGraphInput(graph) {
+  const initializers = new Set(graph.initializers);
+  const candidates = graph.inputs.filter((name) => !initializers.has(name));
+  if (candidates.length === 0) return null;
+
+  let best = candidates[0];
+  let bestReach = -1;
+  for (const name of candidates) {
+    const reached = new Set([name]);
+    let count = 0;
+    for (const node of graph.nodes) {
+      if (node.input.some((inp) => inp && reached.has(inp))) {
+        count += 1;
+        for (const out of node.output) if (out) reached.add(out);
+      }
+    }
+    if (count > bestReach) {
+      best = name;
+      bestReach = count;
+    }
+  }
+  return best;
+}
+
+// Every index at which the graph narrows to a single live activation, with the
+// tensor that survives it: [{ index, name }], where `index` is the node the
+// gap follows (-1 for the gap before the first node). qat.py's _liveness_cuts.
+//
+// Initializers are excluded (they are not activations -- every block gets its
+// own copy in its step graph), and so is every graph input other than
+// `primaryInput`: a mask or a position-id tensor is byte-identical in teacher
+// and student, so teacher-forcing it into a block is exact rather than an
+// approximation, and letting it span the whole graph would otherwise suppress
+// every cut in a model that has one.
+export function livenessCuts(graph, primaryInput) {
+  const initializers = new Set(graph.initializers);
+  const graphInputs = graph.inputs.filter((name) => !initializers.has(name));
+  const ignored = new Set(graphInputs.filter((name) => name !== primaryInput));
+
+  // A tensor is live until its last consumer; a graph output is live past the
+  // end of the graph, so it is never dropped before the final gap.
+  const lastUse = new Map();
+  graph.nodes.forEach((node, index) => {
+    for (const name of node.input) {
+      if (name && !initializers.has(name) && !ignored.has(name)) lastUse.set(name, index);
+    }
+  });
+  for (const name of graph.outputs) {
+    if (name && !initializers.has(name) && !ignored.has(name)) lastUse.set(name, graph.nodes.length);
+  }
+
+  const cuts = [];
+  const live = new Set(
+    graphInputs.filter((name) => !ignored.has(name) && (lastUse.get(name) ?? -1) > -1),
+  );
+  if (live.size === 1) cuts.push({ index: -1, name: [...live][0] });
+  graph.nodes.forEach((node, index) => {
+    for (const name of node.output) {
+      if (name && !ignored.has(name) && (lastUse.get(name) ?? -1) > index) live.add(name);
+    }
+    for (const name of [...live]) {
+      if ((lastUse.get(name) ?? -1) <= index) live.delete(name);
+    }
+    if (live.size === 1) cuts.push({ index, name: [...live][0] });
+  });
+  return cuts;
+}
+
+// True for a node onnxsim's quantizers would turn into a quantized layer: a
+// MatMul/Gemm/Conv whose weight is a constant. See the header note.
+function isWeightedLayer(node, constants) {
+  return node.opType && WEIGHTED_OPS.has(node.opType) && node.input.some((n) => n && constants.has(n));
+}
+
+// Partition a model into blocks the step-graph builder can be asked to train,
+// as [{ input, output, layers, nodes }] in graph order -- `input`/`output` are
+// the two tensor names to pass to onnxsim_qat_build_step_graph, `layers` is how
+// many weight-bearing ops the block contains and `nodes` how many nodes.
+//
+// Consecutive blocks need not be adjacent: a span containing an op with no
+// gradient rule becomes a gap between blocks rather than a refusal of the whole
+// model. An empty result is a legitimate answer (a graph whose activations
+// never narrow to one live tensor has no cut to make), not an error.
+//
+// `maxLayersPerBlock` is qat.py's own knob and its default of 2 is the
+// paired-projection shape BRECQ targets (a ResNet BasicBlock's two convolutions,
+// a transformer FFN's up/down pair): 1 gives per-layer blocks, a large value
+// gives one block per gap between undifferentiable ops -- on a model with no
+// such gap, one block spanning the whole graph, which is the end-to-end
+// objective rather than a surrogate for it, and which docs/qat.md measures as
+// fitting the calibration set better while generalizing worse.
+export function discoverBlocks(modelBytes, { maxLayersPerBlock = 2 } = {}) {
+  if (maxLayersPerBlock < 1) throw new Error("maxLayersPerBlock must be at least 1");
+  const graph = readGraph(modelBytes);
+  const cuts = livenessCuts(graph, primaryGraphInput(graph));
+  const constants = new Set(graph.initializers);
+
+  const blocks = [];
+  let start = cuts.length ? cuts[0] : null;
+  let layers = 0;
+  let nodes = 0;
+  const close = (end) => {
+    blocks.push({ input: start.name, output: end.name, layers, nodes });
+    start = end;
+    layers = 0;
+    nodes = 0;
+  };
+  for (let i = 1; i < cuts.length; i++) {
+    const previous = cuts[i - 1];
+    const current = cuts[i];
+    const span = graph.nodes.slice(previous.index + 1, current.index + 1);
+    if (span.some((node) => !DIFFERENTIABLE_OPS.has(node.opType))) {
+      // A gap. Close whatever was pending *before* it (the pending block ends
+      // at the last cut still on the trainable side) and reopen after it.
+      if (start !== null && layers && start.index < previous.index) close(previous);
+      start = current;
+      layers = 0;
+      nodes = 0;
+      continue;
+    }
+    if (start === null) start = previous;
+    layers += span.filter((node) => isWeightedLayer(node, constants)).length;
+    nodes += span.length;
+    if (layers >= maxLayersPerBlock) close(current);
+  }
+  const last = cuts.length ? cuts[cuts.length - 1] : null;
+  if (start !== null && layers && last && start.index < last.index) close(last);
+  return blocks;
+}

--- a/scripts/convertmodel/qat_finetune.mjs
+++ b/scripts/convertmodel/qat_finetune.mjs
@@ -1,0 +1,557 @@
+// The driving half of block-wise QAT in the browser, for the converter page's
+// "Fine-tune (QAT)" panel (qat_ui.mjs).
+//
+// onnxsim/qat_entry.h splits the feature in two on purpose: building the step
+// graph is graph surgery and lives in wasm
+// (onnxsim_qat_build_step_graph / _write_back / _release_plan, see
+// interface.cpp), while *running* it is an ordinary inference loop and belongs
+// wherever the inference runtime is -- here, on onnxruntime-web. That header's
+// "intended browser flow" comment is the contract this file implements:
+//
+//   1. build the step graph for one block, getting back its state ping-pong
+//      map, the activations to capture, the per-step scalars and the initial
+//      state tensors;
+//   2. capture those activations from the *float* model, bind them plus the
+//      initial state, and run the step graph `n` times, feeding the per-step
+//      scalars and carrying each state output back into its state input;
+//   3. write the final state back into the quantized model, and release the
+//      plan.
+//
+// Everything that decides *what* is fed -- the scalar schedule, the minibatch
+// row stream, which capture binds to which input, the state ping-pong -- is a
+// pure function here, taking injected fakes, so the loop's mechanics are
+// testable under Node with no browser and no wasm (test/qat_finetune.test.mjs),
+// exactly the way quantize_calibration.mjs is. Only captureActivations() and
+// fineTuneBlock() touch onnxruntime-web, and they take their ORT entry points
+// injected too.
+//
+// Two contract details from interface.cpp are load-bearing and easy to get
+// wrong, so they are enforced rather than remembered:
+//   - a capture binds to its `input`, never its `source`. The two differ
+//     whenever the step graph renames a tensor (under a minibatch the whole
+//     set is bound to a resident `qat__all_<name>` table and the block reads
+//     gathered rows out of it), and binding by `source` would train on
+//     uninitialized memory rather than fail.
+//   - `stepGraph` and every `initialState.data` are views over wasm buffers
+//     the next call reuses. They are copied out here, immediately, before any
+//     other binding runs.
+
+import { loadOrt, makeDummyInputs } from "./inference_browser.mjs";
+import { createSampleContext } from "./sample_inputs.mjs";
+
+// Adam's decay rates, as onnxsim/qat_graph.py and qat_graph_builder.cpp fix
+// them. The optimizer itself lives in the step graph; only the two
+// bias-correction factors are host-side.
+export const ADAM_BETA1 = 0.9;
+export const ADAM_BETA2 = 0.999;
+
+// Adam's two bias-correction factors at (0-based) step `t`, named the way the
+// step graph's inputs are: qat_graph.adam_bias_corrections and the C++
+// AdamBiasCorrections, which this must agree with element for element.
+//
+// They are fed as scalars rather than derived inside the graph because that is
+// two host-side floats per step against the state a Pow over a step counter
+// would need -- see qat_graph_builder.h's note on AdamUpdate.
+export function adamBiasCorrections(t) {
+  return {
+    m_correction: 1 / (1 - Math.pow(ADAM_BETA1, t + 1)),
+    v_correction: 1 / (1 - Math.pow(ADAM_BETA2, t + 1)),
+  };
+}
+
+// The value for every scalar the plan asks for, at step `t` of `numSteps`.
+//
+// The learning rates decay linearly to zero over the run (apply_qat's
+// `lr_decay`, on by default there and here); the bias corrections do not
+// depend on the schedule at all. An unknown scalar name throws rather than
+// being skipped: a step graph input left unfed is an opaque onnxruntime error
+// at run time, and a new scalar appearing in the plan is exactly the kind of
+// contract change that should stop the loop and name itself.
+export function stepScalars(scalarNames, t, options = {}) {
+  const {
+    numSteps = 1,
+    learningRate = 1e-4,
+    scaleLearningRate = 1e-5,
+    activationLearningRate = 1e-2,
+    lrDecay = true,
+  } = options;
+  const decay = lrDecay && numSteps > 0 ? 1 - t / numSteps : 1;
+  const rates = {
+    qat__lr: learningRate * decay,
+    qat__lr_scale: scaleLearningRate * decay,
+    qat__lr_act: activationLearningRate * decay,
+    ...adamBiasCorrections(t),
+  };
+  const values = {};
+  for (const name of scalarNames) {
+    if (!(name in rates)) {
+      throw new Error(`the step graph asks for an unknown per-step scalar '${name}'`);
+    }
+    values[name] = rates[name];
+  }
+  return values;
+}
+
+// A seeded permutation of [0, n), drawn from (seed, epoch) alone.
+//
+// The xorshift32 is input_fill.mjs's, for the same reason it is used there:
+// the page has no seeded RNG of its own and this one is four lines. It
+// deliberately does *not* reproduce qat_graph.minibatch_indices' permutation,
+// which comes from numpy's PCG64 via np.random.default_rng([seed, epoch]) --
+// nothing in a browser can. What matters is the property, not the sequence:
+// a permutation drawn from (seed, epoch) rather than advanced from a running
+// generator is what keeps the row stream a pure function of the step index, so
+// a run is reproducible and a loop stopped at step N and resumed there sees
+// the same batches. The one thing this changes against Python is that the same
+// seed picks different (equally valid) batches in the two, which is why the
+// panel reports its seed.
+function permutation(n, seed, epoch) {
+  // imul, not `*`: the products exceed 2^53 for a large seed and would lose
+  // low bits -- the only bits a hash of (seed, epoch) has to offer.
+  let s = (Math.imul(seed | 0, 0x9e3779b1) ^ Math.imul(epoch | 0, 0x85ebca6b) ^ 0x2545f491) | 0;
+  if (s === 0) s = 0x2545f491;
+  const next = () => {
+    s ^= s << 13;
+    s ^= s >>> 17;
+    s ^= s << 5;
+    return s >>> 0;
+  };
+  const order = Array.from({ length: n }, (_, i) => i);
+  for (let i = n - 1; i > 0; i--) {
+    const j = next() % (i + 1);
+    const tmp = order[i];
+    order[i] = order[j];
+    order[j] = tmp;
+  }
+  return order;
+}
+
+// The row indices step `t` should train on, as a pure function of `t` --
+// qat_graph.minibatch_indices, ported. Returns (t) => BigInt64Array, the dtype
+// the step graph's row-index input declares (it is the only non-float input a
+// step graph ever has).
+//
+// The stream is an endless concatenation of per-epoch permutations chopped
+// into fixed-size chunks: step `t` gets stream positions [t*B, (t+1)*B), and
+// position `p` is row perm[p / N][p % N]. A batch that would run off the end
+// of an epoch is *completed from the front of the next* rather than being
+// short, because a step graph's shapes are static -- that is the property that
+// lets it compile for an NPU -- so a ragged final batch would need a second
+// graph. Dropping the tail would silently discard rows, and systematically the
+// same ones without shuffling; padding by repeat would quietly reweight one.
+// Wrapping keeps every row's visit count equal and every batch full.
+export function minibatchIndices(numRows, batchSize, { seed = 0, shuffle = true } = {}) {
+  if (numRows < 1) throw new Error(`numRows must be at least 1, got ${numRows}`);
+  if (batchSize < 1) throw new Error(`batchSize must be at least 1, got ${batchSize}`);
+  // A batch straddling an epoch boundary asks for two permutations, so the
+  // last two are kept rather than redrawn twice per step.
+  const cache = new Map();
+  const epochOrder = (epoch) => {
+    let order = cache.get(epoch);
+    if (!order) {
+      order = shuffle
+        ? permutation(numRows, seed, epoch)
+        : Array.from({ length: numRows }, (_, i) => i);
+      for (const stale of [...cache.keys()]) if (stale < epoch - 1) cache.delete(stale);
+      cache.set(epoch, order);
+    }
+    return order;
+  };
+  return (t) => {
+    const rows = new BigInt64Array(batchSize);
+    let filled = 0;
+    while (filled < batchSize) {
+      const position = t * batchSize + filled;
+      const epoch = Math.floor(position / numRows);
+      const offset = position % numRows;
+      const take = Math.min(numRows - offset, batchSize - filled);
+      const order = epochOrder(epoch);
+      for (let i = 0; i < take; i++) rows[filled + i] = BigInt(order[offset + i]);
+      filled += take;
+    }
+    return rows;
+  };
+}
+
+// Bind the captured activations to the step graph, keyed by each capture's
+// `input` and looked up by its `source`.
+//
+// This is the one place the two names are allowed to differ, and the reason
+// this is a function rather than a loop at the call site: `captured` is keyed
+// by the tensor read out of the float graph, the feeds are keyed by the step
+// graph's own input, and under a minibatch those are never the same name.
+export function bindCaptures(captures, captured) {
+  const feeds = {};
+  for (const capture of captures) {
+    const value = captured[capture.source];
+    if (value === undefined) {
+      throw new Error(`no captured activation for '${capture.source}'`);
+    }
+    feeds[capture.input] = value;
+  }
+  return feeds;
+}
+
+// The loop's final state, as onnxsim_qat_write_back takes it: keyed by state
+// *input* name, each value a { dims, data } pair.
+//
+// The re-key the binding's doc comment describes -- from each state pair's
+// `output` back onto its `input` -- has already happened, once, in
+// runStepLoop's ping-pong, which is where it has to happen anyway for the loop
+// to carry state at all. So this only checks that every state input the plan
+// declares actually has a value (a plan whose state the loop never ran leaves
+// the model silently untrained) and narrows each tensor to the two fields the
+// binding reads, dropping the loss along with everything else.
+export function finalStateForWriteBack(state, finalState) {
+  const final = {};
+  for (const { input } of state) {
+    const tensor = finalState[input];
+    if (tensor === undefined) {
+      throw new Error(`the loop's final state has no value for '${input}'`);
+    }
+    // { dims, data } -- which is exactly an onnxruntime-web output tensor's
+    // own shape, so this is a narrowing rather than a conversion.
+    final[input] = { dims: [...tensor.dims], data: tensor.data };
+  }
+  return final;
+}
+
+// Run the step graph `numSteps` times, carrying the state.
+//
+// `runStep(feeds)` runs one step and returns its outputs as
+// { name: { dims, data } } -- an onnxruntime-web session.run in the browser, a
+// fake in the tests. The captures and the state tensors are objects of the
+// runtime's own kind and are passed through untouched, so a state output can
+// be fed straight back as the next step's input with no copy: onnxruntime
+// allocates a fresh output tensor per run, so the two buffers ping-pong on
+// their own (the aliasing hazard docs/qat.md records is about *pre-allocated*
+// output buffers under IOBinding, which this path does not use).
+//
+// Returns { state, losses }: the final state keyed by state input, and the
+// per-step loss, which is what the panel plots.
+export async function runStepLoop({
+  state,
+  scalars = [],
+  loss = "",
+  initialState,
+  captures = {},
+  rowIndex = null,
+  numSteps,
+  rates = {},
+  runStep,
+  // The schedule is policy, the loop is mechanism: both of these are the
+  // defaults rather than the definitions, so a caller can drive a step graph
+  // whose scalars are named differently or replay a Python run's own batches
+  // instead of drawing new ones. The panel passes neither.
+  scalarValues = null,
+  makeScalar = (value) => ({ dims: [], data: Float32Array.of(value) }),
+  makeRowIndex = (rows) => ({ dims: [rows.length], data: rows }),
+  onStep = () => {},
+}) {
+  let current = { ...initialState };
+  const losses = [];
+  const rows = rowIndex
+    ? rowIndex.rows || minibatchIndices(rowIndex.numRows, rowIndex.size, rowIndex)
+    : null;
+  for (let t = 0; t < numSteps; t++) {
+    const feeds = { ...captures };
+    for (const { input } of state) feeds[input] = current[input];
+    const values = scalarValues
+      ? scalarValues(t)
+      : stepScalars(scalars, t, { ...rates, numSteps });
+    for (const name of scalars) feeds[name] = makeScalar(values[name]);
+    if (rows) feeds[rowIndex.input] = makeRowIndex(rows(t));
+
+    const outputs = await runStep(feeds, t);
+    const next = {};
+    for (const { input, output } of state) {
+      if (outputs[output] === undefined) {
+        throw new Error(`the step graph produced no '${output}' to carry back into '${input}'`);
+      }
+      next[input] = outputs[output];
+    }
+    current = next;
+    if (loss && outputs[loss]) losses.push(Number(outputs[loss].data[0]));
+    await onStep(t, losses.length ? losses[losses.length - 1] : null);
+  }
+  return { state: current, losses };
+}
+
+// Capture the activations a step graph binds, out of the float model.
+//
+// The names come from the plan's `captures` (their `source` field): the
+// block's own externals plus the teacher, the float model's output for this
+// block. A source that is a graph *input* is not asked of the model at all --
+// its value is the feed we are about to send -- and only the rest are exposed
+// as extra graph outputs, with onnxsim_add_graph_outputs, exactly as
+// quantize_calibration.mjs does for calibration.
+//
+// `rowFeeds` is one feeds object per calibration row; the model is run once
+// per row and the results concatenated along axis 0. That is what qat.py's
+// own _capture does across calibration batches, and running row by row rather
+// than as one batch keeps this working on a model whose batch axis is fixed at
+// 1 -- most exported models.
+//
+// Returns { [source]: { dims, data } } sized exactly as the plan declared,
+// which is checked here: a mismatch means the model was fed something other
+// than what the step graph was built for, and it is far cheaper to say so than
+// to let onnxruntime report a shape error about a `qat__`-prefixed tensor.
+export async function captureActivations(ort, runtime, floatBytes, captures, rowFeeds, options = {}) {
+  const { providers = ["wasm"], log = () => {} } = options;
+  const wanted = new Map();
+  for (const capture of captures) {
+    if (!wanted.has(capture.source)) wanted.set(capture.source, capture.dims);
+  }
+
+  const session = await ort.InferenceSession.create(floatBytes, { executionProviders: providers });
+  const graphInputs = new Set(session.inputNames);
+  const extra = [...wanted.keys()].filter((name) => !graphInputs.has(name));
+
+  let runner = session;
+  if (extra.length) {
+    const augmented = runtime.onnxsim_add_graph_outputs(floatBytes, extra);
+    if (!augmented) {
+      throw new Error("failed to expose the block's activations (add_graph_outputs)");
+    }
+    // Copy out of the wasm heap right away -- the view dies with the next wasm
+    // call, and onnxruntime-web needs its own stable copy anyway.
+    const augmentedBytes = new Uint8Array(augmented).slice();
+    runner = await ort.InferenceSession.create(augmentedBytes, { executionProviders: providers });
+  }
+
+  const parts = new Map([...wanted.keys()].map((name) => [name, []]));
+  try {
+    for (let i = 0; i < rowFeeds.length; i++) {
+      log(`capturing activations: row ${i + 1}/${rowFeeds.length}…`);
+      const outputs = await runner.run(rowFeeds[i]);
+      for (const name of wanted.keys()) {
+        const tensor = graphInputs.has(name) ? rowFeeds[i][name] : outputs[name];
+        if (!tensor || !tensor.data) {
+          throw new Error(`the float model produced no value for '${name}'`);
+        }
+        parts.get(name).push(tensor.data);
+      }
+    }
+  } finally {
+    // These are per block and a whole-model run makes one pair each time
+    // round, so they are released rather than left to the collector.
+    for (const s of new Set([session, runner])) {
+      if (typeof s.release === "function") await s.release();
+    }
+  }
+
+  const captured = {};
+  for (const [name, dims] of wanted) {
+    const total = dims.reduce((a, b) => a * b, 1);
+    const rows = parts.get(name);
+    const perRow = rows.length ? rows[0].length : 0;
+    if (perRow * rows.length !== total) {
+      throw new Error(
+        `'${name}': captured ${rows.length} row(s) of ${perRow} value(s), but the step ` +
+          `graph declares ${dims.join("×")} (${total}) -- the calibration rows do not match ` +
+          `the shape the block was built for`,
+      );
+    }
+    const data = new Float32Array(total);
+    rows.forEach((row, i) => data.set(row, i * perRow));
+    captured[name] = { dims: [...dims], data };
+  }
+  return captured;
+}
+
+// Build one feeds object per calibration row.
+//
+// Each row gets its own sample context, so the "sample data" fill fetches a
+// *fresh* random Hugging Face row per calibration row (hf_datasets.mjs's
+// fetchSample* never memoize a picked row) rather than repeating one sample
+// numRows times -- which would make every row of the reconstruction target
+// identical and the whole calibration set worth one row. The synthetic fills
+// are seeded and therefore identical row to row by construction; that is what
+// they are, and the panel says so.
+export async function buildCalibrationRows(ort, session, numRows, options = {}) {
+  const { fill = "sample", modelName = null, log = () => {} } = options;
+  const rows = [];
+  for (let i = 0; i < numRows; i++) {
+    const ctx = fill === "sample" ? createSampleContext() : null;
+    rows.push(await makeDummyInputs(ort, session, 1, fill, modelName, ctx, log));
+  }
+  return rows;
+}
+
+// Copy a plan out of the wasm heap.
+//
+// Every buffer onnxsim_qat_build_step_graph hands back -- the step graph's
+// bytes and each initial-state tensor's data -- is a view the next wasm call
+// reuses, so this runs before anything else can call in. It also turns the
+// embind arrays into plain ones, which is what the rest of this file expects.
+export function copyPlan(built) {
+  return {
+    planHandle: built.planHandle,
+    stepGraph: new Uint8Array(built.stepGraph).slice(),
+    state: built.state.map((s) => ({ input: s.input, output: s.output })),
+    scalars: [...built.scalars],
+    loss: built.loss,
+    captures: built.captures.map((c) => ({
+      input: c.input,
+      source: c.source,
+      dims: [...c.dims],
+      teacher: c.teacher,
+    })),
+    initialState: built.initialState.map((t) => ({
+      name: t.name,
+      dtype: t.dtype,
+      dims: [...t.dims],
+      data: new Uint8Array(t.data).slice(),
+    })),
+    rowIndexInput: built.rowIndexInput,
+    rowIndexSize: built.rowIndexSize,
+    numRows: built.numRows,
+  };
+}
+
+// Fine-tune one block and return the updated quantized model.
+//
+// `rowFeeds` are the calibration rows (buildCalibrationRows); `blockInput` /
+// `blockOutput` name the block, `options` is the QatOptions object the binding
+// takes ({ learnScales, learnActivationScales, fakeQuant, preserveSparsity,
+// batchSize, batchSeed, shuffle }), and `rates` the scalar schedule
+// (stepScalars' options).
+//
+// Returns { bytes, losses, plan }. The plan is always released, including on a
+// failure: nothing expires on its own, and a page training block after block
+// would otherwise keep every step graph it ever built.
+export async function fineTuneBlock(runtime, {
+  floatBytes,
+  quantBytes,
+  blockInput,
+  blockOutput,
+  rowFeeds,
+  options = {},
+  numSteps = 200,
+  rates = {},
+  providers = ["wasm"],
+  needWebnn = false,
+  ortLoader = loadOrt,
+  log = () => {},
+  onStep = () => {},
+}) {
+  const numRows = rowFeeds.length;
+  const built = runtime.onnxsim_qat_build_step_graph(
+    floatBytes,
+    quantBytes,
+    blockInput,
+    blockOutput,
+    numRows,
+    options,
+  );
+  if (!built) {
+    // BuildQatStepGraph refuses loudly -- an unclosed block, a node with no
+    // gradient rule (named), a block with no layer of the requested scheme --
+    // and the binding turns that into null with the reason on the console,
+    // which the page mirrors into its log.
+    throw new Error(
+      `could not build a step graph for ${blockInput} → ${blockOutput} ` +
+        "(see the log/console for the refusal)",
+    );
+  }
+  const plan = copyPlan(built);
+
+  try {
+    const ort = await ortLoader(needWebnn ? "all" : "default");
+    const captured = await captureActivations(ort, runtime, floatBytes, plan.captures, rowFeeds, {
+      providers,
+      log,
+    });
+    const captureFeeds = bindCaptures(plan.captures, captured);
+    for (const [name, value] of Object.entries(captureFeeds)) {
+      captureFeeds[name] = new ort.Tensor("float32", value.data, value.dims);
+    }
+
+    const session = await ort.InferenceSession.create(plan.stepGraph, {
+      executionProviders: providers,
+    });
+    const initialState = {};
+    for (const tensor of plan.initialState) {
+      // A fresh copy, so the byte offset is 0 and the Float32Array view is
+      // aligned. Every state tensor a step graph carries is float32.
+      const bytes = tensor.data.slice();
+      initialState[tensor.name] = new ort.Tensor(
+        "float32",
+        new Float32Array(bytes.buffer),
+        tensor.dims,
+      );
+    }
+
+    const { state, losses } = await runStepLoop({
+      state: plan.state,
+      scalars: plan.scalars,
+      loss: plan.loss,
+      initialState,
+      captures: captureFeeds,
+      rowIndex: plan.rowIndexInput
+        ? {
+            input: plan.rowIndexInput,
+            size: plan.rowIndexSize,
+            numRows: plan.numRows,
+            seed: options.batchSeed || 0,
+            shuffle: options.shuffle !== false,
+          }
+        : null,
+      numSteps,
+      rates,
+      runStep: (feeds) => session.run(feeds),
+      makeScalar: (value) => new ort.Tensor("float32", Float32Array.of(value), []),
+      makeRowIndex: (rows) => new ort.Tensor("int64", rows, [rows.length]),
+      onStep,
+    });
+
+    const written = runtime.onnxsim_qat_write_back(
+      quantBytes,
+      plan.planHandle,
+      finalStateForWriteBack(plan.state, state),
+    );
+    if (!written) {
+      throw new Error("writing the trained state back failed (see the log/console)");
+    }
+    if (typeof session.release === "function") await session.release();
+    return { bytes: new Uint8Array(written).slice(), losses, plan };
+  } finally {
+    runtime.onnxsim_qat_release_plan(plan.planHandle);
+  }
+}
+
+// The loss curve, as a standalone SVG string the caller assigns to an
+// element's innerHTML -- the same shape as quantize_metrics.mjs's
+// renderQuantizationQuality, and pure for the same reason: it is testable
+// without a DOM.
+//
+// Plotted on a log scale, because a reconstruction loss falls by orders of
+// magnitude over a run and a linear axis shows one initial spike and then a
+// flat line at zero. Every interpolated value is our own computed number.
+export function renderLossCurve(losses, { width = 420, height = 120 } = {}) {
+  if (!losses || losses.length === 0) return "";
+  const pad = 4;
+  const finite = losses.filter((v) => Number.isFinite(v) && v > 0);
+  const lo = finite.length ? Math.log10(Math.min(...finite)) : 0;
+  const hi = finite.length ? Math.log10(Math.max(...finite)) : 1;
+  const span = hi - lo || 1;
+  const x = (i) => pad + (i / Math.max(1, losses.length - 1)) * (width - 2 * pad);
+  const y = (v) => {
+    if (!Number.isFinite(v) || v <= 0) return height - pad;
+    return pad + (1 - (Math.log10(v) - lo) / span) * (height - 2 * pad);
+  };
+  const points = losses.map((v, i) => `${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(" ");
+  const first = losses[0];
+  const last = losses[losses.length - 1];
+  const change = first > 0 ? `${((1 - last / first) * 100).toFixed(1)}% lower` : "";
+  return (
+    `<svg viewBox="0 0 ${width} ${height}" width="${width}" height="${height}" ` +
+    `role="img" aria-label="block reconstruction loss per step" ` +
+    `style="max-width: 100%; border: 1px solid var(--border); border-radius: var(--radius);">` +
+    `<polyline fill="none" stroke="currentColor" stroke-width="1.5" points="${points}"/>` +
+    `</svg>` +
+    `<p class="tool-note" style="margin-top: 0.2em;">Block reconstruction loss (log scale) over ` +
+    `${losses.length} step(s): ${first.toPrecision(4)} → ${last.toPrecision(4)}` +
+    `${change ? `, ${change}` : ""}.</p>`
+  );
+}

--- a/scripts/convertmodel/qat_ui.mjs
+++ b/scripts/convertmodel/qat_ui.mjs
@@ -1,0 +1,311 @@
+// Browser glue for the "Fine-tune (QAT)" panel on the converter page.
+//
+// Block-wise, label-free quantization-aware training, run entirely in the
+// browser: the float model is the teacher, the quantized model is the student,
+// and each block's weights (optionally its scales) are trained by Adam against
+// the teacher's own activations at that block's output. docs/qat.md calls this
+// stage 3, and it is the one place the whole feature becomes something a user
+// can reach without Python -- client-side QAT with no server.
+//
+// The division of labour, from onnxsim/qat_entry.h:
+//   - the wasm module builds one optimizer step as a plain inference graph
+//     (onnxsim_qat_build_step_graph) and folds the finished state back in
+//     (onnxsim_qat_write_back);
+//   - onnxruntime-web captures the teacher's activations and then runs that
+//     step graph in a loop, on whichever execution provider this panel's own
+//     picker selects -- WebGPU by default here, since the loop is hundreds of
+//     forward+backward passes over one block and is the one thing on this page
+//     with enough arithmetic in it to pay for an accelerator;
+//   - qat_finetune.mjs holds the loop itself and every pure decision inside it
+//     (the scalar schedule, the minibatch stream, the capture binding, the
+//     state ping-pong), and qat_blocks.mjs proposes the blocks.
+//
+// This file is only the DOM: reading the controls, sequencing the blocks, and
+// reporting. Like quantize_ui.mjs it runs the wasm calls on the page's own
+// runtime rather than through the worker, since none of them needs a model
+// executor, and it keeps its result independent of every other panel's --
+// published on window.__onnxsimFineTuned, downloadable, and never overwriting
+// the Quantize panel's own output.
+//
+// **Two things the panel does not claim.** Activations are captured from the
+// float model for every block, i.e. onnxsim's capture-once walk rather than
+// apply_qat_all_blocks' sequential one (which re-captures each block's input
+// from the partly-tuned student, and measures better -- docs/qat.md, stage 2).
+// And the objective is reconstruction of the teacher: it cannot exceed the
+// float model, and on a calibration set this small it is a demonstration of
+// the machinery rather than a production tuning run.
+
+import { downloadBytes } from "./download.mjs";
+import { resolveOriginalModelBytes, loadOrt } from "./inference_browser.mjs";
+import { discoverBlocks } from "./qat_blocks.mjs";
+import { buildCalibrationRows, fineTuneBlock, renderLossCurve } from "./qat_finetune.mjs";
+import { computeQuantizationQuality, renderQuantizationQuality } from "./quantize_metrics.mjs";
+import { providersForEp, isWebnnEp } from "./webnn.mjs";
+
+// Resolve one of the page's three model slots, the way quantize_ui.mjs's
+// resolveQuantizeInput resolves its two. "quantized" is the Quantize panel's
+// own output (window.__onnxsimQuantized), which is the student this panel
+// trains; with fake-quant off the student is instead whatever else changed the
+// model (a pruned or simplified graph), which is why "converted" is offered
+// for it too.
+export async function resolveModel(source, fileInput) {
+  if (source === "converted") {
+    const converted = window.__onnxsimConverted;
+    if (!converted || !converted.bytes) {
+      throw new Error(
+        "no onnxsim-simplified result yet -- run Simplify/Optimize in the Convert section first.",
+      );
+    }
+    return { bytes: converted.bytes, name: converted.name };
+  }
+  if (source === "quantized") {
+    const quantized = window.__onnxsimQuantized;
+    if (!quantized || !quantized.bytes) {
+      throw new Error(
+        "no quantized model yet -- quantize one in the Quantize panel above first.",
+      );
+    }
+    return { bytes: quantized.bytes, name: quantized.name };
+  }
+  return resolveOriginalModelBytes(fileInput);
+}
+
+// The QatOptions object onnxsim_qat_build_step_graph takes, read off the
+// panel. Absent fields keep the binding's own defaults, so only what the user
+// actually chose is sent.
+function readOptions(el) {
+  const checked = (id) => {
+    const box = el(id);
+    return box ? box.checked : false;
+  };
+  const number = (id, fallback) => {
+    const input = el(id);
+    const value = parseInt((input && input.value) || "", 10);
+    return Number.isFinite(value) ? value : fallback;
+  };
+  const fakeQuant = !checked("qat-finetune-only");
+  if (!fakeQuant && (checked("qat-learn-scales") || checked("qat-learn-act-scales"))) {
+    // Both flags name a parameter of a quantizer, and fake-quant off is the
+    // mode with no quantizer in it. BuildQatStepGraph refuses that pairing
+    // rather than ignoring it, and the panel says why rather than quietly
+    // unticking a box: a user who asked to learn scales and got a model whose
+    // scales are untouched has no way to tell that from a run where learning
+    // them did not help.
+    throw new Error(
+      "'fine-tune only' takes the quantizer out of the middle, so there are no weight or " +
+        "activation scales left to learn -- untick one of the three.",
+    );
+  }
+  return {
+    fakeQuant,
+    learnScales: checked("qat-learn-scales"),
+    learnActivationScales: checked("qat-learn-act-scales"),
+    preserveSparsity: checked("qat-preserve-sparsity"),
+    batchSize: number("qat-batch-size", 0),
+    batchSeed: number("qat-batch-seed", 0),
+    shuffle: true,
+  };
+}
+
+function initQatPanel() {
+  const el = (id) => document.getElementById(id);
+  const btn = el("qat-button");
+  if (!btn) return;
+  const fileInput = el("file-input");
+  const statusEl = el("qat-status");
+  const dlBtn = el("qat-download");
+  const curveEl = el("qat-curve");
+  const metricsEl = el("qat-metrics");
+
+  const setStatus = (msg) => {
+    if (statusEl) statusEl.textContent = msg;
+  };
+
+  let lastBytes = null;
+
+  btn.addEventListener("click", async () => {
+    btn.disabled = true;
+    if (dlBtn) dlBtn.style.display = "none";
+    for (const box of [curveEl, metricsEl]) {
+      if (box) {
+        box.style.display = "none";
+        box.innerHTML = "";
+      }
+    }
+    try {
+      setStatus("loading models…");
+      const teacherSource = el("qat-teacher") ? el("qat-teacher").value : "original";
+      const studentSource = el("qat-student") ? el("qat-student").value : "quantized";
+      const teacher = await resolveModel(teacherSource, fileInput);
+      const student = await resolveModel(studentSource, fileInput);
+      const floatBytes = teacher.bytes.slice();
+      let studentBytes = student.bytes.slice();
+
+      const runtime = await window.__onnxsimRuntimePromise;
+      const options = readOptions(el);
+      const numRows = Math.max(1, parseInt((el("qat-rows") || {}).value || "8", 10) || 8);
+      const numSteps = Math.max(1, parseInt((el("qat-steps") || {}).value || "200", 10) || 200);
+      const rates = {
+        learningRate: parseFloat((el("qat-lr") || {}).value || "1e-4") || 1e-4,
+        scaleLearningRate: 1e-5,
+        activationLearningRate: 1e-2,
+        lrDecay: !el("qat-lr-decay") || el("qat-lr-decay").checked,
+      };
+      const epValue = el("qat-ep") ? el("qat-ep").value : "webgpu";
+      const { providers, needWebnn } = providersForEp(epValue);
+      if (isWebnnEp(epValue)) {
+        setStatus(
+          "WebNN is experimental; the training loop falls back to WASM if the device or an operator is unsupported.",
+        );
+      }
+
+      // The blocks: either the two tensor names the user typed, or the
+      // liveness-cut proposal over the float graph.
+      let blocks;
+      const blockInput = ((el("qat-block-input") || {}).value || "").trim();
+      const blockOutput = ((el("qat-block-output") || {}).value || "").trim();
+      if (blockInput && blockOutput) {
+        blocks = [{ input: blockInput, output: blockOutput }];
+      } else {
+        const maxLayers = Math.max(1, parseInt((el("qat-max-layers") || {}).value || "2", 10) || 2);
+        blocks = discoverBlocks(floatBytes, { maxLayersPerBlock: maxLayers });
+        if (blocks.length === 0) {
+          setStatus(
+            "no trainable block found in this model -- its activations never narrow to a " +
+              "single live tensor, so there is nowhere to cut. Name a block's input and " +
+              "output tensor explicitly to train one anyway.",
+          );
+          return;
+        }
+        setStatus(`discovered ${blocks.length} block(s).`);
+      }
+
+      // The calibration rows, built once and reused by every block: one
+      // Hugging Face sample per row under "sample data" (hf_datasets.mjs), or
+      // a synthetic fill.
+      const fill = el("qat-fill") ? el("qat-fill").value : "sample";
+      const ort = await loadOrt(needWebnn ? "all" : "default");
+      const metaSession = await ort.InferenceSession.create(floatBytes, {
+        executionProviders: ["wasm"],
+      });
+      setStatus(`building ${numRows} calibration row(s) (${fill})…`);
+      const rowFeeds = await buildCalibrationRows(ort, metaSession, numRows, {
+        fill,
+        modelName: teacher.name,
+        log: setStatus,
+      });
+
+      const allLosses = [];
+      let trained = 0;
+      const skipped = [];
+      for (let i = 0; i < blocks.length; i++) {
+        const block = blocks[i];
+        const label = `block ${i + 1}/${blocks.length} (${block.input} → ${block.output})`;
+        try {
+          const result = await fineTuneBlock(runtime, {
+            floatBytes,
+            quantBytes: studentBytes,
+            blockInput: block.input,
+            blockOutput: block.output,
+            rowFeeds,
+            options,
+            numSteps,
+            rates,
+            providers,
+            needWebnn,
+            log: setStatus,
+            onStep: (t, loss) => {
+              if (t % 10 === 0) {
+                setStatus(
+                  `${label}: step ${t + 1}/${numSteps}` +
+                    (loss != null ? `, loss ${loss.toPrecision(4)}` : "") + "…",
+                );
+              }
+            },
+          });
+          studentBytes = result.bytes;
+          allLosses.push(...result.losses);
+          trained += 1;
+        } catch (blockErr) {
+          // A block the builder refuses -- an op with no gradient rule, no
+          // layer of the requested scheme, shapes that will not infer -- is a
+          // block to skip, not a run to abandon: apply_qat_all_blocks records
+          // the reason and moves on, and so does this.
+          skipped.push(`${label}: ${blockErr && blockErr.message ? blockErr.message : blockErr}`);
+        }
+      }
+
+      if (trained === 0) {
+        setStatus(`no block could be trained. ${skipped.join(" | ")}`);
+        return;
+      }
+
+      lastBytes = studentBytes;
+      const outName = student.name.replace(/\.onnx$/i, "") + ".qat.onnx";
+      const skippedNote = skipped.length ? ` ${skipped.length} block(s) skipped (see below).` : "";
+      setStatus(
+        `done: ${trained}/${blocks.length} block(s) trained, ` +
+          `${studentBytes.length.toLocaleString()} bytes.${skippedNote}`,
+      );
+      if (dlBtn) {
+        dlBtn.style.display = "";
+        dlBtn.onclick = () => downloadBytes(lastBytes, outName);
+      }
+      window.__onnxsimFineTuned = { bytes: studentBytes, name: outName };
+
+      if (curveEl && allLosses.length) {
+        curveEl.innerHTML =
+          renderLossCurve(allLosses) +
+          (skipped.length
+            ? `<p class="tool-note">skipped: ${skipped.map(escapeHtml).join("<br>")}</p>`
+            : "");
+        curveEl.style.display = "";
+      }
+
+      // Before/after against the float model, the same measurement the
+      // Quantize panel reports for its own output -- best-effort, exactly as
+      // there: a failure here (no usable execution provider, an input
+      // onnxruntime-web cannot auto-fill) must not take away the tuned model,
+      // which is already valid and downloadable.
+      if (metricsEl && (!el("qat-metrics-toggle") || el("qat-metrics-toggle").checked)) {
+        try {
+          setStatus("measuring result quality (before vs after)…");
+          const before = await computeQuantizationQuality(floatBytes, student.bytes, setStatus);
+          const after = await computeQuantizationQuality(floatBytes, studentBytes, setStatus);
+          metricsEl.innerHTML =
+            "<p class=\"tool-note\"><b>Before fine-tuning</b> (quantized vs float)</p>" +
+            renderQuantizationQuality(before) +
+            "<p class=\"tool-note\"><b>After fine-tuning</b> (tuned vs float)</p>" +
+            renderQuantizationQuality(after);
+          metricsEl.style.display = "";
+          setStatus(
+            `done: ${trained}/${blocks.length} block(s) trained, ` +
+              `relative L2 error ${(before.relL2 * 100).toFixed(2)}% → ` +
+              `${(after.relL2 * 100).toFixed(2)}%.${skippedNote}`,
+          );
+        } catch (metricsErr) {
+          setStatus(
+            `done: ${trained}/${blocks.length} block(s) trained. result-quality check failed: ` +
+              (metricsErr && metricsErr.message ? metricsErr.message : metricsErr),
+          );
+        }
+      }
+    } catch (err) {
+      setStatus("fine-tune error: " + (err && err.message ? err.message : err));
+    } finally {
+      btn.disabled = false;
+    }
+  });
+}
+
+// Skipped-block reasons come from exception messages, which can carry a tensor
+// name straight out of the model -- untrusted text, unlike every other value
+// this panel interpolates.
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+  );
+}
+
+initQatPanel();

--- a/scripts/convertmodel/test/qat_blocks.test.mjs
+++ b/scripts/convertmodel/test/qat_blocks.test.mjs
@@ -1,0 +1,241 @@
+// Unit test for the QAT panel's block discovery (qat_blocks.mjs). No DOM, no
+// onnxruntime-web and no wasm: discovery reads the model bytes with the page's
+// own protobuf wire reader, so the whole thing -- the liveness argument, the
+// primary-input heuristic, the span walk -- is exercisable under Node against
+// models assembled here, byte by byte.
+//
+// The models are encoded rather than committed for the reason
+// qat_step_graph.test.mjs builds its fixture in-process: what is under test is
+// a handful of *topologies* (a chain, a residual, a mask input, an
+// undifferentiable op in the middle), and a topology is clearer as six lines of
+// makeNode than as a checked-in .onnx nobody can read.
+//
+// Usage:
+//   node test/qat_blocks.test.mjs
+
+import assert from "node:assert/strict";
+import {
+  DIFFERENTIABLE_OPS,
+  discoverBlocks,
+  livenessCuts,
+  primaryGraphInput,
+  readGraph,
+} from "../qat_blocks.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+// ---------------------------------------------------------------------------
+// A protobuf encoder just large enough for the fields readGraph reads. The
+// mirror image of macs.mjs's `fields` reader, and no more general than it
+// needs to be: length-delimited fields and nothing else.
+function varint(n) {
+  const out = [];
+  let v = n;
+  do {
+    let byte = v & 0x7f;
+    v >>>= 7;
+    if (v) byte |= 0x80;
+    out.push(byte);
+  } while (v);
+  return out;
+}
+
+function bytesField(field, bytes) {
+  return [...varint(field * 8 + 2), ...varint(bytes.length), ...bytes];
+}
+
+const utf8 = new TextEncoder();
+const strField = (field, s) => bytesField(field, [...utf8.encode(s)]);
+
+// NodeProto: input = 1, output = 2, name = 3, op_type = 4
+function makeNode(opType, inputs, outputs, name = "") {
+  return [
+    ...inputs.flatMap((n) => strField(1, n)),
+    ...outputs.flatMap((n) => strField(2, n)),
+    ...strField(3, name || outputs[0] || opType),
+    ...strField(4, opType),
+  ];
+}
+
+// ModelProto { graph = 7 } wrapping GraphProto { node = 1, initializer = 5,
+// input = 11, output = 12 }; initializers are TensorProto { name = 8 } and
+// graph inputs/outputs ValueInfoProto { name = 1 }.
+function makeModel({ nodes = [], initializers = [], inputs = [], outputs = [] }) {
+  const graph = [
+    ...nodes.flatMap((n) => bytesField(1, n)),
+    ...initializers.flatMap((n) => bytesField(5, strField(8, n))),
+    ...inputs.flatMap((n) => bytesField(11, strField(1, n))),
+    ...outputs.flatMap((n) => bytesField(12, strField(1, n))),
+  ];
+  return new Uint8Array(bytesField(7, graph));
+}
+
+// X -> MatMul -> h -> MatMul -> Y, the shape every "a plain MLP has a cut
+// between every pair of layers" claim is about.
+const CHAIN = makeModel({
+  nodes: [makeNode("MatMul", ["X", "W1"], ["h"]), makeNode("MatMul", ["h", "W2"], ["Y"])],
+  initializers: ["W1", "W2"],
+  inputs: ["X"],
+  outputs: ["Y"],
+});
+
+// ---------------------------------------------------------------------------
+
+check("readGraph reads nodes, initializers and the graph interface", () => {
+  const graph = readGraph(CHAIN);
+  assert.deepEqual(
+    graph.nodes.map((n) => [n.opType, n.input, n.output]),
+    [
+      ["MatMul", ["X", "W1"], ["h"]],
+      ["MatMul", ["h", "W2"], ["Y"]],
+    ],
+  );
+  assert.deepEqual(graph.initializers, ["W1", "W2"]);
+  assert.deepEqual(graph.inputs, ["X"]);
+  assert.deepEqual(graph.outputs, ["Y"]);
+});
+
+check("the differentiable set tracks graph_grad's rule table", () => {
+  // Not an exact-membership assertion: graph_grad's table grows, this list is
+  // only a pre-filter for it (see qat_blocks.mjs), and pinning a count here
+  // would fail on a rule being *added* -- which is not a bug. What must hold is
+  // that the ops a block-wise reconstruction is made of are in it and that an
+  // arbitrary op is not.
+  for (const op of ["MatMul", "Gemm", "LayerNormalization", "Softmax", "Transpose", "Add"]) {
+    assert.ok(DIFFERENTIABLE_OPS.has(op), `${op} should be differentiable`);
+  }
+  assert.ok(!DIFFERENTIABLE_OPS.has("Sin"));
+  assert.ok(DIFFERENTIABLE_OPS.size >= 21, "graph_grad had 21 rules when this landed");
+});
+
+check("a chain cuts at every gap", () => {
+  const graph = readGraph(CHAIN);
+  assert.deepEqual(livenessCuts(graph, primaryGraphInput(graph)), [
+    { index: -1, name: "X" },
+    { index: 0, name: "h" },
+    { index: 1, name: "Y" },
+  ]);
+});
+
+// The point of the whole liveness formulation: inside `y = f(x) + x` the skip
+// tensor is live alongside every intermediate, so there is no cut in the middle
+// of the residual and the next one is the Add's own output -- where a person
+// would have drawn the boundary, derived rather than special-cased.
+check("a residual places the boundary at the Add, not inside it", () => {
+  const residual = makeModel({
+    nodes: [makeNode("MatMul", ["X", "W"], ["h"]), makeNode("Add", ["h", "X"], ["Y"])],
+    initializers: ["W"],
+    inputs: ["X"],
+    outputs: ["Y"],
+  });
+  const graph = readGraph(residual);
+  assert.deepEqual(livenessCuts(graph, primaryGraphInput(graph)), [
+    { index: -1, name: "X" },
+    { index: 1, name: "Y" },
+  ]);
+});
+
+// A mask input is byte-identical in teacher and student, so teacher-forcing it
+// is exact; letting it stay live would suppress every cut in the model.
+check("a secondary graph input does not suppress cuts", () => {
+  const masked = makeModel({
+    nodes: [makeNode("MatMul", ["X", "W"], ["h"]), makeNode("Mul", ["h", "mask"], ["Y"])],
+    initializers: ["W"],
+    inputs: ["X", "mask"],
+    outputs: ["Y"],
+  });
+  const graph = readGraph(masked);
+  assert.equal(primaryGraphInput(graph), "X", "X reaches both nodes, mask only one");
+  assert.deepEqual(
+    livenessCuts(graph, "X").map((c) => c.name),
+    ["X", "h", "Y"],
+  );
+  // Choosing the other input costs granularity (X is then the live one that
+  // spans the model), never correctness -- qat.py's own note on the heuristic.
+  assert.deepEqual(
+    livenessCuts(graph, "mask").map((c) => c.name),
+    ["mask", "Y"],
+  );
+});
+
+check("maxLayersPerBlock decides how many layers a block merges", () => {
+  assert.deepEqual(discoverBlocks(CHAIN, { maxLayersPerBlock: 1 }), [
+    { input: "X", output: "h", layers: 1, nodes: 1 },
+    { input: "h", output: "Y", layers: 1, nodes: 1 },
+  ]);
+  assert.deepEqual(discoverBlocks(CHAIN, { maxLayersPerBlock: 2 }), [
+    { input: "X", output: "Y", layers: 2, nodes: 2 },
+  ]);
+  assert.throws(() => discoverBlocks(CHAIN, { maxLayersPerBlock: 0 }), /at least 1/);
+});
+
+// A MatMul against another activation is not a layer -- there is no weight to
+// train -- so it never closes a block on its own.
+check("only a MatMul with a constant weight counts as a layer", () => {
+  const attentionish = makeModel({
+    nodes: [makeNode("MatMul", ["X", "X2"], ["h"]), makeNode("MatMul", ["h", "W"], ["Y"])],
+    initializers: ["W"],
+    inputs: ["X", "X2"],
+    outputs: ["Y"],
+  });
+  assert.deepEqual(discoverBlocks(attentionish, { maxLayersPerBlock: 1 }), [
+    { input: "X", output: "Y", layers: 1, nodes: 2 },
+  ]);
+});
+
+// The behaviour that makes whole-model discovery usable: one op with no
+// gradient rule becomes a gap between blocks instead of refusing the model.
+check("an undifferentiable op becomes a gap, not a failure", () => {
+  const withSin = makeModel({
+    nodes: [
+      makeNode("MatMul", ["X", "W1"], ["h"]),
+      makeNode("Sin", ["h"], ["g"]),
+      makeNode("MatMul", ["g", "W2"], ["Y"]),
+    ],
+    initializers: ["W1", "W2"],
+    inputs: ["X"],
+    outputs: ["Y"],
+  });
+  assert.deepEqual(
+    discoverBlocks(withSin, { maxLayersPerBlock: 1 }).map((b) => [b.input, b.output]),
+    [
+      ["X", "h"],
+      ["g", "Y"],
+    ],
+  );
+  // A gap also *closes* whatever block was still accumulating, even when it
+  // has not reached maxLayersPerBlock yet -- a pending block ends at the last
+  // cut still on the trainable side rather than swallowing the gap.
+  assert.deepEqual(
+    discoverBlocks(withSin, { maxLayersPerBlock: 2 }).map((b) => [b.input, b.output]),
+    [
+      ["X", "h"],
+      ["g", "Y"],
+    ],
+  );
+});
+
+// An empty plan is a legitimate answer, not an error: a graph whose
+// activations never narrow to one live tensor has nowhere to cut.
+check("a never-reconverging branch yields no blocks", () => {
+  const forked = makeModel({
+    nodes: [makeNode("MatMul", ["X", "W1"], ["a"]), makeNode("MatMul", ["X", "W2"], ["b"])],
+    initializers: ["W1", "W2"],
+    inputs: ["X"],
+    outputs: ["a", "b"],
+  });
+  assert.deepEqual(discoverBlocks(forked), []);
+});
+
+check("a model with no graph input at all is handled", () => {
+  const empty = makeModel({});
+  assert.equal(primaryGraphInput(readGraph(empty)), null);
+  assert.deepEqual(discoverBlocks(empty), []);
+});
+
+console.log(`\nqat_blocks: ${passed} checks passed`);

--- a/scripts/convertmodel/test/qat_finetune.test.mjs
+++ b/scripts/convertmodel/test/qat_finetune.test.mjs
@@ -1,0 +1,536 @@
+// Unit test for the QAT panel's training loop (qat_finetune.mjs).
+//
+// No DOM, no onnxruntime-web and no wasm. The loop's mechanics are pure
+// functions taking injected fakes for exactly this reason -- the same shape
+// quantize_calibration.test.mjs exercises calibration in -- because the parts
+// that can silently go wrong here are not the parts that need a browser:
+// binding a capture to its `source` instead of its `input` trains on
+// uninitialized memory rather than failing, a state output not carried back
+// makes every step start over from the initial weights, and a wrong
+// bias-correction factor makes the browser train a model differently from the
+// Python with nothing to say so.
+//
+// The Adam bias corrections are checked against values printed from
+// onnxsim.qat_graph.adam_bias_corrections itself, exactly rather than within a
+// tolerance: both sides compute 1/(1 - beta**(t+1)) in IEEE754 double from the
+// same two constants, so anything but bit-equality is a real divergence.
+//
+// Usage:
+//   node test/qat_finetune.test.mjs
+
+import assert from "node:assert/strict";
+
+// qat_finetune.mjs pulls onnxruntime-web's loader and makeDummyInputs from
+// inference_browser.mjs, which wires the inference panel at import time; a
+// getElementById that finds nothing makes that wiring bail out immediately
+// (`if (!btn) return`), the same stub quantize_calibration.test.mjs uses.
+globalThis.document = { getElementById: () => null, querySelector: () => null };
+globalThis.window = { addEventListener: () => {} };
+const {
+  adamBiasCorrections,
+  bindCaptures,
+  captureActivations,
+  copyPlan,
+  finalStateForWriteBack,
+  fineTuneBlock,
+  minibatchIndices,
+  renderLossCurve,
+  runStepLoop,
+  stepScalars,
+} = await import("../qat_finetune.mjs");
+
+let passed = 0;
+async function check(name, fn) {
+  await fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+const tensor = (dims, data) => ({ dims, data: Float32Array.from(data) });
+
+// ---------------------------------------------------------------------------
+// The scalars fed fresh every step.
+
+await check("Adam's bias corrections match qat_graph.adam_bias_corrections", async () => {
+  // Printed from onnxsim.qat_graph.adam_bias_corrections(t) with repr(), i.e.
+  // the exact doubles. The C++ AdamBiasCorrections narrows the same doubles to
+  // float32, so all three implementations agree before the narrowing.
+  const reference = {
+    0: [10.000000000000002, 999.9999999999991],
+    1: [5.263157894736843, 500.250125062538],
+    7: [1.7558251562653666, 125.4381565776313],
+    99: [1.0000265621044142, 10.503335278386363],
+  };
+  for (const [t, [m, v]] of Object.entries(reference)) {
+    const got = adamBiasCorrections(Number(t));
+    assert.equal(got.m_correction, m, `m_correction at t=${t}`);
+    assert.equal(got.v_correction, v, `v_correction at t=${t}`);
+  }
+});
+
+await check("only the scalars the plan names are produced", async () => {
+  // apply_qat's own set: the weight learning rate plus the two corrections,
+  // with the scale rates present only when those scales are trained.
+  const weightsOnly = stepScalars(["qat__lr", "m_correction", "v_correction"], 0, {
+    numSteps: 10,
+    learningRate: 1e-3,
+  });
+  assert.deepEqual(Object.keys(weightsOnly).sort(), [
+    "m_correction",
+    "qat__lr",
+    "v_correction",
+  ]);
+  const withScales = stepScalars(
+    ["qat__lr", "m_correction", "v_correction", "qat__lr_scale", "qat__lr_act"],
+    0,
+    { numSteps: 10, scaleLearningRate: 5e-5, activationLearningRate: 0.02 },
+  );
+  assert.equal(withScales.qat__lr_scale, 5e-5);
+  assert.equal(withScales.qat__lr_act, 0.02);
+});
+
+await check("the learning rate decays linearly and can be turned off", async () => {
+  const at = (t, lrDecay) =>
+    stepScalars(["qat__lr"], t, { numSteps: 4, learningRate: 1, lrDecay }).qat__lr;
+  assert.deepEqual([at(0, true), at(1, true), at(2, true), at(3, true)], [1, 0.75, 0.5, 0.25]);
+  assert.deepEqual([at(0, false), at(3, false)], [1, 1]);
+});
+
+await check("an unknown scalar throws instead of being left unfed", async () => {
+  assert.throws(() => stepScalars(["qat__lr", "qat__lr_bias"], 0, {}), /unknown per-step scalar/);
+});
+
+// ---------------------------------------------------------------------------
+// The minibatch row stream.
+
+const rowsOf = (fn, t) => Array.from(fn(t), Number);
+
+await check("every row is visited once per epoch", async () => {
+  const rows = minibatchIndices(6, 3, { seed: 1 });
+  const epoch = [...rowsOf(rows, 0), ...rowsOf(rows, 1)];
+  assert.deepEqual([...epoch].sort((a, b) => a - b), [0, 1, 2, 3, 4, 5]);
+});
+
+await check("a batch that would run off the end wraps rather than being short", async () => {
+  // Static shapes are what let a step graph compile for an NPU, so every batch
+  // is full: the straddling one is completed from the front of the next epoch.
+  const rows = minibatchIndices(5, 3, { seed: 2 });
+  for (const t of [0, 1, 2, 3]) assert.equal(rows(t).length, 3);
+  const first = [...rowsOf(rows, 0), ...rowsOf(rows, 1)].slice(0, 5);
+  assert.deepEqual([...first].sort((a, b) => a - b), [0, 1, 2, 3, 4]);
+});
+
+await check("the stream is a pure function of the step index", async () => {
+  const a = minibatchIndices(7, 2, { seed: 3 });
+  const b = minibatchIndices(7, 2, { seed: 3 });
+  // Out of order on purpose: a loop stopped at step N and resumed there must
+  // see the same batch, which a running generator would not give.
+  assert.deepEqual(rowsOf(a, 5), rowsOf(b, 5));
+  assert.deepEqual(rowsOf(a, 0), rowsOf(b, 0));
+  assert.deepEqual(rowsOf(a, 5), rowsOf(b, 5));
+  const other = minibatchIndices(7, 2, { seed: 4 });
+  const differs = [0, 1, 2, 3].some((t) => rowsOf(a, t).join() !== rowsOf(other, t).join());
+  assert.ok(differs, "a different seed should draw different batches");
+});
+
+await check("shuffle:false walks the rows in order", async () => {
+  const rows = minibatchIndices(4, 2, { shuffle: false });
+  assert.deepEqual(rowsOf(rows, 0), [0, 1]);
+  assert.deepEqual(rowsOf(rows, 1), [2, 3]);
+  assert.deepEqual(rowsOf(rows, 2), [0, 1]);
+});
+
+await check("the row index is int64, the one non-float input a step graph has", async () => {
+  assert.ok(minibatchIndices(4, 2, {})(0) instanceof BigInt64Array);
+  assert.throws(() => minibatchIndices(0, 2, {}), /numRows/);
+  assert.throws(() => minibatchIndices(4, 0, {}), /batchSize/);
+});
+
+// ---------------------------------------------------------------------------
+// Binding.
+
+await check("a capture binds to its input, never its source", async () => {
+  // Under a minibatch the whole set is bound to a resident qat__all_<name>
+  // table and the block reads gathered rows out of it, so the two names
+  // differ; binding by `source` would train on uninitialized memory.
+  const captures = [
+    { input: "qat__all_X", source: "X", dims: [4, 2], teacher: false },
+    { input: "qat__teacher_all", source: "Y", dims: [4, 3], teacher: true },
+  ];
+  const feeds = bindCaptures(captures, { X: "x-values", Y: "y-values" });
+  assert.deepEqual(feeds, { qat__all_X: "x-values", qat__teacher_all: "y-values" });
+  assert.throws(() => bindCaptures(captures, { X: "x-values" }), /no captured activation for 'Y'/);
+});
+
+await check("the write-back state is keyed by state input and carries only dims/data", async () => {
+  const state = [
+    { input: "qat__w0", output: "qat__w0_next" },
+    { input: "qat__mw0", output: "qat__mw0_next" },
+  ];
+  const final = finalStateForWriteBack(state, {
+    qat__w0: tensor([2], [1, 2]),
+    qat__mw0: tensor([2], [3, 4]),
+  });
+  assert.deepEqual(Object.keys(final), ["qat__w0", "qat__mw0"]);
+  assert.deepEqual([...final.qat__w0.data], [1, 2]);
+  assert.deepEqual(final.qat__w0.dims, [2]);
+  assert.throws(() => finalStateForWriteBack(state, {}), /no value for 'qat__w0'/);
+});
+
+// ---------------------------------------------------------------------------
+// The loop.
+
+// A step graph stand-in: each state output is its input plus the learning
+// rate, and the loss halves each step, so what came back can be told from what
+// went in.
+function fakeStepGraph(state, { loss = "qat__loss" } = {}) {
+  const seen = [];
+  return {
+    seen,
+    async runStep(feeds, t) {
+      seen.push(feeds);
+      const outputs = { [loss]: tensor([], [1 / 2 ** t]) };
+      for (const { input, output } of state) {
+        const lr = feeds.qat__lr.data[0];
+        outputs[output] = tensor(feeds[input].dims, [...feeds[input].data].map((v) => v + lr));
+      }
+      return outputs;
+    },
+  };
+}
+
+await check("each state output is carried into the next step's input", async () => {
+  const state = [{ input: "qat__w0", output: "qat__w0_next" }];
+  const graph = fakeStepGraph(state);
+  const { state: final, losses } = await runStepLoop({
+    state,
+    scalars: ["qat__lr", "m_correction", "v_correction"],
+    loss: "qat__loss",
+    initialState: { qat__w0: tensor([2], [0, 0]) },
+    captures: { qat__X: tensor([2, 2], [1, 2, 3, 4]) },
+    numSteps: 3,
+    rates: { learningRate: 1, lrDecay: false },
+    runStep: graph.runStep,
+  });
+  // Three steps of +1 each, i.e. the state really made it round the loop.
+  assert.deepEqual([...final.qat__w0.data], [3, 3]);
+  assert.deepEqual(losses, [1, 0.5, 0.25]);
+  // The step after the first was handed the previous step's *output*.
+  assert.deepEqual([...graph.seen[1].qat__w0.data], [1, 1]);
+  assert.deepEqual([...graph.seen[2].qat__w0.data], [2, 2]);
+});
+
+await check("captures are bound once and every scalar is fed every step", async () => {
+  const state = [{ input: "qat__w0", output: "qat__w0_next" }];
+  const graph = fakeStepGraph(state);
+  const capture = tensor([1], [7]);
+  await runStepLoop({
+    state,
+    scalars: ["qat__lr", "m_correction", "v_correction"],
+    loss: "qat__loss",
+    initialState: { qat__w0: tensor([1], [0]) },
+    captures: { qat__X: capture },
+    numSteps: 4,
+    rates: { learningRate: 0.5, lrDecay: true },
+    runStep: graph.runStep,
+  });
+  for (let t = 0; t < 4; t++) {
+    const feeds = graph.seen[t];
+    assert.equal(feeds.qat__X, capture, "the capture is the same tensor every step");
+    assert.equal(feeds.qat__lr.data[0], 0.5 * (1 - t / 4));
+    // fround because the graph's scalar inputs are float32: this is the same
+    // narrowing the C++ AdamBiasCorrections does, applied once, at the point
+    // the value is fed rather than while it is computed.
+    assert.equal(feeds.m_correction.data[0], Math.fround(adamBiasCorrections(t).m_correction));
+    assert.equal(feeds.v_correction.data[0], Math.fround(adamBiasCorrections(t).v_correction));
+    assert.deepEqual(feeds.qat__lr.dims, [], "the scalars are rank-0");
+  }
+});
+
+await check("a minibatch feeds its row index and nothing else changes", async () => {
+  const state = [{ input: "qat__w0", output: "qat__w0_next" }];
+  const graph = fakeStepGraph(state);
+  await runStepLoop({
+    state,
+    scalars: ["qat__lr", "m_correction", "v_correction"],
+    loss: "qat__loss",
+    initialState: { qat__w0: tensor([1], [0]) },
+    captures: {},
+    rowIndex: { input: "qat__rows", size: 2, numRows: 4, seed: 0, shuffle: false },
+    numSteps: 2,
+    rates: { learningRate: 1, lrDecay: false },
+    runStep: graph.runStep,
+  });
+  assert.deepEqual(Array.from(graph.seen[0].qat__rows.data, Number), [0, 1]);
+  assert.deepEqual(Array.from(graph.seen[1].qat__rows.data, Number), [2, 3]);
+  assert.deepEqual(graph.seen[0].qat__rows.dims, [2]);
+});
+
+await check("a missing state output stops the loop instead of restarting it", async () => {
+  const state = [{ input: "qat__w0", output: "qat__w0_next" }];
+  await assert.rejects(
+    runStepLoop({
+      state,
+      scalars: ["qat__lr", "m_correction", "v_correction"],
+      initialState: { qat__w0: tensor([1], [0]) },
+      numSteps: 1,
+      runStep: async () => ({}),
+    }),
+    /produced no 'qat__w0_next'/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Capturing the teacher's activations.
+
+// An ORT stand-in: one session per created model, reporting `inputNames` and
+// returning `outputs` (per run index) from run().
+function fakeOrt(inputNames, outputsPerRun, seen = { created: [] }) {
+  let run = 0;
+  return {
+    seen,
+    Tensor: class {
+      constructor(type, data, dims) {
+        this.type = type;
+        this.data = data;
+        this.dims = dims;
+      }
+    },
+    InferenceSession: {
+      async create(bytes, options) {
+        seen.created.push({ bytes, options });
+        return {
+          inputNames,
+          outputNames: [],
+          async run(feeds) {
+            seen.lastFeeds = feeds;
+            return outputsPerRun[Math.min(run++, outputsPerRun.length - 1)];
+          },
+        };
+      },
+    },
+  };
+}
+
+const fakeRuntime = (extra = {}) => ({
+  added: [],
+  onnxsim_add_graph_outputs(bytes, names) {
+    this.added.push([...names]);
+    return new Uint8Array([9, 9, 9]).buffer;
+  },
+  ...extra,
+});
+
+await check("captures concatenate the rows along axis 0", async () => {
+  const captures = [
+    { input: "qat__X", source: "X", dims: [3, 2], teacher: false },
+    { input: "qat__teacher", source: "Y", dims: [3, 1], teacher: true },
+  ];
+  const runtime = fakeRuntime();
+  const ort = fakeOrt(["X"], [
+    { Y: tensor([1, 1], [10]) },
+    { Y: tensor([1, 1], [20]) },
+    { Y: tensor([1, 1], [30]) },
+  ]);
+  const rowFeeds = [
+    { X: tensor([1, 2], [1, 2]) },
+    { X: tensor([1, 2], [3, 4]) },
+    { X: tensor([1, 2], [5, 6]) },
+  ];
+  const captured = await captureActivations(ort, runtime, new Uint8Array([1]), captures, rowFeeds);
+  // 'X' is a graph input, so its value is the feed we already have and it is
+  // never asked of the model; only 'Y' needs exposing as an extra output.
+  assert.deepEqual(runtime.added, [["Y"]]);
+  assert.deepEqual([...captured.X.data], [1, 2, 3, 4, 5, 6]);
+  assert.deepEqual(captured.X.dims, [3, 2]);
+  assert.deepEqual([...captured.Y.data], [10, 20, 30]);
+});
+
+await check("no extra outputs are added when every source is a graph input", async () => {
+  const runtime = fakeRuntime();
+  const ort = fakeOrt(["X"], [{}]);
+  await captureActivations(
+    ort,
+    runtime,
+    new Uint8Array([1]),
+    [{ input: "qat__X", source: "X", dims: [1, 2] }],
+    [{ X: tensor([1, 2], [1, 2]) }],
+  );
+  assert.deepEqual(runtime.added, [], "add_graph_outputs should not have been called");
+  assert.equal(ort.seen.created.length, 1, "one session, not two");
+});
+
+await check("rows that do not fill the declared shape are refused", async () => {
+  const runtime = fakeRuntime();
+  const ort = fakeOrt(["X"], [{}]);
+  await assert.rejects(
+    captureActivations(
+      ort,
+      runtime,
+      new Uint8Array([1]),
+      [{ input: "qat__X", source: "X", dims: [4, 2] }],
+      [{ X: tensor([1, 2], [1, 2]) }],
+    ),
+    /do not match the shape the block was built for/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The whole per-block flow against a fake wasm runtime.
+
+function builtPlan({ rowIndexInput = "", rowIndexSize = 0 } = {}) {
+  return {
+    planHandle: 7,
+    // Views over wasm buffers in the real thing; plain arrays here, since what
+    // matters is that copyPlan takes its own copy of them.
+    stepGraph: new Uint8Array([1, 2, 3]),
+    state: [{ input: "qat__w0", output: "qat__w0_next" }],
+    scalars: ["qat__lr", "m_correction", "v_correction"],
+    loss: "qat__loss",
+    captures: [
+      { input: "qat__X", source: "X", dims: [2, 2], teacher: false },
+      { input: "qat__teacher", source: "Y", dims: [2, 1], teacher: true },
+    ],
+    initialState: [
+      { name: "qat__w0", dtype: 1, dims: [2], data: new Uint8Array(new Float32Array([1, 2]).buffer) },
+    ],
+    rowIndexInput,
+    rowIndexSize,
+    numRows: 2,
+  };
+}
+
+function qatRuntime(built, calls = []) {
+  return {
+    calls,
+    onnxsim_add_graph_outputs: () => new Uint8Array([9]).buffer,
+    onnxsim_qat_build_step_graph(...args) {
+      calls.push(["build", args]);
+      return built;
+    },
+    onnxsim_qat_write_back(bytes, handle, finalState) {
+      calls.push(["write_back", handle, finalState]);
+      return new Uint8Array([4, 5, 6]).buffer;
+    },
+    onnxsim_qat_release_plan(handle) {
+      calls.push(["release", handle]);
+      return true;
+    },
+  };
+}
+
+await check("copyPlan copies every wasm view out", async () => {
+  const built = builtPlan();
+  const plan = copyPlan(built);
+  // The real buffers are reused by the next wasm call; overwriting them here
+  // stands in for that.
+  built.stepGraph.fill(0);
+  built.initialState[0].data.fill(0);
+  assert.deepEqual([...plan.stepGraph], [1, 2, 3]);
+  assert.deepEqual([...new Float32Array(plan.initialState[0].data.buffer)], [1, 2]);
+});
+
+await check("a block trains, writes back and releases its plan", async () => {
+  const runtime = qatRuntime(builtPlan());
+  const ort = fakeOrt(["X"], [{ Y: tensor([1, 1], [1]) }, { Y: tensor([1, 1], [2]) }]);
+  // The step session is the third created (float, augmented, step graph); its
+  // run() must therefore answer with the step graph's own outputs.
+  const stepOutputs = {
+    qat__w0_next: tensor([2], [9, 9]),
+    qat__loss: tensor([], [0.25]),
+  };
+  ort.InferenceSession.create = async (bytes, options) => {
+    ort.seen.created.push({ bytes, options });
+    return {
+      inputNames: ["X"],
+      outputNames: [],
+      async run(feeds) {
+        ort.seen.lastFeeds = feeds;
+        if (feeds.qat__w0) return stepOutputs;
+        return { Y: tensor([1, 1], [1]) };
+      },
+    };
+  };
+
+  const result = await fineTuneBlock(runtime, {
+    floatBytes: new Uint8Array([1]),
+    quantBytes: new Uint8Array([2]),
+    blockInput: "X",
+    blockOutput: "Y",
+    rowFeeds: [{ X: tensor([1, 2], [1, 2]) }, { X: tensor([1, 2], [3, 4]) }],
+    numSteps: 2,
+    rates: { learningRate: 1e-3 },
+    providers: ["webgpu", "wasm"],
+    ortLoader: async () => ort,
+  });
+
+  assert.deepEqual([...result.bytes], [4, 5, 6]);
+  assert.deepEqual(result.losses, [0.25, 0.25]);
+  const kinds = runtime.calls.map((c) => c[0]);
+  assert.deepEqual(kinds, ["build", "write_back", "release"]);
+  // num_rows is the row count the captures will carry, and the options object
+  // reaches the binding unchanged.
+  assert.equal(runtime.calls[0][1][4], 2);
+  // The write-back is keyed by state *input*, not by the output that produced
+  // the value.
+  assert.deepEqual(Object.keys(runtime.calls[1][2]), ["qat__w0"]);
+  assert.deepEqual([...runtime.calls[1][2].qat__w0.data], [9, 9]);
+  assert.equal(runtime.calls[2][1], 7, "the plan is released by handle");
+  // The panel's execution provider choice reaches every session, training loop
+  // included -- the whole point of running this in the browser at all.
+  for (const created of ort.seen.created) {
+    assert.deepEqual(created.options.executionProviders, ["webgpu", "wasm"]);
+  }
+});
+
+await check("a plan is released even when the loop fails", async () => {
+  const runtime = qatRuntime(builtPlan());
+  const ort = fakeOrt(["X"], [{}]);
+  await assert.rejects(
+    fineTuneBlock(runtime, {
+      floatBytes: new Uint8Array([1]),
+      quantBytes: new Uint8Array([2]),
+      blockInput: "X",
+      blockOutput: "Y",
+      // One row where the plan declares two: the capture check fires.
+      rowFeeds: [{ X: tensor([1, 2], [1, 2]) }],
+      numSteps: 1,
+      ortLoader: async () => ort,
+    }),
+  );
+  assert.deepEqual(
+    runtime.calls.map((c) => c[0]),
+    ["build", "release"],
+    "nothing expires on its own -- a failed block must still drop its step graph",
+  );
+});
+
+await check("a refused block reports the refusal rather than returning null", async () => {
+  const runtime = qatRuntime(null);
+  await assert.rejects(
+    fineTuneBlock(runtime, {
+      floatBytes: new Uint8Array([1]),
+      quantBytes: new Uint8Array([2]),
+      blockInput: "X",
+      blockOutput: "X",
+      rowFeeds: [{ X: tensor([1, 2], [1, 2]) }],
+      ortLoader: async () => fakeOrt(["X"], [{}]),
+    }),
+    /could not build a step graph for X → X/,
+  );
+  assert.deepEqual(runtime.calls.map((c) => c[0]), ["build"], "there is no plan to release");
+});
+
+// ---------------------------------------------------------------------------
+
+await check("the loss curve is an SVG with one point per step", async () => {
+  assert.equal(renderLossCurve([]), "");
+  const svg = renderLossCurve([100, 10, 1]);
+  assert.match(svg, /<polyline/);
+  assert.equal(svg.match(/\d+\.\d+,\d+\.\d+/g).length, 3);
+  assert.match(svg, /99\.0% lower/);
+  // A zero or negative loss has no log; it must not produce NaN coordinates.
+  assert.ok(!renderLossCurve([1, 0]).includes("NaN"));
+});
+
+console.log(`\nqat_finetune: ${passed} checks passed`);

--- a/scripts/convertmodel/test/qat_loop_ort.test.mjs
+++ b/scripts/convertmodel/test/qat_loop_ort.test.mjs
@@ -1,0 +1,172 @@
+// Does the QAT panel's own training loop reproduce Python's trajectory?
+//
+// qat_finetune.test.mjs checks the loop's mechanics against fakes; this checks
+// them against the real thing. The fixtures are the step graphs onnxsim's own
+// builders emit (test/step_graphs.json + the four .onnx files beside it, made
+// by make_step_graph_fixtures.py) together with the per-step losses
+// onnxruntime's CPU provider produced for the same feeds in Python. Driving
+// them through qat_finetune.mjs's runStepLoop on onnxruntime-web and landing
+// on the same losses is what says the browser half of the flow -- bind the
+// captures once, feed the scalars fresh, carry every state output back into
+// its state input -- agrees with qat_graph.run_step_graph rather than merely
+// running without error.
+//
+// It is a strong check precisely because getting the loop subtly wrong does
+// not throw. A state output not carried back makes every step start from the
+// initial weights again; a constant rebound per step, or a scalar fed one step
+// late, changes the trajectory and nothing else. All three produce finite,
+// plausible, wrong losses -- and all three would move these numbers.
+//
+// This is the *loop*, not the panel: no wasm module is involved, so nothing
+// here covers onnxsim_qat_build_step_graph or _write_back (qat_step_graph.test.mjs
+// owns those, and needs a built onnxsim.wasm). It runs on onnxruntime-web's
+// wasm backend, the only one a headless Node container has -- step_graph_ep.test.mjs
+// is where the accelerated providers are attempted and reported.
+//
+// Usage:
+//   node test/qat_loop_ort.test.mjs
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+globalThis.document = { getElementById: () => null, querySelector: () => null };
+globalThis.window = { addEventListener: () => {} };
+const { runStepLoop } = await import("../qat_finetune.mjs");
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DIST = join(HERE, "..", "node_modules", "onnxruntime-web", "dist") + "/";
+const MANIFEST = JSON.parse(readFileSync(join(HERE, "step_graphs.json"), "utf8"));
+
+// onnxruntime-web's CPU kernels and onnxruntime's are the same C++ code, so the
+// two trajectories agree to float32 round-off. Same tolerance and same reason
+// as step_graph_ep.test.mjs, which compares against these very numbers.
+const RTOL = 1e-3;
+const ATOL = 1e-9;
+
+let passed = 0;
+async function check(name, fn) {
+  await fn();
+  passed += 1;
+  console.log("  ok -", name);
+}
+
+const ort = await import("onnxruntime-web").then((m) => {
+  const mod = m.default ?? m;
+  // Local wasm artifacts, single-threaded, no worker proxy: the offline
+  // configuration every onnxruntime-web test here uses.
+  mod.env.wasm.wasmPaths = DIST;
+  mod.env.wasm.numThreads = 1;
+  mod.env.wasm.proxy = false;
+  return mod;
+});
+
+const floatTensor = (spec) => new ort.Tensor("float32", Float32Array.from(spec.data), spec.dims);
+
+// Drive one fixture through the panel's own runStepLoop.
+//
+// The mapping is the whole point of the test, so it is spelled out rather than
+// helper-ed away: a fixture's `constants` are what the panel binds as captures
+// (bound once, for the life of the loop), its `state` map is the ping-pong the
+// plan's `state` pairs describe, and its recorded `scalars`/`perStep` stand in
+// for the schedule the panel computes -- injected here so what is under test
+// is the loop and not stepScalars, which qat_finetune.test.mjs pins against
+// qat_graph.adam_bias_corrections separately.
+async function runFixture(graph) {
+  const model = new Uint8Array(readFileSync(join(HERE, graph.file)));
+  const session = await ort.InferenceSession.create(model, {
+    executionProviders: ["wasm"],
+    graphOptimizationLevel: "disabled",
+  });
+
+  const captures = {};
+  for (const [name, spec] of Object.entries(graph.constants)) captures[name] = floatTensor(spec);
+  const initialState = {};
+  const state = [];
+  for (const [name, spec] of Object.entries(graph.state)) {
+    initialState[name] = floatTensor(spec);
+    state.push({ input: name, output: spec.output });
+  }
+  const perStep = graph.perStep || [];
+  const rowInput = perStep.length ? Object.keys(perStep[0])[0] : null;
+
+  const result = await runStepLoop({
+    state,
+    scalars: Object.keys(graph.scalars[0]),
+    loss: graph.loss,
+    initialState,
+    captures,
+    rowIndex: rowInput
+      ? {
+          input: rowInput,
+          // The fixture's own row draw, replayed rather than redrawn: the
+          // browser's minibatchIndices cannot reproduce numpy's PCG64
+          // permutation, and what is being compared here is the loop.
+          rows: (t) => BigInt64Array.from(perStep[t][rowInput].data.map(BigInt)),
+        }
+      : null,
+    numSteps: graph.scalars.length,
+    scalarValues: (t) => graph.scalars[t],
+    runStep: (feeds) => session.run(feeds),
+    makeScalar: (value) => new ort.Tensor("float32", Float32Array.from([value]), []),
+    makeRowIndex: (rows) => new ort.Tensor("int64", rows, [rows.length]),
+  });
+  if (typeof session.release === "function") await session.release();
+  return result;
+}
+
+for (const graph of MANIFEST.graphs) {
+  await check(`${graph.name}: the loop tracks onnxruntime's Python trajectory`, async () => {
+    const { state, losses } = await runFixture(graph);
+    assert.equal(losses.length, graph.referenceLosses.length);
+    losses.forEach((got, t) => {
+      const want = graph.referenceLosses[t];
+      assert.ok(
+        Math.abs(got - want) <= ATOL + RTOL * Math.abs(want),
+        `${graph.name} step ${t}: loss ${got} against Python's ${want}`,
+      );
+    });
+    // The loss moving is what says the state really went round the loop: a
+    // loop that re-fed the initial state every step would report the first
+    // step's loss four times.
+    assert.notEqual(losses[0], losses[losses.length - 1]);
+    // Every state input the plan declares comes back, ready for the write-back.
+    assert.deepEqual(
+      Object.keys(state).sort(),
+      Object.keys(graph.state).sort(),
+      "the final state must cover every state input",
+    );
+  });
+}
+
+// The negative control for the check above: with the state dropped between
+// steps -- exactly the bug that does not throw -- the trajectory is flat and
+// visibly different, so the agreement above is evidence and not a coincidence.
+await check("a loop that does not carry its state diverges", async () => {
+  const graph = MANIFEST.graphs.find((g) => g.name === "qat_backward");
+  const model = new Uint8Array(readFileSync(join(HERE, graph.file)));
+  const session = await ort.InferenceSession.create(model, {
+    executionProviders: ["wasm"],
+    graphOptimizationLevel: "disabled",
+  });
+  const feeds = {};
+  for (const [name, spec] of Object.entries(graph.constants)) feeds[name] = floatTensor(spec);
+  for (const [name, spec] of Object.entries(graph.state)) feeds[name] = floatTensor(spec);
+  const stuck = [];
+  for (let t = 0; t < graph.scalars.length; t++) {
+    for (const [name, value] of Object.entries(graph.scalars[t])) {
+      feeds[name] = new ort.Tensor("float32", Float32Array.from([value]), []);
+    }
+    const out = await session.run(feeds);
+    stuck.push(Number(out[graph.loss].data[0]));
+  }
+  if (typeof session.release === "function") await session.release();
+  assert.equal(stuck[0], graph.referenceLosses[0], "step 0 is the same either way");
+  assert.ok(
+    Math.abs(stuck[3] - graph.referenceLosses[3]) > RTOL * Math.abs(graph.referenceLosses[3]),
+    "a stuck loop should not reach Python's step-3 loss",
+  );
+});
+
+console.log(`\nqat loop (onnxruntime-web): ${passed} checks passed`);


### PR DESCRIPTION
The wasm bindings for block-wise QAT landed in #1237/#1239. What was missing was the half that drives them — `docs/qat.md`'s stage 3, the only one not implemented.

- **`qat_finetune.mjs`** — the loop `qat_entry.h`'s "intended browser flow" describes: build the step graph, capture the block's activations from the float model, run the loop feeding per-step scalars and carrying each state output back to its input, write the trained state back, release the plan.
- **`qat_blocks.mjs`** — block discovery, porting `_primary_graph_input` / `_liveness_cuts` / `discover_qat_blocks`.
- **`qat_ui.mjs`** + a panel in `index.html` — teacher/student pickers, discovered or typed boundaries, calibration rows, EP picker, `learnScales` / `learnActivationScales` / `preserveSparsity` / `fakeQuant`, a loss curve, and before/after via `quantize_metrics.mjs`.

## Verification, given there is no `emcc` here

None of this has ever called the real bindings, and the panel has never run end to end. That constraint is where most of the work went rather than a caveat bolted on at the end: everything decidable without wasm is a pure function taking injected fakes, and the loop mechanics are then driven **for real**.

`test/qat_loop_ort.test.mjs` runs the *production* `runStepLoop` over the four committed step-graph fixtures through onnxruntime-web, and reproduces the per-step losses onnxruntime's CPU provider recorded in Python — minibatch fixture included — within the tolerance the existing EP test uses. It carries a **negative control**: a loop that drops its state matches at step 0 and diverges by step 3, so the agreement is evidence rather than coincidence.

I mutation-tested that myself rather than taking it on trust: removing the state carry-back from `runStepLoop` turns the suite red (exit 1), and the isolated ORT test red on its own, then green again restored.

The ports were also checked against Python directly: liveness cuts and primary-input selection agree exactly on five topologies (chain, residual, mask input, unsupported-op gap, fork), and `adamBiasCorrections` is **bit-identical** to `qat_graph.adam_bias_corrections` at t = 0, 1, 7, 99.

`npm run test:all` is green, with the three new suites in it: `qat_blocks: 10`, `qat_finetune: 23`, `qat loop (onnxruntime-web): 5`.

**Still unverified, and stated as such:** the three wasm bindings are exercised only against fakes shaped from their doc comments; `test/qat_step_graph.test.mjs` still skips without a built module; and WebGPU/WebNN are unreachable in headless Node, as they already are for the existing suite. The DOM layer has no test, matching `quantize_ui.mjs`.

## Two things in the design note's sketch did not survive contact with the loop

Both are now recorded in `docs/qat.md` rather than quietly diverging from it.

**`ort_executor.mjs` is the wrong runner.** Its `makeOrtRunner` creates a session per call and passes tensors positionally as one packed blob — exactly right for the constant-folding trampoline it was written for, exactly wrong for a training loop that needs one session held across every step and binds by name. The panel opens an onnxruntime-web session directly, as `quantize_calibration.mjs` does.

**The minibatch row stream cannot be bit-compatible with Python.** `minibatch_indices` draws each epoch's permutation from `np.random.default_rng([seed, epoch])` — numpy's PCG64, which a browser cannot regenerate. The port keeps every property that docstring argues for (a permutation per epoch from `(seed, epoch)` alone, a straddling batch completed from the front of the next epoch, the whole stream a pure function of `t`) but not the sequence, so the same seed picks different, equally valid batches. This is confined to *which rows* a step sees — the emitted step graph stays byte-identical, which is what `qat_parity_fixtures.txt` pins.

That second one was a false claim in my own header. `batch_seed` said it "matches `minibatch_indices`' own seed", which no caller of that header can do. Corrected — and while there, `scalars` now names its five inputs (`qat__lr`, `m_correction`, `v_correction`, `qat__lr_scale`, `qat__lr_act`), because they are all bare floats and feeding the right count in the wrong order is silent.

## One thing the panel does not claim

It captures every block's activations from the float model — the capture-once walk, not `apply_qat_all_blocks`' sequential one, which this note's own numbers show is better (206.2 against 168.1). `QatCapture` carries no "recapture this from the student" flag, so closing that needs a change to the plan rather than to the panel. Flagged in `qat_ui.mjs` rather than left to be discovered.

Block discovery's "layer" count is a float-side weight-bearing op rather than `_find_layers`' match against the quantized model, since no binding exposes that. It only affects where blocks close, and a mis-merged block is refused loudly by the builder and skipped with its reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_