### PR TITLE
Differentiate Conv, so a convolution stops splitting a block

### DIFF
--- a/docs/qat.md
+++ b/docs/qat.md
@@ -422,10 +422,14 @@ learn scales and got a model whose scales are untouched has no way to tell
 that from a run where learning them did not help.
 
 Operator coverage is the same constraint it is under QAT, and it is still the
-binding one on a real model: `graph_grad.SUPPORTED_OPS` is 21 rules
-(`LayerNormalization` among them since this branch), so a normalization in the
-middle of a block is now more nodes in the slice rather than a boundary
-between blocks -- but the whole default ONNX domain is 202 operators.
+binding one on a real model: `graph_grad.SUPPORTED_OPS` is 22 rules
+(`LayerNormalization` among them since this branch, and `Conv` since a later
+one), so a normalization -- or a convolution -- in the middle of a block is
+now more nodes in the slice rather than a boundary between blocks. On a CNN
+that is the difference between blocks carved *around* every convolution and
+blocks that contain them; the convolution's own weights still do not train,
+since only MatMul and Gemm have a layer finder. The whole default ONNX domain
+is 202 operators.
 
 ### Against `apply_pruning_finetune`, which came first
 

--- a/onnxsim/graph_grad.cpp
+++ b/onnxsim/graph_grad.cpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 // Every rule below is a transcription of the same-named rule in
@@ -58,6 +59,14 @@ int64_t AttrInt(const onnx::NodeProto& node, const std::string& name,
   return a == nullptr ? fallback : a->i();
 }
 
+std::vector<int64_t> AttrInts(const onnx::NodeProto& node,
+                              const std::string& name,
+                              const std::vector<int64_t>& fallback) {
+  const onnx::AttributeProto* a = FindAttr(node, name);
+  if (a == nullptr) return fallback;
+  return std::vector<int64_t>(a->ints().begin(), a->ints().end());
+}
+
 onnx::AttributeProto IntAttr(const std::string& name, int64_t value) {
   onnx::AttributeProto attribute;
   attribute.set_name(name);
@@ -90,6 +99,17 @@ std::string ShapeStr(const Shape& shape) {
 }
 
 std::string Quoted(const std::string& value) { return "'" + value + "'"; }
+
+// An int list the way Python prints one -- "[3, 3]" -- for the Conv
+// refusals, whose messages name strides, dilations and pads.
+std::string IntsStr(const std::vector<int64_t>& values) {
+  std::string out = "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i != 0) out += ", ";
+    out += std::to_string(values[i]);
+  }
+  return out + "]";
+}
 
 // numpy's broadcast_shapes, for the batch axes of a batched MatMul.
 Shape BroadcastShapes(const Shape& a, const Shape& b) {
@@ -300,6 +320,349 @@ std::vector<OptStr> GradGemm(Backward& ctx, const onnx::NodeProto& node,
       // C spelled as an omitted optional input ("") rather than left off the
       // node entirely -- there is no tensor to give a gradient to.
       grads.push_back(std::nullopt);
+    }
+  }
+  return grads;
+}
+
+// The Conv rule's helpers. graph_grad.py's _prod/_unflatten/_im2col_indices/
+// _col2im_indices, transcribed; the derivation and the reason a convolution's
+// gradient is written as im2col rather than as a ConvTranspose are in
+// _grad_conv's docstring there.
+int64_t Prod(const std::vector<int64_t>& dims) {
+  int64_t total = 1;
+  for (int64_t d : dims) total *= d;
+  return total;
+}
+
+std::vector<int64_t> Unflatten(int64_t index,
+                               const std::vector<int64_t>& dims) {
+  std::vector<int64_t> coords(dims.size(), 0);
+  for (size_t i = dims.size(); i-- > 0;) {
+    coords[i] = index % dims[i];
+    index /= dims[i];
+  }
+  return coords;
+}
+
+// Where each (kernel tap, output position) pair reads its input, and a 0/1
+// mask of the pairs that read real input rather than padding.
+std::pair<std::vector<int64_t>, std::vector<float>> Im2ColIndices(
+    const std::vector<int64_t>& in_dims, const std::vector<int64_t>& out_dims,
+    const std::vector<int64_t>& kernel, const std::vector<int64_t>& strides,
+    const std::vector<int64_t>& dilations,
+    const std::vector<int64_t>& pads_begin) {
+  const size_t spatial = in_dims.size();
+  const int64_t out_count = Prod(out_dims);
+  const int64_t taps = Prod(kernel);
+  std::vector<int64_t> index(static_cast<size_t>(taps * out_count), 0);
+  std::vector<float> mask(index.size(), 0.0f);
+  for (int64_t tap = 0; tap < taps; ++tap) {
+    const std::vector<int64_t> taps_at = Unflatten(tap, kernel);
+    for (int64_t out = 0; out < out_count; ++out) {
+      const std::vector<int64_t> position = Unflatten(out, out_dims);
+      int64_t flat = 0;
+      for (size_t i = 0; i < spatial; ++i) {
+        const int64_t p = position[i] * strides[i] - pads_begin[i] +
+                          taps_at[i] * dilations[i];
+        if (p < 0 || p >= in_dims[i]) {
+          flat = -1;
+          break;
+        }
+        flat = flat * in_dims[i] + p;
+      }
+      if (flat >= 0) {
+        index[static_cast<size_t>(tap * out_count + out)] = flat;
+        mask[static_cast<size_t>(tap * out_count + out)] = 1.0f;
+      }
+    }
+  }
+  return {index, mask};
+}
+
+// The same correspondence read the other way: which output position a given
+// (kernel tap, input position) pair came from -- what turns dX's scatter-add
+// into a gather.
+std::pair<std::vector<int64_t>, std::vector<float>> Col2ImIndices(
+    const std::vector<int64_t>& in_dims, const std::vector<int64_t>& out_dims,
+    const std::vector<int64_t>& kernel, const std::vector<int64_t>& strides,
+    const std::vector<int64_t>& dilations,
+    const std::vector<int64_t>& pads_begin) {
+  const size_t spatial = in_dims.size();
+  const int64_t in_count = Prod(in_dims);
+  const int64_t taps = Prod(kernel);
+  std::vector<int64_t> index(static_cast<size_t>(taps * in_count), 0);
+  std::vector<float> mask(index.size(), 0.0f);
+  for (int64_t tap = 0; tap < taps; ++tap) {
+    const std::vector<int64_t> taps_at = Unflatten(tap, kernel);
+    for (int64_t entry = 0; entry < in_count; ++entry) {
+      const std::vector<int64_t> position = Unflatten(entry, in_dims);
+      int64_t flat = 0;
+      for (size_t i = 0; i < spatial; ++i) {
+        const int64_t shifted =
+            position[i] + pads_begin[i] - taps_at[i] * dilations[i];
+        // Divisibility first: C++ truncates towards zero where Python floors,
+        // so the quotient is only read once it is known to be exact and the
+        // two languages cannot disagree about it.
+        if (shifted % strides[i] != 0) {
+          flat = -1;
+          break;
+        }
+        const int64_t o = shifted / strides[i];
+        if (o < 0 || o >= out_dims[i]) {
+          flat = -1;
+          break;
+        }
+        flat = flat * out_dims[i] + o;
+      }
+      if (flat >= 0) {
+        index[static_cast<size_t>(tap * in_count + entry)] = flat;
+        mask[static_cast<size_t>(tap * in_count + entry)] = 1.0f;
+      }
+    }
+  }
+  return {index, mask};
+}
+
+struct ConvGeometry {
+  int64_t group;
+  std::vector<int64_t> kernel;
+  std::vector<int64_t> strides;
+  std::vector<int64_t> dilations;
+  std::vector<int64_t> pads_begin;
+};
+
+// Conv's attributes resolved against its actual shapes, with auto_pad turned
+// into explicit padding -- _conv_geometry in graph_grad.py, refusal for
+// refusal. The last check is the one that matters: the resolved geometry has
+// to reproduce the node's own output shape, so a misreading of the attributes
+// cannot survive into a wrong gradient.
+ConvGeometry ConvGeometryOf(const onnx::NodeProto& node, const Shape& x_shape,
+                            const Shape& w_shape, const Shape& y_shape) {
+  const std::string name = Quoted(node.output(0));
+  const size_t rank = x_shape.size();
+  if (rank < 3) {
+    throw UnsupportedOpError(
+        "Conv needs at least one spatial dimension, got input shape " +
+        ShapeStr(x_shape) + " (node " + name + ")");
+  }
+  const size_t spatial = rank - 2;
+  if (w_shape.size() != rank || y_shape.size() != rank) {
+    throw UnsupportedOpError("Conv's X, W and Y must have the same rank, got " +
+                             ShapeStr(x_shape) + ", " + ShapeStr(w_shape) +
+                             " and " + ShapeStr(y_shape) + " (node " + name +
+                             ")");
+  }
+  ConvGeometry geo;
+  geo.group = AttrInt(node, "group", 1);
+  const int64_t channels = x_shape[1];
+  const int64_t features = w_shape[0];
+  if (geo.group < 1 || channels % geo.group != 0 || features % geo.group != 0) {
+    throw UnsupportedOpError(
+        "Conv with group=" + std::to_string(geo.group) +
+        " does not divide its " + std::to_string(channels) + " input and " +
+        std::to_string(features) + " output channels (node " + name + ")");
+  }
+  if (w_shape[1] != channels / geo.group) {
+    throw UnsupportedOpError(
+        "Conv's W has " + std::to_string(w_shape[1]) +
+        " channels per group, but group=" + std::to_string(geo.group) +
+        " over " + std::to_string(channels) + " input channels needs " +
+        std::to_string(channels / geo.group) + " (node " + name + ")");
+  }
+
+  geo.kernel.assign(w_shape.begin() + 2, w_shape.end());
+  const onnx::AttributeProto* declared = FindAttr(node, "kernel_shape");
+  if (declared != nullptr) {
+    const std::vector<int64_t> spelled(declared->ints().begin(),
+                                       declared->ints().end());
+    if (spelled != geo.kernel) {
+      throw UnsupportedOpError("Conv's kernel_shape attribute " +
+                               IntsStr(spelled) +
+                               " disagrees with W's own spatial shape " +
+                               IntsStr(geo.kernel) + " (node " + name + ")");
+    }
+  }
+  geo.strides = AttrInts(node, "strides", std::vector<int64_t>(spatial, 1));
+  geo.dilations = AttrInts(node, "dilations", std::vector<int64_t>(spatial, 1));
+  if (geo.strides.size() != spatial || geo.dilations.size() != spatial) {
+    throw UnsupportedOpError("Conv's strides " + IntsStr(geo.strides) +
+                             " and dilations " + IntsStr(geo.dilations) +
+                             " must have one entry per spatial axis (" +
+                             std::to_string(spatial) + ") (node " + name + ")");
+  }
+  for (size_t i = 0; i < spatial; ++i) {
+    if (geo.strides[i] < 1 || geo.dilations[i] < 1) {
+      throw UnsupportedOpError(
+          "Conv with strides " + IntsStr(geo.strides) + " and dilations " +
+          IntsStr(geo.dilations) +
+          " is not a convolution this rule can invert (node " + name + ")");
+    }
+  }
+
+  const onnx::AttributeProto* pad_mode = FindAttr(node, "auto_pad");
+  const std::string auto_pad =
+      pad_mode == nullptr ? std::string("NOTSET") : pad_mode->s();
+  std::vector<int64_t> pads;
+  if (auto_pad == "NOTSET") {
+    pads = AttrInts(node, "pads", std::vector<int64_t>(2 * spatial, 0));
+    if (pads.size() != 2 * spatial) {
+      throw UnsupportedOpError("Conv's pads " + IntsStr(pads) +
+                               " must have two entries per spatial axis (" +
+                               std::to_string(spatial) + ") (node " + name +
+                               ")");
+    }
+  } else if (auto_pad == "VALID") {
+    pads.assign(2 * spatial, 0);
+  } else if (auto_pad == "SAME_UPPER" || auto_pad == "SAME_LOWER") {
+    // The spec's own formula, resolved here rather than left to the runtime:
+    // the shapes are static, so "same" is a number at build time.
+    pads.assign(2 * spatial, 0);
+    for (size_t i = 0; i < spatial; ++i) {
+      const int64_t size = x_shape[2 + i];
+      const int64_t out = (size + geo.strides[i] - 1) / geo.strides[i];
+      const int64_t span = (geo.kernel[i] - 1) * geo.dilations[i] + 1;
+      const int64_t needed =
+          std::max<int64_t>(0, (out - 1) * geo.strides[i] + span - size);
+      pads[i] = auto_pad == "SAME_UPPER" ? needed / 2 : needed - needed / 2;
+      pads[spatial + i] = needed - pads[i];
+    }
+  } else {
+    throw UnsupportedOpError("Conv with auto_pad '" + auto_pad +
+                             "' is not differentiated here (node " + name +
+                             ")");
+  }
+
+  if (y_shape[0] != x_shape[0] || y_shape[1] != features) {
+    throw UnsupportedOpError("Conv's output shape " + ShapeStr(y_shape) +
+                             " does not match its input " + ShapeStr(x_shape) +
+                             " and weight " + ShapeStr(w_shape) + " (node " +
+                             name + ")");
+  }
+  for (size_t i = 0; i < spatial; ++i) {
+    const int64_t span = (geo.kernel[i] - 1) * geo.dilations[i] + 1;
+    const int64_t reach = x_shape[2 + i] + pads[i] + pads[spatial + i] - span;
+    // A negative reach is spelled out rather than divided: Python's floor
+    // division and C++'s truncation disagree there, and this refusal is the
+    // one place the two could have produced different numbers.
+    const int64_t expected = reach >= 0 ? reach / geo.strides[i] + 1 : 0;
+    if (expected != y_shape[2 + i]) {
+      throw UnsupportedOpError(
+          "Conv's declared output shape " + ShapeStr(y_shape) +
+          " does not follow from input " + ShapeStr(x_shape) + ", kernel " +
+          IntsStr(geo.kernel) + ", strides " + IntsStr(geo.strides) +
+          ", dilations " + IntsStr(geo.dilations) + " and pads " +
+          IntsStr(pads) + ": axis " + std::to_string(i) + " should be " +
+          std::to_string(expected) + ", not " + std::to_string(y_shape[2 + i]) +
+          " (node " + name + ")");
+    }
+  }
+  geo.pads_begin.assign(pads.begin(), pads.begin() + spatial);
+  return geo;
+}
+
+std::vector<OptStr> GradConv(Backward& ctx, const onnx::NodeProto& node,
+                             const std::string& g) {
+  // Conv's three gradients, written as im2col plus a MatMul so that nothing
+  // outside BackwardOps() is emitted -- neither Conv nor ConvTranspose is in
+  // EpFriendlyOps(), and the note beside that set records why they were left
+  // out rather than added for this rule. _grad_conv in graph_grad.py carries
+  // the derivation; this is a transcription of it, node for node.
+  const std::string& x = node.input(0);
+  const std::string& w = node.input(1);
+  const Shape x_shape = ctx.ShapeOf(x);
+  const Shape w_shape = ctx.ShapeOf(w);
+  const Shape y_shape = ctx.ShapeOf(node.output(0));
+  const ConvGeometry geo = ConvGeometryOf(node, x_shape, w_shape, y_shape);
+  bool has_bias = false;
+  if (node.input_size() > 2 && !node.input(2).empty()) {
+    has_bias = true;
+    const Shape bias_shape = ctx.ShapeOf(node.input(2));
+    if (bias_shape.size() != 1 || bias_shape[0] != w_shape[0]) {
+      throw UnsupportedOpError("Conv's B has shape " + ShapeStr(bias_shape) +
+                               ", not (" + std::to_string(w_shape[0]) +
+                               ",) (node " + Quoted(node.output(0)) + ")");
+    }
+  }
+
+  const int64_t batch = x_shape[0];
+  const int64_t features = w_shape[0] / geo.group;
+  const int64_t channels = x_shape[1] / geo.group;
+  const Shape in_dims(x_shape.begin() + 2, x_shape.end());
+  const Shape out_dims(y_shape.begin() + 2, y_shape.end());
+  const int64_t taps = Prod(geo.kernel);
+  const int64_t in_count = Prod(in_dims);
+  const int64_t out_count = Prod(out_dims);
+
+  // The incoming gradient with the group axis split out, which is the layout
+  // both halves below want: [N, group, M/group, output positions].
+  const std::string g_shape =
+      ctx.b().ConstInt64({batch, geo.group, features, out_count}, "shape");
+  const std::string g4 = ctx.b().Op("Reshape", {g, g_shape}, "reshape");
+
+  // dX = sum over (m, t) of W[m, c, t] * dY[m, position], one gather of dY
+  // per tap.
+  const std::pair<std::vector<int64_t>, std::vector<float>> col2im =
+      Col2ImIndices(in_dims, out_dims, geo.kernel, geo.strides, geo.dilations,
+                    geo.pads_begin);
+  const std::string g_index = ctx.b().ConstInt64(col2im.first, "idx");
+  const std::string gathered_g =
+      ctx.b().Op("Gather", {g4, g_index}, {IntAttr("axis", 3)}, "gather");
+  const std::string g_mask =
+      ctx.b().Const(col2im.second, {1, 1, 1, taps * in_count}, "mask");
+  const std::string masked_g = ctx.b().Mul(gathered_g, g_mask);
+  const std::string dcol_shape = ctx.b().ConstInt64(
+      {batch, geo.group, features * taps, in_count}, "shape");
+  const std::string dcol =
+      ctx.b().Op("Reshape", {masked_g, dcol_shape}, "reshape");
+  const std::string w4_shape =
+      ctx.b().ConstInt64({geo.group, features, channels, taps}, "shape");
+  const std::string w4 = ctx.b().Op("Reshape", {w, w4_shape}, "reshape");
+  const std::string w4t = ctx.b().Transpose(w4, {0, 2, 1, 3});
+  // The leading 1 keeps both MatMul operands rank 4.
+  const std::string wt_shape =
+      ctx.b().ConstInt64({1, geo.group, channels, features * taps}, "shape");
+  const std::string wt = ctx.b().Op("Reshape", {w4t, wt_shape}, "reshape");
+  const std::string dx4 = ctx.b().MatMul(wt, dcol);
+  const std::string dx_shape = ctx.b().ConstInt64(x_shape, "shape");
+  const std::string dx = ctx.b().Op("Reshape", {dx4, dx_shape}, "reshape");
+
+  // dW = sum over (n, o) of dY[n, m, o] * col[n, c, t, o], with col the
+  // forward's own im2col of X.
+  const std::string x4_shape =
+      ctx.b().ConstInt64({batch, geo.group, channels, in_count}, "shape");
+  const std::string x4 = ctx.b().Op("Reshape", {x, x4_shape}, "reshape");
+  const std::pair<std::vector<int64_t>, std::vector<float>> im2col =
+      Im2ColIndices(in_dims, out_dims, geo.kernel, geo.strides, geo.dilations,
+                    geo.pads_begin);
+  const std::string x_index = ctx.b().ConstInt64(im2col.first, "idx");
+  const std::string gathered_x =
+      ctx.b().Op("Gather", {x4, x_index}, {IntAttr("axis", 3)}, "gather");
+  const std::string x_mask =
+      ctx.b().Const(im2col.second, {1, 1, 1, taps * out_count}, "mask");
+  const std::string masked_x = ctx.b().Mul(gathered_x, x_mask);
+  const std::string col_shape = ctx.b().ConstInt64(
+      {batch, geo.group, channels * taps, out_count}, "shape");
+  const std::string col =
+      ctx.b().Op("Reshape", {masked_x, col_shape}, "reshape");
+  const std::string colt = ctx.b().Transpose(col, {0, 1, 3, 2});
+  const std::string dw4 = ctx.b().MatMul(g4, colt);
+  const std::string dw_axes = ctx.b().ConstInt64({0}, "axes");
+  const std::string dw3 = ctx.b().Op("ReduceSum", {dw4, dw_axes},
+                                     {IntAttr("keepdims", 0)}, "reducesum");
+  const std::string dw_shape = ctx.b().ConstInt64(w_shape, "shape");
+  const std::string dw = ctx.b().Op("Reshape", {dw3, dw_shape}, "reshape");
+
+  std::vector<OptStr> grads{dx, dw};
+  if (node.input_size() > 2) {
+    if (!has_bias) {
+      grads.push_back(std::nullopt);
+    } else {
+      const std::string db_axes = ctx.b().ConstInt64({0, 3}, "axes");
+      const std::string db = ctx.b().Op("ReduceSum", {g4, db_axes},
+                                        {IntAttr("keepdims", 0)}, "reducesum");
+      const std::string db_shape = ctx.b().ConstInt64({w_shape[0]}, "shape");
+      grads.push_back(ctx.b().Op("Reshape", {db, db_shape}, "reshape"));
     }
   }
   return grads;
@@ -710,6 +1073,7 @@ const std::map<std::string, Rule>& Rules() {
       new std::map<std::string, Rule>{
           {"Add", &GradAdd},
           {"Clip", &GradClip},
+          {"Conv", &GradConv},
           {"Div", &GradDiv},
           {"Erf", &GradErf},
           {"Exp", &GradExp},
@@ -753,10 +1117,15 @@ const std::set<std::string>& BackwardOps() {
   // needs a mean over the normalized axes and the reciprocal square root of
   // the variance; the Python set says at length why that is not a loosening
   // of the criterion.
+  // Gather was admitted for GradConv, which writes a convolution's gradient
+  // as im2col rather than as the ConvTranspose it naturally is; the Python
+  // set says why that is not a loosening either, and the EP_FRIENDLY_OPS note
+  // in qat_graph.py records what a Conv/ConvTranspose membership would have
+  // cost instead.
   static const std::set<std::string>* ops = new std::set<std::string>{
-      "Add",       "Cast",    "Div",  "Exp", "Greater",
-      "Less",      "MatMul",  "Mul",  "Neg", "ReduceMean",
-      "ReduceSum", "Reshape", "Sqrt", "Sub", "Transpose"};
+      "Add",     "Cast",   "Div", "Exp",      "Gather",     "Greater",
+      "Less",    "MatMul", "Mul", "Neg",      "ReduceMean", "ReduceSum",
+      "Reshape", "Sqrt",   "Sub", "Transpose"};
   return *ops;
 }
 

--- a/onnxsim/graph_grad.py
+++ b/onnxsim/graph_grad.py
@@ -81,6 +81,7 @@ BACKWARD_OPS = frozenset(
         "Cast",
         "Div",
         "Exp",
+        "Gather",
         "Greater",
         "Less",
         "MatMul",
@@ -104,6 +105,15 @@ BACKWARD_OPS = frozenset(
 # be avoided by dividing a ``ReduceSum`` by a constant, but ``Sqrt`` could
 # not, so contorting one of the two to keep the set at its old size would buy
 # nothing.
+
+# ``Gather`` was admitted for :func:`_grad_conv`, and is the one member here
+# that is not arithmetic. It is also not a loosening: it was already in
+# :data:`onnxsim.qat_graph.EP_FRIENDLY_OPS` -- the note beside that set is
+# where its coverage was established, and the same note now records what a
+# ``Conv``/``ConvTranspose`` membership would have cost instead. The use is
+# the same shape as the minibatching one it was admitted for there: a single
+# axis, a constant int64 index, and no dependence of the *index* on any
+# runtime value.
 
 
 class UnsupportedOpError(ValueError):
@@ -307,6 +317,396 @@ def _grad_gemm(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[st
             # C spelled as an omitted optional input ("") rather than left off
             # the node entirely -- there is no tensor to give a gradient to.
             grads.append(None)
+    return grads
+
+
+def _prod(dims: Sequence[int]) -> int:
+    """The number of elements a shape holds; ``1`` for a rank-0 one."""
+    total = 1
+    for d in dims:
+        total *= int(d)
+    return total
+
+
+def _unflatten(index: int, dims: Sequence[int]) -> List[int]:
+    """``index`` as row-major coordinates in ``dims``."""
+    coords = [0] * len(dims)
+    for i in reversed(range(len(dims))):
+        coords[i] = index % int(dims[i])
+        index //= int(dims[i])
+    return coords
+
+
+def _im2col_indices(
+    in_dims: Sequence[int],
+    out_dims: Sequence[int],
+    kernel: Sequence[int],
+    strides: Sequence[int],
+    dilations: Sequence[int],
+    pads_begin: Sequence[int],
+) -> Tuple[List[int], np.ndarray]:
+    """Where each ``(kernel tap, output position)`` pair reads its input.
+
+    The pair ``(t, o)`` reads input position ``o * stride - pad + t *
+    dilation`` along each spatial axis; a pair whose position falls outside
+    the input is one the padding invented. Both are returned flattened in
+    ``[tap, output position]`` order: the index (with an invented tap pointing
+    at element 0, since ONNX's ``Gather`` rejects an out-of-range index
+    outright) and a 0/1 float mask that multiplies the invented ones away
+    afterwards.
+    """
+    spatial = len(in_dims)
+    out_count = _prod(out_dims)
+    index = [0] * (_prod(kernel) * out_count)
+    mask = np.zeros(len(index), dtype=np.float32)
+    for tap in range(_prod(kernel)):
+        taps = _unflatten(tap, kernel)
+        for out in range(out_count):
+            position = _unflatten(out, out_dims)
+            flat = 0
+            for i in range(spatial):
+                p = position[i] * strides[i] - pads_begin[i] + taps[i] * dilations[i]
+                if p < 0 or p >= in_dims[i]:
+                    flat = -1
+                    break
+                flat = flat * in_dims[i] + p
+            if flat >= 0:
+                index[tap * out_count + out] = flat
+                mask[tap * out_count + out] = 1.0
+    return index, mask
+
+
+def _col2im_indices(
+    in_dims: Sequence[int],
+    out_dims: Sequence[int],
+    kernel: Sequence[int],
+    strides: Sequence[int],
+    dilations: Sequence[int],
+    pads_begin: Sequence[int],
+) -> Tuple[List[int], np.ndarray]:
+    """The same correspondence read the other way: which *output* position a
+    given ``(kernel tap, input position)`` pair came from.
+
+    Inverting ``p = o * stride - pad + t * dilation`` for ``o`` is what turns
+    the gradient's scatter-add into a gather: for a fixed tap, every input
+    position is written by at most one output position, so the whole ``dx``
+    is a sum of ``prod(kernel)`` gathers of the incoming gradient rather than
+    an accumulation into overlapping windows. A stride greater than one makes
+    the division inexact for most positions -- those are exactly the input
+    elements that tap never touched -- and they are masked away like the
+    padded ones above.
+    """
+    spatial = len(in_dims)
+    in_count = _prod(in_dims)
+    index = [0] * (_prod(kernel) * in_count)
+    mask = np.zeros(len(index), dtype=np.float32)
+    for tap in range(_prod(kernel)):
+        taps = _unflatten(tap, kernel)
+        for entry in range(in_count):
+            position = _unflatten(entry, in_dims)
+            flat = 0
+            for i in range(spatial):
+                shifted = position[i] + pads_begin[i] - taps[i] * dilations[i]
+                if shifted % strides[i] != 0:
+                    flat = -1
+                    break
+                o = shifted // strides[i]
+                if o < 0 or o >= out_dims[i]:
+                    flat = -1
+                    break
+                flat = flat * out_dims[i] + o
+            if flat >= 0:
+                index[tap * in_count + entry] = flat
+                mask[tap * in_count + entry] = 1.0
+    return index, mask
+
+
+def _conv_geometry(
+    node: onnx.NodeProto,
+    x_shape: Tuple[int, ...],
+    w_shape: Tuple[int, ...],
+    y_shape: Tuple[int, ...],
+) -> Tuple[int, List[int], List[int], List[int], List[int]]:
+    """``Conv``'s attributes resolved against its actual shapes.
+
+    Returns ``(group, kernel, strides, dilations, pads_begin)`` -- everything
+    :func:`_grad_conv` needs to say where each output element read from --
+    with ``auto_pad`` already turned into explicit padding.
+
+    Every one of the refusals below is a configuration whose gradient this
+    rule would otherwise compute against a geometry it invented. The last one
+    is the important one: the resolved geometry is required to *reproduce the
+    node's own output shape*, so a mistake in reading the attributes cannot
+    survive to become a wrong gradient.
+    """
+    name = node.output[0]
+    rank = len(x_shape)
+    if rank < 3:
+        raise UnsupportedOpError(
+            f"Conv needs at least one spatial dimension, got input shape "
+            f"{x_shape} (node {name!r})"
+        )
+    spatial = rank - 2
+    if len(w_shape) != rank or len(y_shape) != rank:
+        raise UnsupportedOpError(
+            f"Conv's X, W and Y must have the same rank, got {x_shape}, "
+            f"{w_shape} and {y_shape} (node {name!r})"
+        )
+    group = int(_attr(node, "group", 1))
+    channels, features = int(x_shape[1]), int(w_shape[0])
+    if group < 1 or channels % group != 0 or features % group != 0:
+        raise UnsupportedOpError(
+            f"Conv with group={group} does not divide its {channels} input and "
+            f"{features} output channels (node {name!r})"
+        )
+    if int(w_shape[1]) != channels // group:
+        raise UnsupportedOpError(
+            f"Conv's W has {w_shape[1]} channels per group, but group={group} "
+            f"over {channels} input channels needs {channels // group} "
+            f"(node {name!r})"
+        )
+
+    kernel = [int(d) for d in w_shape[2:]]
+    declared = _attr(node, "kernel_shape", None)
+    if declared is not None and [int(k) for k in declared] != kernel:
+        raise UnsupportedOpError(
+            f"Conv's kernel_shape attribute {[int(k) for k in declared]} "
+            f"disagrees with W's own spatial shape {kernel} (node {name!r})"
+        )
+    strides = [int(s) for s in _attr(node, "strides", [1] * spatial)]
+    dilations = [int(d) for d in _attr(node, "dilations", [1] * spatial)]
+    if len(strides) != spatial or len(dilations) != spatial:
+        raise UnsupportedOpError(
+            f"Conv's strides {strides} and dilations {dilations} must have one "
+            f"entry per spatial axis ({spatial}) (node {name!r})"
+        )
+    if any(s < 1 for s in strides) or any(d < 1 for d in dilations):
+        raise UnsupportedOpError(
+            f"Conv with strides {strides} and dilations {dilations} is not a "
+            f"convolution this rule can invert (node {name!r})"
+        )
+
+    auto_pad = _attr(node, "auto_pad", "NOTSET")
+    if isinstance(auto_pad, bytes):
+        auto_pad = auto_pad.decode("utf-8")
+    if auto_pad == "NOTSET":
+        pads = [int(p) for p in _attr(node, "pads", [0] * (2 * spatial))]
+        if len(pads) != 2 * spatial:
+            raise UnsupportedOpError(
+                f"Conv's pads {pads} must have two entries per spatial axis "
+                f"({spatial}) (node {name!r})"
+            )
+    elif auto_pad == "VALID":
+        pads = [0] * (2 * spatial)
+    elif auto_pad in ("SAME_UPPER", "SAME_LOWER"):
+        # The spec's own formula, resolved here rather than left to the
+        # runtime: the shapes are static, so "same" is a number at build time.
+        pads = [0] * (2 * spatial)
+        for i in range(spatial):
+            size = int(x_shape[2 + i])
+            out = -(-size // strides[i])
+            span = (kernel[i] - 1) * dilations[i] + 1
+            needed = max(0, (out - 1) * strides[i] + span - size)
+            if auto_pad == "SAME_UPPER":
+                pads[i] = needed // 2
+            else:
+                pads[i] = needed - needed // 2
+            pads[spatial + i] = needed - pads[i]
+    else:
+        raise UnsupportedOpError(
+            f"Conv with auto_pad {auto_pad!r} is not differentiated here "
+            f"(node {name!r})"
+        )
+
+    if int(y_shape[0]) != int(x_shape[0]) or int(y_shape[1]) != features:
+        raise UnsupportedOpError(
+            f"Conv's output shape {y_shape} does not match its input {x_shape} "
+            f"and weight {w_shape} (node {name!r})"
+        )
+    for i in range(spatial):
+        span = (kernel[i] - 1) * dilations[i] + 1
+        reach = int(x_shape[2 + i]) + pads[i] + pads[spatial + i] - span
+        expected = reach // strides[i] + 1 if reach >= 0 else 0
+        if expected != int(y_shape[2 + i]):
+            raise UnsupportedOpError(
+                f"Conv's declared output shape {y_shape} does not follow from "
+                f"input {x_shape}, kernel {kernel}, strides {strides}, "
+                f"dilations {dilations} and pads {pads}: axis {i} should be "
+                f"{expected}, not {int(y_shape[2 + i])} (node {name!r})"
+            )
+    return group, kernel, strides, dilations, pads[:spatial]
+
+
+def _grad_conv(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    """``Conv``'s three gradients, without emitting a convolution.
+
+    **Why not a convolution.** ``dX`` is naturally a ``ConvTranspose`` and
+    ``dW`` a ``Conv`` over permuted axes, and neither operator is in
+    :data:`onnxsim.qat_graph.EP_FRIENDLY_OPS`. Putting them there would have
+    bought a rule that is dead on the very backends the allowlist exists for
+    as soon as the convolution is not 2-D -- the note beside that set records
+    what WebNN and onnxruntime-web's WebGPU backend actually implement. So
+    this rule takes the other road: the im2col identity, which needs nothing
+    the allowlist does not already have.
+
+    **The identity.** Write the forward as a matrix product. With ``t``
+    ranging over the kernel's taps and ``o`` over the output positions,
+
+    .. code-block:: text
+
+        col[c, t, o] = X[c, position(o, t)]      (im2col: one gather)
+        Y[m, o]      = sum_{c, t} W[m, c, t] * col[c, t, o]
+
+    which is a plain ``MatMul`` of ``W`` reshaped to ``[M, C*K]`` against
+    ``col``. Differentiating a matrix product is the rule
+    :func:`_grad_matmul` already implements, so::
+
+        dW[m, c, t] = sum_o dY[m, o] * col[c, t, o]        (a MatMul)
+        dcol[c, t, o] = sum_m W[m, c, t] * dY[m, o]        (a MatMul)
+        dX = col2im(dcol)                                  (a scatter-add)
+
+    and the last line is the only awkward one, because a scatter-add is not
+    an operator here. It does not have to be: for a *fixed* tap, ``position``
+    is injective -- input element ``p`` is read by at most one output
+    position -- so col2im rearranges into a sum of ``prod(kernel)`` gathers
+    of ``dY`` (:func:`_col2im_indices`), which is again one ``Gather`` and
+    one ``MatMul``. Both directions are therefore the same three nodes:
+    gather, mask, matmul.
+
+    **Padding and stride, as a mask.** A tap that reads outside the input
+    (padding) or an input element a strided tap never touched has no
+    correspondent, and ONNX's ``Gather`` refuses an out-of-range index rather
+    than producing a zero. Those entries are pointed at element 0 and
+    multiplied by a 0/1 constant instead -- the same "a mask is a float 0/1,
+    multiplied in" convention :class:`onnxsim.qat_graph.GraphBuilder` uses
+    everywhere else. It is emitted unconditionally, even for a geometry whose
+    mask is all ones, so that the two implementations of this rule cannot
+    disagree about when to branch.
+
+    **Groups** cost nothing extra: the group axis is split out of the channel
+    axis by the reshapes that are already there, and the ``MatMul`` batches
+    over it. The same is true of the number of spatial dimensions, which this
+    rule never looks at beyond building the index tables -- a 1-D or 3-D
+    convolution differentiates exactly like a 2-D one.
+
+    **What it costs.** The two index tables are ``prod(kernel) *
+    prod(output spatial)`` and ``prod(kernel) * prod(input spatial)``
+    elements, materialized as initializers. That is the price of not needing
+    a convolution kernel on the backend, and on a large feature map it is
+    megabytes per node: a 3x3 convolution over 224x224 carries ~3.6 MB of
+    int64 index and ~1.8 MB of mask. Reconstruction blocks are small and this
+    is bounded and predictable, but it is real, and it is the reason this
+    rule would not be the right one for a general-purpose trainer.
+    """
+    x, w = node.input[0], node.input[1]
+    x_shape, w_shape = ctx.shape(x), ctx.shape(w)
+    y_shape = ctx.shape(node.output[0])
+    group, kernel, strides, dilations, pads = _conv_geometry(
+        node, x_shape, w_shape, y_shape
+    )
+    bias: Optional[str] = None
+    if len(node.input) > 2 and node.input[2]:
+        bias = node.input[2]
+        bias_shape = ctx.shape(bias)
+        if tuple(bias_shape) != (int(w_shape[0]),):
+            raise UnsupportedOpError(
+                f"Conv's B has shape {tuple(bias_shape)}, not "
+                f"({int(w_shape[0])},) (node {node.output[0]!r})"
+            )
+
+    batch = int(x_shape[0])
+    features = int(w_shape[0]) // group
+    channels = int(x_shape[1]) // group
+    in_dims = [int(d) for d in x_shape[2:]]
+    out_dims = [int(d) for d in y_shape[2:]]
+    taps = _prod(kernel)
+    in_count, out_count = _prod(in_dims), _prod(out_dims)
+
+    # The incoming gradient with the group axis split out, which is the
+    # layout both halves below want: [N, group, M/group, output positions].
+    g4 = ctx.b.op(
+        "Reshape",
+        [g, ctx.int64_const([batch, group, features, out_count], "shape")],
+    )
+
+    # dX = sum over (m, t) of W[m, c, t] * dY[m, position], one gather of dY
+    # per tap. See _col2im_indices for why the scatter-add is a gather here.
+    index, mask = _col2im_indices(in_dims, out_dims, kernel, strides, dilations, pads)
+    gathered = ctx.b.op("Gather", [g4, ctx.int64_const(index, "idx")], axis=3)
+    masked = ctx.b.mul(
+        gathered,
+        ctx.b.const(mask.reshape(1, 1, 1, taps * in_count), "mask"),
+    )
+    dcol = ctx.b.op(
+        "Reshape",
+        [
+            masked,
+            ctx.int64_const([batch, group, features * taps, in_count], "shape"),
+        ],
+    )
+    w4 = ctx.b.op(
+        "Reshape",
+        [w, ctx.int64_const([group, features, channels, taps], "shape")],
+    )
+    w4t = ctx.b.transpose(w4, [0, 2, 1, 3])
+    # The leading 1 keeps both MatMul operands rank 4: a batch axis that
+    # broadcasts is the mildest form of the broadcasting MatMul the rules
+    # already rely on, and it keeps every tensor here inside the rank limit
+    # WebNN's matmul states.
+    wt = ctx.b.op(
+        "Reshape",
+        [
+            w4t,
+            ctx.int64_const([1, group, channels, features * taps], "shape"),
+        ],
+    )
+    dx4 = ctx.b.matmul(wt, dcol)
+    dx = ctx.b.op("Reshape", [dx4, ctx.int64_const(x_shape, "shape")])
+
+    # dW = sum over (n, o) of dY[n, m, o] * col[n, c, t, o], with col the
+    # forward's own im2col of X.
+    x4 = ctx.b.op(
+        "Reshape",
+        [x, ctx.int64_const([batch, group, channels, in_count], "shape")],
+    )
+    index, mask = _im2col_indices(in_dims, out_dims, kernel, strides, dilations, pads)
+    gathered = ctx.b.op("Gather", [x4, ctx.int64_const(index, "idx")], axis=3)
+    masked = ctx.b.mul(
+        gathered,
+        ctx.b.const(mask.reshape(1, 1, 1, taps * out_count), "mask"),
+    )
+    col = ctx.b.op(
+        "Reshape",
+        [
+            masked,
+            ctx.int64_const([batch, group, channels * taps, out_count], "shape"),
+        ],
+    )
+    colt = ctx.b.transpose(col, [0, 1, 3, 2])
+    dw4 = ctx.b.matmul(g4, colt)
+    dw3 = ctx.b.op(
+        "ReduceSum",
+        [dw4, ctx.int64_const([0], "axes")],
+        keepdims=0,
+    )
+    dw = ctx.b.op("Reshape", [dw3, ctx.int64_const(w_shape, "shape")])
+
+    grads: List[Optional[str]] = [dx, dw]
+    if len(node.input) > 2:
+        if bias is None:
+            grads.append(None)
+        else:
+            db = ctx.b.op(
+                "ReduceSum",
+                [g4, ctx.int64_const([0, 3], "axes")],
+                keepdims=0,
+            )
+            grads.append(
+                ctx.b.op(
+                    "Reshape",
+                    [db, ctx.int64_const([int(w_shape[0])], "shape")],
+                )
+            )
     return grads
 
 
@@ -614,6 +1014,7 @@ def _grad_clip(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[st
 _RULES: Dict[str, Rule] = {
     "Add": _grad_add,
     "Clip": _grad_clip,
+    "Conv": _grad_conv,
     "Div": _grad_div,
     "Erf": _grad_erf,
     "Exp": _grad_exp,

--- a/onnxsim/graph_grad_test.cpp
+++ b/onnxsim/graph_grad_test.cpp
@@ -30,6 +30,7 @@
 #include <onnx/onnx_pb.h>
 
 #include <cstdio>
+#include <cstring>
 #include <functional>
 #include <map>
 #include <set>
@@ -93,6 +94,15 @@ onnx::AttributeProto FloatAttr(const std::string& name, float value) {
   attribute.set_name(name);
   attribute.set_type(onnx::AttributeProto::FLOAT);
   attribute.set_f(value);
+  return attribute;
+}
+
+onnx::AttributeProto StrAttr(const std::string& name,
+                             const std::string& value) {
+  onnx::AttributeProto attribute;
+  attribute.set_name(name);
+  attribute.set_type(onnx::AttributeProto::STRING);
+  attribute.set_s(value);
   return attribute;
 }
 
@@ -211,6 +221,20 @@ Shapes LayerNormShapes() {
   return {{"X", {2, 3, 4}}, {"S", {4}}, {"Bn", {4}}, {"Y", {2, 3, 4}}};
 }
 
+// A convolution with a bias -- the only rule that emits a Gather, and the
+// only one whose emission depends on arithmetic (the index tables) rather
+// than only on the shapes.
+std::vector<onnx::NodeProto> ConvSlice() {
+  return {Node("Conv", {"X", "Wc", "Bc"}, {"Y"})};
+}
+
+Shapes ConvShapes() {
+  return {{"X", {1, 2, 4, 4}},
+          {"Wc", {3, 2, 3, 3}},
+          {"Bc", {3}},
+          {"Y", {1, 3, 2, 2}}};
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -221,11 +245,13 @@ Shapes LayerNormShapes() {
 // browser that the Python refuses, or the reverse.
 void TheSupportedOpsAreExactlyThePythonRuleTable() {
   const std::set<std::string> expected = {
-      "Add",       "Clip", "Div",      "Erf",
-      "Exp",       "Gemm", "Identity", "LayerNormalization",
-      "MatMul",    "Mul",  "Neg",      "ReduceMean",
-      "ReduceSum", "Relu", "Reshape",  "Sigmoid",
-      "Softmax",   "Sqrt", "Sub",      "Tanh",
+      "Add",        "Clip",      "Conv",
+      "Div",        "Erf",       "Exp",
+      "Gemm",       "Identity",  "LayerNormalization",
+      "MatMul",     "Mul",       "Neg",
+      "ReduceMean", "ReduceSum", "Relu",
+      "Reshape",    "Sigmoid",   "Softmax",
+      "Sqrt",       "Sub",       "Tanh",
       "Transpose"};
   Check(SupportedOps() == expected,
         "SupportedOps() should equal graph_grad.py's _RULES keys, got {" +
@@ -238,9 +264,9 @@ void TheSupportedOpsAreExactlyThePythonRuleTable() {
 // as the forward and the optimizer step.
 void TheBackwardOpsAreThePythonAllowlistAndSitInsideEpFriendlyOps() {
   const std::set<std::string> expected = {
-      "Add",       "Cast",    "Div",  "Exp", "Greater",
-      "Less",      "MatMul",  "Mul",  "Neg", "ReduceMean",
-      "ReduceSum", "Reshape", "Sqrt", "Sub", "Transpose"};
+      "Add",     "Cast",   "Div", "Exp",      "Gather",     "Greater",
+      "Less",    "MatMul", "Mul", "Neg",      "ReduceMean", "ReduceSum",
+      "Reshape", "Sqrt",   "Sub", "Transpose"};
   Check(BackwardOps() == expected,
         "BackwardOps() should equal graph_grad.py's BACKWARD_OPS, got {" +
             Join(BackwardOps()) + "}");
@@ -265,6 +291,7 @@ void TheEmittedBackwardStaysInsideTheOperatorAllowlist() {
       {TranscendentalSlice(), TranscendentalShapes(), {"A"}},
       {GemmSlice(), GemmShapes(), {"A", "W", "Cb"}},
       {LayerNormSlice(), LayerNormShapes(), {"X", "S", "Bn"}},
+      {ConvSlice(), ConvShapes(), {"X", "Wc", "Bc"}},
   };
 
   std::set<std::string> emitted;
@@ -279,7 +306,7 @@ void TheEmittedBackwardStaysInsideTheOperatorAllowlist() {
     emitted.insert(types.begin(), types.end());
   }
   Check(emitted == BackwardOps(),
-        "the four slices together should emit every allowlisted op and no "
+        "the six slices together should emit every allowlisted op and no "
         "other; got {" +
             Join(emitted) + "}");
 }
@@ -493,6 +520,215 @@ void TheLayerNormRuleEmitsTheSameNodesInTheSameOrderAsThePython() {
   }
 }
 
+// Little-endian readers for an initializer's raw_data. GraphBuilder writes
+// tensors little-endian on purpose (see AppendLittleEndian), so a big-endian
+// host has to decode rather than reinterpret -- the same care
+// docs/big-endian.md asks of everything else that touches raw_data.
+std::vector<int64_t> Int64Data(const onnx::TensorProto& tensor) {
+  std::vector<int64_t> values;
+  const std::string& raw = tensor.raw_data();
+  for (size_t i = 0; i + 8 <= raw.size(); i += 8) {
+    uint64_t bits = 0;
+    for (int k = 7; k >= 0; --k) {
+      bits = (bits << 8) | static_cast<unsigned char>(raw[i + k]);
+    }
+    values.push_back(static_cast<int64_t>(bits));
+  }
+  return values;
+}
+
+std::vector<float> FloatData(const onnx::TensorProto& tensor) {
+  std::vector<float> values;
+  const std::string& raw = tensor.raw_data();
+  for (size_t i = 0; i + 4 <= raw.size(); i += 4) {
+    uint32_t bits = 0;
+    for (int k = 3; k >= 0; --k) {
+      bits = (bits << 8) | static_cast<unsigned char>(raw[i + k]);
+    }
+    float value = 0.0f;
+    std::memcpy(&value, &bits, sizeof(value));
+    values.push_back(value);
+  }
+  return values;
+}
+
+// If this fails, the C++ Conv rule has drifted from _grad_conv in
+// graph_grad.py. Pinned the same way and for the same reason as the
+// LayerNorm rule above: the nodes are numbered by the builder's counter in
+// emission order, so a reordering alone renames every tensor a browser-built
+// step graph produces from there on.
+void TheConvRuleEmitsTheSameNodesInTheSameOrderAsThePython() {
+  GraphBuilder b("bw_");
+  const std::map<std::string, std::string> grads = BuildBackward(
+      b, ConvSlice(), ConvShapes(), {{"Y", "dY"}}, {"X", "Wc", "Bc"});
+  // dY reshaped with the group axis split out; then dX -- gather dY per
+  // kernel tap, mask the taps that fall outside, matmul against W laid out
+  // [group, C/group, (M/group)*taps]; then dW -- im2col of X, matmul against
+  // dY, sum over the batch; then dB, dY summed over batch and positions.
+  const std::vector<std::string> expected = {
+      "Reshape",   "Gather",  "Mul",       "Reshape",   "Reshape",
+      "Transpose", "Reshape", "MatMul",    "Reshape",   "Reshape",
+      "Gather",    "Mul",     "Reshape",   "Transpose", "MatMul",
+      "ReduceSum", "Reshape", "ReduceSum", "Reshape"};
+  Check(OpTypes(b) == expected,
+        "the Conv rule should emit graph_grad.py's nodes in its order");
+  Check(b.nodes().size() == expected.size() &&
+            grads.at("X") == b.nodes()[8].output(0) &&
+            grads.at("Wc") == b.nodes()[16].output(0) &&
+            grads.at("Bc") == b.nodes().back().output(0),
+        "dX, dW and dB should be the three Reshapes that close each half");
+  // Neither Conv nor ConvTranspose: the whole point of writing the gradient
+  // as im2col is that the emitted graph needs no convolution kernel on the
+  // backend. See the note beside EpFriendlyOps() in qat_graph_builder.h.
+  const std::set<std::string> emitted = OpTypeSet(b);
+  Check(emitted.count("Conv") == 0 && emitted.count("ConvTranspose") == 0,
+        "a Conv's gradient must not itself contain a convolution");
+  for (const onnx::NodeProto& node : b.nodes()) {
+    if (node.op_type() != "Gather") continue;
+    Check(node.attribute_size() == 1 && node.attribute(0).name() == "axis" &&
+              node.attribute(0).i() == 3,
+          "both gathers run along axis 3, the flattened spatial axis");
+  }
+}
+
+// If this fails, the index tables the two gathers read from have been
+// computed differently here from the Python -- which no allowlist or op-order
+// check would catch, because the graph would have exactly the same shape and
+// simply read the wrong elements. The case is small enough to write the
+// answer out by hand: a 1-D convolution of a length-3 input by a width-2
+// kernel, padded on both sides, whose output is length 4.
+void TheConvIndexTablesAreTheOnesTheGeometryImplies() {
+  const std::vector<onnx::NodeProto> nodes = {
+      Node("Conv", {"X", "Wc"}, {"Y"}, {IntsAttr("pads", {1, 1})})};
+  const Shapes shapes = {{"X", {1, 1, 3}}, {"Wc", {1, 1, 2}}, {"Y", {1, 1, 4}}};
+  GraphBuilder b("bw_");
+  BuildBackward(b, nodes, shapes, {{"Y", "dY"}}, {"X", "Wc"});
+
+  // dX's gather: for tap t, input position p came from output position
+  // p + 1 - t. Tap 0 reads outputs 1, 2, 3; tap 1 reads outputs 0, 1, 2.
+  Check(b.initializer().size() == 13, "the rule emits thirteen initializers");
+  Check(
+      Int64Data(b.initializer()[1]) == std::vector<int64_t>({1, 2, 3, 0, 1, 2}),
+      "dX gathers output position p + 1 - t for tap t");
+  Check(FloatData(b.initializer()[2]) == std::vector<float>({1, 1, 1, 1, 1, 1}),
+        "with a width-2 kernel and one pad each side, every input position "
+        "is reached by both taps");
+
+  // dW's im2col: for tap t, output position o reads input o - 1 + t. Tap 0's
+  // first read and tap 1's last are the padding, and are masked away rather
+  // than gathered from out of range.
+  Check(Int64Data(b.initializer()[8]) ==
+            std::vector<int64_t>({0, 0, 1, 2, 0, 1, 2, 0}),
+        "im2col reads input position o - 1 + t, clamped to 0 where the tap "
+        "falls in the padding");
+  Check(FloatData(b.initializer()[9]) ==
+            std::vector<float>({0, 1, 1, 1, 1, 1, 1, 0}),
+        "the mask is 0 exactly where the tap read padding");
+}
+
+// If this fails, a convolution the rule cannot invert would be
+// differentiated against a geometry it invented, which is the one failure
+// mode that produces a plausible-looking wrong gradient rather than an
+// error. Each of these is a refusal graph_grad.py makes by the same name.
+void AConvWhoseGeometryDoesNotAddUpIsRefused() {
+  const Shapes ok = {
+      {"X", {1, 2, 5, 5}}, {"Wc", {2, 2, 3, 3}}, {"Y", {1, 2, 3, 3}}};
+  {
+    // The output shape the node declares has to follow from the attributes;
+    // if it does not, one of the two is being misread and neither can be
+    // trusted.
+    const Shapes wrong = {
+        {"X", {1, 2, 5, 5}}, {"Wc", {2, 2, 3, 3}}, {"Y", {1, 2, 4, 4}}};
+    GraphBuilder b;
+    CheckThrows<UnsupportedOpError>(
+        [&] {
+          BuildBackward(b, {Node("Conv", {"X", "Wc"}, {"Y"})}, wrong,
+                        {{"Y", "dY"}}, {"X"});
+        },
+        "does not follow from", "an inconsistent output shape is refused");
+  }
+  {
+    // "SAME" is not a spelling ONNX has; a typo in the attribute must not
+    // silently fall back to no padding.
+    GraphBuilder b;
+    CheckThrows<UnsupportedOpError>(
+        [&] {
+          BuildBackward(
+              b,
+              {Node("Conv", {"X", "Wc"}, {"Y"}, {StrAttr("auto_pad", "SAME")})},
+              ok, {{"Y", "dY"}}, {"X"});
+        },
+        "auto_pad", "an unknown auto_pad is refused by name");
+  }
+  {
+    // A group count that does not divide the channels describes no
+    // convolution at all.
+    GraphBuilder b;
+    CheckThrows<UnsupportedOpError>(
+        [&] {
+          BuildBackward(
+              b, {Node("Conv", {"X", "Wc"}, {"Y"}, {IntAttr("group", 3)})}, ok,
+              {{"Y", "dY"}}, {"X"});
+        },
+        "group=3", "a group that does not divide the channels is refused");
+  }
+  {
+    // A kernel_shape attribute that disagrees with W's own spatial shape:
+    // the two say different things about what the node computes.
+    GraphBuilder b;
+    CheckThrows<UnsupportedOpError>(
+        [&] {
+          BuildBackward(b,
+                        {Node("Conv", {"X", "Wc"}, {"Y"},
+                              {IntsAttr("kernel_shape", {2, 2})})},
+                        ok, {{"Y", "dY"}}, {"X"});
+        },
+        "kernel_shape", "a kernel_shape that disagrees with W is refused");
+  }
+  {
+    // No spatial axis at all: a rank-2 "convolution" is a matrix product
+    // spelled wrong, and this rule will not guess which.
+    const Shapes flat = {{"X", {2, 3}}, {"Wc", {3, 4}}, {"Y", {2, 4}}};
+    GraphBuilder b;
+    CheckThrows<UnsupportedOpError>(
+        [&] {
+          BuildBackward(b, {Node("Conv", {"X", "Wc"}, {"Y"})}, flat,
+                        {{"Y", "dY"}}, {"X"});
+        },
+        "spatial dimension", "a Conv with no spatial axis is refused");
+  }
+}
+
+// If this fails, the rule has grown a special case for the number of spatial
+// dimensions -- and since WebNN has conv2d and convTranspose2d and no other
+// convolution, a rank-dependent rule is exactly what writing this backward
+// as a convolution would have forced. The 1-D and 3-D cases must emit the
+// same nodes as the 2-D one, differing only in the tables' contents.
+void ConvsOfAnyRankDifferentiateIdentically() {
+  const std::vector<std::string> expected = {
+      "Reshape", "Gather",    "Mul",     "Reshape",   "Reshape", "Transpose",
+      "Reshape", "MatMul",    "Reshape", "Reshape",   "Gather",  "Mul",
+      "Reshape", "Transpose", "MatMul",  "ReduceSum", "Reshape"};
+  {
+    const Shapes shapes = {
+        {"X", {1, 2, 7}}, {"Wc", {3, 2, 3}}, {"Y", {1, 3, 3}}};
+    GraphBuilder b;
+    BuildBackward(
+        b, {Node("Conv", {"X", "Wc"}, {"Y"}, {IntsAttr("strides", {2})})},
+        shapes, {{"Y", "dY"}}, {"X", "Wc"});
+    Check(OpTypes(b) == expected, "a 1-D convolution emits the same nodes");
+  }
+  {
+    const Shapes shapes = {{"X", {1, 1, 3, 3, 3}},
+                           {"Wc", {2, 1, 2, 2, 2}},
+                           {"Y", {1, 2, 2, 2, 2}}};
+    GraphBuilder b;
+    BuildBackward(b, {Node("Conv", {"X", "Wc"}, {"Y"})}, shapes, {{"Y", "dY"}},
+                  {"X", "Wc"});
+    Check(OpTypes(b) == expected, "a 3-D convolution emits the same nodes");
+  }
+}
+
 // If this fails, a tensor read by two consumers -- a residual connection's
 // own input, which is why this matters -- would keep only one contribution,
 // and the parameter upstream of it would train on a fraction of its
@@ -596,6 +832,10 @@ int main() {
   ReducedAxesComeFromTheAttributeWhenThereIsOne();
   ABroadcastGradientIsSummedBackToTheOperandShape();
   TheLayerNormRuleEmitsTheSameNodesInTheSameOrderAsThePython();
+  TheConvRuleEmitsTheSameNodesInTheSameOrderAsThePython();
+  TheConvIndexTablesAreTheOnesTheGeometryImplies();
+  AConvWhoseGeometryDoesNotAddUpIsRefused();
+  ConvsOfAnyRankDifferentiateIdentically();
   ATensorReadTwiceAccumulatesItsContributions();
   AnIdentityAliasesTheSeedInsteadOfEmittingANode();
   TheReturnedMapCoversExactlyTheRequestedTargets();

--- a/onnxsim/qat.py
+++ b/onnxsim/qat.py
@@ -125,7 +125,7 @@ that backend's coverage of the block's own operators as well.
   node without a gradient rule refuses the entire model, whereas
   :func:`apply_qat_all_blocks` turns that node into a gap and trains
   everything either side of it. :data:`onnxsim.graph_grad.SUPPORTED_OPS`
-  covers 21 of the 202 operators in ONNX's default domain, so on a real
+  covers 22 of the 202 operators in ONNX's default domain, so on a real
   model that is the binding constraint long before the accuracy question
   above is reached.
 

--- a/onnxsim/qat_graph.py
+++ b/onnxsim/qat_graph.py
@@ -119,8 +119,12 @@ _IR_VERSION = 8
 #
 # What is deliberately absent: control flow, boolean logic ops (a mask is a
 # float 0/1 from ``Cast(Greater(...))``, multiplied in), ``Where``,
-# ``Expand``, and ``Round`` -- WebNN has no rounding operator at all, which is
-# why :mod:`onnxsim.adaquant` composes one out of ``Sign``/``Abs``/``Cast``.
+# ``Expand``, and ``Round`` -- which :mod:`onnxsim.adaquant` composes out of
+# ``Sign``/``Abs``/``Cast`` instead. That composition was written when WebNN
+# had no rounding operator at all; it has since gained ``roundEven``, and
+# onnxruntime-web's WebNN EP maps ``Round`` onto it, so the reason has
+# weakened rather than held. See the ``Conv`` note below, which is where that
+# was re-checked and what it was checked against.
 # Adding to this set is a real decision: check the operator actually has
 # coverage on the WebGPU and WebNN backends first, not just on ORT's CPU
 # kernels.
@@ -140,6 +144,51 @@ _IR_VERSION = 8
 # new operator -- feeding the batch's rows themselves as a per-step input --
 # is rejected in :func:`run_step_graph`'s own docstring, where the trade-off
 # it loses is spelled out.
+#
+# ``Conv`` and ``ConvTranspose`` were considered for this set and deliberately
+# left out, which is worth recording because the case for them looks strong:
+# :func:`onnxsim.graph_grad._grad_conv` differentiates a convolution, and the
+# textbook way to write that backward is a ``ConvTranspose`` for ``dX`` and a
+# ``Conv`` over permuted axes for ``dW``. Both operators do have coverage --
+# onnxruntime-web's WebGPU EP lists ``Conv`` and ``ConvTranspose``, and its
+# WebNN EP maps them onto WebNN's ``conv2d``/``convTranspose2d`` -- so the
+# membership test above is not what refuses them. What refuses them is the
+# shape of that coverage:
+#
+# - It is 2-D only, on *both* backends. The WebGPU EP's own operator table
+#   annotates ``Conv`` with "conv3d is not supported" and ``ConvTranspose``
+#   with "ConvTranspose3d is not supported"; the WebNN EP's table restricts
+#   both to "3-D or 4-D input and 'W'", and the WebNN specification defines
+#   ``conv2d`` and ``convTranspose2d`` and no other convolution at all
+#   ("Compute a 2-D convolution given 4-D input and filter tensors"). A rule
+#   emitting them would therefore be a rule that runs for a 2-D convolution
+#   and is dead in the browser for a 3-D one, which is precisely the failure
+#   this list exists to prevent -- and a *silent* one, since the graph would
+#   still be valid ONNX and still run on CPU.
+# - ``dW``-as-a-``Conv`` is not attribute-for-attribute the forward: it swaps
+#   strides with dilations and, when the stride does not divide the input,
+#   needs its result cropped -- a ``Slice``, which is a second new member.
+#   ``dX``-as-a-``ConvTranspose`` needs ``output_shape`` for the same reason.
+#
+# So ``_grad_conv`` is written as im2col instead -- one ``Gather`` with a
+# constant index, one ``Mul`` by a 0/1 mask, one ``MatMul`` -- which adds
+# nothing to this set, is rank-agnostic (1-D, 2-D and 3-D convolutions
+# differentiate identically), and stays inside the ranks the WebNN spec
+# *requires* implementations to support: its ``gather`` states allowed input
+# rank 1 to N with 1 to 5 required, and its ``matmul`` "2 to N" with "2 to 5"
+# required, against the rank-4 tensors that rule emits. What it costs instead
+# is memory -- a materialized index table per convolution -- which is stated
+# where the rule pays it rather than here.
+#
+# Sources checked when this was written (September 2026), rather than
+# remembered: onnxruntime's ``js/web/docs/webgpu-operators.md`` and
+# ``js/web/docs/webnn-operators.md`` on ``main``, and the WebNN
+# specification's operator definitions. One thing they say that the paragraph
+# above this one no longer does: WebNN today *has* gained a rounding
+# operator (``roundEven``, which the WebNN EP maps ``Round`` onto). The
+# composition in :mod:`onnxsim.adaquant` is not therefore wrong, but its
+# reason has weakened, and this note is here so the next person to reach for
+# ``Round`` re-checks rather than trusting the older sentence.
 EP_FRIENDLY_OPS = frozenset(
     {
         "Abs",
@@ -251,10 +300,15 @@ class GraphBuilder:
     def round_to_nearest(self, a: str) -> str:
         """``round(a)``, composed rather than emitted as ``Round``.
 
-        WebNN has no rounding operator at all, so ``Round`` is deliberately
-        absent from :data:`EP_FRIENDLY_OPS` -- and a fake-quant forward, which
-        is what every caller of this wants it for, is exactly the code that
-        must run on those backends. A float-to-int32 ``Cast`` truncates toward
+        ``Round`` is deliberately absent from :data:`EP_FRIENDLY_OPS` -- and
+        a fake-quant forward, which is what every caller of this wants it for,
+        is exactly the code that must run on the accelerator backends. The
+        original reason was that WebNN had no rounding operator at all, which
+        is no longer true (it has ``roundEven``, and the WebNN EP maps
+        ``Round`` onto it); see the ``Conv`` note beside
+        :data:`EP_FRIENDLY_OPS` for when that was re-checked. The composition
+        is kept because it works and is verified, not because the original
+        argument still stands. A float-to-int32 ``Cast`` truncates toward
         zero, so truncating ``|a| + 0.5`` and re-applying the sign is
         round-half-away-from-zero. That differs from ``Round``'s (and numpy's)
         round-half-to-even on *exact* ties only: a value landing on a precise

--- a/onnxsim/qat_graph_builder.h
+++ b/onnxsim/qat_graph_builder.h
@@ -44,8 +44,10 @@
 // Expand and Round deliberately absent; Round because WebNN has no rounding
 // operator at all, which is why RoundToNearest composes one; Gather admitted
 // on the same coverage criterion rather than for convenience, because it is
-// what lets a step read a minibatch out of a resident calibration set) lives
-// in qat_graph.py next to the Python set. It is not repeated here, so that
+// what lets a step read a minibatch out of a resident calibration set; Conv
+// and ConvTranspose considered for GradConv and refused, because the coverage
+// they have on both browser backends is 2-D only) lives in qat_graph.py next
+// to the Python set. It is not repeated here, so that
 // there is one place to update when the reasoning changes.
 const std::set<std::string>& EpFriendlyOps();
 
@@ -133,12 +135,15 @@ class GraphBuilder {
 
   // round(a), composed rather than emitted as Round.
   //
-  // WebNN has no rounding operator at all, so Round is deliberately absent
-  // from EpFriendlyOps -- and a fake-quant forward, which is what every caller
-  // wants this for, is exactly the code that must run on those backends. A
-  // float-to-int32 Cast truncates toward zero, so truncating |a| + 0.5 and
-  // re-applying the sign is round-half-away-from-zero. That differs from
-  // Round's (and numpy's) round-half-to-even on *exact* ties only.
+  // Round is deliberately absent from EpFriendlyOps -- originally because
+  // WebNN had no rounding operator at all, which has since stopped being
+  // true (see qat_graph.py's Conv note); the composition is kept because it
+  // is verified, not because that argument still holds -- and a fake-quant
+  // forward, which is what every caller wants this for, is exactly the code
+  // that must run on those backends. A float-to-int32 Cast truncates toward
+  // zero, so truncating |a| + 0.5 and re-applying the sign is
+  // round-half-away-from-zero. That differs from Round's (and numpy's)
+  // round-half-to-even on *exact* ties only.
   std::string RoundToNearest(const std::string& a);
 
   // mean(a * a) as a scalar, for a reported loss.

--- a/onnxsim/qat_graph_builder_test.cpp
+++ b/onnxsim/qat_graph_builder_test.cpp
@@ -274,7 +274,7 @@ void EpFriendlyOpsHasExactlyThePythonSetsMembers() {
   CheckEqual(expected.size(), size_t{21}, "the Python set has 21 members");
   Check(EpFriendlyOps() == expected, "EpFriendlyOps() equals EP_FRIENDLY_OPS");
   Check(EpFriendlyOps().count("Round") == 0,
-        "Round stays out: WebNN has no rounding operator");
+        "Round stays out of EpFriendlyOps");
   Check(EpFriendlyOps().count("Where") == 0, "Where stays out");
 }
 

--- a/onnxsim/qat_parity_fixtures.txt
+++ b/onnxsim/qat_parity_fixtures.txt
@@ -3,8 +3,8 @@
 # Asserted against onnxsim/qat_graph.py (tests/test_qat_parity.py) and
 # against onnxsim/qat_graph_builder.cpp (onnxsim/qat_graph_parity_test.cpp).
 ops Abs,Add,Cast,Clip,Div,Exp,Gather,Greater,Less,MatMul,Mul,Neg,Pow,ReduceMean,ReduceSum,Reshape,Sigmoid,Sign,Sqrt,Sub,Transpose
-rules Add,Clip,Div,Erf,Exp,Gemm,Identity,LayerNormalization,MatMul,Mul,Neg,ReduceMean,ReduceSum,Relu,Reshape,Sigmoid,Softmax,Sqrt,Sub,Tanh,Transpose
-backward_ops Add,Cast,Div,Exp,Greater,Less,MatMul,Mul,Neg,ReduceMean,ReduceSum,Reshape,Sqrt,Sub,Transpose
+rules Add,Clip,Conv,Div,Erf,Exp,Gemm,Identity,LayerNormalization,MatMul,Mul,Neg,ReduceMean,ReduceSum,Relu,Reshape,Sigmoid,Softmax,Sqrt,Sub,Tanh,Transpose
+backward_ops Add,Cast,Div,Exp,Gather,Greater,Less,MatMul,Mul,Neg,ReduceMean,ReduceSum,Reshape,Sqrt,Sub,Transpose
 model_text <ir_version: 10, opset_import: ["" : 21]>
 model_text g (float[4,32] X) => (float[4,32] Y) {
 model_text   H = MatMul(X, W1)

--- a/scripts/convertmodel/qat_blocks.mjs
+++ b/scripts/convertmodel/qat_blocks.mjs
@@ -57,6 +57,7 @@ import { fields, decode } from "./macs.mjs";
 export const DIFFERENTIABLE_OPS = new Set([
   "Add",
   "Clip",
+  "Conv",
   "Div",
   "Erf",
   "Exp",

--- a/scripts/convertmodel/test/qat_blocks.test.mjs
+++ b/scripts/convertmodel/test/qat_blocks.test.mjs
@@ -14,6 +14,7 @@
 //   node test/qat_blocks.test.mjs
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   DIFFERENTIABLE_OPS,
   discoverBlocks,
@@ -111,6 +112,32 @@ check("the differentiable set tracks graph_grad's rule table", () => {
   }
   assert.ok(!DIFFERENTIABLE_OPS.has("Sin"));
   assert.ok(DIFFERENTIABLE_OPS.size >= 21, "graph_grad had 21 rules when this landed");
+});
+
+// The set above is a hand-kept copy of graph_grad's rule table, and the
+// header explains why drifting from it is *safe* -- the builder is the
+// authority and refuses a block it cannot differentiate. Safe is not the same
+// as free: a stale entry silently costs block granularity, which is the
+// failure that looks exactly like success. So it is pinned against the same
+// fixture the Python and C++ emitters are pinned against.
+//
+// It has already drifted once. Conv landed in graph_grad while this file was
+// being written, and nothing here noticed.
+check("DIFFERENTIABLE_OPS matches the committed rule table", () => {
+  const fixture = readFileSync(
+    new URL("../../../onnxsim/qat_parity_fixtures.txt", import.meta.url),
+    "utf8",
+  );
+  const line = fixture
+    .split("\n")
+    .find((l) => l.startsWith("rules "));
+  assert.ok(line, "qat_parity_fixtures.txt should carry a 'rules' line");
+  const pinned = line.slice("rules ".length).split(",");
+  assert.deepStrictEqual(
+    [...DIFFERENTIABLE_OPS].sort(),
+    pinned.slice().sort(),
+    "add the op here too, or regenerate the fixture",
+  );
 });
 
 check("a chain cuts at every gap", () => {

--- a/scripts/make_qat_parity_fixtures.py
+++ b/scripts/make_qat_parity_fixtures.py
@@ -176,7 +176,9 @@ def _case_round_to_nearest() -> Dict[str, Any]:
     Six names in a fixed order, and the single most likely thing to be
     reordered by someone porting it from the expression form the Python
     writes it in. It must also contain no ``Round`` node at all -- WebNN has
-    no rounding operator, which is the reason the composition exists.
+    no rounding operator when this was written, which is why the
+    composition exists (see qat_graph.py's Conv note: WebNN has since
+    gained roundEven).
     """
     b = qat_graph.GraphBuilder()
     result = b.round_to_nearest("x")

--- a/tests/test_graph_grad.py
+++ b/tests/test_graph_grad.py
@@ -511,6 +511,111 @@ _CASES = {
         """,
         None,
     ),
+    # Conv, whose rule is written as im2col rather than as the ConvTranspose
+    # a convolution's gradient naturally is (see _grad_conv for why). Every
+    # attribute below changes the index tables that stand in for the
+    # convolution, and a table that is wrong produces a gradient that is
+    # finite, correctly shaped and quietly wrong -- so each combination is
+    # differenced separately rather than trusted to the plain case.
+    "conv": (
+        """
+        g (float[1,2,4,4] A, float[3,2,3,3] B) => (float[1,3,2,2] Y) {
+          Y = Conv(A, B)
+        }
+        """,
+        None,
+    ),
+    "conv_bias": (
+        """
+        g (float[1,1,4,4] A, float[2,1,3,3] B, float[2] C)
+            => (float[1,2,2,2] Y) {
+          Y = Conv(A, B, C)
+        }
+        """,
+        None,
+    ),
+    "conv_pointwise": (
+        """
+        g (float[1,2,3,3] A, float[3,2,1,1] B) => (float[1,3,3,3] Y) {
+          Y = Conv(A, B)
+        }
+        """,
+        None,
+    ),
+    "conv_strided_padded": (
+        """
+        g (float[1,2,5,5] A, float[2,2,3,3] B) => (float[1,2,3,3] Y) {
+          Y = Conv <strides = [2, 2], pads = [1, 1, 1, 1]> (A, B)
+        }
+        """,
+        None,
+    ),
+    "conv_dilated": (
+        """
+        g (float[1,1,5,5] A, float[1,1,2,2] B) => (float[1,1,3,3] Y) {
+          Y = Conv <dilations = [2, 2]> (A, B)
+        }
+        """,
+        None,
+    ),
+    "conv_grouped": (
+        """
+        g (float[1,4,3,3] A, float[4,2,2,2] B) => (float[1,4,2,2] Y) {
+          Y = Conv <group = 2> (A, B)
+        }
+        """,
+        None,
+    ),
+    "conv_depthwise": (
+        """
+        g (float[1,3,3,3] A, float[3,1,2,2] B, float[3] C)
+            => (float[1,3,2,2] Y) {
+          Y = Conv <group = 3> (A, B, C)
+        }
+        """,
+        None,
+    ),
+    "conv_1d": (
+        """
+        g (float[1,2,7] A, float[2,2,3] B) => (float[1,2,3] Y) {
+          Y = Conv <strides = [2]> (A, B)
+        }
+        """,
+        None,
+    ),
+    "conv_3d": (
+        """
+        g (float[1,1,3,3,3] A, float[2,1,2,2,2] B) => (float[1,2,2,2,2] Y) {
+          Y = Conv(A, B)
+        }
+        """,
+        None,
+    ),
+    # The two ``auto_pad`` spellings whose padding is asymmetric, which is
+    # what makes them worth differencing rather than only checking
+    # structurally: 5 and 6 against a 3-wide kernel at stride 2 need two and
+    # one pad respectively, so SAME_UPPER and SAME_LOWER put them in
+    # different places and a rule that confused the two would still produce
+    # the right *shape*. Both are two-input-channel on purpose -- see
+    # ``test_auto_pad_resolves_to_the_padding_the_spec_asks_for`` for the
+    # reference evaluator bug that makes the single-channel case unusable as
+    # a reference here.
+    "conv_same_upper": (
+        """
+        g (float[1,2,5,6] A, float[2,2,3,3] B) => (float[1,2,3,3] Y) {
+          Y = Conv <strides = [2, 2], auto_pad = "SAME_UPPER"> (A, B)
+        }
+        """,
+        None,
+    ),
+    "conv_same_lower": (
+        """
+        g (float[1,2,5,6] A, float[2,2,3,3] B) => (float[1,2,3,3] Y) {
+          Y = Conv <strides = [2, 2], auto_pad = "SAME_LOWER"> (A, B)
+        }
+        """,
+        None,
+    ),
     "clip": (
         """
         g (float[3,4] A) => (float[3,4] Y)
@@ -877,6 +982,249 @@ def test_a_matmul_with_a_1d_operand_is_refused():
     with pytest.raises(graph_grad.UnsupportedOpError, match="1-D"):
         graph_grad.build_backward(
             b, list(model.graph.node), _static_shapes(model), {"Y": "dY"}, ["A"]
+        )
+
+
+def _emitted(model: onnx.ModelProto):
+    """The backward a model's nodes emit, as comparable plain data.
+
+    Node op types, names and attributes plus every initializer's name, shape
+    and values -- the same things ``onnx/qat_parity_fixtures.txt`` compares,
+    and for the same reason: the builder's counter makes the names, so two
+    emissions with equal names ran the same operations in the same order.
+    """
+    shapes = _static_shapes(model)
+    b = qat_graph.GraphBuilder("bw_")
+    graph_grad.build_backward(
+        b,
+        list(model.graph.node),
+        shapes,
+        {model.graph.output[0].name: "dY"},
+        [value.name for value in model.graph.input],
+    )
+    nodes = [
+        (
+            n.op_type,
+            list(n.input),
+            list(n.output),
+            [onnx.helper.printable_attribute(a) for a in n.attribute],
+        )
+        for n in b.nodes
+    ]
+    initializers = [
+        (t.name, list(t.dims), t.data_type, onnx.numpy_helper.to_array(t).tolist())
+        for t in b.initializer
+    ]
+    return nodes, initializers
+
+
+@pytest.mark.parametrize(
+    "auto_pad,pads,in_shape,out_shape",
+    [
+        ("VALID", "0, 0, 0, 0", "1,2,5,5", "1,2,3,3"),
+        ("SAME_UPPER", "1, 0, 1, 1", "1,2,5,6", "1,2,3,3"),
+        ("SAME_LOWER", "1, 1, 1, 0", "1,2,5,6", "1,2,3,3"),
+        ("SAME_UPPER", "1, 0, 1, 1", "1,1,5,6", "1,2,3,3"),
+    ],
+    ids=["valid", "same_upper", "same_lower", "same_upper_single_channel"],
+)
+def test_auto_pad_resolves_to_the_padding_the_spec_asks_for(
+    auto_pad, pads, in_shape, out_shape
+):
+    """``auto_pad`` is resolved at build time, so the gradient of a
+    ``SAME_UPPER`` convolution must be *the same graph* as the gradient of the
+    explicitly padded one it stands for.
+
+    The expected padding is written out here rather than recomputed: 5 and 6
+    against a 3-wide kernel at stride 2 need 2 and 1 pads, and SAME_UPPER puts
+    the odd one at the end where SAME_LOWER puts it at the beginning. This is
+    the check that a misreading of the spec cannot pass.
+
+    It is also the only check ``VALID`` gets, and the reason is worth
+    recording: onnx's reference evaluator computes ``auto_pad="VALID"`` as if
+    it were ``SAME`` (a 5x5 input through a 3x3 kernel comes back 5x5 rather
+    than 3x3), and it disagrees with onnxruntime on ``SAME_UPPER`` for a
+    single-channel input as well. Both were checked against onnxruntime and
+    against a hand-written convolution when this rule was written; the
+    finite-difference cases above therefore avoid exactly those two shapes,
+    and the equivalence here covers them instead.
+    """
+    strides = "" if auto_pad == "VALID" else "strides = [2, 2], "
+    channels = in_shape.split(",")[1]
+    features = out_shape.split(",")[1]
+    automatic = _model(
+        f"""
+        g (float[{in_shape}] A, float[{features},{channels},3,3] B)
+            => (float[{out_shape}] Y) {{
+          Y = Conv <{strides}auto_pad = "{auto_pad}"> (A, B)
+        }}
+        """
+    )
+    explicit = _model(
+        f"""
+        g (float[{in_shape}] A, float[{features},{channels},3,3] B)
+            => (float[{out_shape}] Y) {{
+          Y = Conv <{strides}pads = [{pads}]> (A, B)
+        }}
+        """
+    )
+    assert _emitted(automatic) == _emitted(explicit)
+
+
+def test_a_convolutions_gradient_contains_no_convolution():
+    """The design claim of :func:`onnxsim.graph_grad._grad_conv`, checked
+    rather than only argued.
+
+    ``dX`` is naturally a ``ConvTranspose`` and ``dW`` a ``Conv``, and neither
+    is in :data:`onnxsim.qat_graph.EP_FRIENDLY_OPS` -- the note beside that
+    set records what their coverage on the WebGPU and WebNN backends actually
+    is and why it was not enough. So the rule is written as im2col instead,
+    and what it emits has to stay inside the allowlist like every other rule.
+    """
+    model = _model(_CASES["conv_grouped"][0])
+    b = qat_graph.GraphBuilder()
+    graph_grad.build_backward(
+        b,
+        list(model.graph.node),
+        _static_shapes(model),
+        {"Y": "dY"},
+        ["A", "B"],
+    )
+    emitted = {node.op_type for node in b.nodes}
+    assert not emitted & {"Conv", "ConvTranspose"}
+    assert emitted <= graph_grad.BACKWARD_OPS
+    # And the one operator this rule needed that arithmetic does not give: a
+    # Gather with a constant index, the same shape of thing gather_rows was
+    # admitted to EP_FRIENDLY_OPS for.
+    assert "Gather" in emitted
+
+
+@pytest.mark.parametrize(
+    "body,fragment",
+    [
+        (
+            """
+            g (float[2,3] A, float[3,4] B) => (float[2,4] Y) {
+              Y = Conv(A, B)
+            }
+            """,
+            "spatial dimension",
+        ),
+        (
+            """
+            g (float[1,4,5,5] A, float[4,2,3,3] B) => (float[1,4,3,3] Y) {
+              Y = Conv <group = 3> (A, B)
+            }
+            """,
+            "group=3",
+        ),
+        (
+            """
+            g (float[1,4,5,5] A, float[2,2,3,3] B) => (float[1,2,3,3] Y) {
+              Y = Conv(A, B)
+            }
+            """,
+            "channels per group",
+        ),
+        (
+            """
+            g (float[1,2,5,5] A, float[2,2,3,3] B) => (float[1,2,3,3] Y) {
+              Y = Conv <kernel_shape = [2, 2]> (A, B)
+            }
+            """,
+            "kernel_shape",
+        ),
+        (
+            """
+            g (float[1,2,5,5] A, float[2,2,3,3] B) => (float[1,2,3,3] Y) {
+              Y = Conv <auto_pad = "SAME"> (A, B)
+            }
+            """,
+            "auto_pad",
+        ),
+        (
+            """
+            g (float[1,2,5,5] A, float[2,2,3,3] B) => (float[1,2,3,3] Y) {
+              Y = Conv <strides = [2]> (A, B)
+            }
+            """,
+            "one entry per spatial axis",
+        ),
+        (
+            """
+            g (float[1,2,4,4] A, float[3,2,3,3] B, float[1,3] C)
+                => (float[1,3,2,2] Y) {
+              Y = Conv(A, B, C)
+            }
+            """,
+            "B has shape",
+        ),
+    ],
+    ids=[
+        "no_spatial_axis",
+        "group_does_not_divide",
+        "weight_channel_mismatch",
+        "kernel_shape_disagrees",
+        "unknown_auto_pad",
+        "wrong_strides_length",
+        "bias_not_rank_1",
+    ],
+)
+def test_a_conv_this_rule_cannot_invert_is_refused(body, fragment):
+    """A convolution whose geometry does not add up is refused by name.
+
+    This is the boundary that matters most for this rule, because its whole
+    method is to precompute *where every element came from*: a misread
+    attribute does not produce an error at build time or a wrong shape at run
+    time, it produces index tables that gather the wrong elements, and the
+    gradient that comes out is finite, correctly shaped and wrong. So each
+    disagreement between the attributes, the weight and the declared output
+    is refused rather than resolved in favour of one of them.
+    """
+    model = _model(body)
+    # The parser accepts these; onnx's own shape inference is not asked,
+    # because several of them are exactly the case where it would object
+    # first and the point is what this module does with them.
+    shapes = {
+        value.name: [d.dim_value for d in value.type.tensor_type.shape.dim]
+        for value in list(model.graph.input) + list(model.graph.output)
+    }
+    with pytest.raises(graph_grad.UnsupportedOpError, match=fragment):
+        graph_grad.build_backward(
+            qat_graph.GraphBuilder(),
+            list(model.graph.node),
+            shapes,
+            {"Y": "dY"},
+            ["A"],
+        )
+
+
+def test_a_conv_whose_output_shape_does_not_follow_is_refused():
+    """The catch-all the rest of the refusals lean on: whatever the
+    attributes say, the geometry they resolve to has to reproduce the output
+    shape the node itself declares.
+
+    Written with the shapes passed in by hand rather than inferred, since a
+    model this inconsistent is one onnx's shape inference rejects outright --
+    which is the point: ``build_backward`` is given shapes by its caller, and
+    a caller that got them from somewhere else must not be trusted to have
+    got them right.
+    """
+    model = _model(
+        """
+        g (float[1,2,5,5] A, float[2,2,3,3] B) => (float[1,2,3,3] Y) {
+          Y = Conv(A, B)
+        }
+        """
+    )
+    shapes = {"A": [1, 2, 5, 5], "B": [2, 2, 3, 3], "Y": [1, 2, 4, 4]}
+    with pytest.raises(graph_grad.UnsupportedOpError, match="does not follow from"):
+        graph_grad.build_backward(
+            qat_graph.GraphBuilder(),
+            list(model.graph.node),
+            shapes,
+            {"Y": "dY"},
+            ["A"],
         )
 
 

--- a/tests/test_qat.py
+++ b/tests/test_qat.py
@@ -315,6 +315,77 @@ def test_a_gelu_block_trains():
     assert losses[-1] < 0.25 * losses[0]
 
 
+def test_a_convolution_no_longer_splits_a_block():
+    """What :func:`onnxsim.graph_grad._grad_conv` bought, measured at the
+    level a caller sees it.
+
+    ``discover_qat_blocks`` treats an op with no gradient rule as a *gap*: the
+    blocks it finds stop either side of it. So before ``Conv`` had a rule, the
+    model below -- a projection, a convolution, a second projection -- came
+    back as two single-layer blocks with the convolution stranded between
+    them, and naming its two ends by hand was refused outright. It is now one
+    block, and the two quantized MatMuls are trained *through* the
+    convolution against the whole span's reconstruction error.
+
+    The convolution's own weight is not trained, and that is checked here
+    rather than left implicit: a rule that differentiates an op is not the
+    same thing as a layer finder that would fake-quantize and train it, and
+    only the first of those exists for ``Conv``. It is teacher-forced like any
+    other constant in the block.
+    """
+    rng = np.random.default_rng(0)
+    w1 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    w2 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    wc = (rng.standard_normal((2, 2, 3, 3)) * 0.3).astype(np.float32)
+    model = _model(
+        """
+        g (float[batch,32] X) => (float[batch,32] Yout)
+        <int64[4] to_image = {-1, 2, 4, 4}, int64[2] to_rows = {-1, 32}>
+        {
+          H = MatMul(X, W1)
+          Img = Reshape(H, to_image)
+          C = Conv <pads = [1, 1, 1, 1]> (Img, Wc)
+          Flat = Reshape(C, to_rows)
+          Yout = MatMul(Flat, W2)
+        }
+        """,
+        [_f32(w1, "W1"), _f32(w2, "W2"), _f32(wc, "Wc")],
+    )
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+
+    (block,) = onnxsim.discover_qat_blocks(model, quant)
+    assert (block.input_name, block.output_name) == ("X", "Yout")
+    assert "Conv" in block.op_types
+    assert block.quantized_outputs == ("H", "Yout")
+
+    x = _correlated_calibration(rank=2)
+    losses = []
+    tuned = onnxsim.apply_qat(
+        model, quant, "X", "Yout", calibration_data=[{"X": x}], losses=losses
+    )
+    onnx.checker.check_model(tuned)
+    assert losses[-1] < 0.25 * losses[0]
+
+    # The gradient really did cross the convolution: the second projection is
+    # upstream of nothing else, so only a gradient that came back through the
+    # Conv could have moved the first one.
+    session = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    reference = session.run(None, {"X": x})[0]
+
+    def error(candidate):
+        run = ort.InferenceSession(
+            candidate.SerializeToString(), providers=["CPUExecutionProvider"]
+        )
+        return float(np.linalg.norm(reference - run.run(None, {"X": x})[0]))
+
+    assert error(tuned) < 0.6 * error(quant)
+
+    frozen = {t.name: t for t in tuned.graph.initializer}["Wc"]
+    assert onnx.numpy_helper.to_array(frozen).tobytes() == wc.tobytes()
+
+
 def test_freeing_the_weights_beats_optimizing_only_their_rounding():
     """Claim 2, isolated as cleanly as it can be.
 


### PR DESCRIPTION
`graph_grad` had no `Conv` rule, so `discover_qat_blocks` treated every convolution as a gap: a CNN got carved into blocks *around* its convs, and a caller-named block containing one was refused outright. This adds the rule.

`tests/test_qat.py::test_a_convolution_no_longer_splits_a_block`: MatMul → Conv → MatMul now discovers as **one** block where it previously came back as two stranded either side — loss 0.224 → 0.016, reconstruction error 21.5 → 6.2.

## `EP_FRIENDLY_OPS` did not need to grow, and checking why is the point

I set this work up expecting the opposite. The textbook backward is a `ConvTranspose` for `dX` and a `Conv` over permuted axes for `dW`, which would have meant adding both to the allowlist — a real decision, since that set is a *verified claim* about what the accelerator backends implement.

Both operators do have coverage. onnxruntime-web's WebGPU EP lists them, and its WebNN EP maps them onto `conv2d`/`convTranspose2d`. **So coverage is not what refuses them.** The *shape* of that coverage is:

- **It is 2-D only, on both backends.** The WebGPU EP's operator table annotates `Conv` with "conv3d is not supported" and `ConvTranspose` with "ConvTranspose3d is not supported"; the WebNN EP's table restricts both to "Only supports 3-D or 4-D input and 'W'"; and the WebNN specification defines `conv2d` and `convTranspose2d` and no other convolution at all. A rule emitting them would run for a 2-D convolution and be **silently dead in the browser for a 3-D one** — while still being valid ONNX that runs fine on CPU. That is precisely the failure this list exists to prevent.
- `dW`-as-a-`Conv` is not attribute-for-attribute the forward: it swaps strides with dilations and needs its result cropped, which is a `Slice` — a second new member.

So the rule is **im2col** instead: a `Gather` with a constant index, a `Mul` by a 0/1 mask, a `MatMul`. It adds nothing to `EP_FRIENDLY_OPS`, is rank-agnostic (1-D, 2-D and 3-D differentiate identically), and stays inside the ranks WebNN *requires* implementations to support. Only `BACKWARD_OPS` grows, by `Gather`, whose coverage was already established there for `gather_rows`. What it costs instead is memory — a materialized index table per convolution — stated in the rule's docstring where it is paid.

I verified the emission independently rather than from the reasoning: the backward for a strided, padded `Conv` emits only `Gather, MatMul, Mul, ReduceSum, Reshape, Transpose`, contains no convolution, and `EP_FRIENDLY_OPS` is untouched.

## A claim already in the tree turned out to be false

The coverage check found that **"WebNN has no rounding operator at all"** — the stated reason `Round` is excluded and `adaquant` composes one out of `Sign`/`Abs`/`Cast` — is no longer true. WebNN has gained `roundEven`, and onnxruntime's `webnn-operators.md` maps `Round` onto it. Confirmed against that file directly.

Corrected in all five places it appeared, rather than left standing beside a new note contradicting it. The composition is kept because it is verified, not because its original argument still holds.

## Supported, and refused

**Supported** and finite-difference verified: any spatial rank, strides, dilations, asymmetric pads, `group` including depthwise, bias, 1×1, and every `auto_pad` mode. Gradients for all three inputs.

**Refused by name**, identically in both languages: no spatial axis; rank disagreement; `group` not dividing the channels; `kernel_shape` disagreeing with `W`; unknown `auto_pad`; wrong-length `strides`/`dilations`/`pads`; non-positive stride or dilation; bias not `[M]`; and the catch-all — the resolved geometry must reproduce the node's own declared output shape. That last one is what stops a misread attribute becoming a plausible-but-wrong gradient.

The convolution's **weights still do not train**: only MatMul and Gemm have a layer finder, and a test asserts the Conv weight comes back byte-identical. The value here is that a Conv stops being a block boundary.

## The browser's copy of the rule table had already drifted

`qat_blocks.mjs` (merged in #1245) keeps a hand-written copy of the rule table as a discovery pre-filter. Its header argues correctly that drifting is *safe* — the builder is the authority and refuses what it cannot differentiate — but safe is not free: a stale entry costs block granularity silently.

It drifted within the hour. `Conv` landed in `graph_grad` while that file was being written, and the only guard (`size >= 21`) was satisfied by a 21-entry list against a 22-rule Python. It is now pinned against `qat_parity_fixtures.txt`'s `rules` line — the same fixture the Python and C++ emitters are pinned against — so all three move together or the test says so. Mutation-tested: removing `Conv` again fails with "add the op here too, or regenerate the fixture".

## Verification

- **215 Python tests**, including 11 new finite-difference `_CASES` (central differences vs a float64 reference, 2 seeds each), an `auto_pad`-equivalence test, a "the gradient contains no convolution" test, and 8 refusal tests.
- All four **C++ tests** pass; new cases pin the 19-node emission order, hand-computed index/mask tables for a 1-D padded conv, four refusals, and rank-invariance.
- **Differential dump**, C++ against Python: 392 lines, byte-identical, same md5, over 18 configurations including every refusal message. The comparison was proven able to fail first — an early version silently diffed against a stale `libonnxsim.a` and passed a deliberately corrupted rule; after fixing the harness, a changed `Transpose` perm and a name-counter shift are both detected.
- `npm run test:all` green (`qat_blocks` now 11); ruff, clang-format clean.

**Two onnx `ReferenceEvaluator` bugs shaped the tests.** It mis-evaluates `Conv`'s `auto_pad`: `VALID` behaves like `SAME`, and `SAME_UPPER` disagrees with onnxruntime for single-input-channel convs. Checked against onnxruntime *and* a hand-written numpy convolution — this geometry matches both (max diff 1.8e-7) and the reference is the one that is wrong (7.85 off). So the finite-difference cases avoid those shapes, and `auto_pad` is instead verified by graph-equivalence against hand-written explicit pads, with the reason recorded in the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_