### PR TITLE
MaxPool and AveragePool's gradients, so pooling no longer splits a block

### DIFF
--- a/onnxsim/graph_grad.cpp
+++ b/onnxsim/graph_grad.cpp
@@ -668,6 +668,359 @@ std::vector<OptStr> GradConv(Backward& ctx, const onnx::NodeProto& node,
   return grads;
 }
 
+struct PoolGeometry {
+  std::vector<int64_t> kernel;
+  std::vector<int64_t> strides;
+  std::vector<int64_t> dilations;
+  std::vector<int64_t> pads_begin;
+};
+
+// MaxPool's/AveragePool's attributes resolved against their actual shapes --
+// _pool_geometry in graph_grad.py, refusal for refusal. Unlike Conv there is
+// no weight tensor to read kernel_shape off, so it is read directly (it is a
+// required attribute for both ops); ceil_mode=1 is refused outright rather
+// than reproduced, for the reason the Python docstring gives (it can put a
+// window's far edge fully inside the padding, a case runtimes do not agree
+// on). The final check is the same one ConvGeometryOf ends on: the resolved
+// geometry has to reproduce the node's own declared output shape.
+PoolGeometry PoolGeometryOf(const onnx::NodeProto& node, const Shape& x_shape,
+                            const Shape& y_shape, bool has_dilations) {
+  const std::string& op_type = node.op_type();
+  const std::string name = Quoted(node.output(0));
+  const size_t rank = x_shape.size();
+  if (rank < 3) {
+    throw UnsupportedOpError(op_type +
+                             " needs at least one spatial dimension, got "
+                             "input shape " +
+                             ShapeStr(x_shape) + " (node " + name + ")");
+  }
+  const size_t spatial = rank - 2;
+  if (y_shape.size() != rank) {
+    throw UnsupportedOpError(op_type +
+                             "'s X and Y must have the same rank, got " +
+                             ShapeStr(x_shape) + " and " + ShapeStr(y_shape) +
+                             " (node " + name + ")");
+  }
+  if (y_shape[0] != x_shape[0] || y_shape[1] != x_shape[1]) {
+    throw UnsupportedOpError(op_type + "'s output shape " + ShapeStr(y_shape) +
+                             " does not match its input " + ShapeStr(x_shape) +
+                             " in batch or channel size (node " + name + ")");
+  }
+
+  PoolGeometry geo;
+  const onnx::AttributeProto* declared = FindAttr(node, "kernel_shape");
+  if (declared == nullptr) {
+    throw UnsupportedOpError(op_type +
+                             " without a kernel_shape attribute is not "
+                             "differentiated here (node " +
+                             name + ")");
+  }
+  geo.kernel.assign(declared->ints().begin(), declared->ints().end());
+  if (geo.kernel.size() != spatial) {
+    throw UnsupportedOpError(op_type + "'s kernel_shape " +
+                             IntsStr(geo.kernel) +
+                             " must have one entry per spatial axis (" +
+                             std::to_string(spatial) + ") (node " + name + ")");
+  }
+
+  geo.strides = AttrInts(node, "strides", std::vector<int64_t>(spatial, 1));
+  geo.dilations = has_dilations ? AttrInts(node, "dilations",
+                                           std::vector<int64_t>(spatial, 1))
+                                : std::vector<int64_t>(spatial, 1);
+  if (geo.strides.size() != spatial || geo.dilations.size() != spatial) {
+    throw UnsupportedOpError(op_type + "'s strides " + IntsStr(geo.strides) +
+                             " and dilations " + IntsStr(geo.dilations) +
+                             " must have one entry per spatial axis (" +
+                             std::to_string(spatial) + ") (node " + name + ")");
+  }
+  for (size_t i = 0; i < spatial; ++i) {
+    if (geo.strides[i] < 1 || geo.dilations[i] < 1) {
+      throw UnsupportedOpError(
+          op_type + " with strides " + IntsStr(geo.strides) +
+          " and dilations " + IntsStr(geo.dilations) +
+          " is not a pooling this rule can invert (node " + name + ")");
+    }
+  }
+
+  if (AttrInt(node, "ceil_mode", 0) != 0) {
+    throw UnsupportedOpError(op_type +
+                             " with ceil_mode=1 is not differentiated here "
+                             "(node " +
+                             name + ")");
+  }
+
+  const onnx::AttributeProto* pad_mode = FindAttr(node, "auto_pad");
+  const std::string auto_pad =
+      pad_mode == nullptr ? std::string("NOTSET") : pad_mode->s();
+  std::vector<int64_t> pads;
+  if (auto_pad == "NOTSET") {
+    pads = AttrInts(node, "pads", std::vector<int64_t>(2 * spatial, 0));
+    if (pads.size() != 2 * spatial) {
+      throw UnsupportedOpError(op_type + "'s pads " + IntsStr(pads) +
+                               " must have two entries per spatial axis (" +
+                               std::to_string(spatial) + ") (node " + name +
+                               ")");
+    }
+  } else if (auto_pad == "VALID") {
+    pads.assign(2 * spatial, 0);
+  } else if (auto_pad == "SAME_UPPER" || auto_pad == "SAME_LOWER") {
+    // The spec's own formula, same as ConvGeometryOf's: output_shape[i] =
+    // ceil(input_shape[i] / strides[i]), the odd remainder going to the end
+    // for SAME_UPPER and the beginning for SAME_LOWER.
+    pads.assign(2 * spatial, 0);
+    for (size_t i = 0; i < spatial; ++i) {
+      const int64_t size = x_shape[2 + i];
+      const int64_t out = (size + geo.strides[i] - 1) / geo.strides[i];
+      const int64_t span = (geo.kernel[i] - 1) * geo.dilations[i] + 1;
+      const int64_t needed =
+          std::max<int64_t>(0, (out - 1) * geo.strides[i] + span - size);
+      pads[i] = auto_pad == "SAME_UPPER" ? needed / 2 : needed - needed / 2;
+      pads[spatial + i] = needed - pads[i];
+    }
+  } else {
+    throw UnsupportedOpError(op_type + " with auto_pad '" + auto_pad +
+                             "' is not differentiated here (node " + name +
+                             ")");
+  }
+
+  for (size_t i = 0; i < spatial; ++i) {
+    const int64_t span = (geo.kernel[i] - 1) * geo.dilations[i] + 1;
+    const int64_t reach = x_shape[2 + i] + pads[i] + pads[spatial + i] - span;
+    // A negative reach is spelled out rather than divided, for the same
+    // reason ConvGeometryOf's does: Python's floor division and C++'s
+    // truncation disagree there.
+    const int64_t expected = reach >= 0 ? reach / geo.strides[i] + 1 : 0;
+    if (expected != y_shape[2 + i]) {
+      throw UnsupportedOpError(
+          op_type + "'s declared output shape " + ShapeStr(y_shape) +
+          " does not follow from input " + ShapeStr(x_shape) + ", kernel " +
+          IntsStr(geo.kernel) + ", strides " + IntsStr(geo.strides) +
+          ", dilations " + IntsStr(geo.dilations) + " and pads " +
+          IntsStr(pads) + ": axis " + std::to_string(i) + " should be " +
+          std::to_string(expected) + ", not " + std::to_string(y_shape[2 + i]) +
+          " (node " + name + ")");
+    }
+  }
+  geo.pads_begin.assign(pads.begin(), pads.begin() + spatial);
+  return geo;
+}
+
+std::vector<OptStr> GradAveragePool(Backward& ctx, const onnx::NodeProto& node,
+                                    const std::string& g) {
+  // AveragePool's gradient: col2im of dY, scaled by each window's own
+  // divisor -- GradConv's dX half with the MatMul against W deleted
+  // outright, since pooling is depthwise and there is no weight to sum
+  // over. _grad_averagepool in graph_grad.py carries the derivation; this is
+  // a transcription of it, node for node.
+  const std::string& x = node.input(0);
+  const Shape x_shape = ctx.ShapeOf(x);
+  const Shape y_shape = ctx.ShapeOf(node.output(0));
+  const PoolGeometry geo =
+      PoolGeometryOf(node, x_shape, y_shape, /*has_dilations=*/false);
+  const bool count_include_pad = AttrInt(node, "count_include_pad", 0) != 0;
+
+  const int64_t planes = x_shape[0] * x_shape[1];
+  const Shape in_dims(x_shape.begin() + 2, x_shape.end());
+  const Shape out_dims(y_shape.begin() + 2, y_shape.end());
+  const int64_t taps = Prod(geo.kernel);
+  const int64_t in_count = Prod(in_dims);
+  const int64_t out_count = Prod(out_dims);
+
+  // Every window's divisor, in double precision to match the Python's
+  // np.float64. Always the mask-summing general path when
+  // count_include_pad=0, never a "no padding" shortcut keyed on pads_begin
+  // alone -- pads_begin can be all zero while pads_end is not (asymmetric,
+  // end-only padding), and a shortcut keyed on it once got that case wrong
+  // on the Python side. The mask sum below already comes out to
+  // prod(kernel) everywhere when there truly is no padding, so nothing is
+  // lost by always taking it.
+  std::vector<double> divisor(static_cast<size_t>(out_count));
+  if (count_include_pad) {
+    std::fill(divisor.begin(), divisor.end(), static_cast<double>(taps));
+  } else {
+    const std::pair<std::vector<int64_t>, std::vector<float>> im2col =
+        Im2ColIndices(in_dims, out_dims, geo.kernel, geo.strides, geo.dilations,
+                      geo.pads_begin);
+    for (int64_t tap = 0; tap < taps; ++tap) {
+      for (int64_t out = 0; out < out_count; ++out) {
+        divisor[static_cast<size_t>(out)] +=
+            im2col.second[static_cast<size_t>(tap * out_count + out)];
+      }
+    }
+    for (double d : divisor) {
+      if (d == 0.0) {
+        throw UnsupportedOpError(
+            "AveragePool has a window with no non-padding elements at all "
+            "(node " +
+            Quoted(node.output(0)) +
+            "); its average, and this rule's divisor, are undefined for "
+            "that window");
+      }
+    }
+  }
+  std::vector<float> recip(divisor.size());
+  for (size_t i = 0; i < divisor.size(); ++i) {
+    recip[i] = static_cast<float>(1.0 / divisor[i]);
+  }
+
+  const std::string g2_shape = ctx.b().ConstInt64({planes, out_count}, "shape");
+  const std::string g2 = ctx.b().Op("Reshape", {g, g2_shape}, "reshape");
+  const std::string recip_const = ctx.b().Const(recip, {1, out_count}, "recip");
+  const std::string scaled = ctx.b().Mul(g2, recip_const);
+
+  const std::pair<std::vector<int64_t>, std::vector<float>> col2im =
+      Col2ImIndices(in_dims, out_dims, geo.kernel, geo.strides, geo.dilations,
+                    geo.pads_begin);
+  const std::string idx_const = ctx.b().ConstInt64(col2im.first, "idx");
+  const std::string gathered =
+      ctx.b().Op("Gather", {scaled, idx_const}, {IntAttr("axis", 1)}, "gather");
+  const std::string mask_const =
+      ctx.b().Const(col2im.second, {1, taps * in_count}, "mask");
+  const std::string masked = ctx.b().Mul(gathered, mask_const);
+  const std::string col_shape =
+      ctx.b().ConstInt64({planes, taps, in_count}, "shape");
+  const std::string col = ctx.b().Op("Reshape", {masked, col_shape}, "reshape");
+  const std::string axes_const = ctx.b().ConstInt64({1}, "axes");
+  const std::string dx_flat = ctx.b().Op("ReduceSum", {col, axes_const},
+                                         {IntAttr("keepdims", 0)}, "reducesum");
+  const std::string dx_shape = ctx.b().ConstInt64(x_shape, "shape");
+  const std::string dx = ctx.b().Op("Reshape", {dx_flat, dx_shape}, "reshape");
+  return {dx};
+}
+
+std::vector<OptStr> GradMaxPool(Backward& ctx, const onnx::NodeProto& node,
+                                const std::string& g) {
+  // MaxPool's gradient: route dY to whichever input element(s) achieved
+  // node.output(0) in each window, without a fresh ReduceMax and without a
+  // MatMul. _grad_maxpool in graph_grad.py carries the full derivation (why
+  // no ReduceMax is needed, the tie-splitting convention, the per-tap-offset
+  // scatter trick this rule needs that GradConv's dX half does not); this is
+  // a transcription of it, node for node. MaxPool's optional Indices output
+  // is never reached here at all -- BuildBackward refuses any node with more
+  // than one declared output before a rule ever runs.
+  const std::string& x = node.input(0);
+  const std::string& y = node.output(0);
+  const Shape x_shape = ctx.ShapeOf(x);
+  const Shape y_shape = ctx.ShapeOf(y);
+  const PoolGeometry geo =
+      PoolGeometryOf(node, x_shape, y_shape, /*has_dilations=*/true);
+
+  const int64_t planes = x_shape[0] * x_shape[1];
+  const Shape in_dims(x_shape.begin() + 2, x_shape.end());
+  const Shape out_dims(y_shape.begin() + 2, y_shape.end());
+  const int64_t taps = Prod(geo.kernel);
+  const int64_t in_count = Prod(in_dims);
+  const int64_t out_count = Prod(out_dims);
+
+  const std::string x2_shape = ctx.b().ConstInt64({planes, in_count}, "shape");
+  const std::string x2 = ctx.b().Op("Reshape", {x, x2_shape}, "reshape");
+  const std::pair<std::vector<int64_t>, std::vector<float>> im2col =
+      Im2ColIndices(in_dims, out_dims, geo.kernel, geo.strides, geo.dilations,
+                    geo.pads_begin);
+  for (int64_t out = 0; out < out_count; ++out) {
+    float sum = 0.0f;
+    for (int64_t tap = 0; tap < taps; ++tap) {
+      sum += im2col.second[static_cast<size_t>(tap * out_count + out)];
+    }
+    if (sum == 0.0f) {
+      // A window every tap of which the padding invented has no real
+      // element to route dY to at all: the forward's own max over such a
+      // window is -inf by construction, which no real input value equals,
+      // so the tie count below would be a division by zero rather than a
+      // quietly wrong credit. Caught here, at build time, rather than
+      // producing a NaN gradient at run time.
+      throw UnsupportedOpError(
+          "MaxPool has a window with no non-padding elements at all (node " +
+          Quoted(node.output(0)) +
+          "); its max, and this rule's gradient for that window, are "
+          "undefined");
+    }
+  }
+  const std::string x_index = ctx.b().ConstInt64(im2col.first, "idx");
+  const std::string gathered =
+      ctx.b().Op("Gather", {x2, x_index}, {IntAttr("axis", 1)}, "gather");
+  const std::string windows_shape =
+      ctx.b().ConstInt64({planes, taps, out_count}, "shape");
+  const std::string windows =
+      ctx.b().Op("Reshape", {gathered, windows_shape}, "reshape");
+  const std::string y3_shape =
+      ctx.b().ConstInt64({planes, 1, out_count}, "shape");
+  const std::string y3 = ctx.b().Op("Reshape", {y, y3_shape}, "reshape");
+
+  // eq[plane, tap, out] = 1 iff the tap's input element equals the window's
+  // max: neither strictly greater (impossible, Y is the max) nor strictly
+  // less -- Cast(Greater)/Cast(Less), no Equal needed. A tap the padding
+  // invented is excluded outright by multiplying in the same validity mask
+  // GradConv uses, since a masked tap's gathered value is an arbitrary
+  // element that could spuriously equal Y.
+  const std::string one_a = ctx.b().Const(1.0f);
+  const std::string greater_mask = ctx.MaskGreater(windows, y3);
+  const std::string not_greater = ctx.b().Sub(one_a, greater_mask);
+  const std::string one_b = ctx.b().Const(1.0f);
+  const std::string less_mask = ctx.MaskLess(windows, y3);
+  const std::string not_less = ctx.b().Sub(one_b, less_mask);
+  const std::string eq_raw = ctx.b().Mul(not_greater, not_less);
+  const std::string valid_const =
+      ctx.b().Const(im2col.second, {1, taps, out_count}, "valid");
+  const std::string eq = ctx.b().Mul(eq_raw, valid_const);
+
+  // Ties split the credited gradient so a window's total outgoing gradient
+  // still sums to exactly the dY that came in -- see _grad_maxpool's
+  // docstring for why, and for the near-zero real-world likelihood of a tie
+  // this exists to handle without crashing or misbehaving silently.
+  const std::string tie_axes = ctx.b().ConstInt64({1}, "axes");
+  const std::string tie_count = ctx.b().Op(
+      "ReduceSum", {eq, tie_axes}, {IntAttr("keepdims", 1)}, "reducesum");
+  const std::string credit = ctx.b().Div(eq, tie_count);
+
+  const std::string g3_shape =
+      ctx.b().ConstInt64({planes, 1, out_count}, "shape");
+  const std::string g3 = ctx.b().Op("Reshape", {g, g3_shape}, "reshape");
+  const std::string contrib = ctx.b().Mul(credit, g3);
+  const std::string contrib2_shape =
+      ctx.b().ConstInt64({planes, taps * out_count}, "shape");
+  const std::string contrib2 =
+      ctx.b().Op("Reshape", {contrib, contrib2_shape}, "reshape");
+
+  std::pair<std::vector<int64_t>, std::vector<float>> scatter =
+      Col2ImIndices(in_dims, out_dims, geo.kernel, geo.strides, geo.dilations,
+                    geo.pads_begin);
+  // Offset each tap's block into its own slice of the flattened
+  // [taps, out_count] axis contrib2 holds: unlike GradConv's dX (whose
+  // gathered value is the same for every tap, since the weight does the
+  // differentiating), here each tap's credited gradient genuinely differs
+  // per tap, so the plain Col2ImIndices trick of gathering the same
+  // [planes, out_count] tensor for every tap does not apply as-is. Tap t's
+  // block starts at t * out_count, so one Gather still reaches the right
+  // tap's own contribution for every input element.
+  for (int64_t tap = 0; tap < taps; ++tap) {
+    const int64_t base = tap * in_count;
+    const int64_t offset = tap * out_count;
+    for (int64_t entry = 0; entry < in_count; ++entry) {
+      scatter.first[static_cast<size_t>(base + entry)] += offset;
+    }
+  }
+
+  const std::string scatter_idx_const =
+      ctx.b().ConstInt64(scatter.first, "idx");
+  const std::string gathered_back = ctx.b().Op(
+      "Gather", {contrib2, scatter_idx_const}, {IntAttr("axis", 1)}, "gather");
+  const std::string scatter_mask_const =
+      ctx.b().Const(scatter.second, {1, taps * in_count}, "mask");
+  const std::string masked_back =
+      ctx.b().Mul(gathered_back, scatter_mask_const);
+  const std::string col_shape =
+      ctx.b().ConstInt64({planes, taps, in_count}, "shape");
+  const std::string col =
+      ctx.b().Op("Reshape", {masked_back, col_shape}, "reshape");
+  const std::string dx_axes = ctx.b().ConstInt64({1}, "axes");
+  const std::string dx_flat = ctx.b().Op("ReduceSum", {col, dx_axes},
+                                         {IntAttr("keepdims", 0)}, "reducesum");
+  const std::string dx_shape = ctx.b().ConstInt64(x_shape, "shape");
+  const std::string dx = ctx.b().Op("Reshape", {dx_flat, dx_shape}, "reshape");
+  return {dx};
+}
+
 std::vector<OptStr> GradAdd(Backward& ctx, const onnx::NodeProto& node,
                             const std::string& g) {
   const Shape out = ctx.ShapeOf(node.output(0));
@@ -1162,6 +1515,7 @@ const std::map<std::string, Rule>& Rules() {
   static const std::map<std::string, Rule>* rules =
       new std::map<std::string, Rule>{
           {"Add", &GradAdd},
+          {"AveragePool", &GradAveragePool},
           {"Clip", &GradClip},
           {"Conv", &GradConv},
           {"Div", &GradDiv},
@@ -1172,6 +1526,7 @@ const std::map<std::string, Rule>& Rules() {
           {"Identity", &GradIdentity},
           {"LayerNormalization", &GradLayerNormalization},
           {"MatMul", &GradMatMul},
+          {"MaxPool", &GradMaxPool},
           {"Mul", &GradMul},
           {"Neg", &GradNeg},
           {"ReduceMean", &GradReduce},

--- a/onnxsim/graph_grad.py
+++ b/onnxsim/graph_grad.py
@@ -710,6 +710,335 @@ def _grad_conv(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[st
     return grads
 
 
+def _pool_geometry(
+    node: onnx.NodeProto,
+    x_shape: Tuple[int, ...],
+    y_shape: Tuple[int, ...],
+    *,
+    has_dilations: bool,
+) -> Tuple[List[int], List[int], List[int], List[int]]:
+    """``MaxPool``/``AveragePool``'s attributes resolved against their actual
+    shapes -- the same discipline :func:`_conv_geometry` applies to ``Conv``:
+    the resolved kernel/strides/dilations/pads are required to reproduce the
+    node's own declared output shape, so a misread attribute cannot survive
+    to become a gradient computed against the wrong geometry.
+
+    Unlike ``Conv``, a pooling node carries no weight tensor to read
+    ``kernel_shape`` off, so it is read directly -- it is a required
+    attribute for both ops -- and there is no "does the weight agree with
+    it" check to make.
+
+    ``ceil_mode=1`` is refused outright rather than reproduced: it can make
+    the rightmost window's far edge fall entirely inside the padding region,
+    and ONNX's own spec leaves what happens then ("the sliding window ...
+    will start as long as the starting index ... is less than the padded
+    input size") looser than the exact-reproduction discipline this module
+    otherwise holds itself to. Guessing which convention a given model was
+    built for would be exactly the quietly-wrong gradient
+    :class:`UnsupportedOpError`'s docstring warns about, so it is refused
+    instead. Same for any ``auto_pad`` beyond ``NOTSET``/``VALID``/
+    ``SAME_UPPER``/``SAME_LOWER``, and for a ``kernel_shape`` that never
+    resolves to the declared output shape.
+    """
+    name = node.output[0]
+    rank = len(x_shape)
+    if rank < 3:
+        raise UnsupportedOpError(
+            f"{node.op_type} needs at least one spatial dimension, got input "
+            f"shape {x_shape} (node {name!r})"
+        )
+    spatial = rank - 2
+    if len(y_shape) != rank:
+        raise UnsupportedOpError(
+            f"{node.op_type}'s X and Y must have the same rank, got {x_shape} "
+            f"and {y_shape} (node {name!r})"
+        )
+    if int(y_shape[0]) != int(x_shape[0]) or int(y_shape[1]) != int(x_shape[1]):
+        raise UnsupportedOpError(
+            f"{node.op_type}'s output shape {y_shape} does not match its "
+            f"input {x_shape} in batch or channel size (node {name!r})"
+        )
+
+    declared = _attr(node, "kernel_shape", None)
+    if declared is None:
+        raise UnsupportedOpError(
+            f"{node.op_type} without a kernel_shape attribute is not "
+            f"differentiated here (node {name!r})"
+        )
+    kernel = [int(k) for k in declared]
+    if len(kernel) != spatial:
+        raise UnsupportedOpError(
+            f"{node.op_type}'s kernel_shape {kernel} must have one entry per "
+            f"spatial axis ({spatial}) (node {name!r})"
+        )
+
+    strides = [int(s) for s in _attr(node, "strides", [1] * spatial)]
+    dilations = (
+        [int(d) for d in _attr(node, "dilations", [1] * spatial)]
+        if has_dilations
+        else [1] * spatial
+    )
+    if len(strides) != spatial or len(dilations) != spatial:
+        raise UnsupportedOpError(
+            f"{node.op_type}'s strides {strides} and dilations {dilations} "
+            f"must have one entry per spatial axis ({spatial}) (node {name!r})"
+        )
+    if any(s < 1 for s in strides) or any(d < 1 for d in dilations):
+        raise UnsupportedOpError(
+            f"{node.op_type} with strides {strides} and dilations {dilations} "
+            f"is not a pooling this rule can invert (node {name!r})"
+        )
+
+    if int(_attr(node, "ceil_mode", 0)):
+        raise UnsupportedOpError(
+            f"{node.op_type} with ceil_mode=1 is not differentiated here "
+            f"(node {name!r})"
+        )
+
+    auto_pad = _attr(node, "auto_pad", "NOTSET")
+    if isinstance(auto_pad, bytes):
+        auto_pad = auto_pad.decode("utf-8")
+    if auto_pad == "NOTSET":
+        pads = [int(p) for p in _attr(node, "pads", [0] * (2 * spatial))]
+        if len(pads) != 2 * spatial:
+            raise UnsupportedOpError(
+                f"{node.op_type}'s pads {pads} must have two entries per "
+                f"spatial axis ({spatial}) (node {name!r})"
+            )
+    elif auto_pad == "VALID":
+        pads = [0] * (2 * spatial)
+    elif auto_pad in ("SAME_UPPER", "SAME_LOWER"):
+        # The spec's own formula, same as _conv_geometry's: output_shape[i] =
+        # ceil(input_shape[i] / strides[i]), the odd remainder going to the
+        # end for SAME_UPPER and the beginning for SAME_LOWER.
+        pads = [0] * (2 * spatial)
+        for i in range(spatial):
+            size = int(x_shape[2 + i])
+            out = -(-size // strides[i])
+            span = (kernel[i] - 1) * dilations[i] + 1
+            needed = max(0, (out - 1) * strides[i] + span - size)
+            if auto_pad == "SAME_UPPER":
+                pads[i] = needed // 2
+            else:
+                pads[i] = needed - needed // 2
+            pads[spatial + i] = needed - pads[i]
+    else:
+        raise UnsupportedOpError(
+            f"{node.op_type} with auto_pad {auto_pad!r} is not "
+            f"differentiated here (node {name!r})"
+        )
+
+    for i in range(spatial):
+        span = (kernel[i] - 1) * dilations[i] + 1
+        reach = int(x_shape[2 + i]) + pads[i] + pads[spatial + i] - span
+        expected = reach // strides[i] + 1 if reach >= 0 else 0
+        if expected != int(y_shape[2 + i]):
+            raise UnsupportedOpError(
+                f"{node.op_type}'s declared output shape {y_shape} does not "
+                f"follow from input {x_shape}, kernel {kernel}, strides "
+                f"{strides}, dilations {dilations} and pads {pads}: axis {i} "
+                f"should be {expected}, not {int(y_shape[2 + i])} "
+                f"(node {name!r})"
+            )
+    return kernel, strides, dilations, pads[:spatial]
+
+
+def _grad_averagepool(
+    ctx: _Backward, node: onnx.NodeProto, g: str
+) -> List[Optional[str]]:
+    """``AveragePool``'s gradient: ``col2im`` of ``dY``, scaled by each
+    window's own divisor.
+
+    Pooling is depthwise by construction -- no channel mixes with another --
+    so this is exactly the ``dX`` half of :func:`_grad_conv`'s im2col
+    identity with the ``MatMul`` against ``W`` deleted outright: there is no
+    weight, every "tap" contributes with the same fixed coefficient
+    (``1 / divisor``), so summing a window's contributions is the ``ReduceSum``
+    :func:`_grad_conv` uses to sum ``dW`` over its batch axis, not a weighted
+    sum. Batch and channel are flattened into one axis throughout (called
+    ``planes`` below) since neither this rule nor the index tables it uses
+    ever need to tell them apart.
+
+    **The divisor.** With ``count_include_pad=1``, or no padding at all, every
+    window holds exactly ``prod(kernel)`` elements and the divisor is that one
+    number for the whole tensor. With ``count_include_pad=0`` (the default)
+    and nonzero padding, a window near the border is only averaged over its
+    *non-padding* elements, so the divisor varies by output position -- it is
+    exactly the count :func:`_im2col_indices`'s own validity mask already
+    computes (a tap is "valid" there iff it is not padding), summed over the
+    kernel taps. Both cases are folded into one ``[1, out_count]`` numpy array
+    computed once at build time and baked into a constant, so the emitted
+    graph never branches on which case it is.
+    """
+    x = node.input[0]
+    x_shape = ctx.shape(x)
+    y_shape = ctx.shape(node.output[0])
+    kernel, strides, dilations, pads = _pool_geometry(
+        node, x_shape, y_shape, has_dilations=False
+    )
+    count_include_pad = bool(_attr(node, "count_include_pad", 0))
+
+    planes = int(x_shape[0]) * int(x_shape[1])
+    in_dims = [int(d) for d in x_shape[2:]]
+    out_dims = [int(d) for d in y_shape[2:]]
+    taps = _prod(kernel)
+    in_count, out_count = _prod(in_dims), _prod(out_dims)
+
+    if count_include_pad or not any(pads):
+        divisor = np.full((1, out_count), float(taps), dtype=np.float64)
+    else:
+        _, valid = _im2col_indices(in_dims, out_dims, kernel, strides, dilations, pads)
+        divisor = (
+            valid.reshape(taps, out_count).sum(axis=0, keepdims=True).astype(np.float64)
+        )
+        if np.any(divisor == 0):
+            raise UnsupportedOpError(
+                f"AveragePool has a window with no non-padding elements at "
+                f"all (node {node.output[0]!r}); its average, and this "
+                f"rule's divisor, are undefined for that window"
+            )
+    recip = (1.0 / divisor).astype(np.float32)
+
+    g2 = ctx.b.op("Reshape", [g, ctx.int64_const([planes, out_count], "shape")])
+    scaled = ctx.b.mul(g2, ctx.b.const(recip, "recip"))
+
+    index, mask = _col2im_indices(in_dims, out_dims, kernel, strides, dilations, pads)
+    gathered = ctx.b.op("Gather", [scaled, ctx.int64_const(index, "idx")], axis=1)
+    masked = ctx.b.mul(gathered, ctx.b.const(mask.reshape(1, taps * in_count), "mask"))
+    col = ctx.b.op(
+        "Reshape", [masked, ctx.int64_const([planes, taps, in_count], "shape")]
+    )
+    dx_flat = ctx.b.op("ReduceSum", [col, ctx.int64_const([1], "axes")], keepdims=0)
+    dx = ctx.b.op("Reshape", [dx_flat, ctx.int64_const(x_shape, "shape")])
+    return [dx]
+
+
+def _grad_maxpool(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    """``MaxPool``'s gradient: route ``dY`` to whichever input element each
+    window's max came from.
+
+    A ``MaxPool`` with the optional ``Indices`` output present is never
+    reached here at all -- ``build_backward`` refuses any node with more than
+    one declared output before a rule ever runs, which is exactly right for
+    this one: computing a gradient *for* ``Indices`` (an integer tensor) does
+    not make sense, and this rule does not need ``Indices`` to compute
+    ``dX`` regardless, so nothing is lost by that refusal covering it too.
+    ``GlobalMaxPool`` is a different op type with no rule registered, so it
+    is refused the ordinary way. Neither is a design compromise here -- see
+    :func:`build_backward`'s single-output check and :data:`SUPPORTED_OPS`.
+
+    **No fresh ``ReduceMax``.** The forward already computed the window's max
+    as ``node.output[0]``; recomputing it (besides needing an op outside
+    :data:`BACKWARD_OPS`) would be redundant. Instead each window's input
+    elements are gathered the way :func:`_grad_conv`'s ``dW`` half gathers
+    ``X`` -- one ``Gather`` with :func:`_im2col_indices`'s constant index
+    table -- and compared against the broadcast ``Y`` for that window with
+    the two comparison ops this module already has::
+
+        eq = (1 - Cast(Greater(gathered, Y))) * (1 - Cast(Less(gathered, Y)))
+
+    which is 1 exactly where ``gathered`` equals ``Y`` and 0 elsewhere -- no
+    ``Equal`` needed. A tap the padding invented is masked out unconditionally
+    afterwards (its gathered value is an arbitrary element, which could
+    spuriously equal ``Y``), the same "gather from element 0, multiply the
+    invented ones away" convention :func:`_grad_conv` uses.
+
+    **Ties.** More than one input element exactly equal to a window's max is
+    a measure-zero event for real (or randomly generated) float data, but a
+    rule that assumed it away would misbehave silently the one time it
+    happens. So each window's ``eq`` mask is divided by its own tie count
+    (``ReduceSum`` of ``eq`` over the tap axis, always >= 1 since ``Y`` is
+    that window's max) before being multiplied by the incoming gradient --
+    the same "split the credit" choice :func:`_grad_clip` documents for a
+    value sitting exactly on a bound, made here so that a window's total
+    outgoing gradient sums to exactly the ``dY`` that came in regardless of
+    how many elements tie.
+
+    **The scatter.** Unlike :func:`_grad_conv`'s ``dX`` (whose gathered value
+    is the same for every tap, since the weight does the differentiating),
+    here each tap's credited gradient genuinely differs per tap, so the plain
+    :func:`_col2im_indices` trick -- gather the same ``[planes, out_count]``
+    tensor for every tap -- does not apply as-is. Each tap's slice is instead
+    given its own offset into a flattened ``[taps, out_count]`` axis (tap
+    ``t``'s block starts at ``t * out_count``) so one ``Gather`` still reaches
+    the right tap's own contribution for every input element, then a
+    ``ReduceSum`` over the tap axis sums however many windows each input
+    element belonged to -- the same shape of "sum via gather, not scatter"
+    identity :func:`_col2im_indices`'s own docstring explains.
+    """
+    x, y = node.input[0], node.output[0]
+    x_shape = ctx.shape(x)
+    y_shape = ctx.shape(y)
+    kernel, strides, dilations, pads = _pool_geometry(
+        node, x_shape, y_shape, has_dilations=True
+    )
+
+    planes = int(x_shape[0]) * int(x_shape[1])
+    in_dims = [int(d) for d in x_shape[2:]]
+    out_dims = [int(d) for d in y_shape[2:]]
+    taps = _prod(kernel)
+    in_count, out_count = _prod(in_dims), _prod(out_dims)
+
+    x2 = ctx.b.op("Reshape", [x, ctx.int64_const([planes, in_count], "shape")])
+    index, valid = _im2col_indices(in_dims, out_dims, kernel, strides, dilations, pads)
+    if np.any(valid.reshape(taps, out_count).sum(axis=0) == 0):
+        # A window every tap of which the padding invented has no real
+        # element to route dY to at all: the forward's own max over such a
+        # window is -inf by construction, which no real input value equals,
+        # so the tie count below would be a division by zero rather than a
+        # quietly wrong credit. Caught here, at build time, rather than
+        # producing a NaN gradient at run time.
+        raise UnsupportedOpError(
+            f"MaxPool has a window with no non-padding elements at all "
+            f"(node {node.output[0]!r}); its max, and this rule's gradient "
+            f"for that window, are undefined"
+        )
+    gathered = ctx.b.op("Gather", [x2, ctx.int64_const(index, "idx")], axis=1)
+    windows = ctx.b.op(
+        "Reshape", [gathered, ctx.int64_const([planes, taps, out_count], "shape")]
+    )
+    y3 = ctx.b.op("Reshape", [y, ctx.int64_const([planes, 1, out_count], "shape")])
+
+    not_greater = ctx.b.sub(ctx.b.const(1.0), ctx.mask_greater(windows, y3))
+    not_less = ctx.b.sub(ctx.b.const(1.0), ctx.mask_less(windows, y3))
+    eq = ctx.b.mul(not_greater, not_less)
+    eq = ctx.b.mul(eq, ctx.b.const(valid.reshape(1, taps, out_count), "valid"))
+
+    tie_count = ctx.b.op("ReduceSum", [eq, ctx.int64_const([1], "axes")], keepdims=1)
+    credit = ctx.b.div(eq, tie_count)
+
+    g3 = ctx.b.op("Reshape", [g, ctx.int64_const([planes, 1, out_count], "shape")])
+    contrib = ctx.b.mul(credit, g3)
+    contrib2 = ctx.b.op(
+        "Reshape", [contrib, ctx.int64_const([planes, taps * out_count], "shape")]
+    )
+
+    scatter_index, scatter_mask = _col2im_indices(
+        in_dims, out_dims, kernel, strides, dilations, pads
+    )
+    # Offset each tap's block into its own slice of the flattened
+    # [taps, out_count] axis contrib2 holds -- see the docstring above.
+    for tap in range(taps):
+        base = tap * in_count
+        offset = tap * out_count
+        for entry in range(in_count):
+            scatter_index[base + entry] += offset
+
+    gathered_back = ctx.b.op(
+        "Gather", [contrib2, ctx.int64_const(scatter_index, "idx")], axis=1
+    )
+    masked_back = ctx.b.mul(
+        gathered_back,
+        ctx.b.const(scatter_mask.reshape(1, taps * in_count), "mask"),
+    )
+    col = ctx.b.op(
+        "Reshape", [masked_back, ctx.int64_const([planes, taps, in_count], "shape")]
+    )
+    dx_flat = ctx.b.op("ReduceSum", [col, ctx.int64_const([1], "axes")], keepdims=0)
+    dx = ctx.b.op("Reshape", [dx_flat, ctx.int64_const(x_shape, "shape")])
+    return [dx]
+
+
 def _grad_add(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
     out = ctx.shape(node.output[0])
     return [
@@ -1124,6 +1453,7 @@ def _grad_gather(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[
 
 _RULES: Dict[str, Rule] = {
     "Add": _grad_add,
+    "AveragePool": _grad_averagepool,
     "Clip": _grad_clip,
     "Conv": _grad_conv,
     "Div": _grad_div,
@@ -1134,6 +1464,7 @@ _RULES: Dict[str, Rule] = {
     "Identity": _grad_identity,
     "LayerNormalization": _grad_layer_normalization,
     "MatMul": _grad_matmul,
+    "MaxPool": _grad_maxpool,
     "Mul": _grad_mul,
     "Neg": _grad_neg,
     "ReduceMean": _grad_reduce,

--- a/onnxsim/graph_grad.py
+++ b/onnxsim/graph_grad.py
@@ -884,9 +884,19 @@ def _grad_averagepool(
     taps = _prod(kernel)
     in_count, out_count = _prod(in_dims), _prod(out_dims)
 
-    if count_include_pad or not any(pads):
+    if count_include_pad:
+        # Every window is divided by the full kernel size regardless of
+        # padding -- that is what count_include_pad=1 means -- so this needs
+        # no padding information at all.
         divisor = np.full((1, out_count), float(taps), dtype=np.float64)
     else:
+        # Always the general path, never a "no padding, so it's just
+        # prod(kernel)" shortcut: ``pads`` here is _pool_geometry's
+        # pads_begin only, so a shortcut keyed on it would (and once did)
+        # miss padding that is entirely on the *end* side of an axis, e.g.
+        # explicit pads=[0, 0, 1, 1]. The mask sum below is exactly
+        # prod(kernel) anyway when there truly is no padding on either side,
+        # so nothing is lost by always taking this path.
         _, valid = _im2col_indices(in_dims, out_dims, kernel, strides, dilations, pads)
         divisor = (
             valid.reshape(taps, out_count).sum(axis=0, keepdims=True).astype(np.float64)

--- a/onnxsim/graph_grad_test.cpp
+++ b/onnxsim/graph_grad_test.cpp
@@ -221,9 +221,10 @@ Shapes LayerNormShapes() {
   return {{"X", {2, 3, 4}}, {"S", {4}}, {"Bn", {4}}, {"Y", {2, 3, 4}}};
 }
 
-// A convolution with a bias -- the only rule that emits a Gather, and the
-// only one whose emission depends on arithmetic (the index tables) rather
-// than only on the shapes.
+// A convolution with a bias -- the rule with a weight tensor to
+// differentiate, and (along with MaxPool/AveragePool below) one whose
+// emission depends on arithmetic (the index tables) rather than only on the
+// shapes.
 std::vector<onnx::NodeProto> ConvSlice() {
   return {Node("Conv", {"X", "Wc", "Bc"}, {"Y"})};
 }
@@ -233,6 +234,21 @@ Shapes ConvShapes() {
           {"Wc", {3, 2, 3, 3}},
           {"Bc", {3}},
           {"Y", {1, 3, 2, 2}}};
+}
+
+// A MaxPool feeding an AveragePool -- the two rules that share Conv's
+// im2col/col2im index tables without a weight tensor, and (MaxPool) the one
+// rule other than Clip that emits Greater/Less/Cast.
+std::vector<onnx::NodeProto> PoolSlice() {
+  return {
+      Node("MaxPool", {"X"}, {"M"},
+           {IntsAttr("kernel_shape", {2, 2}), IntsAttr("strides", {2, 2})}),
+      Node("AveragePool", {"M"}, {"Y"}, {IntsAttr("kernel_shape", {1, 1})}),
+  };
+}
+
+Shapes PoolShapes() {
+  return {{"X", {1, 1, 4, 4}}, {"M", {1, 1, 2, 2}}, {"Y", {1, 1, 2, 2}}};
 }
 
 // ---------------------------------------------------------------------------
@@ -245,11 +261,12 @@ Shapes ConvShapes() {
 // browser that the Python refuses, or the reverse.
 void TheSupportedOpsAreExactlyThePythonRuleTable() {
   const std::set<std::string> expected = {
-      "Add",    "Clip",    "Conv",     "Div",        "Erf",
-      "Exp",    "Gather",  "Gemm",     "Identity",   "LayerNormalization",
-      "MatMul", "Mul",     "Neg",      "ReduceMean", "ReduceSum",
-      "Relu",   "Reshape", "Sigmoid",  "Softmax",    "Sqrt",
-      "Sub",    "Tanh",    "Transpose"};
+      "Add",     "AveragePool", "Clip",       "Conv",     "Div",
+      "Erf",     "Exp",         "Gather",     "Gemm",     "Identity",
+      "LayerNormalization",     "MatMul",     "MaxPool",  "Mul",
+      "Neg",     "ReduceMean",  "ReduceSum",  "Relu",     "Reshape",
+      "Sigmoid", "Softmax",     "Sqrt",       "Sub",      "Tanh",
+      "Transpose"};
   Check(SupportedOps() == expected,
         "SupportedOps() should equal graph_grad.py's _RULES keys, got {" +
             Join(SupportedOps()) + "}");
@@ -289,6 +306,7 @@ void TheEmittedBackwardStaysInsideTheOperatorAllowlist() {
       {GemmSlice(), GemmShapes(), {"A", "W", "Cb"}},
       {LayerNormSlice(), LayerNormShapes(), {"X", "S", "Bn"}},
       {ConvSlice(), ConvShapes(), {"X", "Wc", "Bc"}},
+      {PoolSlice(), PoolShapes(), {"X"}},
   };
 
   std::set<std::string> emitted;
@@ -303,7 +321,7 @@ void TheEmittedBackwardStaysInsideTheOperatorAllowlist() {
     emitted.insert(types.begin(), types.end());
   }
   Check(emitted == BackwardOps(),
-        "the six slices together should emit every allowlisted op and no "
+        "the seven slices together should emit every allowlisted op and no "
         "other; got {" +
             Join(emitted) + "}");
 }
@@ -800,6 +818,157 @@ void AGatherWithRankTwoIndicesIsRefused() {
       "rank-2", "a rank-2 index tensor should be refused");
 }
 
+// If this fails, the C++ AveragePool rule has drifted from
+// _grad_averagepool in graph_grad.py. Pinned the same way and for the same
+// reason as the Conv rule above.
+void TheAveragePoolRuleEmitsTheSameNodesInTheSameOrderAsThePython() {
+  const std::vector<onnx::NodeProto> nodes = {
+      Node("AveragePool", {"X"}, {"Y"},
+           {IntsAttr("kernel_shape", {2, 2}), IntsAttr("strides", {2, 2})})};
+  const Shapes shapes = {{"X", {1, 1, 4, 4}}, {"Y", {1, 1, 2, 2}}};
+  GraphBuilder b("bw_");
+  const std::map<std::string, std::string> grads =
+      BuildBackward(b, nodes, shapes, {{"Y", "dY"}}, {"X"});
+  // dY reshaped to [planes, out_count], scaled by the per-window divisor,
+  // then col2im: one gather of the scaled gradient per kernel tap, masked,
+  // and summed over taps -- Conv's dX half with the MatMul against W deleted
+  // outright, since pooling has no weight to sum over.
+  const std::vector<std::string> expected = {
+      "Reshape", "Mul", "Gather", "Mul", "Reshape", "ReduceSum", "Reshape"};
+  Check(OpTypes(b) == expected,
+        "the AveragePool rule should emit graph_grad.py's nodes in its "
+        "order");
+  Check(b.initializer().size() == 7,
+        "the rule emits seven initializers: the reshape-to-[planes,"
+        "out_count] shape, the divisor, the gather index, the mask, the "
+        "col shape, the reduce axes and the final output shape");
+  Check(grads.at("X") == b.nodes().back().output(0),
+        "dX should be the last Reshape's output");
+  const std::set<std::string> emitted = OpTypeSet(b);
+  Check(emitted.count("Conv") == 0 && emitted.count("MatMul") == 0,
+        "AveragePool's gradient needs no weight, so unlike Conv's dX it "
+        "emits no MatMul");
+}
+
+// The same shape of pin as the AveragePool one above, for _grad_maxpool. The
+// sequence is Conv's dW-style windowing gather of X, the eq mask built from
+// Greater/Less/Cast with no Equal and no fresh ReduceMax, the tie count and
+// its Div, then the per-tap-offset scatter this rule needs that
+// AveragePool's uniform-per-tap gradient does not.
+void TheMaxPoolRuleEmitsTheSameNodesInTheSameOrderAsThePython() {
+  const std::vector<onnx::NodeProto> nodes = {
+      Node("MaxPool", {"X"}, {"Y"},
+           {IntsAttr("kernel_shape", {2, 2}), IntsAttr("strides", {2, 2})})};
+  const Shapes shapes = {{"X", {1, 1, 4, 4}}, {"Y", {1, 1, 2, 2}}};
+  GraphBuilder b("bw_");
+  const std::map<std::string, std::string> grads =
+      BuildBackward(b, nodes, shapes, {{"Y", "dY"}}, {"X"});
+  const std::vector<std::string> expected = {
+      "Reshape",   "Gather",  "Reshape",   "Reshape", "Greater", "Cast",
+      "Sub",       "Less",    "Cast",      "Sub",     "Mul",     "Mul",
+      "ReduceSum", "Div",     "Reshape",   "Mul",     "Reshape", "Gather",
+      "Mul",       "Reshape", "ReduceSum", "Reshape"};
+  Check(OpTypes(b) == expected,
+        "the MaxPool rule should emit graph_grad.py's nodes in its order");
+  Check(b.initializer().size() == 15, "the rule emits fifteen initializers");
+  Check(grads.at("X") == b.nodes().back().output(0),
+        "dX should be the last Reshape's output");
+  const std::set<std::string> emitted = OpTypeSet(b);
+  Check(emitted.count("Equal") == 0,
+        "the eq mask is built from Greater/Less/Cast, never Equal");
+  Check(emitted.count("Conv") == 0 && emitted.count("MatMul") == 0 &&
+            emitted.count("ReduceMax") == 0,
+        "MaxPool's gradient needs no weight and reuses the forward's own "
+        "output instead of a fresh ReduceMax");
+}
+
+// If this fails, a pooling geometry this rule cannot invert would be
+// differentiated against one it invented instead -- the same hazard
+// AConvWhoseGeometryDoesNotAddUpIsRefused checks for Conv, and the same
+// refusals PoolGeometryOf makes by the same name as _pool_geometry.
+void APoolGeometryThatDoesNotResolveIsRefused() {
+  for (const std::string& op :
+       {std::string("MaxPool"), std::string("AveragePool")}) {
+    {
+      // kernel_shape is required for both -- unlike Conv, there is no
+      // weight tensor to read it off.
+      const Shapes shapes = {{"X", {1, 1, 4, 4}}, {"Y", {1, 1, 2, 2}}};
+      GraphBuilder b;
+      CheckThrows<UnsupportedOpError>(
+          [&] {
+            BuildBackward(b, {Node(op, {"X"}, {"Y"})}, shapes, {{"Y", "dY"}},
+                          {"X"});
+          },
+          "kernel_shape", op + " without kernel_shape is refused");
+    }
+    {
+      // ceil_mode=1 is refused outright rather than reproduced -- see
+      // PoolGeometryOf's comment for why.
+      const Shapes shapes = {{"X", {1, 1, 5, 5}}, {"Y", {1, 1, 3, 3}}};
+      GraphBuilder b;
+      CheckThrows<UnsupportedOpError>(
+          [&] {
+            BuildBackward(
+                b,
+                {Node(op, {"X"}, {"Y"},
+                      {IntsAttr("kernel_shape", {2, 2}),
+                       IntsAttr("strides", {2, 2}), IntAttr("ceil_mode", 1)})},
+                shapes, {{"Y", "dY"}}, {"X"});
+          },
+          "ceil_mode", op + " with ceil_mode=1 is refused");
+    }
+    {
+      // A typo'd auto_pad must not silently fall back to no padding.
+      const Shapes shapes = {{"X", {1, 1, 5, 5}}, {"Y", {1, 1, 3, 3}}};
+      GraphBuilder b;
+      CheckThrows<UnsupportedOpError>(
+          [&] {
+            BuildBackward(b,
+                          {Node(op, {"X"}, {"Y"},
+                                {IntsAttr("kernel_shape", {3, 3}),
+                                 IntsAttr("strides", {2, 2}),
+                                 StrAttr("auto_pad", "SAME")})},
+                          shapes, {{"Y", "dY"}}, {"X"});
+          },
+          "auto_pad", op + " with an unknown auto_pad is refused");
+    }
+    {
+      // The declared output shape has to follow from the attributes.
+      const Shapes shapes = {{"X", {1, 1, 5, 5}}, {"Y", {1, 1, 4, 4}}};
+      GraphBuilder b;
+      CheckThrows<UnsupportedOpError>(
+          [&] {
+            BuildBackward(b,
+                          {Node(op, {"X"}, {"Y"},
+                                {IntsAttr("kernel_shape", {3, 3}),
+                                 IntsAttr("strides", {2, 2})})},
+                          shapes, {{"Y", "dY"}}, {"X"});
+          },
+          "does not follow from",
+          op + " with an inconsistent output shape is refused");
+    }
+    {
+      // A window that is entirely padding: kernel_shape=[1] against a
+      // length-1 input padded by 1 on each side puts the first and last of
+      // three output windows fully in the padding, where neither this
+      // rule's divisor (AveragePool) nor its tie count (MaxPool) is
+      // defined.
+      const Shapes shapes = {{"X", {1, 1, 1}}, {"Y", {1, 1, 3}}};
+      GraphBuilder b;
+      CheckThrows<UnsupportedOpError>(
+          [&] {
+            BuildBackward(b,
+                          {Node(op, {"X"}, {"Y"},
+                                {IntsAttr("kernel_shape", {1}),
+                                 IntsAttr("pads", {1, 1})})},
+                          shapes, {{"Y", "dY"}}, {"X"});
+          },
+          "no non-padding elements",
+          op + " with a window that is entirely padding is refused");
+    }
+  }
+}
+
 // If this fails, a tensor read by two consumers -- a residual connection's
 // own input, which is why this matters -- would keep only one contribution,
 // and the parameter upstream of it would train on a fraction of its
@@ -909,6 +1078,9 @@ int main() {
   ConvsOfAnyRankDifferentiateIdentically();
   TheGatherRuleEmitsTheSameNodesInTheSameOrderAsThePython();
   AGatherWithRankTwoIndicesIsRefused();
+  TheAveragePoolRuleEmitsTheSameNodesInTheSameOrderAsThePython();
+  TheMaxPoolRuleEmitsTheSameNodesInTheSameOrderAsThePython();
+  APoolGeometryThatDoesNotResolveIsRefused();
   ATensorReadTwiceAccumulatesItsContributions();
   AnIdentityAliasesTheSeedInsteadOfEmittingANode();
   TheReturnedMapCoversExactlyTheRequestedTargets();

--- a/onnxsim/graph_grad_test.cpp
+++ b/onnxsim/graph_grad_test.cpp
@@ -260,13 +260,31 @@ Shapes PoolShapes() {
 // SupportedOps rather than to catch refusals) would admit a block in the
 // browser that the Python refuses, or the reverse.
 void TheSupportedOpsAreExactlyThePythonRuleTable() {
-  const std::set<std::string> expected = {
-      "Add",     "AveragePool", "Clip",       "Conv",     "Div",
-      "Erf",     "Exp",         "Gather",     "Gemm",     "Identity",
-      "LayerNormalization",     "MatMul",     "MaxPool",  "Mul",
-      "Neg",     "ReduceMean",  "ReduceSum",  "Relu",     "Reshape",
-      "Sigmoid", "Softmax",     "Sqrt",       "Sub",      "Tanh",
-      "Transpose"};
+  const std::set<std::string> expected = {"Add",
+                                          "AveragePool",
+                                          "Clip",
+                                          "Conv",
+                                          "Div",
+                                          "Erf",
+                                          "Exp",
+                                          "Gather",
+                                          "Gemm",
+                                          "Identity",
+                                          "LayerNormalization",
+                                          "MatMul",
+                                          "MaxPool",
+                                          "Mul",
+                                          "Neg",
+                                          "ReduceMean",
+                                          "ReduceSum",
+                                          "Relu",
+                                          "Reshape",
+                                          "Sigmoid",
+                                          "Softmax",
+                                          "Sqrt",
+                                          "Sub",
+                                          "Tanh",
+                                          "Transpose"};
   Check(SupportedOps() == expected,
         "SupportedOps() should equal graph_grad.py's _RULES keys, got {" +
             Join(SupportedOps()) + "}");

--- a/onnxsim/qat_parity_fixtures.txt
+++ b/onnxsim/qat_parity_fixtures.txt
@@ -3,7 +3,7 @@
 # Asserted against onnxsim/qat_graph.py (tests/test_qat_parity.py) and
 # against onnxsim/qat_graph_builder.cpp (onnxsim/qat_graph_parity_test.cpp).
 ops Abs,Add,Cast,Clip,Div,Exp,Gather,Greater,Less,MatMul,Mul,Neg,Pow,ReduceMean,ReduceSum,Reshape,Sigmoid,Sign,Sqrt,Sub,Transpose
-rules Add,Clip,Conv,Div,Erf,Exp,Gather,Gemm,Identity,LayerNormalization,MatMul,Mul,Neg,ReduceMean,ReduceSum,Relu,Reshape,Sigmoid,Softmax,Sqrt,Sub,Tanh,Transpose
+rules Add,AveragePool,Clip,Conv,Div,Erf,Exp,Gather,Gemm,Identity,LayerNormalization,MatMul,MaxPool,Mul,Neg,ReduceMean,ReduceSum,Relu,Reshape,Sigmoid,Softmax,Sqrt,Sub,Tanh,Transpose
 backward_ops Add,Cast,Div,Exp,Gather,Greater,Less,MatMul,Mul,Neg,ReduceMean,ReduceSum,Reshape,Sqrt,Sub,Transpose
 model_text <ir_version: 10, opset_import: ["" : 21]>
 model_text g (float[4,32] X) => (float[4,32] Y) {

--- a/tests/test_graph_grad.py
+++ b/tests/test_graph_grad.py
@@ -616,6 +616,140 @@ _CASES = {
         """,
         None,
     ),
+    # MaxPool/AveragePool: both share _pool_geometry with Conv's discipline
+    # (resolve attributes, then require the resolved geometry to reproduce
+    # the node's own declared output shape), and both rules reuse the same
+    # im2col/col2im index tables Conv's rule does -- see _grad_maxpool and
+    # _grad_averagepool for why neither needs a MatMul or a ReduceMax.
+    "maxpool": (
+        """
+        g (float[1,2,4,4] A) => (float[1,2,2,2] Y) {
+          Y = MaxPool <kernel_shape = [2, 2], strides = [2, 2]> (A)
+        }
+        """,
+        None,
+    ),
+    "maxpool_strided_padded": (
+        """
+        g (float[1,2,5,5] A) => (float[1,2,3,3] Y) {
+          Y = MaxPool <kernel_shape = [3, 3], strides = [2, 2],
+                       pads = [1, 1, 1, 1]> (A)
+        }
+        """,
+        None,
+    ),
+    # dilations is MaxPool-only -- AveragePool has no such attribute, per the
+    # ONNX spec, and this rule does not invent support for it.
+    "maxpool_dilated": (
+        """
+        g (float[1,1,5,5] A) => (float[1,1,3,3] Y) {
+          Y = MaxPool <kernel_shape = [2, 2], dilations = [2, 2]> (A)
+        }
+        """,
+        None,
+    ),
+    "maxpool_1d": (
+        """
+        g (float[1,2,7] A) => (float[1,2,3] Y) {
+          Y = MaxPool <kernel_shape = [3], strides = [2]> (A)
+        }
+        """,
+        None,
+    ),
+    "maxpool_3d": (
+        """
+        g (float[1,1,4,4,4] A) => (float[1,1,2,2,2] Y) {
+          Y = MaxPool <kernel_shape = [2, 2, 2], strides = [2, 2, 2]> (A)
+        }
+        """,
+        None,
+    ),
+    # SAME_UPPER only: onnx's reference evaluator itself computes the wrong
+    # output shape for a MaxPool with auto_pad=SAME_LOWER (checked against
+    # onnxruntime when this was written -- the same shape of reference-
+    # evaluator bug the Conv auto_pad cases' comment already notes for a
+    # different attribute combination). SAME_LOWER is covered instead, for
+    # both ops, by the graph-equivalence check beside the Conv one.
+    "maxpool_same_upper": (
+        """
+        g (float[1,2,5,6] A) => (float[1,2,3,3] Y) {
+          Y = MaxPool <kernel_shape = [3, 3], strides = [2, 2],
+                       auto_pad = "SAME_UPPER"> (A)
+        }
+        """,
+        None,
+    ),
+    "averagepool": (
+        """
+        g (float[1,2,4,4] A) => (float[1,2,2,2] Y) {
+          Y = AveragePool <kernel_shape = [2, 2], strides = [2, 2]> (A)
+        }
+        """,
+        None,
+    ),
+    # The interesting AveragePool path: count_include_pad=0 (the default)
+    # with nonzero padding gives each border window a smaller divisor than
+    # the interior windows get, which is exactly what a uniform
+    # prod(kernel) divisor would get wrong.
+    "averagepool_count_exclude_pad": (
+        """
+        g (float[1,2,5,5] A) => (float[1,2,3,3] Y) {
+          Y = AveragePool <kernel_shape = [3, 3], strides = [2, 2],
+                           pads = [1, 1, 1, 1]> (A)
+        }
+        """,
+        None,
+    ),
+    # Same shape and padding, but count_include_pad=1: the divisor is
+    # prod(kernel) everywhere, including the border windows the case above
+    # gives a smaller divisor -- the two cases are a minimal pair for that
+    # branch in the divisor computation.
+    "averagepool_count_include_pad": (
+        """
+        g (float[1,2,5,5] A) => (float[1,2,3,3] Y) {
+          Y = AveragePool <kernel_shape = [3, 3], strides = [2, 2],
+                           pads = [1, 1, 1, 1], count_include_pad = 1> (A)
+        }
+        """,
+        None,
+    ),
+    "averagepool_1d": (
+        """
+        g (float[1,2,7] A) => (float[1,2,3] Y) {
+          Y = AveragePool <kernel_shape = [3], strides = [2]> (A)
+        }
+        """,
+        None,
+    ),
+    "averagepool_3d": (
+        """
+        g (float[1,1,4,4,4] A) => (float[1,1,2,2,2] Y) {
+          Y = AveragePool <kernel_shape = [2, 2, 2], strides = [2, 2, 2]> (A)
+        }
+        """,
+        None,
+    ),
+    # Unlike MaxPool's, onnx's reference evaluator agrees with onnxruntime on
+    # AveragePool's SAME_LOWER, so both spellings are differenced directly
+    # here rather than only checked for graph equivalence.
+    "averagepool_same_upper": (
+        """
+        g (float[1,2,5,6] A) => (float[1,2,3,3] Y) {
+          Y = AveragePool <kernel_shape = [3, 3], strides = [2, 2],
+                           auto_pad = "SAME_UPPER"> (A)
+        }
+        """,
+        None,
+    ),
+    "averagepool_same_lower": (
+        """
+        g (float[1,2,5,6] A) => (float[1,2,3,3] Y) {
+          Y = AveragePool <kernel_shape = [3, 3], strides = [2, 2],
+                           auto_pad = "SAME_LOWER"> (A)
+        }
+        """,
+        None,
+    ),
     "clip": (
         """
         g (float[3,4] A) => (float[3,4] Y)
@@ -1144,6 +1278,39 @@ def test_auto_pad_resolves_to_the_padding_the_spec_asks_for(
     assert _emitted(automatic) == _emitted(explicit)
 
 
+def test_maxpool_same_lower_resolves_to_the_padding_the_spec_asks_for():
+    """The pooling equivalent of the Conv check above, for the one auto_pad
+    spelling ``_CASES`` cannot finite-difference directly.
+
+    5 and 6 against a 3-wide kernel at stride 2 need 2 and 1 pads
+    respectively, so SAME_LOWER puts the odd one at the *beginning* --
+    ``pads = [1, 1, 1, 0]`` -- where SAME_UPPER (already differenced in
+    ``_CASES`` as ``maxpool_same_upper``) puts it at the end. onnx's own
+    reference evaluator computes the wrong *output shape* for a MaxPool with
+    auto_pad=SAME_LOWER (checked against onnxruntime when this rule was
+    written -- shape ``(1, 2, 2, 3)`` instead of ``(1, 2, 3, 3)``), which
+    rules out finite-differencing this one the way every other case here is
+    checked; this equivalence covers it instead.
+    """
+    automatic = _model(
+        """
+        g (float[1,2,5,6] A) => (float[1,2,3,3] Y) {
+          Y = MaxPool <kernel_shape = [3, 3], strides = [2, 2],
+                       auto_pad = "SAME_LOWER"> (A)
+        }
+        """
+    )
+    explicit = _model(
+        """
+        g (float[1,2,5,6] A) => (float[1,2,3,3] Y) {
+          Y = MaxPool <kernel_shape = [3, 3], strides = [2, 2],
+                       pads = [1, 1, 1, 0]> (A)
+        }
+        """
+    )
+    assert _emitted(automatic) == _emitted(explicit)
+
+
 def test_a_convolutions_gradient_contains_no_convolution():
     """The design claim of :func:`onnxsim.graph_grad._grad_conv`, checked
     rather than only argued.
@@ -1296,6 +1463,114 @@ def test_a_conv_whose_output_shape_does_not_follow_is_refused():
             qat_graph.GraphBuilder(),
             list(model.graph.node),
             shapes,
+            {"Y": "dY"},
+            ["A"],
+        )
+
+
+@pytest.mark.parametrize(
+    "op", ["MaxPool", "AveragePool"], ids=["maxpool", "averagepool"]
+)
+@pytest.mark.parametrize(
+    "attributes,fragment",
+    [
+        ("", "kernel_shape"),
+        ("<kernel_shape = [3, 3], strides = [2]>", "one entry per spatial axis"),
+        (
+            '<kernel_shape = [3, 3], strides = [2, 2], auto_pad = "SAME">',
+            "auto_pad",
+        ),
+        (
+            "<kernel_shape = [2, 2], strides = [2, 2], ceil_mode = 1>",
+            "ceil_mode",
+        ),
+    ],
+    ids=["no_kernel_shape", "wrong_strides_length", "unknown_auto_pad", "ceil_mode"],
+)
+def test_a_pool_this_rule_cannot_invert_is_refused(op, attributes, fragment):
+    """A ``MaxPool``/``AveragePool`` whose geometry does not add up, or whose
+    ``ceil_mode``/``auto_pad`` this rule refuses to guess at, is refused by
+    name -- the same discipline :func:`_conv_geometry` is held to, since
+    :func:`_pool_geometry` is written to the same standard.
+
+    ``ceil_mode=1`` is deliberately never made to work here (see
+    ``_pool_geometry``'s docstring): it can put a window's far edge fully
+    inside the padding, a case runtimes do not agree on, and this rule cannot
+    reproduce a convention it has not pinned down.
+    """
+    # The declared output shape only has to be one the parser accepts -- each
+    # of these is refused before _pool_geometry ever reaches its own
+    # output-shape check.
+    model = _model(
+        f"""
+        g (float[1,2,5,5] A) => (float[1,2,2,2] Y) {{
+          Y = {op} {attributes} (A)
+        }}
+        """
+    )
+    shapes = {
+        value.name: [d.dim_value for d in value.type.tensor_type.shape.dim]
+        for value in list(model.graph.input) + list(model.graph.output)
+    }
+    with pytest.raises(graph_grad.UnsupportedOpError, match=fragment):
+        graph_grad.build_backward(
+            qat_graph.GraphBuilder(),
+            list(model.graph.node),
+            shapes,
+            {"Y": "dY"},
+            ["A"],
+        )
+
+
+@pytest.mark.parametrize(
+    "op", ["MaxPool", "AveragePool"], ids=["maxpool", "averagepool"]
+)
+def test_a_pool_with_a_window_that_is_entirely_padding_is_refused(op):
+    """A geometry where some window has no non-padding element in it at all
+    -- the pooling analogue of dividing by zero. ``kernel_shape=[1]`` with a
+    pad of 1 on each side of a length-1 input puts the first and last of the
+    three output windows entirely in the padding, which this rule refuses
+    rather than emitting a graph that divides by zero (AveragePool's
+    divisor) or a tie count of zero (MaxPool's credit) at run time.
+    """
+    model = _model(
+        f"""
+        g (float[1,1,1] A) => (float[1,1,3] Y) {{
+          Y = {op} <kernel_shape = [1], pads = [1, 1]> (A)
+        }}
+        """
+    )
+    with pytest.raises(graph_grad.UnsupportedOpError, match="no non-padding elements"):
+        graph_grad.build_backward(
+            qat_graph.GraphBuilder(),
+            list(model.graph.node),
+            {"A": [1, 1, 1], "Y": [1, 1, 3]},
+            {"Y": "dY"},
+            ["A"],
+        )
+
+
+def test_a_maxpools_indices_output_is_refused():
+    """``MaxPool``'s optional second output is refused the same way any
+    multi-output node is -- ``build_backward``'s own single-output check,
+    which runs before any rule does -- rather than by a check in
+    ``_grad_maxpool`` itself. There is nothing this rule could sensibly
+    return a gradient *for* on an integer ``Indices`` tensor anyway, so the
+    existing refusal already covers it exactly.
+    """
+    model = onnx.parser.parse_model(
+        f"{_HEADER}\n"
+        """
+        g (float[1,1,4,4] A) => (float[1,1,2,2] Y) {
+          Y, Ind = MaxPool <kernel_shape = [2, 2], strides = [2, 2]> (A)
+        }
+        """
+    )
+    with pytest.raises(graph_grad.UnsupportedOpError, match="2 outputs"):
+        graph_grad.build_backward(
+            qat_graph.GraphBuilder(),
+            list(model.graph.node),
+            {"A": [1, 1, 4, 4], "Y": [1, 1, 2, 2]},
             {"Y": "dY"},
             ["A"],
         )

--- a/tests/test_graph_grad.py
+++ b/tests/test_graph_grad.py
@@ -700,6 +700,20 @@ _CASES = {
         """,
         None,
     ),
+    # A regression case for a real bug this rule had while count_include_pad
+    # was applied to the padding's *begin* side only: an all-zero pads_begin
+    # with a nonzero pads_end (asymmetric, end-only padding) was
+    # misdetected as "no padding at all" and given a uniform prod(kernel)
+    # divisor instead of the smaller one its last window actually needs.
+    "averagepool_count_exclude_pad_end_only": (
+        """
+        g (float[1,1,4,4] A) => (float[1,1,4,4] Y) {
+          Y = AveragePool <kernel_shape = [2, 2], strides = [1, 1],
+                           pads = [0, 0, 1, 1]> (A)
+        }
+        """,
+        None,
+    ),
     # Same shape and padding, but count_include_pad=1: the divisor is
     # prod(kernel) everywhere, including the border windows the case above
     # gives a smaller divisor -- the two cases are a minimal pair for that


### PR DESCRIPTION
## What this does

Adds VJP rules for `MaxPool` and `AveragePool` to `graph_grad`, in both the Python emitter and its C++ port. `#1247`/`#1249` gave `Conv` a gradient rule so a convolution stops splitting a block; pooling was the other block boundary a real CNN hits constantly, so this was the natural next gap.

**The shared geometry.** `_pool_geometry`/`PoolGeometryOf` resolve `kernel_shape`/`strides`/`dilations`/`pads`/`auto_pad` against the node's own declared shapes, modeled directly on `_conv_geometry`/`ConvGeometryOf`. `ceil_mode=1` is refused outright rather than reproduced — ONNX leaves the last-window/padding interaction underspecified there and runtimes disagree — and so is any `auto_pad` other than `NOTSET`/`VALID`/`SAME_UPPER`/`SAME_LOWER`.

**`AveragePool`** reuses `_grad_conv`'s `dX` half with the `MatMul` against `W` deleted outright (pooling is depthwise, so there's no weight to sum over): a `Gather`+mask col2im of the incoming gradient, scaled by a per-window divisor baked into a constant (uniform `prod(kernel)` normally, per-position when `count_include_pad=0` with nonzero padding).

**`MaxPool`** gathers each window's input elements, compares them against the forward's own output (`node.output[0]`) with `Greater`/`Less`/`Cast` to build an equality mask — no `Equal`, no fresh `ReduceMax` — splits credit across ties, then scatters back the same col2im way. Both rules emit only ops already in `BACKWARD_OPS`; no new op admitted for either.

**Refused, not guessed at:** `ceil_mode=1`, an unresolvable `kernel_shape`, an unknown `auto_pad`, a declared output shape the geometry doesn't reproduce, and a window with zero non-padding elements (would otherwise divide by zero for `AveragePool` or hit a zero tie-count for `MaxPool`). `GlobalMaxPool`/`GlobalAveragePool` are different op types with no rule, refused the ordinary way. `MaxPool`'s optional `Indices` output is already refused by `build_backward`'s existing single-output check.

**A real bug found and fixed during the C++ transcription.** Porting the rule line-by-line surfaced that `_grad_averagepool`'s "no padding, use the uniform `prod(kernel)` divisor" shortcut checked `pads`, which `_pool_geometry` returns as `pads_begin` only — so asymmetric, end-only padding (e.g. `pads=[0,0,1,1]`) with `count_include_pad=0` silently got the wrong divisor. Confirmed via finite difference (mismatches up to 38% relative error) before fixing it by dropping the shortcut in favor of the mask-summing general path (which already reduces to `prod(kernel)` when there's truly no padding), adding a regression case, then porting the corrected version to C++.

**What this does not fix.** Pooling no longer splits a block, but the rest of a real CNN's usual neighbors — nonlinearities and normalization aside — are unaffected. This PR is scoped to pooling's own gradient; no other op gained a rule here.

## Parity

`onnxsim/graph_grad.cpp` mirrors both Python rules node-for-node (`GradMaxPool`/`GradAveragePool`/`PoolGeometryOf`, modeled on `GradConv`/`ConvGeometryOf`), registered in the C++ rules map. `onnxsim/qat_parity_fixtures.txt` regenerated. This branch was rebased onto `#1256` (Gather's gradient, merged first) — both PRs touched `graph_grad_test.cpp`'s `SupportedOps()` pin and the parity fixture, so this includes the union of both rule sets plus a clang-format pass on the merged initializer list.

## Verification

- `pytest tests/test_graph_grad.py tests/test_qat_parity.py tests/test_qat.py tests/test_qat_graph.py tests/test_qat_interop.py -q` — 303 passed.
- `mypy onnxsim/graph_grad.py`, `ruff check`/`ruff format --check` — clean.
- `clang-format --dry-run --Werror` on both touched C++ files — clean.
- Fresh from-scratch C++ build (`-DONNXSIM_BUILTIN_ORT=OFF -DONNXSIM_TESTS=ON`), independently reproduced on the final merged branch: `graph_grad_test`, `qat_graph_parity_test`, and `qat_entry_test` all pass on freshly built binaries (verified by binary mtime postdating every touched source file).

New Python cases: plain/strided+padded/dilated/1-D/3-D/`auto_pad` variants for both ops, `count_include_pad` variants for `AveragePool`, a `MaxPool` graph-equivalence test for `SAME_LOWER` (onnx's reference evaluator computes the wrong output shape for that specific combination — verified against onnxruntime), and refusal tests for `ceil_mode`, bad geometry, an all-padding window, and the `Indices` output. New C++ tests mirror the same node-sequence pins and refusals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_