### PR TITLE
mcode: dilation reorders the weights -- the vocoder goes from 4 to 10 of 23 layers

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4443,17 +4443,56 @@ The chunk boundary was the other thing the earlier probes missed: they only
 touched slots below 36, so they never crossed one. Slot 36 lands at byte 144
 and slot 64 at 172, so the chunk stride is 144, unchanged from 32 channels.
 
-**On the vocoder this moves 1 layer to 4 of 23** -- one each at 32, 64 and 128
-channels plus the final 1-channel convolution, which reads at 1.0000. That is
-3.9% of its weights, so the headline is still that the vocoder is mostly
-unread. What now blocks it is narrower and visible: every located layer has
-`K = 3`, and every `K = 5`, `K = 7` and `ConvTranspose` layer still fails. A
-single 32-channel `K = 7` convolution locates perfectly on its own, so the
-kernel size is not the problem by itself -- something about those shapes
-inside a larger graph is, and that is the next thing to probe.
+**On the vocoder this moves 1 layer to 4 of 23**, and reading the failures
+properly then moved it to 10 -- see the next section.
 
 Test: `test_1d_weight_layout_holds_at_64_and_128_channels` (Docker, no
 device).
+
+### Dilation reorders the weights
+
+The "every located layer has K=3" reading of the vocoder was the wrong
+variable. Its resblocks pair convolutions of the *same* shape that differ only
+in dilation -- 1 against 2, 2 against 6, 3 against 12 -- and exactly one of
+each pair was locating. Every failure had dilation greater than one.
+
+**Dilation changes the layout, and only the layout.** A 64-channel `K = 3`
+convolution built at dilation 1, 2 and 4 produces a weight table of *identical
+size* (14,376 bytes) each time, and the undilated rule reads them at 100%,
+33.7% and 33.7%. Same data, rearranged -- and the two dilated builds agree
+with each other, so the arrangement does not depend on *how much* dilation,
+only on whether there is any.
+
+**The dilated rule is simpler than the undilated one.** Probing gives the
+kernel index its own chunk:
+
+    undilated:  slot = (Cin/2)*k + i//2, then chunk by 36 with stride 144
+    dilated:    byte = 144*k + i//2
+
+Each tap starts a fresh 144-byte chunk instead of packing taps together, which
+is what you would expect when the taps read discontiguous input. Everything
+else -- the output-channel map, the 36-byte plane gap, the nibble by `i % 2`
+-- is unchanged. Verified at 100.000% of codes.
+
+**The vocoder goes from 4 to 10 of 23 layers.** Every 32-channel layer now
+reads, and most 64-channel ones. The remaining failures are a narrower set
+again:
+
+| still unread | why it is plausible |
+| --- | --- |
+| all three `ConvTranspose` | a layout never probed at all |
+| `conv_pre` (256, 192, 7) | 192 and 256 channels, past anything measured |
+| 128-channel dilated layers | 128 works undilated, so the two rules interact |
+| dilation 6 and 12 at 64 channels | 32 channels handles both, so it interacts with width |
+
+That is still only **7.1% of the vocoder's weights**, because the three
+transposed convolutions and `conv_pre` hold most of them. The honest summary
+is that the vocoder's *small* layers are now fully readable and its *large*
+ones are not.
+
+Test: `test_dilation_changes_the_weight_layout` (Docker, no device), which
+checks both rules against their own builds and that the undilated rule does
+not read a dilated one.
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4924,6 +4924,68 @@ def _weight1d_offset_wide(o, i, k, cin, cout, kernel, top):
     ), (4 if i % 2 else 0)
 
 
+def test_dilation_changes_the_weight_layout(tmp_path):
+    """Confirmed real (see the README's "Dilation reorders the weights"
+    section): a dilated convolution stores its weights in a *different*
+    arrangement from an undilated one of the same shape. Each kernel tap gets
+    its own 144-byte chunk instead of packing into the shared slot index.
+
+    The table is the same size either way, so this is a reordering rather
+    than a different amount of data -- which is why reading a dilated layer
+    with the undilated rule returns plausible-looking noise (about a third of
+    the codes right by chance) rather than failing outright. Needs Docker, no
+    device.
+    """
+    cin = cout = 64
+    kernel, length = 3, 64
+    rng = np.random.RandomState(5)
+    weights = rng.randn(cout, cin, kernel) * 0.05
+    for o in range(cout):
+        weights[o] *= 0.2 / np.abs(weights[o]).max()
+    weights = weights.astype(np.float32)
+    expected = _quantize_conv_weights(weights)
+
+    def read(wbt, dilated):
+        got = np.zeros(weights.shape, dtype=int)
+        for o in range(cout):
+            for i in range(cin):
+                for k in range(kernel):
+                    if dilated:
+                        off = (
+                            432 * (o % 16)
+                            + 72 * ((o >> 4) & 1)
+                            + 16 * 432 * (o >> 5)
+                            + 144 * k
+                            + i // 2
+                        )
+                        shift = 4 if i % 2 else 0
+                    else:
+                        off, shift = _weight1d_offset_wide(
+                            o, i, k, cin, cout, kernel, 16 * 432
+                        )
+                    got[o, i, k] = (
+                        ((wbt[off + _WBT_PLANE_GAP] >> shift) & 0xF) << 4
+                    ) | ((wbt[off] >> shift) & 0xF)
+        return got
+
+    tables = {}
+    for dilation in (1, 2):
+        work = tmp_path / f"d{dilation}"
+        work.mkdir()
+        model = _one_conv_model(
+            cin, cout, length, kernel, dilation=dilation, weights=weights
+        )
+        tables[dilation] = _wbt_of(_build_single_op_axmodel(str(work), "m", model))
+
+    # Each layout reads its own build exactly...
+    assert (read(tables[1], dilated=False) == expected).all(), "undilated"
+    assert (read(tables[2], dilated=True) == expected).all(), "dilated"
+    # ... and the undilated rule does not read the dilated build.
+    assert not (read(tables[2], dilated=False) == expected).all()
+    # Same size: a reordering, not more data.
+    assert len(tables[1]) == len(tables[2]), (len(tables[1]), len(tables[2]))
+
+
 def test_1d_weight_layout_holds_at_64_and_128_channels(tmp_path):
     """Confirmed real (see the README's "Closing the 1-D layout to 128
     channels" section): the 1-D weight layout, which stopped working past 32


### PR DESCRIPTION
#1255 read the vocoder's failures as "every located layer has K=3". That was the **wrong variable**.

The vocoder's resblocks pair convolutions of the *same shape* that differ only in **dilation** -- 1 against 2, 2 against 6, 3 against 12 -- and exactly one of each pair was locating. Every failure had dilation greater than one.

### Dilation changes the layout, and only the layout

A 64-channel `K = 3` convolution built at dilation 1, 2 and 4 produces a weight table of **identical size** (14,376 bytes) every time, and the undilated rule reads them at 100%, 33.7% and 33.7%.

Same data, rearranged. The two dilated builds also agree with each other, so the arrangement depends on *whether* there is dilation, not on how much.

### The dilated rule is simpler than the undilated one

```
undilated:  slot = (Cin/2)*k + i//2, then chunk by 36 with stride 144
dilated:    byte = 144*k + i//2
```

Each kernel tap starts a fresh 144-byte chunk instead of packing taps together -- which is what you would expect when the taps read discontiguous input. Everything else (the output-channel map, the 36-byte plane gap, the nibble by `i % 2`) is unchanged. Verified at **100.000%** of codes.

### The vocoder goes from 4 to 10 of 23 layers

Every 32-channel layer now reads, and most 64-channel ones. The remaining failures are a narrower set again:

| still unread | why it is plausible |
| --- | --- |
| all three `ConvTranspose` | a layout never probed at all |
| `conv_pre` (256, 192, 7) | 192 and 256 channels, past anything measured |
| 128-channel dilated layers | 128 works undilated, so the two rules interact |
| dilation 6 and 12 at 64 channels | 32 channels handles both, so it interacts with width |

That is still only **7.1% of the vocoder's weights**, because the three transposed convolutions and `conv_pre` hold most of them. The honest summary: the vocoder's *small* layers are now fully readable and its *large* ones are not.

### Test

`test_dilation_changes_the_weight_layout` (Docker, no device) -- checks both rules against their own builds, and that the undilated rule does **not** read a dilated one (it returns about a third of the codes right by chance, which is why this failed quietly before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS