### PR TITLE
mcode: close the 1-D weight layout to 128 channels

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4364,6 +4364,58 @@ reports `r_zeropoint = 121`.
 
 Test: `test_conv_weight_quantiser_is_reproduced_exactly` (Docker, no device).
 
+### Where the 1-D layout stops: 32 channels
+
+The TTS vocoder is the easier of the two remaining test beds -- it compiles
+through the same `pulsar2 build` path as everything else here, unlike the LLM
+pipeline. Pointing the weight locator at it fails almost completely: **1 of 23
+layers**, and reading its convolutions as 2-D with a unit dimension (either
+`1xk` or `kx1`) locates none at all.
+
+**The cause is a channel-count boundary, not the model.** A controlled sweep
+of single 1-D convolutions:
+
+| shape | located |
+| --- | --- |
+| 32 channels, K=3 | 1.0000 |
+| 32 channels, K=7 | 1.0000 |
+| 64 channels, K=3 | 0.42 |
+| 64 channels, K=7 | 0.19 |
+| 128 channels, K=3 | 0.27 |
+
+So the 1-D layout is right up to 32 input channels and wrong from 64. That
+explains the vocoder exactly: its convolutions run 32 to 256 channels, and the
+single layer that *did* locate is the one 32-channel `3x3`... which is to say
+the locator was never failing on the vocoder, it was failing on every shape
+past a limit nothing had tested.
+
+Two checks rule out the obvious alternatives. A **three-layer** 1-D model at
+32 channels locates all three layers at 1.0000, on contiguous bases -- so
+depth is not the problem. And kernel size is not either: 32 channels works at
+K=3 and K=7 alike.
+
+**What the 64-channel addressing looks like.** Dense single-weight probes give
+the output-channel map directly:
+
+    base(o) = 432*(o % 16) + 72*((o >> 4) & 1) + 6912*(o >> 5)
+
+with the input-channel and kernel rules unchanged (`i//2` bytes with the
+nibble chosen by `i % 2`, kernel stride `Cin/2`). The same
+bits-0-to-3/bit-4/higher-bits structure as everywhere else, with different
+constants.
+
+**What is still missing, and why the probe could not settle it.** The two
+nibble planes' separation at 64 channels is unknown. The probe flips a weight
+from `+0.1` to `-0.1`, and for this model's scale those quantise to `0xC0` and
+`0x40` -- a *low nibble of zero in both*, so only the high plane ever moved
+and the low one stayed invisible. Searching gaps from -2000 to +2000 bytes for
+a pair that reconstructs the weights found nothing, so the placement is not a
+simple offset from the plane the probe did find.
+
+The fix is mechanical and known: probe with a pair of values whose codes
+differ in *both* nibbles. That is the next step, and until it is done the
+vocoder's weights stay unreadable past 32 channels.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4413,8 +4413,47 @@ a pair that reconstructs the weights found nothing, so the placement is not a
 simple offset from the plane the probe did find.
 
 The fix is mechanical and known: probe with a pair of values whose codes
-differ in *both* nibbles. That is the next step, and until it is done the
-vocoder's weights stay unreadable past 32 channels.
+differ in *both* nibbles. That was done -- see the next section.
+
+### Closing the 1-D layout to 128 channels
+
+The blind spot was the probe, not the format. Flipping a weight between `+0.1`
+and `-0.1` at a pinned peak of 0.2 quantises to `0xC0` and `0x40` -- both with
+a **low nibble of zero** -- so only the high plane ever moved and the byte it
+moved was mistaken for the block's base. A pair differing in both nibbles
+(`+0.1` and `-0.1176`, codes `0xC0` and `0x35`) shows both planes at once, and
+the separation is the same 36 bytes it always was.
+
+**Both widths are now exact -- every code, not a correlation:**
+
+    A    = 144 * ceil((Cin/2) * K / 36)
+    m    = min(Cout // 4, 16)
+    slot = (Cin/2)*k + i//2
+    byte = A*(o % m) + 72*((o // m) & 1) + top*(o // (2*m))
+         + 144*(slot // 36) + (slot % 36)
+    high plane = byte + 36,  nibble = i % 2
+
+`A` is the piece that unifies the widths: 288, 432 and 864 at 32, 64 and 128
+channels, all from `144 * ceil((Cin/2)*K/36)`. Bit `log2(m)` of the output
+channel always costs 72, exactly as at every other width. `top` is `m*A` at 64
+channels and `m*A + 256` at 128 -- an extra 256-byte region per super-block
+that is not yet explained.
+
+The chunk boundary was the other thing the earlier probes missed: they only
+touched slots below 36, so they never crossed one. Slot 36 lands at byte 144
+and slot 64 at 172, so the chunk stride is 144, unchanged from 32 channels.
+
+**On the vocoder this moves 1 layer to 4 of 23** -- one each at 32, 64 and 128
+channels plus the final 1-channel convolution, which reads at 1.0000. That is
+3.9% of its weights, so the headline is still that the vocoder is mostly
+unread. What now blocks it is narrower and visible: every located layer has
+`K = 3`, and every `K = 5`, `K = 7` and `ConvTranspose` layer still fails. A
+single 32-channel `K = 7` convolution locates perfectly on its own, so the
+kernel size is not the problem by itself -- something about those shapes
+inside a larger graph is, and that is the next thing to probe.
+
+Test: `test_1d_weight_layout_holds_at_64_and_128_channels` (Docker, no
+device).
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4903,6 +4903,62 @@ def _quantize_conv_weights(weights):
     return np.clip(np.round(w / shaped) + 128, 0, 255).astype(int)
 
 
+def _weight1d_offset_wide(o, i, k, cin, cout, kernel, top):
+    """1-D weight address at 64 and 128 channels.
+
+    `A = 144 * ceil((Cin/2)*kernel / 36)` is the one constant that unifies 32,
+    64 and 128 channels (288, 432, 864). `m = min(Cout//4, 16)` members share
+    it, bit `log2(m)` of the output channel always costs 72, and whole
+    super-blocks cost `top` -- which is `m*A` at 64 channels and `m*A + 256` at
+    128, an extra region this has not explained.
+    """
+    a = 144 * -(-((cin // 2) * kernel) // 36)
+    m = min(max(cout // 4, 1), 16)
+    slot = (cin // 2) * k + i // 2
+    return (
+        a * (o % m)
+        + 72 * ((o // m) & 1)
+        + top * (o // (2 * m))
+        + 144 * (slot // 36)
+        + (slot % 36)
+    ), (4 if i % 2 else 0)
+
+
+def test_1d_weight_layout_holds_at_64_and_128_channels(tmp_path):
+    """Confirmed real (see the README's "Closing the 1-D layout to 128
+    channels" section): the 1-D weight layout, which stopped working past 32
+    input channels, is exact at 64 and 128 once the addressing constants are
+    measured there -- every code, not a correlation.
+
+    The probe that found them matters as much as the result. Flipping a weight
+    between `+0.1` and `-0.1` moves only one of the two nibble planes at this
+    scale, because both quantise to a low nibble of zero; the pair used here
+    differs in *both* nibbles, which is what made the second plane visible.
+    Needs Docker, no device.
+    """
+    kernel, length = 3, 64
+    for cin, top in ((64, 16 * 432), (128, 16 * 864 + 256)):
+        cout = cin
+        rng = np.random.RandomState(5)
+        weights = rng.randn(cout, cin, kernel) * 0.05
+        for o in range(cout):
+            weights[o] *= 0.2 / np.abs(weights[o]).max()
+        weights = weights.astype(np.float32)
+        work = tmp_path / f"c{cin}"
+        work.mkdir()
+        model = _one_conv_model(cin, cout, length, kernel, weights=weights)
+        wbt = _wbt_of(_build_single_op_axmodel(str(work), "m", model))
+        got = np.zeros(weights.shape, dtype=int)
+        for o in range(cout):
+            for i in range(cin):
+                for k in range(kernel):
+                    off, shift = _weight1d_offset_wide(o, i, k, cin, cout, kernel, top)
+                    got[o, i, k] = (
+                        ((wbt[off + _WBT_PLANE_GAP] >> shift) & 0xF) << 4
+                    ) | ((wbt[off] >> shift) & 0xF)
+        assert (got == _quantize_conv_weights(weights)).all(), cin
+
+
 def test_conv_weight_quantiser_is_reproduced_exactly(tmp_path):
     """Confirmed real (see the README's "The weight quantiser, exactly"
     section): `_quantize_conv_weights()` reproduces **every** code pulsar2


### PR DESCRIPTION
Closes the gap #1254 left open.

### The blind spot was the probe, not the format

Flipping a weight between `+0.1` and `-0.1` at a pinned peak of 0.2 quantises to `0xC0` and `0x40` -- **both with a low nibble of zero** -- so only the high plane ever moved, and the byte it moved was mistaken for the block's base. A pair differing in *both* nibbles (`+0.1` and `-0.1176`, codes `0xC0` and `0x35`) shows both planes at once, and the separation is the same 36 bytes it always was.

### Both widths are now exact -- every code, not a correlation

```
A    = 144 * ceil((Cin/2) * K / 36)
m    = min(Cout // 4, 16)
slot = (Cin/2)*k + i//2
byte = A*(o % m) + 72*((o // m) & 1) + top*(o // (2*m))
     + 144*(slot // 36) + (slot % 36)
high plane = byte + 36,  nibble = i % 2
```

`A` is the piece that unifies the widths: **288, 432 and 864** at 32, 64 and 128 channels, all from `144 * ceil((Cin/2)*K/36)`. Bit `log2(m)` of the output channel always costs 72, exactly as at every other width.

`top` is `m*A` at 64 channels and `m*A + 256` at 128 -- an extra 256-byte region per super-block that is **not yet explained**.

The chunk boundary was the other thing the earlier probes missed: they only touched slots below 36, so they never crossed one. Slot 36 lands at byte 144 and slot 64 at 172, so the chunk stride is 144, unchanged from 32 channels.

### On the vocoder: 1 layer becomes 4 of 23

One each at 32, 64 and 128 channels, plus the final 1-channel convolution which reads at 1.0000. That is **3.9%** of its weights, so the headline is still that the vocoder is mostly unread.

But what blocks it is now narrower and visible: **every located layer has `K = 3`**, and every `K = 5`, `K = 7` and `ConvTranspose` layer still fails. A single 32-channel `K = 7` convolution locates perfectly on its own, so kernel size alone is not the problem -- something about those shapes inside a larger graph is, and that is the next thing to probe.

### Test

`test_1d_weight_layout_holds_at_64_and_128_channels` (Docker, no device) -- checks every code against the confirmed quantiser, at both widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS