### PR TITLE
axera: time prefill via the engine API -- INT4 does nothing for it

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4078,6 +4078,56 @@ groups, of which these layer files have none.
 Test: `test_llm_build_offers_an_int4_weight_path_the_cnn_path_lacks`
 (Docker, no device).
 
+### Prefill: why it cannot be timed directly, and what stands in for it
+
+Decode measures memory. Prefill is the compute-bound half of an LLM, and it
+is what a 43.2 TOPS INT4 rating would have to be claiming. It cannot be timed
+on this stack, and the reasons are worth recording so nobody repeats the
+attempt.
+
+**The two halves are both in the file.** An `llm_build` layer `.axmodel`
+holds *two independent* `neu mode` nodes: `subgraph_npu_0` takes
+`K_cache, V_cache, indices, input, mask` (decode) and `subgraph_npu_1` takes
+the same names suffixed `_1` (prefill). Neither consumes the other's output.
+
+**`axcl_run_model` always runs the first one.** Its `--group` flag indexes
+*shape* groups, of which these files have none -- asking for group 0 or 1
+both return "Selected shape group index {n vs. 0} is out of range". Feeding
+only the `_1` inputs fails; feeding all ten runs decode and reports decode's
+latency. There is no other runner: `/usr/bin/axcl/` ships `axcl_run_model`,
+`axcl_demo` and hardware samples, nothing LLM-specific.
+
+**Editing the wrapper does not redirect it.** Deleting the decode node makes
+the model fail to load, while an unmodified load-and-re-save runs fine
+(9.268 ms against 9.182 ms), so the surgery is the cause, not the round trip.
+Renaming so prefill becomes `subgraph_npu_0` gets past loading and then fails
+at "Feed stimulus failed" -- the runtime takes its input specification from
+the compiled blob, not from the ONNX names, so the wrapper cannot choose
+which subgraph runs.
+
+**And a prefill-only build is not on offer.** `llm_build --kv_cache_len 0`
+fails in the frontend with degenerate RoPE parameters (`shape (0, 64)`).
+
+**What stands in for it: the arithmetic prefill is made of.** A prefill step
+is dominated by large matrix multiplications, and those compile through the
+ordinary path:
+
+| matmul stack | GMAC | min ms | TOPS |
+| --- | --- | --- | --- |
+| S=128, 4096x11008, 4 layers | 46.2 | 16.21 | 5.70 |
+| S=512, 2048x5632, 6 layers | 70.9 | 19.01 | 7.46 |
+
+So transformer-shaped INT8 arithmetic sustains **5.7 to 7.5 TOPS**, against
+10.13 for convolution. Longer sequences do better, which is the same tiling
+story as the CNN measurements: 128 rows do not fill the engine as well as 512.
+
+That puts a bound on the INT4 claim rather than testing it. Prefill
+arithmetic on this card runs at roughly 6-7 TOPS in INT8; for INT4 to reach
+43.2 it would have to be six times faster than INT8 matmul measured here,
+where the decode measurements show INT4 buying 1.56x. The rating is not
+verifiable on this toolchain, and nothing measured here suggests it is
+reachable.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4078,7 +4078,56 @@ groups, of which these layer files have none.
 Test: `test_llm_build_offers_an_int4_weight_path_the_cnn_path_lacks`
 (Docker, no device).
 
-### Prefill: why it cannot be timed directly, and what stands in for it
+### Prefill, timed at last -- and INT4 does nothing for it
+
+The section below records four routes that all closed. The fifth works: go
+under `axcl_run_model` to the engine API it is built on.
+
+**The CLI was wrong about the shape groups.** `axcl_run_model -g 1` reports
+"Selected shape group index {1 vs. 0} is out of range", which reads as "this
+model has no groups". Asking the engine directly --
+`axclrtEngineGetShapeGroupsCount()` -- says an `llm_build` layer has **two**,
+and their sizes say exactly what they are:
+
+| | group 0 | group 1 |
+| --- | --- | --- |
+| `input` | 8,192 B (1 x 4096 x bf16) | 1,048,576 B (128 x 4096 x bf16) |
+| `mask` | 512 B | 32,768 B |
+
+Group 0 is decode, group 1 is prefill. `axclrtEngineExecute()` takes the
+group index, so a twenty-line C program can run either. `scripts/axera/tools/`
+carries it. Its group-0 timing reproduces `axcl_run_model`'s to within a few
+percent (9.117 ms against 9.14 ms), which is the check that the buffers and
+the timing loop are honest.
+
+**The result, on both models:**
+
+| model | group | `s8` | `s4` | INT4 gain |
+| --- | --- | --- | --- | --- |
+| 4096-hidden | decode | 9.117 ms | 5.751 ms | **1.59x** |
+| 4096-hidden | prefill, S=128 | 23.493 ms | 22.359 ms | **1.05x** |
+| SmolLM2-135M | decode | 0.476 ms | 0.447 ms | 1.06x |
+| SmolLM2-135M | prefill, S=512 | 19.952 ms | 19.553 ms | 1.02x |
+
+**INT4 buys 1.59x on decode and essentially nothing on prefill.** That is the
+whole answer to the 43.2 TOPS question. Four-bit weights cut weight *traffic*,
+which is what decode is made of; they do not make the arithmetic faster, which
+is what prefill is made of.
+
+**And prefill's arithmetic is slow in absolute terms.** The 4096-hidden layer
+is 22.8 GMAC of prefill, so 23.5 ms is **1.94 TOPS** -- against 5.7-7.5 for an
+INT8 matmul stack and 10.13 for convolution. The reason is in the build
+options: `llm_build --hidden_state_type` offers `fp16`, `bf16` and `fp32`, and
+nothing narrower. **The LLM pipeline is weight-only quantised**: `s4`/`s8`
+weights against 16-bit activations. Its arithmetic therefore never touches the
+INT8 or INT4 datapath the TOPS ratings describe, whatever the weights are
+stored as.
+
+So the 43.2 TOPS INT4 rating is not reachable through either pipeline, and now
+for a measured reason rather than a missing measurement: `pulsar2 build` has no
+4-bit weights at all, and `llm_build` has 4-bit weights but 16-bit activations.
+
+### Why the earlier routes closed (recorded so nobody repeats them)
 
 Decode measures memory. Prefill is the compute-bound half of an LLM, and it
 is what a 43.2 TOPS INT4 rating would have to be claiming. It cannot be timed

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3971,6 +3971,31 @@ build config's `weight_data_type` for convolution accepts only `S8` or
 `FP32`, and `pulsar2 build --help` offers no 4-bit flag either. There is a
 4-bit path, but it is in the other pipeline -- see the next section.
 
+**Against the compiler's own cycle model.** Building with `profile=True`
+gives a modelled critical path, and a per-op profile in which convolutions
+are **98.9%** of the modelled cycles -- so the benchmark really is measuring
+arithmetic and not plumbing. Dividing that cycle count by the measured time
+gives an implied clock:
+
+| graph | max_cycle | min ms | implied MHz | MAC/cycle |
+| --- | --- | --- | --- | --- |
+| 1024ch 16x16 | 3,905,355 | 4.12 | 949 | 4,949 |
+| 512ch 32x32 | 3,704,778 | 4.30 | 862 | 5,217 |
+| 256ch 64x64 | 3,831,460 | 4.49 | 854 | 5,044 |
+
+**MAC-per-cycle is stable at about 5,000** across the three cores (roughly
+1,650 each), which is the more meaningful figure -- it is a property of the
+engine, not of the graph. The implied clock is *not* stable: 854 to 949 MHz.
+Since the clock cannot actually vary by 11% between two runs a minute apart,
+what that spread measures is the cycle model being optimistic by up to ~10%
+on some shapes -- stalls it does not account for. The best-matching graph is
+also the fastest one, which is consistent with that reading rather than with
+a variable clock.
+
+So the honest summary is: the engine sustains ~5,000 MAC/cycle at somewhere
+around 0.95 GHz, 9-10 TOPS is what that product comes to, and the compiler's
+cycle estimate is a good predictor to within about 10%.
+
 Test: `test_int8_throughput_reaches_a_useful_fraction_of_the_rating` (Docker
 and device). Its floor of 5 TOPS sits between a healthy NPU3 run and the
 ~3 TOPS a single-core or fallback build produces, so it doubles as a health
@@ -4012,6 +4037,36 @@ token of pure overhead, so this model cannot exceed roughly 80 tokens/s on
 this card no matter how the weights are quantised. INT4 pays off on a model
 whose per-layer weights are large enough for streaming to dominate that fixed
 cost -- which a 135M model's 3.5 MB per layer is not.
+
+**So the next test is a model built to make it pay.** A synthetic
+Llama-shaped checkpoint at 4096 hidden and 11008 intermediate -- **177 M
+parameters per layer**, fifty times SmolLM2's -- puts weight streaming firmly
+in charge:
+
+| weights | per layer | decode/layer | implied GB/s |
+| --- | --- | --- | --- |
+| `s4` | 100.5 MB | 5.91 ms | 17.0 |
+| `s8` | 195.6 MB | 9.20 ms | 21.3 |
+
+**INT4 now buys 1.56x**, against 1.10x on the small model, and the weight
+saving reaches 1.95x once layers are large enough that non-weight structure
+stops diluting it. The benefit scales with per-layer weight size exactly as
+the overhead argument predicts, and 1.56x of a theoretical 2x says roughly a
+third of a decode step is still something other than streaming weights.
+
+Effective weight-streaming bandwidth lands around **21 GB/s** at `s8`.
+
+**One caveat on the earlier model, stated plainly:** fitting
+`time = overhead + bytes / bandwidth` to the large model gives a fixed
+overhead of 2.6 ms per layer, not the 0.40 ms the small model gave. A
+genuinely fixed cost cannot do that, so that two-parameter fit describes each
+model at its own scale and should not be extrapolated between them. What does
+survive across both is the direction and its size: halving the weights buys
+almost nothing when layers are small and about 1.56x when they are large.
+
+For deployment arithmetic: at 9.20 ms per layer, a 32-layer model of this
+width would take 294 ms per token at `s8` and 189 ms at `s4` -- roughly 3.4
+against 5.3 tokens/s.
 
 **And the 43.2 TOPS INT4 rating stays unverified.** It is a compute-throughput
 claim, and the decode path cannot demonstrate it: a decode step is about

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3966,15 +3966,62 @@ The 8x8 collapse is the sharpest result: the same arithmetic runs 3.1x slower
 purely because the spatial dimension no longer covers the tiles the engine
 works in -- which is the same 32-wide tiling the `b0.03` operand counts.
 
-**The 43.2 TOPS INT4 figure is not reachable through this compiler.** The
+**The 43.2 TOPS INT4 figure is not reachable through *this* path.** The
 build config's `weight_data_type` for convolution accepts only `S8` or
-`FP32`; there is no 4-bit weight option in this Pulsar2 version, whatever the
-silicon can do.
+`FP32`, and `pulsar2 build --help` offers no 4-bit flag either. There is a
+4-bit path, but it is in the other pipeline -- see the next section.
 
 Test: `test_int8_throughput_reaches_a_useful_fraction_of_the_rating` (Docker
 and device). Its floor of 5 TOPS sits between a healthy NPU3 run and the
 ~3 TOPS a single-core or fallback build produces, so it doubles as a health
 check for a card that has quietly dropped to one core.
+
+### Where the INT4 path actually is
+
+Searching for 4-bit support the way the LLM pipeline does it finds it
+immediately, and in only one of the two pipelines:
+
+| pipeline | weight types offered |
+| --- | --- |
+| `pulsar2 build` (CNNs, everything above) | `S8`, `FP32` |
+| `pulsar2 llm_build` (transformers) | `fp16`, `bf16`, `fp32`, `s8`, **`s4`**, `fp8_e5m2`, `fp8_e4m3` |
+
+So the toolchain does have INT4 weights -- and FP8 in two flavours -- but only
+for the LLM path. `pulsar2 build` has no 4-bit option at all, neither in its
+config schema nor on its command line.
+
+**It builds, and it is much smaller.** SmolLM2-135M compiled three ways, same
+prefill length and KV cache, measured on the AX650N:
+
+| weights | total | per layer | decode/layer | tokens/s |
+| --- | --- | --- | --- | --- |
+| `s4` | 98.2 MB | 2.30 MB | 0.441 ms | 75.6 |
+| `s8` | 152.7 MB | 4.12 MB | 0.485 ms | 68.7 |
+| `fp16` | 253.4 MB | 7.47 MB | 0.639 ms | 52.2 |
+
+**But at this size the win is memory, not speed.** Going from `s8` to `s4`
+cuts the model 1.56x and buys only 1.10x on decode. The reason is visible in
+the three points: fitting `time = overhead + bytes / bandwidth` gives a fixed
+**per-layer overhead of about 0.40 ms** against roughly 0.09 ms of weight
+streaming at `s8`. Overhead dominates by four to one, so halving the weights
+barely moves the total. The same fit predicts the `fp16` measurement to
+within 10%, which is about as much as a two-parameter model of this deserves.
+
+That also sets a ceiling worth knowing: 0.40 ms x 30 layers is 12 ms per
+token of pure overhead, so this model cannot exceed roughly 80 tokens/s on
+this card no matter how the weights are quantised. INT4 pays off on a model
+whose per-layer weights are large enough for streaming to dominate that fixed
+cost -- which a 135M model's 3.5 MB per layer is not.
+
+**And the 43.2 TOPS INT4 rating stays unverified.** It is a compute-throughput
+claim, and the decode path cannot demonstrate it: a decode step is about
+4.5 MMAC per layer, some 0.02 TOPS, so it is latency-bound by three orders of
+magnitude. Showing it would need the prefill subgraph in isolation, and
+`axcl_run_model` will not select it -- its `--group` flag indexes shape
+groups, of which these layer files have none.
+
+Test: `test_llm_build_offers_an_int4_weight_path_the_cnn_path_lacks`
+(Docker, no device).
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -3914,6 +3914,68 @@ Tests: `test_spatial_extent_lives_in_three_bits_of_b0_03` and
 `test_the_spatial_field_follows_the_innermost_dimension_in_2d` (Docker, no
 device).
 
+### What the card actually does: 10.13 TOPS against a 10.8 TOPS rating
+
+Everything above is about *what* the hardware runs. This is about how fast.
+The graphs are deliberately the most compute-dense thing that will compile --
+stacks of identical same-padded convolutions, nothing else attached -- and
+accuracy is irrelevant to the measurement. Throughput is
+`2 * MACs / latency`, with the MAC count taken from the compiler's own
+`build_context.json` rather than recomputed.
+
+**Peak measured: 10.13 TOPS INT8**, which is **93.8%** of Axera's 10.8
+TOPS "from NPU alone" figure and 56% of the 18 TOPS INT8 headline. The curve
+flattens there:
+
+| graph | GMAC | min ms | TOPS |
+| --- | --- | --- | --- |
+| 1024ch 16x16 3x3, 8 layers | 19.3 | 4.13 | 9.37 |
+| 1024ch 16x16 3x3, 16 layers | 38.7 | 7.82 | 9.89 |
+| 1024ch 16x16 3x3, **24 layers** | 58.0 | 11.45 | **10.13** |
+| 1024ch 32x32 3x3, 8 layers | 77.3 | 15.35 | 10.07 |
+| 512ch 48x48 3x3, 12 layers | 65.2 | 13.04 | 10.01 |
+
+Depth is what buys the last 8%: identical arithmetic at 8, 16 and 24 layers
+gives 9.37, 9.89 and 10.13, so a fixed per-inference overhead of roughly
+0.3 ms is being amortised.
+
+**The cores scale almost linearly.** The same graph under each `npu_mode`:
+
+| mode | min ms | TOPS | relative |
+| --- | --- | --- | --- |
+| NPU1 | 11.49 | 3.37 | 1.00 |
+| NPU2 | 6.03 | 6.41 | 1.90 |
+| NPU3 | 4.09 | 9.45 | 2.80 |
+
+`NPU4` and `NPU5` exist in the toolchain's `NPUMode` enum but are rejected on
+this target, so three cores is the ceiling here.
+
+**Shape matters more than size.** All the 3x3 rows above are the *same* 19.3
+GMAC of arithmetic, and they differ by a factor of three depending on how it
+is shaped:
+
+| shape | TOPS | why |
+| --- | --- | --- |
+| 1024ch, 16x16 | 9.37 | best of the set |
+| 256ch, 64x64 | 8.47 | |
+| 128ch, 128x128 | 7.75 | |
+| 2048ch, **8x8** | 2.99 | spatial extent too small to fill the array |
+| 512ch 32x32, 1x1 kernel | 6.19 | nine times fewer MACs per weight byte |
+
+The 8x8 collapse is the sharpest result: the same arithmetic runs 3.1x slower
+purely because the spatial dimension no longer covers the tiles the engine
+works in -- which is the same 32-wide tiling the `b0.03` operand counts.
+
+**The 43.2 TOPS INT4 figure is not reachable through this compiler.** The
+build config's `weight_data_type` for convolution accepts only `S8` or
+`FP32`; there is no 4-bit weight option in this Pulsar2 version, whatever the
+silicon can do.
+
+Test: `test_int8_throughput_reaches_a_useful_fraction_of_the_rating` (Docker
+and device). Its floor of 5 TOPS sits between a healthy NPU3 run and the
+~3 TOPS a single-core or fallback build produces, so it doubles as a health
+check for a card that has quietly dropped to one core.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/tools/README.md
+++ b/scripts/axera/tools/README.md
@@ -1,0 +1,29 @@
+# AXCL runtime tools
+
+Two small C programs against the AXCL engine API (`/usr/include/axcl`), for
+things `axcl_run_model` cannot do.
+
+`axcl_run_model` only ever runs a model's **first** shape group. An
+`llm_build` layer file has two -- group 0 is decode, group 1 is prefill -- so
+prefill cannot be timed with the shipped CLI. These talk to
+`axclrtEngineExecute()` directly, which takes the group index.
+
+- `probe_model_io.c` -- print a compiled model's shape groups, and each
+  group's input and output names and sizes. This is what shows an
+  `llm_build` layer to have two groups rather than the zero the CLI reports.
+- `bench_shape_group.c` -- allocate device buffers for one group, execute it
+  `repeat` times and report min/avg latency.
+
+Build and run them where the card is visible (inside the VM, if the device is
+passed through -- see `../vm/README.md`):
+
+```sh
+gcc -O2 -I/usr/include/axcl -o bench_shape_group bench_shape_group.c \
+    -L/usr/lib/axcl -laxcl_rt -Wl,-rpath,/usr/lib/axcl
+./probe_model_io  layer.axmodel
+./bench_shape_group layer.axmodel 1 15      # group 1 = prefill
+```
+
+Group 0's latency from `bench_shape_group` matches `axcl_run_model`'s to
+within a few percent (9.117 ms against 9.14 ms on the model measured in the
+README), which is the check that the buffers and the timing loop are right.

--- a/scripts/axera/tools/bench_shape_group.c
+++ b/scripts/axera/tools/bench_shape_group.c
@@ -1,0 +1,72 @@
+/* Time one shape group of a compiled model -- group 1 is an llm_build
+ * layer's prefill subgraph, which axcl_run_model will not select. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "axcl.h"
+
+#define CK(e) do { axclError _r = (e); if (_r != 0) { \
+    fprintf(stderr, "%s failed: 0x%x\n", #e, _r); return 1; } } while (0)
+
+static double now_ms(void) {
+    struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1e6;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 3) { fprintf(stderr, "usage: %s model.axmodel group [repeat]\n", argv[0]); return 2; }
+    uint32_t group = (uint32_t)atoi(argv[2]);
+    int repeat = argc > 3 ? atoi(argv[3]) : 10;
+
+    CK(axclInit(NULL));
+    axclrtDeviceList devs; CK(axclrtGetDeviceList(&devs));
+    if (!devs.num) { fprintf(stderr, "no device\n"); return 1; }
+    CK(axclrtSetDevice(devs.devices[0]));
+    CK(axclrtEngineInit(AXCL_VNPU_DISABLE));
+
+    uint64_t modelId = 0, ctx = 0;
+    CK(axclrtEngineLoadFromFile(argv[1], &modelId));
+    CK(axclrtEngineCreateContext(modelId, &ctx));
+
+    axclrtEngineIOInfo info; CK(axclrtEngineGetIOInfo(modelId, &info));
+    int32_t groups = 0; axclrtEngineGetShapeGroupsCount(info, &groups);
+    if ((int32_t)group >= groups) { fprintf(stderr, "group %u of %d\n", group, groups); return 1; }
+    uint32_t ni = axclrtEngineGetNumInputs(info), no = axclrtEngineGetNumOutputs(info);
+
+    axclrtEngineIO io; CK(axclrtEngineCreateIO(info, &io));
+    void **bufs = calloc(ni + no, sizeof(void *));
+    uint64_t total_in = 0;
+    for (uint32_t i = 0; i < ni; i++) {
+        uint64_t sz = axclrtEngineGetInputSizeByIndex(info, group, i);
+        total_in += sz;
+        CK(axclrtMalloc(&bufs[i], sz, AXCL_MEM_MALLOC_NORMAL_ONLY));
+        CK(axclrtMemset(bufs[i], 0, sz));
+        CK(axclrtEngineSetInputBufferByIndex(io, i, bufs[i], sz));
+    }
+    for (uint32_t i = 0; i < no; i++) {
+        uint64_t sz = axclrtEngineGetOutputSizeByIndex(info, group, i);
+        CK(axclrtMalloc(&bufs[ni + i], sz, AXCL_MEM_MALLOC_NORMAL_ONLY));
+        CK(axclrtEngineSetOutputBufferByIndex(io, i, bufs[ni + i], sz));
+    }
+
+    for (int i = 0; i < 3; i++) CK(axclrtEngineExecute(modelId, ctx, group, io));
+    double best = 1e30, sum = 0;
+    for (int i = 0; i < repeat; i++) {
+        double t0 = now_ms();
+        CK(axclrtEngineExecute(modelId, ctx, group, io));
+        double dt = now_ms() - t0;
+        if (dt < best) best = dt;
+        sum += dt;
+    }
+    printf("group %u: min %.3f ms  avg %.3f ms  (inputs %llu B)\n",
+           group, best, sum / repeat, (unsigned long long)total_in);
+
+    for (uint32_t i = 0; i < ni + no; i++) if (bufs[i]) axclrtFree(bufs[i]);
+    axclrtEngineDestroyIO(io);
+    axclrtEngineDestroyIOInfo(info);
+    axclrtEngineUnload(modelId);
+    axclrtEngineFinalize();
+    axclFinalize();
+    return 0;
+}

--- a/scripts/axera/tools/probe_model_io.c
+++ b/scripts/axera/tools/probe_model_io.c
@@ -1,0 +1,44 @@
+/* Ask the AXCL engine what a compiled llm_build layer actually exposes. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "axcl.h"
+
+#define CK(e) do { axclError _r = (e); if (_r != 0) { \
+    fprintf(stderr, "%s failed: 0x%x\n", #e, _r); return 1; } } while (0)
+
+int main(int argc, char **argv) {
+    if (argc < 2) { fprintf(stderr, "usage: %s model.axmodel\n", argv[0]); return 2; }
+    CK(axclInit(NULL));
+    axclrtDeviceList devs;
+    CK(axclrtGetDeviceList(&devs));
+    if (devs.num == 0) { fprintf(stderr, "no device\n"); return 1; }
+    int32_t dev = devs.devices[0];
+    CK(axclrtSetDevice(dev));
+    CK(axclrtEngineInit(AXCL_VNPU_DISABLE));
+
+    uint64_t modelId = 0;
+    CK(axclrtEngineLoadFromFile(argv[1], &modelId));
+    printf("compiler version: %s\n", axclrtEngineGetModelCompilerVersion(modelId));
+
+    axclrtEngineIOInfo info;
+    CK(axclrtEngineGetIOInfo(modelId, &info));
+    int32_t groups = -1;
+    axclrtEngineGetShapeGroupsCount(info, &groups);
+    uint32_t ni = axclrtEngineGetNumInputs(info), no = axclrtEngineGetNumOutputs(info);
+    printf("shape groups: %d\ninputs: %u\noutputs: %u\n", groups, ni, no);
+    for (uint32_t g = 0; g < (groups > 0 ? (uint32_t)groups : 1u); g++) {
+        printf("-- group %u\n", g);
+        for (uint32_t i = 0; i < ni; i++)
+            printf("   in  %2u %-16s %llu B\n", i, axclrtEngineGetInputNameByIndex(info, i),
+                   (unsigned long long)axclrtEngineGetInputSizeByIndex(info, g, i));
+        for (uint32_t i = 0; i < no; i++)
+            printf("   out %2u %-16s %llu B\n", i, axclrtEngineGetOutputNameByIndex(info, i),
+                   (unsigned long long)axclrtEngineGetOutputSizeByIndex(info, g, i));
+    }
+    axclrtEngineDestroyIOInfo(info);
+    axclrtEngineUnload(modelId);
+    axclrtEngineFinalize();
+    axclFinalize();
+    return 0;
+}

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4656,6 +4656,111 @@ def test_the_spatial_field_follows_the_innermost_dimension_in_2d(tmp_path):
     assert field_for(32, kernel=3) == (32 + 2 - 1) // 32
 
 
+def _conv_stack_model(channels, hw, kernel, layers):
+    """A stack of identical same-padded convolutions -- arithmetic with as
+    little else attached as possible, for a throughput measurement."""
+    rng = np.random.RandomState(0)
+    nodes, inits = [], []
+    current = "x"
+    for i in range(layers):
+        name = f"w{i}"
+        inits.append(
+            numpy_helper.from_array(
+                (rng.randn(channels, channels, kernel, kernel) * 0.02).astype(
+                    np.float32
+                ),
+                name,
+            )
+        )
+        nodes.append(
+            helper.make_node(
+                "Conv",
+                [current, name],
+                [f"h{i}"],
+                name=f"c{i}",
+                kernel_shape=[kernel, kernel],
+                pads=[kernel // 2] * 4,
+            )
+        )
+        current = f"h{i}"
+    shape = [1, channels, hw, hw]
+    graph = helper.make_graph(
+        nodes,
+        "stack",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, shape)],
+        [helper.make_tensor_value_info(current, TensorProto.FLOAT, shape)],
+        inits,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_int8_throughput_reaches_a_useful_fraction_of_the_rating(tmp_path):
+    """Confirmed on the AX650N (see the README's "What the card actually
+    does" section): a compute-dense INT8 convolution stack sustains several
+    TOPS, well above what a misconfigured build would produce.
+
+    This is a hardware health check as much as a performance claim. A card
+    pinned to one NPU core, or a build that quietly fell back, lands around
+    3 TOPS; the floor here sits between the two so either failure shows up.
+    The peak actually measured was 10.13 TOPS against Axera's 10.8 TOPS
+    "NPU alone" INT8 figure. Needs Docker and a device.
+    """
+    if not pulsar2_docker.axcl_available():
+        pytest.skip("no AXCL device")
+    channels, hw, kernel, layers = 512, 32, 3, 8
+    work = tmp_path / "work"
+    work.mkdir()
+    os.makedirs(work / "dataset", exist_ok=True)
+    os.makedirs(work / "config", exist_ok=True)
+    model = _conv_stack_model(channels, hw, kernel, layers)
+    onnx.save(model, str(work / "m.onnx"))
+    rng = np.random.RandomState(1)
+    pulsar2_docker.make_numpy_calibration_tar(
+        str(work / "dataset" / "m.tar"),
+        [rng.randn(1, channels, hw, hw).astype(np.float32) for _ in range(2)],
+    )
+    with open(work / "config" / "m.json", "w") as f:
+        json.dump(
+            {
+                "model_type": "ONNX",
+                "npu_mode": "NPU3",
+                "quant": {
+                    "input_configs": [
+                        {
+                            "tensor_name": "x",
+                            "calibration_dataset": "./dataset/m.tar",
+                            "calibration_format": "Numpy",
+                            "calibration_size": 2,
+                        }
+                    ],
+                    "calibration_method": "MinMax",
+                    "precision_analysis": False,
+                },
+                "compiler": {"check": 0},
+            },
+            f,
+        )
+    result = pulsar2_docker.build(
+        str(work), "m.onnx", "out", config_path="config/m.json", timeout=3000
+    )
+    assert result.success, result.error
+
+    with open(work / "out" / "build_context.json") as f:
+        macs = json.load(f)["macs"]
+    # The compiler's own MAC count must match the arithmetic in the graph.
+    assert macs == channels * channels * kernel * kernel * hw * hw * layers, macs
+
+    stats = pulsar2_docker.run_on_device(
+        str(work / "out" / "compiled.axmodel"), repeat=20, warmup=5, timeout=900
+    )
+    assert not stats.get("error"), stats.get("error")
+    tops = 2 * macs / (stats["min_ms"] * 1e-3) / 1e12
+    assert tops > 5.0, (tops, stats)
+
+
 def test_single_conv_program_encodes_its_output_channel_count(tmp_path):
     """Confirmed real (see the README's "The first operand with a known
     meaning" section): in a program holding exactly one convolution, the

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -11,9 +11,11 @@ Needs a loaded `pulsar2:*` Docker image -- skip-guarded like
 tests/test_pulsar2_hf_to_axmodel.py.
 """
 
+import glob
 import json
 import os
 import re
+import shutil
 import struct
 import sys
 import tempfile
@@ -4759,6 +4761,45 @@ def test_int8_throughput_reaches_a_useful_fraction_of_the_rating(tmp_path):
     assert not stats.get("error"), stats.get("error")
     tops = 2 * macs / (stats["min_ms"] * 1e-3) / 1e12
     assert tops > 5.0, (tops, stats)
+
+
+def test_llm_build_offers_an_int4_weight_path_the_cnn_path_lacks(tmp_path):
+    """Confirmed real (see the README's "Where the INT4 path actually is"
+    section): `pulsar2 llm_build` accepts `-w s4`, and the resulting model is
+    substantially smaller than the `s8` build of the same checkpoint.
+
+    This is the only 4-bit route in the toolchain. `pulsar2 build` -- the CNN
+    path everything else here uses -- has no 4-bit option at all: its
+    `weight_data_type` for convolution accepts only `S8` and `FP32`, and
+    there is no command-line flag either. Needs Docker, no device.
+    """
+    ckpt = _cached_hf_checkpoint("HuggingFaceTB/SmolLM2-135M")
+    if ckpt is None:
+        pytest.skip("HuggingFaceTB/SmolLM2-135M is not in the local HuggingFace cache")
+    work = tmp_path / "work"
+    work.mkdir()
+    shutil.copytree(ckpt, work / "SmolLM2-135M", symlinks=False)
+
+    sizes = {}
+    for weight_type in ("s8", "s4"):
+        result = pulsar2_docker.llm_build(
+            str(work),
+            "SmolLM2-135M",
+            f"out_{weight_type}",
+            weight_type=weight_type,
+            prefill_len=512,
+            kv_cache_len=1023,
+            parallel=8,
+        )
+        assert result.success, (weight_type, getattr(result, "error", None))
+        files = sorted(glob.glob(str(work / f"out_{weight_type}" / "*.axmodel")))
+        assert files, weight_type
+        sizes[weight_type] = sum(os.path.getsize(f) for f in files)
+
+    # 4-bit weights are the bulk of the saving, but a layer file also carries
+    # non-weight structure, so the ratio lands well short of 2x.
+    ratio = sizes["s8"] / sizes["s4"]
+    assert 1.3 < ratio < 2.0, (ratio, sizes)
 
 
 def test_single_conv_program_encodes_its_output_channel_count(tmp_path):


### PR DESCRIPTION
#1243 recorded four routes to timing prefill that all closed. The fifth works: go under `axcl_run_model` to the engine API it is built on.

### The CLI was wrong about the shape groups

`axcl_run_model -g 1` reports "Selected shape group index {1 vs. 0} is out of range", which reads as *this model has no groups*. Asking the engine directly -- `axclrtEngineGetShapeGroupsCount()` -- says an `llm_build` layer has **two**, and their sizes say exactly what they are:

| | group 0 | group 1 |
| --- | --- | --- |
| `input` | 8,192 B (1 x 4096 x bf16) | 1,048,576 B (128 x 4096 x bf16) |
| `mask` | 512 B | 32,768 B |

Group 0 is decode, group 1 is prefill. `axclrtEngineExecute()` takes the group index, so a small C program can run either. `scripts/axera/tools/` now carries it plus an IO probe.

Its group-0 timing reproduces `axcl_run_model`'s to within a few percent (**9.117 ms against 9.14 ms**), which is the check that the buffers and the timing loop are honest.

### The result, on both models

| model | group | `s8` | `s4` | INT4 gain |
| --- | --- | --- | --- | --- |
| 4096-hidden | decode | 9.117 ms | 5.751 ms | **1.59x** |
| 4096-hidden | prefill, S=128 | 23.493 ms | 22.359 ms | **1.05x** |
| SmolLM2-135M | decode | 0.476 ms | 0.447 ms | 1.06x |
| SmolLM2-135M | prefill, S=512 | 19.952 ms | 19.553 ms | 1.02x |

**INT4 buys 1.59x on decode and essentially nothing on prefill.** That is the whole answer to the 43.2 TOPS question: four-bit weights cut weight *traffic*, which is what decode is made of, and do not make the arithmetic faster, which is what prefill is made of.

### And prefill's arithmetic is slow in absolute terms

The 4096-hidden layer is 22.8 GMAC of prefill, so 23.5 ms is **1.94 TOPS** -- against 5.7-7.5 for an INT8 matmul stack (#1243) and 10.13 for convolution (#1238).

The reason is in the build options. `llm_build --hidden_state_type` offers `fp16`, `bf16` and `fp32`, and nothing narrower. **The LLM pipeline is weight-only quantised**: `s4`/`s8` weights against 16-bit activations, so its arithmetic never touches the INT8 or INT4 datapath the TOPS ratings describe, whatever the weights are stored as.

### Conclusion on the rating

43.2 TOPS is unreachable through either pipeline, now for a **measured** reason rather than a missing measurement:

- `pulsar2 build` has no 4-bit weights at all;
- `llm_build` has 4-bit weights but 16-bit activations.

### Tools

`scripts/axera/tools/probe_model_io.c` and `bench_shape_group.c`, with a README covering the build line and the cross-check against the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS