### PR TITLE
mcode: what a weight generator can and cannot do yet -- the limit is output range

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4270,6 +4270,52 @@ So the survey's answer is the same as the narrower one, now checked
 everywhere: **4-bit weights yes, 4-bit arithmetic no**, and the 43.2 TOPS
 rating is unreachable through any route this toolchain exposes.
 
+### What a weight generator can and cannot do yet
+
+The weight table is fully addressable -- every convolution in resnet18d, three
+packings, 100% of its weights. Writing it is more constrained than reading
+it, and this pins down exactly how.
+
+**The per-channel weight scale is findable and writable.** One float32 per
+output channel sits immediately after the weight block, exactly proportional
+to that channel's peak magnitude. It has to be found *by* that
+proportionality rather than at a fixed offset, because the constant absorbs
+the activation scales and differs between models.
+
+**But rewriting weights and scales is still not enough.** Three device
+experiments, each stricter than the last:
+
+| what was rewritten | new weights | result |
+| --- | --- | --- |
+| weights only | a permutation along the input axis | **0.99982** |
+| weights only | random, per-channel peak preserved | 0.19, amplitude 3.1x |
+| weights and scales | random, peaks 0.4x-2.5x | 0.25, amplitude 2.0x |
+
+The amplitude ratios are the diagnosis: the device output is several times
+larger than the reference, which is saturation. Every convolution's *output*
+activation scale was calibrated from the original weights and is stored
+elsewhere, so any edit that widens the output distribution clips against it.
+
+**So the real constraint is not "preserve the peak" -- it is "preserve the
+output distribution".** A permutation does that exactly, which is why it
+works and why random weights with the same peak do not: same maximum,
+different variance, different output range.
+
+**Where the activation scales live, so far.** Of the eleven activation scales
+the compiler's own profile lists for an eight-layer convolution stack, exactly
+one appears verbatim as a float32 in the mcode. The rest do not appear in any
+byte order, which is what you would expect if they are stored as fixed-point
+requantisation multipliers rather than floats. Locating and rewriting those is
+the next step, and it is a decoding problem rather than a search.
+
+Until then the honest capability statement is: **a compiled model's
+convolution weights can be replaced by any set that preserves each output
+tensor's dynamic range, and verified on hardware.** That is narrower than
+"generate a weight table", and wider than it was.
+
+Test: `test_per_channel_weight_scales_sit_just_past_the_weight_block`
+(Docker, no device).
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4229,6 +4229,47 @@ Test: `test_nvfp4_weights_are_accepted_and_then_ignored` (Docker, no device).
 It asserts the two builds' weights are identical, so if a future toolchain
 implements NVFP4 the test fails and says this section needs revisiting.
 
+### Survey: every 4-bit route the toolchain has, and what each is worth
+
+Re-running the question across the whole toolchain rather than one pipeline at
+a time. Six routes, one of which works:
+
+| route | 4-bit? | measured effect |
+| --- | --- | --- |
+| `pulsar2 build` weights, `NVFP4` | parses, silently ignored | none -- weights identical code for code |
+| `pulsar2 build` weights, `U4`/`S4` | not in the enum | rejected at parse |
+| `pulsar2 build` activations | `NVFP4 not in STRING_NUMBER_MAP` | rejected |
+| `llm_build -w s4` | **yes, real** -- 0.567 B/param | **1.59x decode, 1.05x prefill** |
+| `llm_build -w fp8_e4m3` | option exists | build fails, `OpBuildException: op: AxFu` |
+| `llm_build --hidden_state_type` | `fp16, bf16, fp32` only | no narrow activations |
+
+**Peak INT4 arithmetic measured: 2.04 TOPS.** That is the `s4` prefill number
+-- 22.8 GMAC in 22.36 ms -- against a 43.2 TOPS INT4 rating, so under 5% of
+it. The cause is not the 4-bit weights, which are real; it is that nothing
+narrower than 16 bits is available for the activations they multiply.
+
+**A tool that looks like the missing path, and is not.**
+`/opt/pulsar2/convert_to_4w8f_cli` is a real CLI whose name reads as 4-bit
+weights with 8-bit float activations -- exactly the combination that would be
+worth measuring. Run on `Conv`, `MatMul` and `Gemm` models it changes nothing
+but the IR version: same op counts, same model size to within four bytes.
+Whatever it keys on, an ordinary float graph is not it, and it is not a route
+to INT4 from here.
+
+**A methodological note, because it nearly produced a false finding.**
+Grepping the compiler's per-chip backends for `S4` and `U4` reports them in
+~30 of the AX650 backend's 142 files, which reads as "the backend supports
+4-bit even though the frontend does not". It does not: those files are
+Pyarmor-encrypted blobs, and a two-character string appears in almost any
+large binary by chance. The control settles it -- the nonsense pattern `Q7x`
+matches exactly as many files as `INT4` and `4w8f` do. Nothing about backend
+capability can be read this way, and the earlier draft of this section that
+did so was wrong.
+
+So the survey's answer is the same as the narrower one, now checked
+everywhere: **4-bit weights yes, 4-bit arithmetic no**, and the 43.2 TOPS
+rating is unreachable through any route this toolchain exposes.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4887,6 +4887,49 @@ def test_nvfp4_weights_are_accepted_and_then_ignored(tmp_path):
     assert len(set(codes["S8"])) > 32, len(set(codes["S8"]))
 
 
+def test_per_channel_weight_scales_sit_just_past_the_weight_block(tmp_path):
+    """Confirmed real (see the README's "What a weight generator can and
+    cannot do yet" section): the weight table carries one float32 per output
+    channel, immediately after the weight block, exactly proportional to that
+    channel's peak magnitude.
+
+    Finding it by proportionality rather than by a fixed offset is the point:
+    the constant of proportionality absorbs the activation scales and differs
+    between models, so only the *ratios* identify the array. Needs Docker, no
+    device.
+    """
+    cin = cout = 8
+    kernel, hw = 3, 16
+    rng = np.random.RandomState(3)
+    weights = (rng.randn(cout, cin, kernel, kernel) * 0.1).astype(np.float32)
+    work = tmp_path / "work"
+    work.mkdir()
+    axmodel = _build_single_op_axmodel(
+        str(work), "m", _one_conv2d_model(cin, cout, hw, kernel, weights=weights)
+    )
+    wbt = _wbt_of(axmodel)
+    peaks = np.abs(weights.reshape(cout, -1)).max(1).astype(np.float64)
+
+    found = None
+    for off in range(0, len(wbt) - 4 * cout, 4):
+        values = np.frombuffer(wbt[off : off + 4 * cout], dtype=np.float32).astype(
+            np.float64
+        )
+        if not np.all(np.isfinite(values)) or values.min() <= 0:
+            continue
+        ratio = values / peaks
+        if ratio.std() / ratio.mean() < 1e-4:
+            found = (off, ratio.mean())
+            break
+    assert found is not None, "no per-channel scale array proportional to the peaks"
+    off, ratio = found
+    # It sits past the weights, which occupy `_WBT2D_O_STRIDE` per channel.
+    assert off >= _WBT2D_O_STRIDE * cout, (off, _WBT2D_O_STRIDE * cout)
+    assert off < len(wbt), (off, len(wbt))
+    # The constant is a scale, not something degenerate.
+    assert 0 < ratio < 1, ratio
+
+
 def test_single_conv_program_encodes_its_output_channel_count(tmp_path):
     """Confirmed real (see the README's "The first operand with a known
     meaning" section): in a program holding exactly one convolution, the


### PR DESCRIPTION
The weight table is fully addressable (#1229): every convolution in resnet18d, three packings, 100% of its weights. **Writing** it is more constrained than reading it, and this pins down exactly how.

### The per-channel weight scale is findable and writable

One float32 per output channel sits immediately after the weight block, exactly proportional to that channel's peak magnitude. It has to be found *by* that proportionality rather than at a fixed offset, because the constant absorbs the activation scales and differs between models.

### But rewriting weights and scales is still not enough

Three device experiments, each stricter than the last:

| what was rewritten | new weights | result |
| --- | --- | --- |
| weights only | a permutation along the input axis | **0.99982** |
| weights only | random, per-channel peak preserved | 0.19, amplitude **3.1x** |
| weights **and** scales | random, peaks 0.4x-2.5x | 0.25, amplitude **2.0x** |

The amplitude ratios are the diagnosis: the device output is several times larger than the reference, which is **saturation**. Every convolution's *output* activation scale was calibrated from the original weights and is stored elsewhere, so any edit that widens the output distribution clips against it.

### So the real constraint is not "preserve the peak"

It is **"preserve the output distribution"**. A permutation does that exactly, which is why it works and why random weights with the same peak do not -- same maximum, different variance, different output range.

That corrects the implicit reading of #1225/#1229, where the permutation was described as a convenience for keeping the scale valid. It is doing more work than that.

### Where the activation scales live, so far

Of the eleven activation scales the compiler's own profile lists for an eight-layer convolution stack, **exactly one appears verbatim as a float32** in the mcode. The rest do not appear in any byte order -- consistent with fixed-point requantisation multipliers rather than floats. Locating and rewriting those is the next step, and it is a decoding problem rather than a search.

### Honest capability statement

**A compiled model's convolution weights can be replaced by any set that preserves each output tensor's dynamic range, and verified on hardware.** Narrower than "generate a weight table", wider than it was.

### Test

`test_per_channel_weight_scales_sit_just_past_the_weight_block` (Docker, no device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS