### PR TITLE
Fix master CI: sync qat_blocks.mjs's DIFFERENTIABLE_OPS with graph_grad, run all JS tests on PR CI

### DIFF
--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run trace-assembler unit test
         working-directory: scripts/convertmodel
         run: npm run test:trace
+      - name: Run node-reduction chart unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:node-reduction
       - name: Run MAC-metrics reader unit test
         working-directory: scripts/convertmodel
         run: npm run test:macs
@@ -42,15 +45,15 @@ jobs:
       - name: Run Hugging Face loader unit test
         working-directory: scripts/convertmodel
         run: npm run test:hf
+      - name: Run Hugging Face token storage unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:hftoken
       - name: Run Xet chunk-cache unit test
         working-directory: scripts/convertmodel
         run: npm run test:xet
-      - name: Run WebNN helper unit test
+      - name: Run issue-report URL builder unit test
         working-directory: scripts/convertmodel
-        run: npm run test:webnn
-      - name: Run browser-calibration unit test
-        working-directory: scripts/convertmodel
-        run: npm run test:quantize-cal
+        run: npm run test:issue
       - name: Run library-versions unit test
         working-directory: scripts/convertmodel
         run: npm run test:versions
@@ -60,12 +63,45 @@ jobs:
       - name: Run query-parameter unit test
         working-directory: scripts/convertmodel
         run: npm run test:query
+      - name: Run WebNN helper unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:webnn
+      - name: Run ORT log-capture unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:ortlog
       - name: Run CDN source-of-truth unit test
         working-directory: scripts/convertmodel
         run: npm run test:cdn
       - name: Run input-fill helper unit test
         working-directory: scripts/convertmodel
         run: npm run test:fill
+      - name: Run tokenizer-family resolution unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:tokenize
+      - name: Run Hugging Face sample-datasets unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:hfdata
+      - name: Run sample-inputs unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:sample
+      - name: Run output-classification unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:classify
+      - name: Run quantization-risk-estimate unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:quantize-risk
+      - name: Run browser-calibration unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:quantize-cal
+      - name: Run QAT block-discovery unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:qat-blocks
+      - name: Run QAT fine-tune loop unit test
+        working-directory: scripts/convertmodel
+        run: npm run test:qat-finetune
+      - name: Run QAT loop vs. onnxruntime-web parity test (wasm EP)
+        working-directory: scripts/convertmodel
+        run: npm run test:qat-loop
       - name: Run inference smoke test (wasm EP)
         working-directory: scripts/convertmodel
         run: npm run test:inference

--- a/scripts/convertmodel/qat_blocks.mjs
+++ b/scripts/convertmodel/qat_blocks.mjs
@@ -56,15 +56,18 @@ import { fields, decode } from "./macs.mjs";
 // refused and skipped with its reason -- neither trains anything wrongly.
 export const DIFFERENTIABLE_OPS = new Set([
   "Add",
+  "AveragePool",
   "Clip",
   "Conv",
   "Div",
   "Erf",
   "Exp",
+  "Gather",
   "Gemm",
   "Identity",
   "LayerNormalization",
   "MatMul",
+  "MaxPool",
   "Mul",
   "Neg",
   "ReduceMean",


### PR DESCRIPTION
The Coverage workflow (which runs the full npm test:all suite, including
qat_blocks.test.mjs's pinned-fixture check) only runs on push to
master/main, not on pull_request. So PRs #1256/#1257, which added
Gather/MaxPool/AveragePool VJP rules to graph_grad and regenerated
onnxsim/qat_parity_fixtures.txt accordingly, merged without anything
running qat_blocks.test.mjs against the updated fixture -- its hand-kept
copy of the rule table in qat_blocks.mjs drifted out of sync and broke
master's Coverage run.

- Add AveragePool, Gather and MaxPool to qat_blocks.mjs's
  DIFFERENTIABLE_OPS to match the regenerated fixture.
- Wire every npm test:* script in scripts/convertmodel/package.json into
  convertmodel-inference.yml, which already triggers on pull_request for
  scripts/convertmodel/** changes, so the full JS suite (previously only
  reachable via the push-only Coverage workflow) runs on PR CI too.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LL8iRS6sE3szHmPtiGJtYX