### PR TITLE
axera: there is no full INT4 path -- W4A4 is expressible in neither pipeline

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4177,6 +4177,58 @@ where the decode measurements show INT4 buying 1.56x. The rating is not
 verifiable on this toolchain, and nothing measured here suggests it is
 reachable.
 
+### Is there a full INT4 path? No, and here is every place it is not
+
+A 43.2 TOPS INT4 rating describes 4-bit *arithmetic* -- 4-bit weights against
+4-bit activations. Both pipelines were checked for it, config schema and
+behaviour, and it is expressible in neither.
+
+**Activations cannot be 4-bit anywhere.** `pulsar2 build`'s `data_type`
+offers `U8, S8, U16, S16, FP32`; asking for the one 4-bit name in the enum
+gets an explicit rejection, `sepc_type NVFP4 not in STRING_NUMBER_MAP`.
+`llm_build --hidden_state_type` offers `fp16, bf16, fp32`. Nothing narrower
+exists in either.
+
+**The CNN path's one 4-bit weight type is silently ignored.** The `DataType`
+enum contains `NVFP4` even though `weight_data_type` is documented as
+`S8, FP32`, and setting it *builds successfully* -- which looks promising and
+is not. Against the `S8` build of the same graph it produces:
+
+| | S8 | NVFP4 |
+| --- | --- | --- |
+| weight table | 76.02 MB (1.007 B/weight) | 76.02 MB (1.007 B/weight) |
+| `max_cycle` | 3,905,355 | 3,905,355 |
+| device latency | 4.142 ms | 4.126 ms |
+| decoded weight codes | 167 distinct, 26..234 | **the same 167, 26..234** |
+
+The compiled weights are identical code for code -- decoded through the
+layout from the "Reading a real network's weights" section, which is what
+makes the comparison possible at all. `NVFP4` parses, is recorded in the
+build context, and changes nothing about the model.
+
+**`llm_build`'s `s4` is genuinely 4-bit storage, but only storage.** It
+measures 0.567 bytes per parameter against `s8`'s 1.10, so the weights really
+are four bits. The activations beside them are 16-bit, which is why it buys
+1.59x on decode (weight traffic) and 1.05x on prefill (arithmetic).
+
+So the complete picture is **W8A8 in the CNN pipeline, W4A16 or W8A16 in the
+LLM pipeline, and W4A4 nowhere.** The 43.2 TOPS figure cannot be reached
+through the vendor toolchain, not because the measurements fall short but
+because nothing in either pipeline emits that kind of program.
+
+**A note on whether the silicon could.** The weight tables this project
+decodes are stored as *bit planes* -- two 4-bit planes for a 1-D convolution,
+four 2-bit planes for a 2-D one, eight bits either way. A datapath that reads
+weights plane by plane is the kind where fewer weight bits would mean
+proportionally fewer passes, which is what a 2.4x INT8-to-INT4 rating would
+describe. That is consistent with the hardware supporting it and the
+toolchain not exposing it, but it is an inference from a storage format, not
+a measurement, and nothing here tests it.
+
+Test: `test_nvfp4_weights_are_accepted_and_then_ignored` (Docker, no device).
+It asserts the two builds' weights are identical, so if a future toolchain
+implements NVFP4 the test fails and says this section needs revisiting.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4802,6 +4802,91 @@ def test_llm_build_offers_an_int4_weight_path_the_cnn_path_lacks(tmp_path):
     assert 1.3 < ratio < 2.0, (ratio, sizes)
 
 
+def _build_conv_with_weight_type(work_dir, tag, model, weight_type):
+    """Compile a model forcing Conv's `weight_data_type`."""
+    os.makedirs(os.path.join(work_dir, "dataset"), exist_ok=True)
+    os.makedirs(os.path.join(work_dir, "config"), exist_ok=True)
+    onnx.save(model, os.path.join(work_dir, f"{tag}.onnx"))
+    shape = [d.dim_value for d in model.graph.input[0].type.tensor_type.shape.dim]
+    rng = np.random.RandomState(1)
+    pulsar2_docker.make_numpy_calibration_tar(
+        os.path.join(work_dir, "dataset", f"{tag}.tar"),
+        [rng.randn(*shape).astype(np.float32) for _ in range(2)],
+    )
+    with open(os.path.join(work_dir, "config", f"{tag}.json"), "w") as f:
+        json.dump(
+            {
+                "model_type": "ONNX",
+                "npu_mode": "NPU3",
+                "quant": {
+                    "input_configs": [
+                        {
+                            "tensor_name": "x",
+                            "calibration_dataset": f"./dataset/{tag}.tar",
+                            "calibration_format": "Numpy",
+                            "calibration_size": 2,
+                        }
+                    ],
+                    "layer_configs": [
+                        {"op_type": "Conv", "weight_data_type": weight_type}
+                    ],
+                    "calibration_method": "MinMax",
+                    "precision_analysis": False,
+                },
+                "compiler": {"check": 0},
+            },
+            f,
+        )
+    return pulsar2_docker.build(
+        work_dir,
+        f"{tag}.onnx",
+        f"out_{tag}",
+        config_path=f"config/{tag}.json",
+        timeout=2400,
+    )
+
+
+def test_nvfp4_weights_are_accepted_and_then_ignored(tmp_path):
+    """Confirmed real (see the README's "Is there a full INT4 path" section):
+    `weight_data_type: NVFP4` is the only 4-bit type the CNN pipeline's config
+    will parse, and it changes nothing. The compiled convolution weights come
+    out **identical** to the `S8` build, code for code.
+
+    That is worth a regression test in both directions. It documents that
+    there is no 4-bit weight path here today, and if a future toolchain ever
+    implements NVFP4 this test fails and says so. Needs Docker, no device.
+    """
+    cin = cout = 64
+    kernel, hw = 3, 16
+    model = _one_conv2d_model(cin, cout, hw, kernel)
+    codes = {}
+    for weight_type in ("S8", "NVFP4"):
+        work = tmp_path / weight_type
+        work.mkdir()
+        result = _build_conv_with_weight_type(str(work), "m", model, weight_type)
+        assert result.success, (weight_type, result.error)
+        wbt = np.frombuffer(
+            next(
+                i
+                for i in onnx.load(result.axmodel_path).graph.initializer
+                if i.name == "npu_params"
+            ).raw_data,
+            dtype=np.uint8,
+        )
+        codes[weight_type] = [
+            _read_weight2d_code_at(wbt, 0, 0, i, kh, kw, kernel, cin)
+            for i in range(cin)
+            for kh in range(kernel)
+            for kw in range(kernel)
+        ]
+    assert codes["S8"] == codes["NVFP4"], (
+        "NVFP4 changed the compiled weights -- this toolchain may now implement "
+        "a real 4-bit weight path, and the README needs revisiting"
+    )
+    # ... and the weights really are 8-bit, spread over far more than 16 levels.
+    assert len(set(codes["S8"])) > 32, len(set(codes["S8"]))
+
+
 def test_single_conv_program_encodes_its_output_channel_count(tmp_path):
     """Confirmed real (see the README's "The first operand with a known
     meaning" section): in a program holding exactly one convolution, the


### PR DESCRIPTION
A 43.2 TOPS INT4 rating describes 4-bit **arithmetic**: 4-bit weights against 4-bit activations. Both pipelines were checked, schema and behaviour, and it is expressible in neither.

### Activations cannot be 4-bit anywhere

`pulsar2 build`'s `data_type` offers `U8, S8, U16, S16, FP32`, and asking for the one 4-bit name in the enum is rejected outright: `sepc_type NVFP4 not in STRING_NUMBER_MAP`. `llm_build --hidden_state_type` offers `fp16, bf16, fp32`. Nothing narrower exists in either.

### The CNN path's one 4-bit weight type is accepted and then ignored

The `DataType` enum contains `NVFP4` even though `weight_data_type` is documented as `S8, FP32` -- and setting it **builds successfully**, which looks promising and is not:

| | S8 | NVFP4 |
| --- | --- | --- |
| weight table | 76.02 MB (1.007 B/weight) | 76.02 MB (1.007 B/weight) |
| `max_cycle` | 3,905,355 | 3,905,355 |
| device latency | 4.142 ms | 4.126 ms |
| decoded weight codes | 167 distinct, 26..234 | **the same 167, 26..234** |

The compiled weights are identical **code for code** -- decoded through the weight layout from #1229, which is what makes this comparison possible at all. `NVFP4` parses, is recorded in the build context, and changes nothing about the model.

### `llm_build`'s `s4` is genuinely 4-bit storage, but only storage

It measures **0.567 bytes per parameter** against `s8`'s 1.10, so the weights really are four bits. The activations beside them are 16-bit, which is exactly why #1246 found it buying 1.59x on decode (weight traffic) and 1.05x on prefill (arithmetic).

### The complete picture

**W8A8 in the CNN pipeline, W4A16 or W8A16 in the LLM pipeline, and W4A4 nowhere.** The 43.2 TOPS figure cannot be reached through the vendor toolchain -- not because the measurements fall short, but because nothing in either pipeline emits that kind of program.

### A note on whether the silicon could, clearly marked as inference

The weight tables this project decodes are stored as **bit planes** -- two 4-bit planes for a 1-D convolution, four 2-bit planes for a 2-D one, eight bits either way. A datapath that reads weights plane by plane is the kind where fewer weight bits would mean proportionally fewer passes, which is what a 2.4x INT8-to-INT4 rating would describe.

That is consistent with the hardware supporting what the toolchain does not expose. It is an inference from a storage format, not a measurement, and nothing here tests it.

### Test

`test_nvfp4_weights_are_accepted_and_then_ignored` (Docker, no device) asserts the two builds' weights are identical -- so if a future toolchain implements NVFP4, the test fails and flags this section for revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS