### PR TITLE
Train a convolution's own weight, not just through it

### DIFF
--- a/docs/qat.md
+++ b/docs/qat.md
@@ -427,9 +427,20 @@ binding one on a real model: `graph_grad.SUPPORTED_OPS` is 22 rules
 one), so a normalization -- or a convolution -- in the middle of a block is
 now more nodes in the slice rather than a boundary between blocks. On a CNN
 that is the difference between blocks carved *around* every convolution and
-blocks that contain them; the convolution's own weights still do not train,
-since only MatMul and Gemm have a layer finder. The whole default ONNX domain
-is 202 operators.
+blocks that contain them, and the convolution's own weight trains too. The
+whole default ONNX domain is 202 operators.
+
+Conv weights train only with `fake_quant=False`, and that is a property of the
+quantizers rather than a limitation here: `adaround`'s INT4 finder and
+`quantize_static`'s QDQ finder are both MatMul/Gemm-only, so no quantized
+scheme ever produces a Conv layer for QAT to train. It is also what made the
+change cheap. The fake-quant path reads a weight as a 2-D grid of scale blocks,
+which is the only thing in the loop that ever needed rank 2; the rest -- the
+master weight fed to the block's own node in the layout that node already
+reads, Adam's moments sized from it, the write-back storing it back
+unchanged -- was rank-agnostic already, so a `[M, C/group, *kernel]` weight
+needed the finder's rank check relaxed and nothing else. Pooling is still a
+block boundary, which on a real CNN limits how much of this is reachable.
 
 ### Against `apply_pruning_finetune`, which came first
 

--- a/onnxsim/qat.py
+++ b/onnxsim/qat.py
@@ -672,6 +672,29 @@ def _blocked_shapes(
     return split, with_one
 
 
+def _blocked_weight_shape(shape: Tuple[int, ...]) -> Tuple[int, int]:
+    """``shape`` as the 2-D grid the fake-quant path reads a weight as.
+
+    Only that path calls this. A weight of any other rank cannot legitimately
+    reach it: both quantized finders are MatMul/Gemm-only, so a Conv's
+    ``[M, C/group, *kernel]`` weight arrives only with ``fake_quant=False``,
+    where none of the blocked-scale code runs.
+
+    That is an invariant rather than a coincidence, so it is checked here
+    instead of asserted in a comment. The failure it prevents is quiet: a
+    rank-4 weight reinterpreted as a 2-D block grid produces a perfectly
+    valid graph that trains the wrong thing.
+    """
+    if len(shape) != 2:
+        raise ValueError(
+            "the fake-quant path reads a weight as a 2-D grid of scale blocks, "
+            f"but this one has shape {list(shape)}. No quantized scheme "
+            "produces a layer of that rank -- both finders are MatMul/Gemm-only "
+            "-- so a layer has been planned for the wrong scheme."
+        )
+    return (shape[0], shape[1])
+
+
 def _broadcast_scale(
     b: qat_graph.GraphBuilder,
     scale: str,
@@ -1222,7 +1245,12 @@ def _build_step_graph(
         else:
             scale = t.scale_input
         scale_full = _broadcast_scale(
-            b, scale, t.w_shape, t.scale_shape, t.scale_axis, block_size
+            b,
+            scale,
+            _blocked_weight_shape(t.w_shape),
+            t.scale_shape,
+            t.scale_axis,
+            block_size,
         )
         weight_name = t.candidate.float_node.input[1]
         code, ratio, active = _emit_fake_quant(
@@ -1332,7 +1360,7 @@ def _build_step_graph(
             g_scale = _sum_over_blocks(
                 b,
                 b.mul(g, dwhat_ds),
-                t.w_shape,
+                _blocked_weight_shape(t.w_shape),
                 t.scale_shape,
                 t.scale_axis,
                 t.candidate.block_size,

--- a/onnxsim/qat.py
+++ b/onnxsim/qat.py
@@ -479,21 +479,38 @@ def _find_float_layers(model: onnx.ModelProto) -> List[_QuantizedLayer]:
     were pruned, or simplified, or already tuned -- and re-seeding from the
     teacher would throw that away before the first step.
 
-    Rank-2 and fp32 are required for the same reason the other two schemes
-    require them: :class:`_Trained` carries the weight as a 2-D fp32 array,
-    and a layer this does not recognize is simply not trained.
+    ``Conv`` is here and is not in either quantized finder, which is not an
+    oversight in those: ``adaround``'s INT4 finder and ``quantize_static``'s
+    QDQ finder are both MatMul/Gemm-only, so no quantized scheme ever
+    produces a Conv layer and there is nothing for them to train. Training a
+    Conv's weight is therefore inherently a ``fake_quant=False`` feature,
+    which is also what makes it cheap: the fake-quant path reads a weight as
+    a 2-D grid of scale blocks (:func:`_blocked_shapes`), and none of that
+    runs here.
+
+    Rank is otherwise left alone -- a Conv's weight is
+    ``[M, C/group, *kernel]``, rank 3 for a 1-D convolution and 5 for a 3-D
+    one, and the training machinery is indifferent to which: the master
+    weight is fed to the block's own node in the layout that node already
+    reads, Adam's moments are ``zeros_like`` it, and the write-back stores it
+    back unchanged. Only fp32 is still required, because the state tensors
+    the loop carries are fp32.
+
+    A weight of rank < 2 is skipped rather than trained: nothing here would
+    break on one, but no MatMul, Gemm or Conv has a rank-1 weight, so such a
+    tensor is something this function has misidentified.
     """
     initializers = {t.name: t for t in model.graph.initializer}
     layers: List[_QuantizedLayer] = []
     for node in model.graph.node:
-        if node.op_type not in ("MatMul", "Gemm") or len(node.input) < 2:
+        if node.op_type not in ("MatMul", "Gemm", "Conv") or len(node.input) < 2:
             continue
         if not node.output or not node.output[0]:
             continue
         w_init = initializers.get(node.input[1])
         if w_init is None:
             continue
-        if w_init.data_type != onnx.TensorProto.FLOAT or len(w_init.dims) != 2:
+        if w_init.data_type != onnx.TensorProto.FLOAT or len(w_init.dims) < 2:
             continue
         layers.append(_from_float(node, w_init))
     return layers
@@ -537,18 +554,27 @@ class _Trained:
     """One quantized layer's trainable state inside the step graph.
 
     ``w`` is the fp32 master weight in the *storage* layout the graph's own
-    initializer uses ([K, N] for a MatMul, [N, K] for a ``transB`` Gemm) --
-    unlike :mod:`onnxsim.adaround` and :mod:`onnxsim.brecq`, which normalize
-    to [N, K], because nothing here needs a normalized layout: the forward
-    consumes the weight exactly where the block's own node reads it, and the
-    scale's blocked axis is carried explicitly instead.
+    initializer uses ([K, N] for a MatMul, [N, K] for a ``transB`` Gemm,
+    [M, C/group, *kernel] for a Conv) -- unlike :mod:`onnxsim.adaround` and
+    :mod:`onnxsim.brecq`, which normalize to [N, K], because nothing here
+    needs a normalized layout: the forward consumes the weight exactly where
+    the block's own node reads it, and the scale's blocked axis is carried
+    explicitly instead.
+
+    :attr:`w_shape` is therefore whatever rank the layer's own weight has.
+    Only the fake-quant path constrains it: :func:`_blocked_shapes` and the
+    two functions built on it read a weight as a 2-D grid of scale blocks,
+    which is what both quantized schemes produce and neither ever produces
+    for a Conv -- ``adaround``'s INT4 finder and ``quantize_static``'s QDQ
+    finder are both MatMul/Gemm-only. So a rank > 2 weight reaches here only
+    with ``fake_quant=False``, where none of that code runs.
     """
 
     candidate: _QuantizedLayer
     w_input: str
     m_input: str
     v_input: str
-    w_shape: Tuple[int, int]
+    w_shape: Tuple[int, ...]
     w_init: np.ndarray
     scale_axis: int
     scale_shape: Tuple[int, int]
@@ -1054,7 +1080,7 @@ def _plan_trained(
             w_input=f"{_PREFIX}w{i}",
             m_input=f"{_PREFIX}mw{i}",
             v_input=f"{_PREFIX}vw{i}",
-            w_shape=(int(w.shape[0]), int(w.shape[1])),
+            w_shape=tuple(int(d) for d in w.shape),
             w_init=w,
             scale_axis=candidate.axis,
             scale_shape=(int(scale.shape[0]), int(scale.shape[1])),
@@ -1438,11 +1464,11 @@ def _no_layers_message(
     where = f"the block between {block_input_name!r} and {block_output_name!r}"
     if not fake_quant:
         return (
-            f"{where} contains no MatMul/Gemm with a 2-D fp32 weight "
-            "initializer to fine-tune (fake_quant=False trains the model's "
-            "own float weights, so a layer whose weight is computed rather "
-            "than stored, or stored at some other rank or dtype, has nothing "
-            "for the optimizer to hold)"
+            f"{where} contains no MatMul/Gemm/Conv with an fp32 weight "
+            "initializer of rank 2 or more to fine-tune (fake_quant=False "
+            "trains the model's own float weights, so a layer whose weight is "
+            "computed rather than stored, or stored at some other dtype, has "
+            "nothing for the optimizer to hold)"
         )
     if learn_activation_scales:
         if _find_int4_matmul_candidates(float_model, quantized_model):

--- a/onnxsim/qat_entry.cpp
+++ b/onnxsim/qat_entry.cpp
@@ -541,14 +541,28 @@ QuantizedLayer FromFloat(const onnx::NodeProto& node,
 // teacher's -- they were pruned, or simplified, or already tuned -- and
 // re-seeding from the teacher would throw that away before the first step.
 //
-// Rank-2 and fp32 are required for the same reason the other two schemes
-// require them: the loop carries the weight as a 2-D fp32 state tensor, and a
-// layer this does not recognize is simply not trained.
+// Conv is here and is in neither quantized finder, which is not an oversight
+// in those: adaround's INT4 finder and quantize_static's QDQ finder are both
+// MatMul/Gemm-only, so no quantized scheme ever produces a Conv layer and
+// there is nothing for them to train. Training a Conv's weight is therefore
+// inherently a fake_quant=false feature, which is also what makes it cheap --
+// the fake-quant path reads a weight as a 2-D grid of scale blocks
+// (BlockedShapes) and none of that runs here.
+//
+// Rank is otherwise left alone: a Conv's weight is [M, C/group, *kernel],
+// rank 3 for a 1-D convolution and 5 for a 3-D one, and the loop is
+// indifferent to which -- w_shape is already a Shape rather than a pair, the
+// moments are sized from it, and the write-back stores the weight back in the
+// layout the block's own node reads. Only fp32 is still required, because the
+// state tensors the loop carries are fp32. A rank < 2 weight is skipped
+// rather than trained: no MatMul, Gemm or Conv has one, so such a tensor is
+// something this function has misidentified.
 std::vector<QuantizedLayer> FindFloatLayers(const onnx::ModelProto& model) {
   const auto initializers = InitializerIndex(model.graph());
   std::vector<QuantizedLayer> layers;
   for (const onnx::NodeProto& node : model.graph().node()) {
-    if ((node.op_type() != "MatMul" && node.op_type() != "Gemm") ||
+    if ((node.op_type() != "MatMul" && node.op_type() != "Gemm" &&
+         node.op_type() != "Conv") ||
         node.input_size() < 2) {
       continue;
     }
@@ -556,7 +570,7 @@ std::vector<QuantizedLayer> FindFloatLayers(const onnx::ModelProto& model) {
     const onnx::TensorProto* w_init = Lookup(initializers, node.input(1));
     if (w_init == nullptr) continue;
     if (w_init->data_type() != onnx::TensorProto::FLOAT ||
-        w_init->dims_size() != 2) {
+        w_init->dims_size() < 2) {
       continue;
     }
     layers.push_back(FromFloat(node, *w_init));
@@ -1092,11 +1106,11 @@ std::string NoLayersMessage(const onnx::ModelProto& float_model,
                             " and " + Quoted(block_output_name);
   if (!fake_quant) {
     return where +
-           " contains no MatMul/Gemm with a 2-D fp32 weight initializer to "
-           "fine-tune (fake_quant=False trains the model's own float weights, "
-           "so a layer whose weight is computed rather than stored, or stored "
-           "at some other rank or dtype, has nothing for the optimizer to "
-           "hold)";
+           " contains no MatMul/Gemm/Conv with an fp32 weight initializer of "
+           "rank 2 or more to fine-tune (fake_quant=False trains the model's "
+           "own float weights, so a layer whose weight is computed rather than "
+           "stored, or stored at some other dtype, has nothing for the "
+           "optimizer to hold)";
   }
   if (learn_activation_scales) {
     if (!FindInt4Layers(float_model, quantized_model).empty()) {

--- a/onnxsim/qat_entry_test.cpp
+++ b/onnxsim/qat_entry_test.cpp
@@ -345,6 +345,49 @@ onnx::ModelProto FineTuneModel(float weight, float norm) {
   return model;
 }
 
+// A rank-4 value info, for the convolution model below. AddBatchedInput and
+// AddOutput above are [batch, width]; a Conv needs [batch, C, H, W].
+void AddImageValue(onnx::ValueInfoProto* vi, const std::string& name,
+                   int64_t channels, int64_t size) {
+  vi->set_name(name);
+  onnx::TypeProto::Tensor* tensor = vi->mutable_type()->mutable_tensor_type();
+  tensor->set_elem_type(onnx::TensorProto::FLOAT);
+  onnx::TensorShapeProto* shape = tensor->mutable_shape();
+  shape->add_dim()->set_dim_param("batch");
+  shape->add_dim()->set_dim_value(channels);
+  shape->add_dim()->set_dim_value(size);
+  shape->add_dim()->set_dim_value(size);
+}
+
+// X -> Conv(3x3, valid) -> Y, whose weight is [M, C, kH, kW]: rank 4, which is
+// the case the layer finder refused until Conv joined it.
+onnx::ModelProto ConvModel(float weight) {
+  onnx::ModelProto model;
+  onnx::GraphProto* graph = model.mutable_graph();
+  graph->set_name("conv");
+  AddImageValue(graph->add_input(), "X", 3, 8);
+  AddImageValue(graph->add_output(), "Y", 4, 6);
+  onnx::NodeProto* conv = graph->add_node();
+  *conv = MakeNode("Conv", {"X", "W", "B"}, {"Y"});
+  // MakeNode carries scalar int attributes only; Conv's are INTS.
+  for (const auto& [name, values] :
+       std::vector<std::pair<std::string, std::vector<int64_t>>>{
+           {"kernel_shape", {3, 3}},
+           {"strides", {1, 1}},
+           {"pads", {0, 0, 0, 0}}}) {
+    onnx::AttributeProto* attr = conv->add_attribute();
+    attr->set_name(name);
+    attr->set_type(onnx::AttributeProto::INTS);
+    for (int64_t v : values) attr->add_ints(v);
+  }
+  *graph->add_initializer() =
+      FloatTensor("W", {4, 3, 3, 3}, std::vector<float>(4 * 3 * 3 * 3, weight));
+  *graph->add_initializer() =
+      FloatTensor("B", {4}, std::vector<float>(4, 0.0f));
+  Finish(&model);
+  return model;
+}
+
 // The teacher's weights, which fine-tuning must never read: it trains the
 // student, and re-seeding from the teacher would throw away whatever change
 // (a pruning, a simplification, an earlier tuning) made the two differ.
@@ -740,6 +783,53 @@ void ADeeperBlockTrainsEveryLayerAndCapturesTheResidual() {
 // The operators that make up the weight fake-quant are therefore the ones that
 // must be *absent* -- a port that emitted them anyway would round the trained
 // weights to a grid nobody asked for and train on quietly.
+// A Conv's weight is [M, C/group, kH, kW] -- rank 4, where every other layer
+// this trains is rank 2. Nothing in the loop actually needed 2-D: w_shape is a
+// Shape rather than a pair, the moments are sized from it, and the write-back
+// stores the weight back in the layout the block's own node reads. The rank
+// check in the finder was the whole restriction, which is why this test is
+// about the *plan* rather than about arithmetic -- if the plan carries a rank-4
+// state tensor and writes back to the right initializer, the rest already
+// worked.
+void AConvolutionsRank4WeightIsPlannedAndWrittenBack() {
+  QatOptions options;
+  options.fake_quant = false;
+  const QatStepPlan plan = BuildQatStepGraph(ConvModel(0.2f), ConvModel(0.3f),
+                                             "X", "Y", kRows, options);
+  CheckModel(plan.step_graph, "the convolution fine-tuning step graph");
+  CheckEqual(static_cast<int64_t>(plan.layers.size()), 1,
+             "the convolution is the one trained layer");
+  CheckEqual(plan.layers[0].codes_initializer, "W",
+             "it writes back into the weight itself");
+  Check(!plan.layers[0].fake_quant,
+        "no quantized scheme produces a Conv, so this is fine-tuning only");
+  CheckEqual(static_cast<int64_t>(plan.layers[0].weight_dims.size()), 4,
+             "the trained weight keeps its rank rather than being flattened");
+  const std::vector<int64_t> expected{4, 3, 3, 3};
+  Check(plan.layers[0].weight_dims == expected,
+        "and keeps its shape, [M, C, kH, kW]");
+
+  // The master weight seeded into the loop is the student's, at its own rank.
+  const onnx::TensorProto* seed = nullptr;
+  for (const onnx::TensorProto& t : plan.initial_state) {
+    if (t.name() == plan.layers[0].weight_state_input) seed = &t;
+  }
+  Check(seed != nullptr, "the loop is seeded with the convolution's weight");
+  if (seed != nullptr) {
+    const std::vector<int64_t> seed_dims(seed->dims().begin(),
+                                         seed->dims().end());
+    Check(seed_dims == expected, "seeded at rank 4, not flattened");
+    const std::vector<float> values = FloatsOf(*seed);
+    Check(!values.empty() && std::abs(values[0] - 0.3f) < 1e-6f,
+          "seeded from the student's weight, not the teacher's");
+  }
+
+  // The bias is input 2 and is not a trained layer, for Conv as for Gemm's C.
+  for (const QatTrainedLayer& layer : plan.layers) {
+    Check(layer.codes_initializer != "B", "the bias is not trained");
+  }
+}
+
 void AFloatBlockFineTunesWithNoQuantizerInTheStepGraph() {
   QatOptions options;
   options.fake_quant = false;
@@ -1036,7 +1126,8 @@ void ABlockWithNoFloatWeightToFineTuneIsRefusedInThoseTerms() {
         BuildQatStepGraph(FloatModel(), Int4QuantizedModel(), "X", "Y", kRows,
                           options);
       },
-      "contains no MatMul/Gemm with a 2-D fp32 weight initializer to fine-tune",
+      "contains no MatMul/Gemm/Conv with an fp32 weight initializer of rank 2 "
+      "or more to fine-tune",
       "a block with no stored float weight is refused in the scheme's terms");
 }
 
@@ -1146,6 +1237,7 @@ int main() {
   TrainingActivationQuantizersPlansBothOfTheirParameters();
   ADeeperBlockTrainsEveryLayerAndCapturesTheResidual();
   AFloatBlockFineTunesWithNoQuantizerInTheStepGraph();
+  AConvolutionsRank4WeightIsPlannedAndWrittenBack();
   PreserveSparsityPinsTheStartingZerosAndNothingElse();
   UntrainedBlockConstantsComeFromTheStudentWhenFineTuning();
   FineTunedWeightsAreWrittenBackAsFloatUnderTheirOwnName();

--- a/tests/test_block_finetune.py
+++ b/tests/test_block_finetune.py
@@ -380,13 +380,18 @@ def test_the_weights_are_written_back_as_floats():
     onnx.checker.check_model(tuned, full_check=True)
 
 
-def test_only_the_matmul_weights_are_touched():
+def test_a_layer_norms_affine_parameters_are_left_alone():
     """A block's other initializers are left byte-identical.
 
-    :func:`onnxsim.qat._find_float_layers` trains MatMul/Gemm weights and
-    nothing else, so a LayerNorm's scale and bias sit inside the block, get
-    differentiated through, and come out unchanged. That boundary is worth
-    pinning: widening it later is a decision, not a refactor.
+    :func:`onnxsim.qat._find_float_layers` trains the weight of a MatMul, Gemm
+    or Conv -- input 1, and only input 1 -- so a LayerNorm's scale and bias sit
+    inside the block, get differentiated through, and come out unchanged.
+
+    That boundary has already moved once: this test was named for MatMul alone
+    until Conv joined the finder, which is the reason it is written against
+    what is *not* trained rather than what is. The list of trained ops will
+    keep growing; "a LayerNorm's affine parameters are not weights" is the
+    claim worth pinning.
     """
     rng = np.random.default_rng(6)
     w1 = rng.normal(0, 0.3, (D, D)).astype(np.float32)
@@ -504,7 +509,7 @@ def test_a_block_with_no_trainable_weight_says_so():
     }}
     """
     model = _model(body, [_f32(rng.normal(0, 0.1, D), "Bias")])
-    with pytest.raises(ValueError, match="no MatMul/Gemm with a 2-D fp32 weight"):
+    with pytest.raises(ValueError, match="no MatMul/Gemm/Conv with an fp32 weight"):
         onnxsim.apply_block_finetune(
             model, model, "X", "Y", calibration_data=_data(rng, batches=1)
         )
@@ -768,3 +773,127 @@ def test_preserve_sparsity_costs_exactly_one_multiply_per_layer():
         consumers = [node for node in graph.node if product in node.input]
         assert product not in outputs
         assert len(consumers) >= 2
+
+
+_CONV_BODY = """
+g (float[2,3,10,10] X) => (float[2,4,8,8] Y) {
+  Y = Conv<kernel_shape = [3, 3], strides = [1, 1], pads = [0, 0, 0, 0]>(X, W, B)
+}
+"""
+
+
+def _conv_model(weight, bias):
+    return _model(_CONV_BODY, [_f32(weight, "W"), _f32(bias, "B")])
+
+
+def test_a_convolutions_own_weight_trains():
+    """The rank-4 case, which is the whole point of letting the finder see Conv.
+
+    ``graph_grad`` gained a ``Conv`` rule so a convolution would stop *splitting*
+    a block; its weight stayed frozen, because the layer finders were
+    MatMul/Gemm with a 2-D initializer. Nothing in the loop actually needed the
+    weight to be 2-D -- the master weight is fed to the block's own node in the
+    layout that node already reads, Adam's moments are ``zeros_like`` it, and
+    the write-back stores it back unchanged -- so the rank restriction was the
+    only thing in the way.
+
+    A single convolution against its own reference is exactly solvable, so this
+    asserts the strong thing: the trained weight converges *onto* the
+    reference's, not merely toward it.
+    """
+    rng = np.random.default_rng(30)
+    weight = rng.normal(0, 0.3, (4, 3, 3, 3)).astype(np.float32)
+    bias = np.zeros(4, np.float32)
+    reference = _conv_model(weight, bias)
+    student = _conv_model(
+        weight + rng.normal(0, 0.15, weight.shape).astype(np.float32), bias
+    )
+    data = [
+        {"X": rng.normal(0, 1, (2, 3, 10, 10)).astype(np.float32)} for _ in range(16)
+    ]
+
+    losses: list = []
+    tuned = onnxsim.apply_block_finetune(
+        reference,
+        student,
+        "X",
+        "Y",
+        calibration_data=data,
+        num_iterations=300,
+        learning_rate=2e-2,
+        losses=losses,
+    )
+
+    after = _init(tuned, "W")
+    assert after.shape == (4, 3, 3, 3)
+    assert losses[-1] < losses[0] / 1000
+    before_gap = np.abs(_init(student, "W") - weight).mean()
+    assert np.abs(after - weight).mean() < before_gap / 10
+    onnx.checker.check_model(tuned, full_check=True)
+
+
+def test_a_convolutions_bias_is_left_alone():
+    """Only input 1 is trained, for Conv as for MatMul and Gemm.
+
+    A Conv's bias is input 2 and a Gemm's ``C`` is likewise untrained. That is
+    a boundary rather than an oversight -- widening it is a decision about what
+    a "layer" is -- so it is pinned here, where a future change to the finder
+    would trip over it.
+    """
+    rng = np.random.default_rng(31)
+    weight = rng.normal(0, 0.3, (4, 3, 3, 3)).astype(np.float32)
+    bias = rng.normal(0, 0.1, 4).astype(np.float32)
+    reference = _conv_model(weight, bias)
+    student = _conv_model(
+        weight + rng.normal(0, 0.15, weight.shape).astype(np.float32), bias
+    )
+
+    tuned = onnxsim.apply_block_finetune(
+        reference,
+        student,
+        "X",
+        "Y",
+        calibration_data=[
+            {"X": rng.normal(0, 1, (2, 3, 10, 10)).astype(np.float32)} for _ in range(4)
+        ],
+        num_iterations=50,
+    )
+    assert np.array_equal(_init(tuned, "B"), bias)
+    assert not np.array_equal(_init(tuned, "W"), _init(student, "W"))
+
+
+def test_preserve_sparsity_holds_a_pruned_convolutions_zeros():
+    """The rank-4 weight goes through the mask path too.
+
+    ``preserve_sparsity`` builds its mask from ``w_init != 0`` and multiplies
+    it into the gradient, both of which are rank-agnostic -- but "should be
+    fine" and "is fine" are different claims about a code path that had only
+    ever seen 2-D.
+    """
+    rng = np.random.default_rng(32)
+    weight = rng.normal(0, 0.3, (4, 3, 3, 3)).astype(np.float32)
+    bias = np.zeros(4, np.float32)
+    reference = _conv_model(weight, bias)
+
+    pruned = weight.copy()
+    pruned[np.abs(pruned) < np.quantile(np.abs(pruned), 0.5)] = 0.0
+    student = _conv_model(pruned, bias)
+    assert (pruned == 0).sum() == pruned.size // 2
+
+    tuned = onnxsim.apply_block_finetune(
+        reference,
+        student,
+        "X",
+        "Y",
+        calibration_data=[
+            {"X": rng.normal(0, 1, (2, 3, 10, 10)).astype(np.float32)}
+            for _ in range(16)
+        ],
+        num_iterations=200,
+        learning_rate=2e-2,
+        preserve_sparsity=True,
+    )
+
+    after = _init(tuned, "W")
+    assert np.array_equal(after == 0, pruned == 0)
+    assert not np.array_equal(after, pruned)


### PR DESCRIPTION
#1247 gave `graph_grad` a `Conv` rule so a convolution would stop *splitting* a block. Its weight stayed frozen: the layer finders matched MatMul/Gemm with a **2-D** initializer, so a Conv's `[M, C/group, *kernel]` weight was never a trainable layer — a test asserted it came back byte-identical.

## Almost nothing needed changing, and that is the finding

The only code in the loop that ever required rank 2 is the **fake-quant path**, which reads a weight as a 2-D grid of scale blocks (`_blocked_shapes` and the two functions built on it). Everything else was rank-agnostic already:

- the master weight is fed to the block's own node in the layout that node already reads,
- Adam's moments are `zeros_like` it,
- the write-back stores it back unchanged,
- `preserve_sparsity`'s mask is elementwise.

The C++ was further along still — `w_shape` there is a `Shape` rather than a pair, so only its finder's rank check stood in the way.

So this relaxes the two finders and generalizes `_Trained.w_shape` from `Tuple[int, int]`. **No new gradient, no new emitted operator, and `qat_parity_fixtures.txt` is byte-identical.**

## Why this is safe, established rather than assumed

Conv weights train only under `fake_quant=False`, and that is a property of the quantizers rather than a limitation chosen here: **`adaround`'s INT4 finder and `quantize_static`'s QDQ finder are both MatMul/Gemm-only**, so no quantized scheme ever produces a Conv layer for QAT to train.

Checking that is what established the change was safe. The fake-quant code a rank-4 weight would have broken is code a rank-4 weight can never reach.

## Measured

A single convolution against its own reference is exactly solvable, so the test asserts the strong thing — convergence *onto* the reference, not merely toward it:

| | before | after |
| --- | --- | --- |
| block loss | 0.557 | 0.000 |
| mean \|W − W_ref\| | 0.116 | 0.000 |
| held-out output error | 0.613 | 0.000 |

The bias stays byte-identical (input 2 is not trained, for Conv as for Gemm's `C`), and `preserve_sparsity` holds a pruned convolution's zero pattern exactly — that path had only ever seen 2-D.

## Three stale claims, corrected rather than left standing

- The **refusal message**, in both languages, said "no MatMul/Gemm with a **2-D** fp32 weight" — now wrong in both particulars.
- A test named `test_only_the_matmul_weights_are_touched` said the finder "trains MatMul/Gemm weights and nothing else", and closed by noting that widening that boundary would be a decision rather than a refactor. The boundary has now moved, so it is renamed for what it actually pins: that a LayerNorm's affine parameters are not weights. It is written against what is *not* trained precisely because the trained list will keep growing.
- `docs/qat.md` still said the convolution's own weights do not train.

## Verification

- **235 Python tests** pass; all four C++ tests pass; `ruff`, `clang-format` clean; parity fixture unchanged; the JS `DIFFERENTIABLE_OPS` pin still green.
- All three new Python tests **and** the new C++ test fail when the finder is reverted — I checked, because during this change a **stale binary reported "all qat_entry tests passed" before the rebuild landed**. That is the second time this session a differential check passed for reasons unrelated to the code, so the mutation run is the evidence rather than the green tick.

## What this does not fix

Pooling is still a block boundary. `MaxPool`/`AveragePool` have no gradient rule, so on a real CNN the blocks Conv just joined get re-split at every pooling layer — which limits how much of this is reachable in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_