### PR TITLE
Gather's gradient, so an embedding lookup no longer splits a block

### DIFF
--- a/docs/qat.md
+++ b/docs/qat.md
@@ -422,7 +422,7 @@ learn scales and got a model whose scales are untouched has no way to tell
 that from a run where learning them did not help.
 
 Operator coverage is the same constraint it is under QAT, and it is still the
-binding one on a real model: `graph_grad.SUPPORTED_OPS` is 22 rules
+binding one on a real model: `graph_grad.SUPPORTED_OPS` is 23 rules
 (`LayerNormalization` among them since this branch, and `Conv` since a later
 one), so a normalization -- or a convolution -- in the middle of a block is
 now more nodes in the slice rather than a boundary between blocks. On a CNN

--- a/onnxsim/graph_grad.cpp
+++ b/onnxsim/graph_grad.cpp
@@ -1068,6 +1068,96 @@ std::vector<OptStr> GradClip(Backward& ctx, const onnx::NodeProto& node,
   return grads;
 }
 
+std::vector<OptStr> GradGather(Backward& ctx, const onnx::NodeProto& node,
+                               const std::string& g) {
+  // Gather's gradient: a scatter-add into `data`, `indices` itself untouched
+  // -- the embedding-lookup case, not the constant-index-table use GradConv
+  // makes of the *forward* Gather. There is no scatter op in BackwardOps(),
+  // so the accumulation is written as a one-hot matmul instead; the full
+  // derivation, the shape this rule handles (data: [..., N, ...], indices
+  // rank 0 or 1), and what it costs are in _grad_gather in graph_grad.py.
+  // This is a transcription of it, node for node.
+  const std::string& data = node.input(0);
+  const std::string& indices = node.input(1);
+  const Shape data_shape = ctx.ShapeOf(data);
+  const Shape idx_shape = ctx.ShapeOf(indices);
+  if (idx_shape.size() > 1) {
+    throw UnsupportedOpError(
+        "Gather with rank-" + std::to_string(idx_shape.size()) +
+        " indices is not differentiated here (node " + Quoted(node.output(0)) +
+        "); only a scalar or a rank-1 index vector is supported");
+  }
+  const int64_t rank = static_cast<int64_t>(data_shape.size());
+  if (rank == 0) {
+    // Python would raise ZeroDivisionError on its `% rank` below; in C++ the
+    // same modulo is undefined behaviour, so a rank-0 data tensor -- which
+    // Gather's own spec never produces anyway -- is refused by name instead.
+    throw UnsupportedOpError("Gather over a rank-0 data tensor (node " +
+                             Quoted(node.output(0)) + ") has no axis to index");
+  }
+  const int64_t raw_axis = AttrInt(node, "axis", 0);
+  const int64_t axis = ((raw_axis % rank) + rank) % rank;
+  const int64_t count = data_shape[static_cast<size_t>(axis)];
+  const Shape pre_shape(data_shape.begin(), data_shape.begin() + axis);
+  const Shape post_shape(data_shape.begin() + axis + 1, data_shape.end());
+  const int64_t pre = Prod(pre_shape);
+  const int64_t post = Prod(post_shape);
+  const int64_t length = Prod(idx_shape);  // 1 for a scalar, L for a vector
+
+  // indices as a flat float32 [length] vector, with negative values resolved
+  // to indices[i] + count -- a run-time value, so this happens in the graph
+  // rather than at build time.
+  const std::string flat_shape = ctx.b().ConstInt64({length}, "shape");
+  const std::string flat_idx =
+      ctx.b().Op("Reshape", {indices, flat_shape}, "reshape");
+  const std::string idx_f = ctx.b().Op(
+      "Cast", {flat_idx}, {IntAttr("to", onnx::TensorProto::FLOAT)}, "cast");
+  const std::string zero = ctx.b().Const(0.0f);
+  const std::string is_negative = ctx.MaskLess(idx_f, zero);
+  const std::string count_const = ctx.b().Const(static_cast<float>(count));
+  const std::string negative_amount = ctx.b().Mul(is_negative, count_const);
+  const std::string idx_resolved = ctx.b().Add(idx_f, negative_amount);
+
+  // onehot[l, n] = (indices[l] == n), as a float32 [length, count] matrix --
+  // the same two-sided (1 - greater) * (1 - less) trick every other rule
+  // here uses to build a boolean without an Equal node.
+  const std::string col_shape = ctx.b().ConstInt64({length, 1}, "shape");
+  const std::string idx_col =
+      ctx.b().Op("Reshape", {idx_resolved, col_shape}, "reshape");
+  std::vector<float> arange_values(static_cast<size_t>(count));
+  for (int64_t i = 0; i < count; ++i) {
+    arange_values[static_cast<size_t>(i)] = static_cast<float>(i);
+  }
+  const std::string arange = ctx.b().Const(arange_values, {count}, "arange");
+  const std::string row_shape = ctx.b().ConstInt64({1, count}, "shape");
+  const std::string arange_row =
+      ctx.b().Op("Reshape", {arange, row_shape}, "reshape");
+  const std::string one_a = ctx.b().Const(1.0f);
+  const std::string greater_mask = ctx.MaskGreater(idx_col, arange_row);
+  const std::string not_greater = ctx.b().Sub(one_a, greater_mask);
+  const std::string one_b = ctx.b().Const(1.0f);
+  const std::string less_mask = ctx.MaskLess(idx_col, arange_row);
+  const std::string not_less = ctx.b().Sub(one_b, less_mask);
+  const std::string onehot = ctx.b().Mul(not_greater, not_less);
+
+  // dData[n, ...] = sum_l onehot[l, n] * dY[l, ...], batched over `pre` with
+  // a broadcasting leading axis so one onehot matrix serves every batch
+  // element -- see GradConv's `wt` for the same trick.
+  const std::string onehot_t = ctx.b().Transpose(onehot, {1, 0});
+  const std::string batched_shape =
+      ctx.b().ConstInt64({1, count, length}, "shape");
+  const std::string onehot_batched =
+      ctx.b().Op("Reshape", {onehot_t, batched_shape}, "reshape");
+  const std::string dy_shape = ctx.b().ConstInt64({pre, length, post}, "shape");
+  const std::string dy_flat = ctx.b().Op("Reshape", {g, dy_shape}, "reshape");
+  const std::string ddata_flat = ctx.b().MatMul(onehot_batched, dy_flat);
+  const std::string ddata_shape = ctx.b().ConstInt64(data_shape, "shape");
+  const std::string ddata =
+      ctx.b().Op("Reshape", {ddata_flat, ddata_shape}, "reshape");
+
+  return {ddata, std::nullopt};
+}
+
 const std::map<std::string, Rule>& Rules() {
   static const std::map<std::string, Rule>* rules =
       new std::map<std::string, Rule>{
@@ -1077,6 +1167,7 @@ const std::map<std::string, Rule>& Rules() {
           {"Div", &GradDiv},
           {"Erf", &GradErf},
           {"Exp", &GradExp},
+          {"Gather", &GradGather},
           {"Gemm", &GradGemm},
           {"Identity", &GradIdentity},
           {"LayerNormalization", &GradLayerNormalization},

--- a/onnxsim/graph_grad.py
+++ b/onnxsim/graph_grad.py
@@ -1011,6 +1011,117 @@ def _grad_clip(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[st
     return [ctx.b.mul(g, mask)] + rest
 
 
+def _grad_gather(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    """``Gather``'s gradient: a scatter-add into ``data``, ``indices`` itself
+    untouched.
+
+    This is the embedding-lookup case -- ``Gather(table, token_ids)`` -- not
+    the constant-index-table use :func:`_grad_conv` makes of the *forward*
+    ``Gather`` op (see the note above :data:`BACKWARD_OPS`, which is a fact
+    about what the rules may *emit*, not about what they can differentiate).
+    Here ``indices`` is a real, run-time-valued tensor and ``data`` is the
+    thing being trained, so the direction of travel is the opposite one.
+
+    **Why a scatter-add, and why a one-hot matmul instead.** ONNX's
+    ``Gather`` reads ``N = data.shape[axis]`` rows and can read the same row
+    more than once (a repeated token in a sequence); the gradient of a
+    duplicated read is the *sum* of every place it was read, i.e. exactly a
+    scatter-add of ``dY`` into ``dData`` at each row ``indices`` named. There
+    is no scatter op in :data:`BACKWARD_OPS`, and there should not need to
+    be: the same accumulation is a matrix product against a one-hot matrix,
+    built from ops already there --
+
+    .. code-block:: text
+
+        onehot[l, n] = 1 if indices[l] == n else 0     (Greater/Less/Cast/Sub)
+        dData[n, ...] = sum_l onehot[l, n] * dY[l, ...]  (a MatMul)
+
+    ``onehot == 1`` is built the same two-sided way every other rule here
+    builds a boolean without an ``Equal`` node: ``(1 - (idx > n)) * (1 - (idx
+    < n))``, with ``idx`` cast to float and broadcast against a constant
+    ``arange(N)``.
+
+    **Shape handled.** ``data`` has ``axis`` picking out one of its axes
+    (``data: [..., N, ...]``); everything before it flattens to a batch
+    dimension ``pre`` and everything after to ``post``, so the one-hot
+    ``MatMul`` is ``[1, N, L] x [pre, L, post] -> [pre, N, post]`` -- the same
+    "leading 1 broadcasts across a batch axis" trick :func:`_grad_conv` uses
+    to keep every operand inside the rank a batched ``MatMul`` wants.
+    ``indices`` itself must be rank 0 (a single scalar lookup) or rank 1 (a
+    sequence of lookups, ``L`` of them) -- squarely the embedding-lookup
+    shape. A higher-rank index tensor (batched lookups, e.g. ``[batch,
+    seq]``) is the same idea with an extra flatten/unflatten, but is refused
+    here rather than risked: a wrong reshape there would not fail loudly, it
+    would silently mix gradients across batch elements. Negative ``axis`` and
+    negative index *values* (``indices[i] + N`` per the ONNX-13 spec) are
+    both resolved -- the axis at build time, the values in the graph itself,
+    since they are only known at run time.
+
+    **What it costs.** The one-hot matrix is ``L x N`` -- the number of
+    lookups times the *entire* size of the gathered axis, not just the rows
+    actually read. For a small reconstruction block's embedding table this is
+    fine; for a large vocabulary (tens of thousands of rows) times a long
+    sequence it is a lot of both compute and a materialized ``arange``
+    constant, in exactly the same "real, and the reason this rule would not
+    be the right one for a general-purpose trainer" way :func:`_grad_conv`'s
+    own docstring is upfront about for its index tables.
+
+    **What this does not do.** Differentiating a ``Gather`` node makes its
+    contribution to a block *differentiable* -- a block containing an
+    embedding lookup no longer has to be routed around. It does not by itself
+    make the embedding table a *trained* weight: the block-fine-tuning weight
+    finders in :mod:`onnxsim.qat` (the ``MatMul``/``Gemm``/``Conv``-only
+    finder and :func:`onnxsim.qat._plan_trained`) still only recognize those
+    three op types' weight inputs. Teaching them to also recognize
+    ``Gather``'s ``data`` input as trainable is separate, out-of-scope
+    follow-up work.
+    """
+    data, indices = node.input[0], node.input[1]
+    data_shape = ctx.shape(data)
+    idx_shape = ctx.shape(indices)
+    rank = len(data_shape)
+    if len(idx_shape) > 1:
+        raise UnsupportedOpError(
+            f"Gather with rank-{len(idx_shape)} indices is not differentiated "
+            f"here (node {node.output[0]!r}); only a scalar or a rank-1 index "
+            "vector is supported"
+        )
+    axis = int(_attr(node, "axis", 0)) % rank
+    count = int(data_shape[axis])
+    pre_shape, post_shape = data_shape[:axis], data_shape[axis + 1 :]
+    pre, post = _prod(pre_shape), _prod(post_shape)
+    length = _prod(idx_shape)  # 1 for a scalar (empty shape), L for a vector
+
+    # indices as a flat float32 [length] vector, with negative values resolved
+    # to indices[i] + count -- a run-time value, so this happens in the graph
+    # rather than at build time.
+    flat_idx = ctx.b.op("Reshape", [indices, ctx.int64_const([length], "shape")])
+    idx_f = ctx.b.op("Cast", [flat_idx], to=onnx.TensorProto.FLOAT)
+    is_negative = ctx.mask_less(idx_f, ctx.b.const(0.0))
+    idx_resolved = ctx.b.add(idx_f, ctx.b.mul(is_negative, ctx.b.const(float(count))))
+
+    # onehot[l, n] = (indices[l] == n), as a float32 [length, count] matrix.
+    idx_col = ctx.b.op("Reshape", [idx_resolved, ctx.int64_const([length, 1], "shape")])
+    arange = ctx.b.const(np.arange(count, dtype=np.float32), "arange")
+    arange_row = ctx.b.op("Reshape", [arange, ctx.int64_const([1, count], "shape")])
+    not_greater = ctx.b.sub(ctx.b.const(1.0), ctx.mask_greater(idx_col, arange_row))
+    not_less = ctx.b.sub(ctx.b.const(1.0), ctx.mask_less(idx_col, arange_row))
+    onehot = ctx.b.mul(not_greater, not_less)
+
+    # dData[n, ...] = sum_l onehot[l, n] * dY[l, ...], batched over `pre` with
+    # a broadcasting leading axis so one onehot matrix serves every batch
+    # element -- see _grad_conv's `wt` for the same trick.
+    onehot_t = ctx.b.transpose(onehot, [1, 0])  # [count, length]
+    onehot_batched = ctx.b.op(
+        "Reshape", [onehot_t, ctx.int64_const([1, count, length], "shape")]
+    )
+    dy_flat = ctx.b.op("Reshape", [g, ctx.int64_const([pre, length, post], "shape")])
+    ddata_flat = ctx.b.matmul(onehot_batched, dy_flat)  # [pre, count, post]
+    ddata = ctx.b.op("Reshape", [ddata_flat, ctx.int64_const(data_shape, "shape")])
+
+    return [ddata, None]
+
+
 _RULES: Dict[str, Rule] = {
     "Add": _grad_add,
     "Clip": _grad_clip,
@@ -1018,6 +1129,7 @@ _RULES: Dict[str, Rule] = {
     "Div": _grad_div,
     "Erf": _grad_erf,
     "Exp": _grad_exp,
+    "Gather": _grad_gather,
     "Gemm": _grad_gemm,
     "Identity": _grad_identity,
     "LayerNormalization": _grad_layer_normalization,

--- a/onnxsim/graph_grad_test.cpp
+++ b/onnxsim/graph_grad_test.cpp
@@ -245,12 +245,11 @@ Shapes ConvShapes() {
 // browser that the Python refuses, or the reverse.
 void TheSupportedOpsAreExactlyThePythonRuleTable() {
   const std::set<std::string> expected = {
-      "Add",     "Clip",       "Conv",     "Div",   "Erf",
-      "Exp",     "Gather",     "Gemm",     "Identity",
-      "LayerNormalization",    "MatMul",   "Mul",   "Neg",
-      "ReduceMean", "ReduceSum", "Relu",   "Reshape",
-      "Sigmoid", "Softmax",    "Sqrt",     "Sub",   "Tanh",
-      "Transpose"};
+      "Add",    "Clip",    "Conv",     "Div",        "Erf",
+      "Exp",    "Gather",  "Gemm",     "Identity",   "LayerNormalization",
+      "MatMul", "Mul",     "Neg",      "ReduceMean", "ReduceSum",
+      "Relu",   "Reshape", "Sigmoid",  "Softmax",    "Sqrt",
+      "Sub",    "Tanh",    "Transpose"};
   Check(SupportedOps() == expected,
         "SupportedOps() should equal graph_grad.py's _RULES keys, got {" +
             Join(SupportedOps()) + "}");
@@ -747,10 +746,10 @@ void TheGatherRuleEmitsTheSameNodesInTheSameOrderAsThePython() {
   // Mul); then the batched one-hot matmul that stands in for the scatter-add
   // (Transpose, Reshape, Reshape, MatMul, Reshape).
   const std::vector<std::string> expected = {
-      "Reshape", "Cast",      "Less",    "Cast",  "Mul",     "Add",
-      "Reshape", "Reshape",   "Greater", "Cast",  "Sub",     "Less",
-      "Cast",    "Sub",       "Mul",     "Transpose", "Reshape", "Reshape",
-      "MatMul",  "Reshape"};
+      "Reshape",   "Cast",    "Less",    "Cast",    "Mul",
+      "Add",       "Reshape", "Reshape", "Greater", "Cast",
+      "Sub",       "Less",    "Cast",    "Sub",     "Mul",
+      "Transpose", "Reshape", "Reshape", "MatMul",  "Reshape"};
   Check(OpTypes(b) == expected,
         "the Gather rule should emit graph_grad.py's nodes in its order");
   Check(grads.size() == 1 && grads.at("data") == b.nodes().back().output(0),

--- a/onnxsim/graph_grad_test.cpp
+++ b/onnxsim/graph_grad_test.cpp
@@ -245,13 +245,11 @@ Shapes ConvShapes() {
 // browser that the Python refuses, or the reverse.
 void TheSupportedOpsAreExactlyThePythonRuleTable() {
   const std::set<std::string> expected = {
-      "Add",        "Clip",      "Conv",
-      "Div",        "Erf",       "Exp",
-      "Gemm",       "Identity",  "LayerNormalization",
-      "MatMul",     "Mul",       "Neg",
-      "ReduceMean", "ReduceSum", "Relu",
-      "Reshape",    "Sigmoid",   "Softmax",
-      "Sqrt",       "Sub",       "Tanh",
+      "Add",     "Clip",       "Conv",     "Div",   "Erf",
+      "Exp",     "Gather",     "Gemm",     "Identity",
+      "LayerNormalization",    "MatMul",   "Mul",   "Neg",
+      "ReduceMean", "ReduceSum", "Relu",   "Reshape",
+      "Sigmoid", "Softmax",    "Sqrt",     "Sub",   "Tanh",
       "Transpose"};
   Check(SupportedOps() == expected,
         "SupportedOps() should equal graph_grad.py's _RULES keys, got {" +
@@ -729,6 +727,80 @@ void ConvsOfAnyRankDifferentiateIdentically() {
   }
 }
 
+// If this fails, the C++ Gather rule has drifted from _grad_gather in
+// graph_grad.py -- pinned the same way and for the same reason as the
+// LayerNorm and Conv rules above: the nodes are numbered by the builder's
+// counter in emission order, so a reordering alone renames every tensor a
+// browser-built step graph produces from there on. axis=1 on a rank-3 data
+// tensor exercises a non-trivial pre/post split around the gathered axis,
+// not just the plain [N, D] embedding-table case.
+void TheGatherRuleEmitsTheSameNodesInTheSameOrderAsThePython() {
+  const std::vector<onnx::NodeProto> nodes = {
+      Node("Gather", {"data", "idx"}, {"Y"}, {IntAttr("axis", 1)})};
+  const Shapes shapes = {{"data", {2, 5, 3}}, {"idx", {2}}, {"Y", {2, 2, 3}}};
+  GraphBuilder b;
+  const std::map<std::string, std::string> grads =
+      BuildBackward(b, nodes, shapes, {{"Y", "dY"}}, {"data"});
+
+  // Flatten and resolve indices (Reshape, Cast, Less, Cast, Mul, Add); build
+  // the one-hot mask (Reshape, Reshape, Greater, Cast, Sub, Less, Cast, Sub,
+  // Mul); then the batched one-hot matmul that stands in for the scatter-add
+  // (Transpose, Reshape, Reshape, MatMul, Reshape).
+  const std::vector<std::string> expected = {
+      "Reshape", "Cast",      "Less",    "Cast",  "Mul",     "Add",
+      "Reshape", "Reshape",   "Greater", "Cast",  "Sub",     "Less",
+      "Cast",    "Sub",       "Mul",     "Transpose", "Reshape", "Reshape",
+      "MatMul",  "Reshape"};
+  Check(OpTypes(b) == expected,
+        "the Gather rule should emit graph_grad.py's nodes in its order");
+  Check(grads.size() == 1 && grads.at("data") == b.nodes().back().output(0),
+        "dData should be the last Reshape emitted");
+
+  Check(b.initializer().size() == 11,
+        "the rule should emit 11 initializers: the index-resolution "
+        "constants, the arange, and four reshape-shape operands");
+  const std::vector<onnx::TensorProto>& init = b.initializer();
+  Check(Int64Data(init[0]) == std::vector<int64_t>{2},
+        "the flat-index reshape target should be [length] = [2]");
+  Check(FloatData(init[1]) == std::vector<float>{0.0f} &&
+            FloatData(init[2]) == std::vector<float>{5.0f},
+        "the resolved-index constants should be 0.0 (the negativity bound) "
+        "and count = data.shape[axis] = 5");
+  Check(Int64Data(init[3]) == std::vector<int64_t>({2, 1}),
+        "the one-hot column reshape should be [length, 1]");
+  Check(FloatData(init[4]) == std::vector<float>({0, 1, 2, 3, 4}),
+        "the arange constant should be 0..count-1");
+  Check(Int64Data(init[5]) == std::vector<int64_t>({1, 5}),
+        "the one-hot row reshape should be [1, count]");
+  Check(FloatData(init[6]) == std::vector<float>{1.0f} &&
+            FloatData(init[7]) == std::vector<float>{1.0f},
+        "the two-sided one-hot mask should subtract from 1.0 twice");
+  Check(Int64Data(init[8]) == std::vector<int64_t>({1, 5, 2}),
+        "the batched one-hot reshape should be [1, count, length]");
+  Check(Int64Data(init[9]) == std::vector<int64_t>({2, 2, 3}),
+        "dY's flattening reshape should be [pre, length, post] = [2, 2, 3]");
+  Check(Int64Data(init.back()) == std::vector<int64_t>({2, 5, 3}),
+        "the final reshape should restore data's own shape");
+
+  // indices takes no gradient at all -- neither a node nor an entry.
+  Check(grads.count("idx") == 0,
+        "Gather's indices input should have no gradient");
+}
+
+// If this fails, a batched index tensor (e.g. [batch, seq]) would be
+// silently mixed across batch elements by a reshape that only makes sense
+// for a scalar or a rank-1 sequence of lookups -- see _grad_gather in
+// graph_grad.py for why this is refused rather than risked.
+void AGatherWithRankTwoIndicesIsRefused() {
+  const std::vector<onnx::NodeProto> nodes = {
+      Node("Gather", {"data", "idx"}, {"Y"})};
+  const Shapes shapes = {{"data", {5, 3}}, {"idx", {2, 2}}, {"Y", {2, 2, 3}}};
+  GraphBuilder b;
+  CheckThrows<UnsupportedOpError>(
+      [&] { BuildBackward(b, nodes, shapes, {{"Y", "dY"}}, {"data"}); },
+      "rank-2", "a rank-2 index tensor should be refused");
+}
+
 // If this fails, a tensor read by two consumers -- a residual connection's
 // own input, which is why this matters -- would keep only one contribution,
 // and the parameter upstream of it would train on a fraction of its
@@ -836,6 +908,8 @@ int main() {
   TheConvIndexTablesAreTheOnesTheGeometryImplies();
   AConvWhoseGeometryDoesNotAddUpIsRefused();
   ConvsOfAnyRankDifferentiateIdentically();
+  TheGatherRuleEmitsTheSameNodesInTheSameOrderAsThePython();
+  AGatherWithRankTwoIndicesIsRefused();
   ATensorReadTwiceAccumulatesItsContributions();
   AnIdentityAliasesTheSeedInsteadOfEmittingANode();
   TheReturnedMapCoversExactlyTheRequestedTargets();

--- a/onnxsim/qat_parity_fixtures.txt
+++ b/onnxsim/qat_parity_fixtures.txt
@@ -3,7 +3,7 @@
 # Asserted against onnxsim/qat_graph.py (tests/test_qat_parity.py) and
 # against onnxsim/qat_graph_builder.cpp (onnxsim/qat_graph_parity_test.cpp).
 ops Abs,Add,Cast,Clip,Div,Exp,Gather,Greater,Less,MatMul,Mul,Neg,Pow,ReduceMean,ReduceSum,Reshape,Sigmoid,Sign,Sqrt,Sub,Transpose
-rules Add,Clip,Conv,Div,Erf,Exp,Gemm,Identity,LayerNormalization,MatMul,Mul,Neg,ReduceMean,ReduceSum,Relu,Reshape,Sigmoid,Softmax,Sqrt,Sub,Tanh,Transpose
+rules Add,Clip,Conv,Div,Erf,Exp,Gather,Gemm,Identity,LayerNormalization,MatMul,Mul,Neg,ReduceMean,ReduceSum,Relu,Reshape,Sigmoid,Softmax,Sqrt,Sub,Tanh,Transpose
 backward_ops Add,Cast,Div,Exp,Gather,Greater,Less,MatMul,Mul,Neg,ReduceMean,ReduceSum,Reshape,Sqrt,Sub,Transpose
 model_text <ir_version: 10, opset_import: ["" : 21]>
 model_text g (float[4,32] X) => (float[4,32] Y) {

--- a/tests/test_graph_grad.py
+++ b/tests/test_graph_grad.py
@@ -636,6 +636,58 @@ _CASES = {
         """,
         None,
     ),
+    # Gather: an embedding lookup. `idx` is a text-literal int64 initializer,
+    # not a graph input -- `_feeds` only ever produces random float32, so an
+    # integer index has to be spelled as a constant the way CLAUDE.md's
+    # guidance describes, and it also means `data` is the only graph input,
+    # so it is the only (and therefore the default) differentiation target.
+    "gather_embedding": (
+        """
+        g (float[5,3] data) => (float[3,3] Y)
+        <int64[3] idx = {0, 2, 4}>
+        {
+          Y = Gather(data, idx)
+        }
+        """,
+        None,
+    ),
+    # A repeated index: row 1 is read twice, so its gradient must be the sum
+    # of both readings' contributions -- the scatter-add case the one-hot
+    # matmul exists for, not just a permutation of rows.
+    "gather_repeated_index": (
+        """
+        g (float[4,2] data) => (float[3,2] Y)
+        <int64[3] idx = {1, 1, 3}>
+        {
+          Y = Gather(data, idx)
+        }
+        """,
+        None,
+    ),
+    # A negative axis (resolved at build time) and a negative index value
+    # (resolved in the graph, since it is only known at run time), together
+    # with a non-trivial `pre`/`post` split around the gathered axis.
+    "gather_negative_axis_and_index": (
+        """
+        g (float[2,5,3] data) => (float[2,2,3] Y)
+        <int64[2] idx = {-1, 0}>
+        {
+          Y = Gather <axis = -2> (data, idx)
+        }
+        """,
+        None,
+    ),
+    # A scalar (rank-0) index -- the other rank Gather's own spec allows.
+    "gather_scalar_index": (
+        """
+        g (float[4,3] data) => (float[3] Y)
+        <int64 idx = {2}>
+        {
+          Y = Gather(data, idx)
+        }
+        """,
+        None,
+    ),
 }
 
 
@@ -982,6 +1034,27 @@ def test_a_matmul_with_a_1d_operand_is_refused():
     with pytest.raises(graph_grad.UnsupportedOpError, match="1-D"):
         graph_grad.build_backward(
             b, list(model.graph.node), _static_shapes(model), {"Y": "dY"}, ["A"]
+        )
+
+
+def test_a_gather_with_rank_2_indices_is_refused():
+    """Batched lookups (``indices: [batch, seq]``) are a real use case, but
+    the one-hot-matmul construction only handles a scalar or a rank-1 index
+    vector here -- see :func:`onnxsim.graph_grad._grad_gather` for why a
+    higher rank is refused rather than risked."""
+    model = _model(
+        """
+        g (float[5,3] data) => (float[2,2,3] Y)
+        <int64[2,2] idx = {0, 1, 2, 3}>
+        {
+          Y = Gather(data, idx)
+        }
+        """
+    )
+    b = qat_graph.GraphBuilder()
+    with pytest.raises(graph_grad.UnsupportedOpError, match="rank-2"):
+        graph_grad.build_backward(
+            b, list(model.graph.node), _static_shapes(model), {"Y": "dY"}, ["data"]
         )
 
 


### PR DESCRIPTION
## What this does

Adds a VJP rule for `Gather` to `graph_grad`, in both the Python emitter and its C++ port, so a `Gather(embedding_table, token_ids)` node inside a block no longer forces the block walk to stop there. `Gather` was already in `BACKWARD_OPS` (admitted earlier for `Conv`'s im2col use) — this is the separate, previously-missing step of teaching the module to differentiate a *forward* `Gather` node itself.

**The gradient** is a scatter-add: `dData` accumulates `dY` at every row `indices` read, summing where an index repeats (a repeated token in a sequence). There's no scatter op available (nor should there need to be one — see `BACKWARD_OPS`'s own note on what's deliberately excluded), so it's built as a one-hot matmul using only ops already admitted: compare `indices` (cast to float) against a constant `arange` via the file's existing "boolean from two-sided `Greater`/`Less`, no `Equal`" convention, then `MatMul` the one-hot mask against `dY`. `indices` itself is never differentiated (returns `None`, same convention every other rule uses for a non-differentiable input).

**Scope.** Handles rank-0/rank-1 `indices` (the embedding-lookup shape: a sequence of token ids into a `[N, D]` table) with negative `axis`/index support. Rank ≥2 `indices` (e.g. a `[batch, seq]` index tensor) is refused via `UnsupportedOpError` rather than guessed at — same discipline `_conv_geometry` uses for configurations it won't touch.

**Cost, stated plainly.** This is `O(N * count(indices))` — a dense one-hot matrix sized by the whole table times the number of lookups. Expensive for a large vocabulary; the docstring is upfront about this the same way `_grad_conv`'s is about its index tables.

**What this does not do.** Making a `Gather` node differentiable is not the same as making its embedding table a directly-trained weight — `onnxsim/qat.py`'s block-finetuning weight finder (`_plan_trained`, MatMul/Gemm/Conv-only) is untouched. Extending it to recognize `Gather`'s `data` input as trainable is separate follow-up work, deliberately not attempted here.

**A real gap found and left flagged, not fixed.** While auditing every place that enumerates `SUPPORTED_OPS`/block-external tensors, found that `_capture`, `_block_shapes`, and `qat_graph.make_step_graph` all hardcode `float` for every block-external tensor — true of every op `SUPPORTED_OPS` covered before this PR, never true of `Gather`'s `indices`. This only bites when `indices` is a genuine external/runtime tensor (not a same-block initializer, which already works). It fails loudly (a clear shape-inference error), not silently, but it's real and out of scope for this PR — touches `_capture`/`_block_shapes`/`make_step_graph`/the minibatch `gather_rows` machinery across `qat.py` and `qat_graph.py`, which deserves its own change.

## Parity

`onnxsim/graph_grad.cpp` mirrors the Python rule node-for-node (same emission order, same node/const hints), registered in the C++ rules map. `onnxsim/qat_parity_fixtures.txt` regenerated via `scripts/make_qat_parity_fixtures.py`. `docs/qat.md`'s rule count corrected (22 → 23).

## Verification

- `pytest tests/test_graph_grad.py tests/test_qat_parity.py tests/test_qat.py tests/test_qat_graph.py tests/test_qat_interop.py -q` — 263 passed.
- `mypy onnxsim/graph_grad.py`, `ruff check`/`ruff format --check` — clean.
- Fresh from-scratch C++ build (`-DONNXSIM_BUILTIN_ORT=OFF -DONNXSIM_TESTS=ON`), independently reproduced: `graph_grad_test`, `qat_graph_parity_test`, and `qat_entry_test` all pass on freshly built binaries (verified by binary mtime postdating every touched source file).

New Python cases: a plain embedding lookup, a repeated index (exercises the scatter-add summing), a negative axis + negative index, a scalar index, and a rank-2-indices refusal test. New C++ tests mirror the same node-sequence pin and refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_