### PR TITLE
A block-external tensor's real dtype, not always FLOAT

### DIFF
--- a/onnxsim/adaquant.py
+++ b/onnxsim/adaquant.py
@@ -497,10 +497,10 @@ def _build_adaquant_step_graph(num_rows: int, n: int, k: int) -> qat_graph.StepG
     return qat_graph.make_step_graph(
         b,
         constants={
-            x: [num_rows, k],
-            y_float: [num_rows, n],
-            floor_base: [n, k],
-            scale: [n, k],
+            x: ([num_rows, k], onnx.TensorProto.FLOAT),
+            y_float: ([num_rows, n], onnx.TensorProto.FLOAT),
+            floor_base: ([n, k], onnx.TensorProto.FLOAT),
+            scale: ([n, k], onnx.TensorProto.FLOAT),
         },
         state={
             v: ([n, k], v_next),

--- a/onnxsim/adaround.py
+++ b/onnxsim/adaround.py
@@ -316,10 +316,10 @@ def _build_rounding_step_graph(
     return qat_graph.make_step_graph(
         b,
         constants={
-            x: [num_rows, k],
-            y_float: [num_rows, n],
-            floor_base: [n, k],
-            scale: [n, k],
+            x: ([num_rows, k], onnx.TensorProto.FLOAT),
+            y_float: ([num_rows, n], onnx.TensorProto.FLOAT),
+            floor_base: ([n, k], onnx.TensorProto.FLOAT),
+            scale: ([n, k], onnx.TensorProto.FLOAT),
         },
         state={v: ([n, k], v_next), m: ([n, k], m_next), vv: ([n, k], vv_next)},
         scalars=["lr", "reg_scale", "beta", "m_correction", "v_correction"],

--- a/onnxsim/autoround.py
+++ b/onnxsim/autoround.py
@@ -570,10 +570,10 @@ def _build_autoround_step_graph(
     return qat_graph.make_step_graph(
         b,
         constants={
-            x: [num_rows, k],
-            y_float: [num_rows, n],
-            w: [n, k],
-            scale_blocks: [n, num_blocks],
+            x: ([num_rows, k], onnx.TensorProto.FLOAT),
+            y_float: ([num_rows, n], onnx.TensorProto.FLOAT),
+            w: ([n, k], onnx.TensorProto.FLOAT),
+            scale_blocks: ([n, num_blocks], onnx.TensorProto.FLOAT),
         },
         state={
             v: ([n, k], v_next),

--- a/onnxsim/qat.py
+++ b/onnxsim/qat.py
@@ -957,6 +957,56 @@ def _refuse_unsupported(nodes: Sequence[onnx.NodeProto]) -> None:
         )
 
 
+def _tensor_elem_types(model: onnx.ModelProto) -> Dict[str, int]:
+    """``{tensor name: ONNX element type}`` for every tensor ``model``
+    declares a type for, after a best-effort shape-inference pass fills in
+    whatever ``model`` did not already carry.
+
+    Every tensor a block reads from outside itself used to be assumed
+    float32 -- true of every op in :data:`onnxsim.graph_grad.SUPPORTED_OPS`
+    until ``Gather`` joined it, whose ``indices`` input is a genuine integer
+    tensor. This is the single place that assumption is replaced by the
+    model's own answer, mirroring :func:`onnxsim.qat_interop._infer`'s
+    reasoning: inference only *adds* value_info, so a model it fails on is
+    simply used as-is, and a name still missing afterwards (never a graph
+    input/output, never produced by a node, never an initializer) is left
+    out of the map for the caller to default on.
+    """
+    try:
+        inferred = onnx.shape_inference.infer_shapes(model, strict_mode=False)
+    except Exception:  # noqa: BLE001 -- inference is best-effort here
+        inferred = model
+    types: Dict[str, int] = {}
+    for value in (
+        list(inferred.graph.input)
+        + list(inferred.graph.output)
+        + list(inferred.graph.value_info)
+    ):
+        elem_type = value.type.tensor_type.elem_type
+        if elem_type:
+            types[value.name] = elem_type
+    for init in inferred.graph.initializer:
+        types[init.name] = init.data_type
+    return types
+
+
+def _elem_type(types: Dict[str, int], name: str) -> int:
+    """``types[name]``, defaulting to FLOAT for a name shape inference could
+    not type -- the assumption every block-external tensor satisfied
+    unconditionally before ``Gather`` made a non-float one possible.
+    """
+    return types.get(name, onnx.TensorProto.FLOAT)
+
+
+def _np_elem_type(dtype: np.dtype) -> int:
+    """The ONNX element type a captured array's own numpy dtype corresponds
+    to -- what :func:`_build_step_graph` declares a constant's step-graph
+    input as, now that :func:`_capture` preserves each tensor's real dtype
+    instead of forcing float32 on all of them.
+    """
+    return int(onnx.helper.np_dtype_to_tensor_dtype(np.dtype(dtype)))
+
+
 def _block_shapes(
     float_model: onnx.ModelProto,
     nodes: Sequence[onnx.NodeProto],
@@ -977,12 +1027,22 @@ def _block_shapes(
     Inference runs at opset 17, the pairing :mod:`onnxsim.qat_graph` emits, so
     a node the step graph could not legally carry is refused here rather than
     at session-creation time.
+
+    Every external is declared FLOAT here, save one exception: a tensor whose
+    element type the *float model itself* declares (or shape inference over
+    it infers) as something else -- in practice a ``Gather``'s ``indices``,
+    an integer tensor entering the block sideways rather than the float
+    activation every other block-external tensor is. Declaring it FLOAT
+    regardless, the way this used to, is exactly what upset ONNX's own
+    checker over the emitted step graph: a ``Gather`` node with a
+    ``tensor(float)`` ``indices`` input is not a legal graph.
     """
     used = {name for node in nodes for name in node.input if name}
     initializers = [t for t in float_model.graph.initializer if t.name in used]
+    elem_types = _tensor_elem_types(float_model)
     inputs = [
         onnx.helper.make_tensor_value_info(
-            name, onnx.TensorProto.FLOAT, list(value.shape)
+            name, _elem_type(elem_types, name), list(value.shape)
         )
         for name, value in sorted(externals.items())
     ]
@@ -1057,13 +1117,27 @@ def _capture(
     block seeing the shape it was written for; it does assume axis 0 is a
     batch axis the block treats independently, which is what a calibration
     batch axis is.
+
+    Each tensor is cast to the element type ``float_model`` itself declares
+    (or shape inference infers) for it, not unconditionally to float32: a
+    ``Gather``'s ``indices`` input is a genuine integer tensor, and casting
+    its captured values to float32 the way every block-external tensor used
+    to be cast would silently corrupt them (and disagree with the dtype
+    :func:`_block_shapes` and :func:`onnxsim.qat_graph.make_step_graph` now
+    declare for the same tensor). A name shape inference could not type falls
+    back to float32, which is what this did unconditionally before.
     """
     probe = _add_probe_outputs(float_model, names)
+    elem_types = _tensor_elem_types(probe)
+    dtypes = {
+        name: onnx.helper.tensor_dtype_to_np_dtype(_elem_type(elem_types, name))
+        for name in names
+    }
     collected: Dict[str, List[np.ndarray]] = {name: [] for name in names}
     for batch in calibration_data:
         out = backend.run_model(probe, batch, providers=providers)
         for name in names:
-            collected[name].append(np.asarray(out[name], dtype=np.float32))
+            collected[name].append(np.asarray(out[name], dtype=dtypes[name]))
 
     captured: Dict[str, np.ndarray] = {}
     for name, arrays in collected.items():
@@ -1189,12 +1263,22 @@ def _build_step_graph(
     #    still splice those nodes in verbatim. The block never learns that its
     #    input stopped being a graph input.
     teacher = f"{_PREFIX}teacher"
-    constants: Dict[str, Sequence[int]] = {}
+    # Each constant's declared element type is the captured array's own dtype
+    # -- float for every external this ever ran on, and now whatever
+    # non-float type a ``Gather``'s ``indices`` genuinely has, since
+    # :func:`_capture` stopped forcing float32 on every block-external
+    # tensor. The teacher/target is always float: it is the reconstruction
+    # loss's own output, never a block-external a ``Gather`` could have made
+    # non-float.
+    constants: Dict[str, Tuple[Sequence[int], int]] = {}
     if batch is None:
         constants.update(
-            {name: list(value.shape) for name, value in sorted(externals.items())}
+            {
+                name: (list(value.shape), _np_elem_type(value.dtype))
+                for name, value in sorted(externals.items())
+            }
         )
-        constants[teacher] = list(block_output_shape)
+        constants[teacher] = (list(block_output_shape), onnx.TensorProto.FLOAT)
     else:
         rows = batch.index_name
         # A captured tensor's table is ``qat__all_<its name>`` and the
@@ -1203,9 +1287,12 @@ def _build_step_graph(
         # and the other ``qat__teacher_``.
         for name, value in sorted(externals.items()):
             table = f"{_PREFIX}all_{name}"
-            constants[table] = list(value.shape)
+            constants[table] = (list(value.shape), _np_elem_type(value.dtype))
             b.gather_rows(table, rows, name)
-        constants[f"{_PREFIX}teacher_all"] = list(block_output_shape)
+        constants[f"{_PREFIX}teacher_all"] = (
+            list(block_output_shape),
+            onnx.TensorProto.FLOAT,
+        )
         b.gather_rows(f"{_PREFIX}teacher_all", rows, teacher)
         block_output_shape = [batch.size] + list(block_output_shape)[1:]
 

--- a/onnxsim/qat_entry.cpp
+++ b/onnxsim/qat_entry.cpp
@@ -54,6 +54,13 @@ namespace {
 
 using Shape = std::vector<int64_t>;
 using ShapeMap = std::map<std::string, Shape>;
+// A tensor's ONNX element type (onnx::TensorProto::DataType), keyed the same
+// way ShapeMap is. qat.py's block-external tensors were assumed float32
+// unconditionally until Gather's `indices` made a genuine integer one
+// possible; this is the C++ mirror of the map qat.py's
+// `_tensor_elem_types`/`_elem_type` builds to replace that assumption with
+// the float model's own declared/inferred type.
+using ElemTypeMap = std::map<std::string, int32_t>;
 
 // quantize_weight_only_int4's symmetric INT4 range, quantize_static's
 // per-output-channel INT8 one, and its uint8 activation range -- qat.py's
@@ -706,8 +713,18 @@ Shape StaticDims(const onnx::TypeProto& type, bool* ok) {
   return dims;
 }
 
-// Every tensor of the float model, shaped as if the caller had captured
-// `rows` calibration rows.
+// InferFloatShapes' result: each captured tensor's shape (pinned to `rows`
+// calibration rows) alongside its ONNX element type -- float for everything
+// this port used to assume, but whatever the float model itself declares (or
+// shape inference infers) for a genuinely non-float block-external, such as a
+// Gather's `indices`.
+struct FloatShapeInfo {
+  ShapeMap shapes;
+  ElemTypeMap elem_types;
+};
+
+// Every tensor of the float model, shaped (and typed) as if the caller had
+// captured `rows` calibration rows.
 //
 // This is what qat.py gets for free by running the model: its captured
 // activations are concrete arrays whose leading axis is the concatenated
@@ -716,7 +733,8 @@ Shape StaticDims(const onnx::TypeProto& type, bool* ok) {
 // model this port does that qat.py did out of data. Existing value_info and
 // output shapes are cleared first so a stale symbolic dimension cannot
 // survive the pinning and be refused later as "non-static".
-ShapeMap InferFloatShapes(const onnx::ModelProto& float_model, int64_t rows) {
+FloatShapeInfo InferFloatShapes(const onnx::ModelProto& float_model,
+                                int64_t rows) {
   onnx::ModelProto model = float_model;
   std::set<std::string> initializers;
   for (const onnx::TensorProto& t : model.graph().initializer()) {
@@ -743,19 +761,33 @@ ShapeMap InferFloatShapes(const onnx::ModelProto& float_model, int64_t rows) {
     // Fall through with whatever was inferred before the failure.
   }
 
-  ShapeMap shapes;
-  auto collect = [&shapes](const onnx::ValueInfoProto& value) {
+  FloatShapeInfo info;
+  auto collect = [&info](const onnx::ValueInfoProto& value) {
     bool ok = false;
     const Shape dims = StaticDims(value.type(), &ok);
-    if (ok) shapes[value.name()] = dims;
+    if (ok) info.shapes[value.name()] = dims;
+    const int32_t elem_type = value.type().tensor_type().elem_type();
+    if (elem_type != onnx::TensorProto::UNDEFINED) {
+      info.elem_types[value.name()] = elem_type;
+    }
   };
   for (const onnx::ValueInfoProto& v : model.graph().input()) collect(v);
   for (const onnx::ValueInfoProto& v : model.graph().value_info()) collect(v);
   for (const onnx::ValueInfoProto& v : model.graph().output()) collect(v);
   for (const onnx::TensorProto& t : model.graph().initializer()) {
-    shapes[t.name()] = DimsOf(t);
+    info.shapes[t.name()] = DimsOf(t);
+    info.elem_types[t.name()] = t.data_type();
   }
-  return shapes;
+  return info;
+}
+
+// `types[name]`, defaulting to FLOAT for a name shape inference could not
+// type -- the assumption every block-external tensor satisfied
+// unconditionally before Gather made a non-float one possible. Mirrors
+// qat.py's `_elem_type`.
+int32_t ElemTypeOr(const ElemTypeMap& types, const std::string& name) {
+  const auto it = types.find(name);
+  return it == types.end() ? onnx::TensorProto::FLOAT : it->second;
 }
 
 void SetValueInfo(onnx::ValueInfoProto* vi, const std::string& name,
@@ -772,9 +804,17 @@ void SetValueInfo(onnx::ValueInfoProto* vi, const std::string& name,
 // carry this step's concrete row count. Inference runs at opset 17, the
 // pairing the step graph emits, so a node the step graph could not legally
 // carry is refused here rather than at session-creation time.
+//
+// Every external is declared FLOAT here, save one exception: a tensor whose
+// element type `elem_types` (the float model's own declared/inferred types --
+// see InferFloatShapes) names as something else, in practice a Gather's
+// `indices`. Declaring it FLOAT regardless, the way this used to, is exactly
+// what upset the emitted step graph: a Gather node with a tensor(float)
+// `indices` input is not a legal graph.
 ShapeMap BlockShapes(const onnx::ModelProto& float_model,
                      const std::vector<onnx::NodeProto>& nodes,
                      const std::vector<std::pair<std::string, Shape>>& inputs,
+                     const ElemTypeMap& elem_types,
                      const std::string& block_output_name,
                      const Shape& block_output_shape) {
   std::set<std::string> used;
@@ -789,8 +829,8 @@ ShapeMap BlockShapes(const onnx::ModelProto& float_model,
   graph->set_name("qat_block");
   for (const onnx::NodeProto& node : nodes) *graph->add_node() = node;
   for (const auto& input : inputs) {
-    SetValueInfo(graph->add_input(), input.first, onnx::TensorProto::FLOAT,
-                 input.second);
+    SetValueInfo(graph->add_input(), input.first,
+                 ElemTypeOr(elem_types, input.first), input.second);
   }
   SetValueInfo(graph->add_output(), block_output_name, onnx::TensorProto::FLOAT,
                block_output_shape);
@@ -1217,8 +1257,11 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
   }
 
   // --- shapes ------------------------------------------------------------
-  // The whole captured set's shapes, i.e. what the caller binds once.
-  const ShapeMap full_shapes = InferFloatShapes(float_model, num_rows);
+  // The whole captured set's shapes (and element types), i.e. what the
+  // caller binds once.
+  const FloatShapeInfo float_info = InferFloatShapes(float_model, num_rows);
+  const ShapeMap& full_shapes = float_info.shapes;
+  const ElemTypeMap& elem_types = float_info.elem_types;
   auto shape_of = [&full_shapes](const std::string& name) -> const Shape& {
     const auto it = full_shapes.find(name);
     if (it == full_shapes.end()) {
@@ -1269,8 +1312,9 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
     step_inputs.emplace_back(external.first, with_rows(external.second));
   }
   const Shape step_teacher_shape = with_rows(teacher_shape);
-  const ShapeMap shapes = BlockShapes(float_model, slice.nodes, step_inputs,
-                                      block_output_name, step_teacher_shape);
+  const ShapeMap shapes =
+      BlockShapes(float_model, slice.nodes, step_inputs, elem_types,
+                  block_output_name, step_teacher_shape);
 
   // --- _plan_trained and the block's own initializers --------------------
   std::vector<Trained> trained = PlanTrained(candidates, options.learn_scales,
@@ -1314,28 +1358,31 @@ QatStepPlan BuildQatStepGraph(const onnx::ModelProto& float_model,
   std::vector<QatCapture> captures;
   if (!minibatch) {
     for (const auto& external : externals) {
-      constants.push_back({external.first, external.second});
+      const int32_t elem_type = ElemTypeOr(elem_types, external.first);
+      constants.push_back({external.first, external.second, elem_type});
       captures.push_back({external.first, external.first, external.second,
-                          /*is_teacher=*/false});
+                          elem_type, /*is_teacher=*/false});
     }
-    constants.push_back({teacher, teacher_shape});
-    captures.push_back(
-        {teacher, block_output_name, teacher_shape, /*is_teacher=*/true});
+    constants.push_back({teacher, teacher_shape, onnx::TensorProto::FLOAT});
+    captures.push_back({teacher, block_output_name, teacher_shape,
+                        onnx::TensorProto::FLOAT, /*is_teacher=*/true});
   } else {
     // A captured tensor's table is `qat__all_<its name>` and the teacher's is
     // `qat__teacher_all`; the two families cannot collide whatever the model
     // calls its tensors.
     for (const auto& external : externals) {
+      const int32_t elem_type = ElemTypeOr(elem_types, external.first);
       const std::string table = std::string(kPrefix) + "all_" + external.first;
-      constants.push_back({table, external.second});
-      captures.push_back(
-          {table, external.first, external.second, /*is_teacher=*/false});
+      constants.push_back({table, external.second, elem_type});
+      captures.push_back({table, external.first, external.second, elem_type,
+                          /*is_teacher=*/false});
       b.GatherRowsInto(table, rows_input, external.first);
     }
     const std::string teacher_table = std::string(kPrefix) + "teacher_all";
-    constants.push_back({teacher_table, teacher_shape});
+    constants.push_back(
+        {teacher_table, teacher_shape, onnx::TensorProto::FLOAT});
     captures.push_back({teacher_table, block_output_name, teacher_shape,
-                        /*is_teacher=*/true});
+                        onnx::TensorProto::FLOAT, /*is_teacher=*/true});
     b.GatherRowsInto(teacher_table, rows_input, teacher);
   }
   const Shape block_output_shape = step_teacher_shape;

--- a/onnxsim/qat_entry.h
+++ b/onnxsim/qat_entry.h
@@ -112,6 +112,14 @@ struct QatCapture {
   std::string step_graph_input;
   std::string source_tensor;
   std::vector<int64_t> dims;
+  // The ONNX element type (onnx::TensorProto::DataType) to capture and bind
+  // `source_tensor` as. FLOAT for every capture this ever had, and now
+  // whatever non-float type the float model itself gives a genuine
+  // block-external tensor -- in practice a Gather's `indices`. A caller that
+  // captured everything as float32 the way this used to assume would corrupt
+  // an integer tensor's values and then hand the step graph a tensor of the
+  // wrong ONNX type for the input it declared.
+  int32_t elem_type = onnx::TensorProto::FLOAT;
   // True for the block's reconstruction target -- the float model's own output
   // for this block, which is the teacher. It is captured the same way as the
   // rest; the flag exists so a caller can label it in a UI.

--- a/onnxsim/qat_entry_test.cpp
+++ b/onnxsim/qat_entry_test.cpp
@@ -315,6 +315,71 @@ onnx::ModelProto DeepInt4QuantizedModel() {
   return model;
 }
 
+// A batched int64 input -- the shape `SliceBlock`'s own comment names as
+// "an attention mask fed as a second graph input" (an external tensor
+// entering the block sideways), except this one is genuinely non-float: a
+// `Gather`'s row index. It is what
+// `ABlockExternalGatherIndexIsCapturedAndDeclaredAtItsRealDtype` below
+// exists to exercise -- every block-external tensor was assumed float32
+// unconditionally until `Gather` (differentiable via graph_grad's VJP rule)
+// made this legal.
+void AddBatchedInt64Input(onnx::GraphProto* graph, const std::string& name) {
+  onnx::ValueInfoProto* vi = graph->add_input();
+  vi->set_name(name);
+  onnx::TypeProto::Tensor* tensor = vi->mutable_type()->mutable_tensor_type();
+  tensor->set_elem_type(onnx::TensorProto::INT64);
+  tensor->mutable_shape()->add_dim()->set_dim_param("batch");
+}
+
+// `DeepFloatModel`/`DeepInt4QuantizedModel` with a `Gather` spliced into the
+// middle, reading a second graph input (`Idx`, int64) as its `indices` --
+// `data` is `H`, reachable from the block input `X`, which is what keeps
+// `Gather` *inside* the slice (see `SliceBlock`'s forward walk) rather than
+// having its output treated as an ordinary captured (float) external.
+onnx::ModelProto GatherFloatModel() {
+  onnx::ModelProto model;
+  onnx::GraphProto* graph = model.mutable_graph();
+  graph->set_name("gather_float");
+  AddBatchedInput(graph, "X", kK);
+  AddBatchedInt64Input(graph, "Idx");
+  AddOutput(graph, "Y", kK);
+  *graph->add_node() = MakeNode("MatMul", {"X", "W1"}, {"H"});
+  *graph->add_node() = MakeNode("Gather", {"H", "Idx"}, {"G"});
+  *graph->add_node() = MakeNode("MatMul", {"G", "W2"}, {"Y"});
+  *graph->add_initializer() =
+      FloatTensor("W1", {kK, kK}, std::vector<float>(kK * kK, 0.21f));
+  *graph->add_initializer() =
+      FloatTensor("W2", {kK, kK}, std::vector<float>(kK * kK, 0.11f));
+  Finish(&model);
+  return model;
+}
+
+onnx::ModelProto GatherInt4QuantizedModel() {
+  onnx::ModelProto model;
+  onnx::GraphProto* graph = model.mutable_graph();
+  graph->set_name("gather_int4");
+  AddBatchedInput(graph, "X", kK);
+  AddBatchedInt64Input(graph, "Idx");
+  AddOutput(graph, "Y", kK);
+  *graph->add_node() = MakeNode("DequantizeLinear", {"W1q", "W1s"}, {"W1dq"},
+                                {{"axis", 0}, {"block_size", kBlock}});
+  *graph->add_node() = MakeNode("MatMul", {"X", "W1dq"}, {"H"});
+  *graph->add_node() = MakeNode("Gather", {"H", "Idx"}, {"G"});
+  *graph->add_node() = MakeNode("DequantizeLinear", {"W2q", "W2s"}, {"W2dq"},
+                                {{"axis", 0}, {"block_size", kBlock}});
+  *graph->add_node() = MakeNode("MatMul", {"G", "W2dq"}, {"Y"});
+  *graph->add_initializer() =
+      RawTensor("W1q", onnx::TensorProto::INT4, {kK, kK}, std::string(8, '\0'));
+  *graph->add_initializer() =
+      FloatTensor("W1s", {kK / kBlock, kK}, std::vector<float>(8, 0.1f));
+  *graph->add_initializer() =
+      RawTensor("W2q", onnx::TensorProto::INT4, {kK, kK}, std::string(8, '\0'));
+  *graph->add_initializer() =
+      FloatTensor("W2s", {kK / kBlock, kK}, std::vector<float>(8, 0.1f));
+  Finish(&model);
+  return model;
+}
+
 // The fine-tuning pair -- QatOptions::fake_quant off. Nothing here is
 // quantized: this scheme trains the *student's* own float weights against the
 // teacher's activation, so the two models being different weights over one
@@ -1223,6 +1288,59 @@ void ABlockThatIsNotAClosedSliceIsRefused() {
       "a block whose input is downstream of its output is refused");
 }
 
+// The C++ mirror of the Python bug this file exists to close: a block
+// containing a `Gather` whose `indices` is a block-external, non-initializer
+// tensor (`Idx`, a genuine graph input here) used to be declared FLOAT
+// regardless of its real dtype -- both in the emitted step graph's own input
+// (which `onnx::checker` then rejected: a `Gather` node cannot read a
+// `tensor(float)` `indices`) and in the `QatCapture` a caller would use to
+// know what dtype to capture and bind it as. Both are pinned here.
+void ABlockExternalGatherIndexIsCapturedAndDeclaredAtItsRealDtype() {
+  const QatStepPlan plan =
+      BuildQatStepGraph(GatherFloatModel(), GatherInt4QuantizedModel(), "X",
+                        "Y", kRows, QatOptions());
+  CheckModel(plan.step_graph, "the step graph with a block-external Gather index");
+  Check(OpTypes(plan.step_graph).count("Gather") != 0,
+        "the block's own Gather node is carried into the step graph verbatim");
+
+  const onnx::ValueInfoProto* idx_input = nullptr;
+  for (const onnx::ValueInfoProto& v : plan.step_graph.graph().input()) {
+    if (v.name() == "Idx") idx_input = &v;
+  }
+  Check(idx_input != nullptr, "the step graph declares an input named Idx");
+  if (idx_input != nullptr) {
+    CheckEqual(
+        static_cast<int64_t>(idx_input->type().tensor_type().elem_type()),
+        static_cast<int64_t>(onnx::TensorProto::INT64),
+        "Idx is declared at its real dtype (INT64), not hardcoded FLOAT");
+  }
+
+  bool found_idx_capture = false;
+  for (const QatCapture& capture : plan.captures) {
+    if (capture.source_tensor != "Idx") continue;
+    found_idx_capture = true;
+    CheckEqual(
+        static_cast<int64_t>(capture.elem_type),
+        static_cast<int64_t>(onnx::TensorProto::INT64),
+        "the Idx capture says to capture it as INT64, not hardcoded FLOAT");
+    Check(capture.dims == std::vector<int64_t>({kRows}),
+          "the captured index carries num_rows rows, same as every other "
+          "block-external");
+  }
+  Check(found_idx_capture, "Idx is captured as one of the block's externals");
+
+  // The block's other, ordinary float external (X itself) and the teacher
+  // still declare FLOAT -- this is a per-tensor dtype, not a blanket switch
+  // away from float for the whole plan.
+  for (const QatCapture& capture : plan.captures) {
+    if (capture.source_tensor == "Idx") continue;
+    CheckEqual(static_cast<int64_t>(capture.elem_type),
+               static_cast<int64_t>(onnx::TensorProto::FLOAT),
+               "every other capture (" + capture.source_tensor +
+                   ") is still declared FLOAT");
+  }
+}
+
 }  // namespace
 
 int main() {
@@ -1247,6 +1365,7 @@ int main() {
   ABlockWithNoQuantizedLayerIsRefused();
   EachSchemeMismatchIsNamedRatherThanReportedAsABoundaryError();
   ABlockThatIsNotAClosedSliceIsRefused();
+  ABlockExternalGatherIndexIsCapturedAndDeclaredAtItsRealDtype();
 
   if (g_failures != 0) {
     std::fprintf(stderr, "%d qat_entry check(s) failed\n", g_failures);

--- a/onnxsim/qat_entry_test.cpp
+++ b/onnxsim/qat_entry_test.cpp
@@ -1299,7 +1299,8 @@ void ABlockExternalGatherIndexIsCapturedAndDeclaredAtItsRealDtype() {
   const QatStepPlan plan =
       BuildQatStepGraph(GatherFloatModel(), GatherInt4QuantizedModel(), "X",
                         "Y", kRows, QatOptions());
-  CheckModel(plan.step_graph, "the step graph with a block-external Gather index");
+  CheckModel(plan.step_graph,
+             "the step graph with a block-external Gather index");
   Check(OpTypes(plan.step_graph).count("Gather") != 0,
         "the block's own Gather node is carried into the step graph verbatim");
 

--- a/onnxsim/qat_graph.py
+++ b/onnxsim/qat_graph.py
@@ -410,7 +410,7 @@ class StepGraph:
 
 def make_step_graph(
     b: GraphBuilder,
-    constants: Dict[str, Sequence[int]],
+    constants: Dict[str, Tuple[Sequence[int], int]],
     state: Dict[str, Tuple[Sequence[int], str]],
     scalars: Sequence[str] = (),
     loss: Optional[str] = None,
@@ -419,9 +419,14 @@ def make_step_graph(
 ) -> StepGraph:
     """Wraps ``b``'s accumulated nodes into a :class:`StepGraph`.
 
-    :param constants: ``{input name: shape}`` for the tensors that do not
-            change across steps (calibration activations, the reconstruction
-            target, a frozen scale, ...)
+    :param constants: ``{input name: (shape, onnx element type)}`` for the
+            tensors that do not change across steps (calibration activations,
+            the reconstruction target, a frozen scale, ...). Most of these are
+            FLOAT -- an activation, a scale -- but a block-external tensor can
+            be any dtype the source model gave it (a ``Gather``'s integer row
+            ``indices``, captured whole as one of these when there is no
+            minibatch), which is why this takes an element type per entry
+            rather than assuming FLOAT for all of them the way it used to.
     :param state: ``{input name: (shape, output name)}`` for the tensors the
             step updates -- the parameter being optimized and the optimizer's
             own moments
@@ -438,8 +443,8 @@ def make_step_graph(
             scalar's shape and type never need saying.
     """
     inputs = [
-        onnx.helper.make_tensor_value_info(n, onnx.TensorProto.FLOAT, list(shape))
-        for n, shape in constants.items()
+        onnx.helper.make_tensor_value_info(n, elem_type, list(shape))
+        for n, (shape, elem_type) in constants.items()
     ]
     inputs += [
         onnx.helper.make_tensor_value_info(n, onnx.TensorProto.FLOAT, list(shape))
@@ -473,6 +478,26 @@ def make_step_graph(
         state={n: out for n, (_, out) in state.items()},
         loss_name=loss,
     )
+
+
+def _as_constant(v: np.ndarray) -> np.ndarray:
+    """A step-graph constant's value, cast to float32 if it is
+    floating-point and left alone otherwise.
+
+    Every constant used to be forced to float32 unconditionally, back when
+    every one of them was a float tensor. That is no longer true -- a
+    :func:`onnxsim.qat.apply_qat` block containing a ``Gather`` can capture
+    an integer ``indices`` tensor as one of these -- so only the
+    floating-point ones (an activation, a scale, ...; also whichever numpy
+    dtype a caller's own float64 host computation happened to produce, which
+    this cast has always absorbed) are normalized to float32. A non-float
+    array is passed through as the dtype it already is, matching the
+    element type :func:`make_step_graph` declared its graph input as.
+    """
+    array = np.asarray(v)
+    if np.issubdtype(array.dtype, np.floating):
+        return array.astype(np.float32, copy=False)
+    return array
 
 
 def _run_bound_loop(
@@ -531,7 +556,14 @@ def run_step_graph(
     The session (and its execution providers) is created once for the whole
     loop, not once per step -- see :class:`onnxsim.backend.Runner`.
 
-    :param constants: values for the step graph's constant inputs
+    :param constants: values for the step graph's constant inputs. A
+            floating-point array is cast to float32 (a caller may hand this a
+            float64 numpy computation and rely on that), but any other dtype
+            -- in practice a ``Gather``'s captured integer ``indices``, when
+            there is no minibatch -- is passed through as-is: casting it to
+            float32 the way this used to unconditionally would silently
+            corrupt it and then disagree with the dtype
+            :func:`make_step_graph` declared that same input as.
     :param state: initial values for its state inputs
     :param num_steps: iterations to run
     :param scalars: called with the step index, returning that step's scalar
@@ -597,7 +629,7 @@ def run_step_graph(
         fetch.append(step.loss_name)
     runner = backend.Runner(step.model, output_names=fetch, providers=providers)
 
-    fixed = {k: np.asarray(v, dtype=np.float32) for k, v in constants.items()}
+    fixed = {k: _as_constant(v) for k, v in constants.items()}
     initial = {k: np.asarray(v, dtype=np.float32) for k, v in state.items()}
 
     def step_feeds(t: int) -> Dict[str, np.ndarray]:

--- a/onnxsim/qat_graph_builder.cpp
+++ b/onnxsim/qat_graph_builder.cpp
@@ -333,7 +333,7 @@ StepGraph MakeStepGraph(const GraphBuilder& b, const StepGraphSpec& spec) {
   // Python builds these from four dicts in this order and a positional binding
   // (ORT's IOBinding, and the WASM trampoline) reads them positionally.
   for (const StepGraphSpec::NamedShape& c : spec.constants) {
-    SetValueInfo(graph->add_input(), c.name, onnx::TensorProto::FLOAT, c.dims);
+    SetValueInfo(graph->add_input(), c.name, c.elem_type, c.dims);
   }
   for (const StepGraphSpec::StateEntry& s : spec.state) {
     SetValueInfo(graph->add_input(), s.input, onnx::TensorProto::FLOAT, s.dims);

--- a/onnxsim/qat_graph_builder.h
+++ b/onnxsim/qat_graph_builder.h
@@ -194,13 +194,19 @@ std::pair<float, float> AdamBiasCorrections(int64_t t);
 // rebuild per step. `per_step` names the inputs whose value changes every step
 // (the scalars, and a minibatch index vector when there is one).
 struct StepGraphSpec {
-  // Float32 graph inputs whose value does not change across steps
-  // (calibration activations, the reconstruction target, a frozen scale).
-  // They are *inputs* rather than initializers because the runner binds them
-  // once and keeps them resident; the emitter only declares their shape.
+  // Graph inputs whose value does not change across steps (calibration
+  // activations, the reconstruction target, a frozen scale). They are
+  // *inputs* rather than initializers because the runner binds them once and
+  // keeps them resident; the emitter only declares their shape and type.
+  // Most are FLOAT, but a captured block-external can be any dtype the
+  // source model gave it (a Gather's integer row indices, captured whole as
+  // one of these when there is no minibatch) -- `elem_type` defaults to
+  // FLOAT so every existing caller that only ever had float constants needs
+  // no change.
   struct NamedShape {
     std::string name;
     std::vector<int64_t> dims;
+    int32_t elem_type = onnx::TensorProto::FLOAT;
   };
   std::vector<NamedShape> constants;
   // (input name, dims, output name carrying the next value).

--- a/scripts/convertmodel/test/make_step_graph_fixtures.py
+++ b/scripts/convertmodel/test/make_step_graph_fixtures.py
@@ -314,7 +314,10 @@ def build_qat_backward(rng: np.random.Generator) -> Dict:
     )
     step = qat_graph.make_step_graph(
         b,
-        constants={"x": list(x_shape), "teacher": list(out_shape)},
+        constants={
+            "x": (list(x_shape), onnx.TensorProto.FLOAT),
+            "teacher": (list(out_shape), onnx.TensorProto.FLOAT),
+        },
         state={
             "w": (list(w_shape), w_next),
             "mw": (list(w_shape), mw_next),
@@ -384,7 +387,10 @@ def build_minibatch(rng: np.random.Generator) -> Dict:
     )
     step = qat_graph.make_step_graph(
         b,
-        constants={"x_all": [total, kin], "y_all": [total, out]},
+        constants={
+            "x_all": ([total, kin], onnx.TensorProto.FLOAT),
+            "y_all": ([total, out], onnx.TensorProto.FLOAT),
+        },
         state={
             "w": ([kin, out], w_next),
             "mw": ([kin, out], mw_next),

--- a/scripts/make_qat_parity_fixtures.py
+++ b/scripts/make_qat_parity_fixtures.py
@@ -248,7 +248,7 @@ def _case_step_graph() -> Dict[str, Any]:
     )
     step = qat_graph.make_step_graph(
         b,
-        constants={"teacher": [4, 3]},
+        constants={"teacher": ([4, 3], int(onnx.TensorProto.FLOAT))},
         state={
             "w": ([4, 3], param_next),
             "m": ([4, 3], m_next),

--- a/tests/test_graph_grad.py
+++ b/tests/test_graph_grad.py
@@ -1687,7 +1687,11 @@ def test_the_backward_composes_into_a_step_graph_that_trains():
     )
     step = qat_graph.make_step_graph(
         b,
-        constants={"x": [rows, k], "y": [rows, k], "w1": [k, hidden]},
+        constants={
+            "x": ([rows, k], onnx.TensorProto.FLOAT),
+            "y": ([rows, k], onnx.TensorProto.FLOAT),
+            "w1": ([k, hidden], onnx.TensorProto.FLOAT),
+        },
         state={
             "w2": ([hidden, k], w2_next),
             "m": ([hidden, k], m_next),

--- a/tests/test_qat.py
+++ b/tests/test_qat.py
@@ -2358,3 +2358,264 @@ def test_preserve_sparsity_holds_a_pruned_models_zero_codes():
     # nothing.
     assert (zeros & (codes(run(False)) != 0)).sum() > 0
     assert (zeros & (codes(run(True)) != 0)).sum() == 0
+
+
+# --- A `Gather` inside a block, and the non-float block-external it can have ----
+#
+# `onnxsim.graph_grad` grew a VJP rule for `Gather`, which makes it eligible
+# to sit *inside* a block instead of forcing block discovery to stop there.
+# But a `Gather` has two inputs of different semantic types: `data` (float)
+# and `indices` (integer) -- and every op in `SUPPORTED_OPS` before it had
+# exclusively float inputs, so the block-capture machinery in this module
+# assumed every block-external tensor is float32. That is false whenever a
+# block contains a `Gather` whose `indices` is a genuine block-external
+# (fed in from outside the block, not a same-block initializer): declaring
+# it FLOAT regardless -- what `_capture`, `_block_shapes` and
+# `onnxsim.qat_graph.make_step_graph` all used to do unconditionally -- is
+# not a legal type for a `Gather` node to read `indices` at, and building or
+# running the step graph raised for it.
+
+
+def _gather_block_model(seed=0):
+    """Two Linears with a ``Gather`` between them, whose ``indices`` is a
+    second graph input -- exactly the "attention mask fed as a second graph
+    input" shape ``_slice_block``'s own docstring names as a block-external
+    tensor entering sideways, except this one is genuinely non-float: a row
+    index, not a mask.
+
+    ``H``'s row axis is exactly what ``_slice_block``'s forward walk needs
+    ``Gather`` to depend on for the node to land *inside* the block at all
+    (see that function's docstring): its ``data`` input must be reachable
+    from the block input, or the whole node is treated as outside the slice
+    and its output captured as an ordinary (float) external instead -- which
+    would not exercise this bug at all.
+    """
+    rng = np.random.default_rng(seed)
+    w1 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    w2 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    return _model(
+        f"""
+        g (float[batch,{D}] X, int64[batch] idx) => (float[batch,{D}] Yout)
+        {{
+          H = MatMul(X, W1)
+          G = Gather(H, idx)
+          Yout = MatMul(G, W2)
+        }}
+        """,
+        [_f32(w1, "W1"), _f32(w2, "W2")],
+    )
+
+
+def test_a_block_external_gather_index_trains():
+    """The headline regression: building and running the step graph for a
+    block whose ``Gather`` reads a block-external, non-initializer integer
+    ``indices`` tensor no longer raises, and the block still trains.
+
+    Before the fix this failed two different ways depending on how far it
+    got: ``onnxruntime`` refused to even load the emitted step graph
+    (``idx`` declared ``tensor(float)``, which a ``Gather`` node cannot
+    read), and once that declaration was fixed on its own, refused to *run*
+    it instead (the captured ``idx`` array itself was cast to float32 before
+    being fed, disagreeing with the graph's own declared type). Both are
+    pinned here by the fact that this whole call completes.
+    """
+    model = _gather_block_model(seed=0)
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+
+    rng = np.random.default_rng(1)
+    rows = 16
+    x = _correlated_calibration(rank=2, num_samples=rows)
+    idx = rng.integers(0, rows, size=rows).astype(np.int64)
+    calibration_data = [{"X": x, "idx": idx}]
+
+    losses = []
+    tuned = onnxsim.apply_qat(
+        model,
+        quant,
+        "X",
+        "Yout",
+        calibration_data=calibration_data,
+        num_iterations=200,
+        losses=losses,
+    )
+    onnx.checker.check_model(tuned)
+    # The loop really optimized rather than merely surviving: the reported
+    # block loss falls well below where it started.
+    assert losses[-1] < 0.5 * losses[0]
+
+
+def test_a_same_block_gather_initializer_index_still_works():
+    """The case that already worked before this bug was fixed: a ``Gather``
+    whose ``indices`` is an initializer local to the block, not a
+    block-external tensor. ``_slice_block`` special-cases an initializer (it
+    is never added to ``externals``), so this exercises a different path
+    than ``test_a_block_external_gather_index_trains`` above and must be
+    unaffected by the dtype generalization there -- the assertion on
+    ``externals`` below is what pins that this test is actually exercising
+    the "already worked" path and not silently retesting the other one.
+
+    ``axis=1`` rather than the default 0: a block-local initializer's shape
+    cannot depend on the calibration batch size, and the feature axis is the
+    one dimension of ``H`` that is static regardless of it.
+    """
+    rng = np.random.default_rng(2)
+    w1 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    w2 = (rng.standard_normal((D, D)) * 0.3).astype(np.float32)
+    permutation = np.arange(D, dtype=np.int64)[::-1].copy()
+    model = _model(
+        f"""
+        g (float[batch,{D}] X) => (float[batch,{D}] Yout)
+        {{
+          H = MatMul(X, W1)
+          G = Gather <axis = 1> (H, idx)
+          Yout = MatMul(G, W2)
+        }}
+        """,
+        [
+            _f32(w1, "W1"),
+            _f32(w2, "W2"),
+            onnx.numpy_helper.from_array(permutation, "idx"),
+        ],
+    )
+    _, externals = qat._slice_block(model.graph, "X", "Yout")
+    assert "idx" not in externals, "the initializer path is what this pins"
+
+    quant = _quantize_chain_int4(model, {"W1", "W2"})
+    x = _correlated_calibration(rank=2, num_samples=16)
+
+    losses = []
+    tuned = onnxsim.apply_qat(
+        model,
+        quant,
+        "X",
+        "Yout",
+        calibration_data=[{"X": x}],
+        num_iterations=200,
+        losses=losses,
+    )
+    onnx.checker.check_model(tuned)
+    assert losses[-1] < 0.5 * losses[0]
+
+
+def test_capture_preserves_a_non_float_externals_real_dtype():
+    """Unit-level pin on ``qat._capture``: a captured tensor is cast to the
+    element type the float model itself declares for it, not
+    unconditionally to float32 -- so an int64 ``indices`` tensor comes back
+    as int64, byte-for-byte the values that went in, rather than silently
+    reinterpreted as (or rounded into) float32.
+    """
+    model = _gather_block_model(seed=0)
+    rng = np.random.default_rng(3)
+    rows = 8
+    x = rng.standard_normal((rows, D)).astype(np.float32)
+    idx = rng.integers(0, rows, size=rows).astype(np.int64)
+
+    captured = qat._capture(model, ["X", "idx", "Yout"], [{"X": x, "idx": idx}], None)
+    assert captured["idx"].dtype == np.int64
+    np.testing.assert_array_equal(captured["idx"], idx)
+    assert captured["X"].dtype == np.float32
+
+
+def test_block_shapes_declares_a_non_float_externals_real_elem_type():
+    """Unit-level pin on ``qat._block_shapes``: the standalone model it
+    builds to infer the block's shapes declares each external input at the
+    element type the float model itself gives it, not unconditionally
+    FLOAT -- which is what made ONNX's own checker refuse the emitted step
+    graph before this was fixed (a ``Gather`` node cannot read
+    ``tensor(float)`` ``indices``).
+    """
+    model = _gather_block_model(seed=0)
+    nodes, externals = qat._slice_block(model.graph, "X", "Yout")
+    assert set(externals) == {"X", "idx"}
+
+    rows = 8
+    rng = np.random.default_rng(4)
+    block_inputs = {
+        "X": rng.standard_normal((rows, D)).astype(np.float32),
+        "idx": rng.integers(0, rows, size=rows).astype(np.int64),
+    }
+    block_output = rng.standard_normal((rows, D)).astype(np.float32)
+
+    shapes = qat._block_shapes(model, nodes, block_inputs, "Yout", block_output)
+    assert shapes["idx"] == [rows]
+    assert shapes["X"] == [rows, D]
+
+    # `shapes` is shape-only, so pin the element type `_block_shapes` now
+    # declares each external at through the lookup it builds from the float
+    # model itself -- the same one it feeds `onnx.helper.make_tensor_value_info`
+    # for each external input.
+    probe_types = qat._tensor_elem_types(model)
+    assert probe_types["idx"] == onnx.TensorProto.INT64
+    assert qat._elem_type(probe_types, "idx") == onnx.TensorProto.INT64
+    assert qat._elem_type(probe_types, "X") == onnx.TensorProto.FLOAT
+    # A name genuinely absent from the model falls back to FLOAT, the
+    # assumption every block-external tensor satisfied unconditionally
+    # before this fix.
+    assert qat._elem_type(probe_types, "no_such_tensor") == onnx.TensorProto.FLOAT
+
+
+def test_make_step_graph_declares_a_non_float_constant():
+    """Unit-level pin on ``qat_graph.make_step_graph``: a ``constants`` entry
+    is declared at the element type its caller pairs with the shape, not
+    unconditionally FLOAT -- and the emitted graph actually runs end to end
+    with an integer constant feeding a ``Gather``, through
+    ``qat_graph.run_step_graph``'s own dtype handling.
+
+    The step this builds fits ``w`` to two rows of ``table`` gathered by
+    ``idx`` -- ``w``'s only path to those values is through the ``Gather``,
+    so a graph that declared (or fed) ``idx`` as anything but its real int64
+    would either fail to build/run at all (this file's other regressions
+    already pin that) or gather the wrong rows and never converge to them,
+    which is what the final assertion below checks for.
+    """
+    b = qat_graph.GraphBuilder()
+    gathered = b.op("Gather", ["table", "idx"], "gathered")
+    diff = b.sub("w", gathered)
+    grad = b.mul(diff, b.const(2.0 / (2 * D)))
+    w_next, m_next, v_next = qat_graph.adam_update(
+        b, "w", grad, "m", "vv", "lr", "m_correction", "v_correction"
+    )
+    step = qat_graph.make_step_graph(
+        b,
+        constants={
+            "table": ([4, D], onnx.TensorProto.FLOAT),
+            "idx": ([2], onnx.TensorProto.INT64),
+        },
+        state={"w": ([2, D], w_next), "m": ([2, D], m_next), "vv": ([2, D], v_next)},
+        scalars=["lr", "m_correction", "v_correction"],
+        loss=b.mean_square(diff),
+    )
+    idx_input = next(i for i in step.model.graph.input if i.name == "idx")
+    assert idx_input.type.tensor_type.elem_type == onnx.TensorProto.INT64
+    table_input = next(i for i in step.model.graph.input if i.name == "table")
+    assert table_input.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+    onnx.checker.check_model(step.model)
+
+    rng = np.random.default_rng(6)
+    table = rng.standard_normal((4, D)).astype(np.float32)
+    idx = np.array([3, 1], dtype=np.int64)
+    target = table[idx]
+
+    def scalars(t):
+        values = {"lr": 0.1}
+        values.update(qat_graph.adam_bias_corrections(t))
+        return values
+
+    losses = []
+    final = qat_graph.run_step_graph(
+        step,
+        constants={"table": table, "idx": idx},
+        state={
+            "w": np.zeros((2, D), np.float32),
+            "m": np.zeros((2, D), np.float32),
+            "vv": np.zeros((2, D), np.float32),
+        },
+        num_steps=300,
+        scalars=scalars,
+        losses=losses,
+    )
+    assert np.isfinite(final["w"]).all()
+    # The loop really converged onto `table`'s rows 3 and 1 -- not onto
+    # garbage a mistyped or miscast `idx` would have gathered instead.
+    assert losses[-1] < 1e-3 * losses[0]
+    np.testing.assert_allclose(final["w"], target, atol=0.05)

--- a/tests/test_qat_graph.py
+++ b/tests/test_qat_graph.py
@@ -39,7 +39,10 @@ def _linear_fit_step_graph(rows, k, n):
     )
     return qat_graph.make_step_graph(
         b,
-        constants={"x": [rows, k], "y": [rows, n]},
+        constants={
+            "x": ([rows, k], onnx.TensorProto.FLOAT),
+            "y": ([rows, n], onnx.TensorProto.FLOAT),
+        },
         state={
             "w": ([n, k], w_next),
             "m": ([n, k], m_next),
@@ -531,7 +534,10 @@ def _gathered_linear_fit_step_graph(rows, batch, k, n):
     )
     return qat_graph.make_step_graph(
         b,
-        constants={"xs": [rows, k], "ys": [rows, n]},
+        constants={
+            "xs": ([rows, k], onnx.TensorProto.FLOAT),
+            "ys": ([rows, n], onnx.TensorProto.FLOAT),
+        },
         state={
             "w": ([n, k], w_next),
             "m": ([n, k], m_next),


### PR DESCRIPTION
## The gap this closes

`Gather`'s gradient rule (merged in #1256) made a `Gather` node inside a fine-tuning block differentiable, so the block-discovery walk stops splitting there. But `Gather` has two inputs of different semantic types: `data` (float, e.g. an embedding table) and `indices` (an **integer** tensor of row indices). Every op previously in `SUPPORTED_OPS` had exclusively float inputs, so the block-capture machinery was written assuming every tensor a block reads from *outside itself* is float32. That assumption is false whenever a block contains a `Gather` whose `indices` is a genuine external/runtime tensor rather than a same-block baked-in initializer (a same-block initializer already worked, since it carries its own real dtype unmodified).

**Confirmed failure mode, reproduced before fixing:** a block-external `Gather` `indices` input hits `onnxruntime.InferenceSession` creation with `INVALID_GRAPH: Type Error: Type 'tensor(float)' of input parameter (idx) of operator (Gather) ... is invalid` — the step graph's own `Gather` node declares a float `indices` input when the real tensor is int64. `_block_shapes`'s own shape inference (opset 17, `strict_mode=True`) doesn't itself reject this, so the failure surfaces one step later than a first guess would place it — at session creation, not at graph construction.

## What changed

**`_tensor_elem_types`/`_elem_type`** (new, in `qat.py`): reads each tensor's real ONNX element type from the float model's own declared types plus a best-effort shape-inference pass (mirroring `qat_interop._infer`'s "inference only adds information, a model it fails on is used as-is" discipline), falling back to FLOAT for anything it can't type — which is exactly what every block-external tensor was declared as unconditionally before this change, so the fallback preserves old behavior for the common case.

**Three call sites now use the real dtype instead of hardcoding FLOAT:**
- `_block_shapes` (`qat.py`) — declares each external's `ValueInfoProto` at its real type.
- `_capture` (`qat.py`) — captures calibration values at their real dtype instead of force-casting every array to float32.
- `qat_graph.make_step_graph`'s `constants` parameter — changed from `Dict[str, Shape]` to `Dict[str, Tuple[Shape, ElemType]]`, an intentionally breaking signature change (this function is internal, not part of `onnxsim`'s public API) so every caller states a dtype explicitly rather than a default silently re-introducing the bug. All five in-repo callers (`qat.py`, `adaround.py`, `adaquant.py`, `autoround.py`, plus the two fixture-generating scripts) updated accordingly — every existing caller passes `onnx.TensorProto.FLOAT` explicitly, so this is a mechanical, behavior-preserving change for all of them.

**A second, downstream half of the same bug, found while fixing the first:** after declaring the real dtype at graph-construction time, `run_step_graph`'s own `fixed = {k: np.asarray(v, dtype=np.float32) ...}` was still unconditionally force-casting every constant array to float32 before feeding the session — which now legitimately declares that input as `int64`, producing `Unexpected input data type. Actual: (tensor(float)), expected: (tensor(int64))`. Fixed via `_as_constant`: only floating-point arrays are normalized to float32 (preserving today's behavior, including absorbing a caller's float64 host computation, exactly as before); anything else passes through as its own dtype.

**Minibatch `gather_rows` needed no fix.** `Gather` preserves whatever dtype its `table` input has, so once the resident table constant is declared/fed at its real dtype (the two fixes above), the row-gather path is automatically correct — verified, not assumed.

**C++ mirror.** `qat_entry.{h,cpp}` and `qat_graph_builder.{h,cpp}` (the browser/WASM path) had the identical hardcoded-FLOAT bug in their own `QatCapture`/`BuildQatStepGraph`/`StepGraphSpec::NamedShape`/`MakeStepGraph`. Ported the same generalization: `InferFloatShapes` now also collects each tensor's ONNX element type, and both `QatCapture` and `StepGraphSpec::NamedShape` gained an `elem_type` field (defaulting to FLOAT for source compatibility with existing callers).

**Explicitly out of scope, left alone on purpose:** `_plan_trained` and the MatMul/Gemm/Conv-only trainable-weight finder. Making a `Gather` node's `data` differentiable is not the same as making its embedding table a directly-trained weight — that's separate follow-up work, not touched here.

## Verification

- Regression test reproduces the actual `INVALID_GRAPH`/dtype-mismatch failures first, confirmed against the current code before fixing, confirmed fixed after.
- `pytest tests/test_qat.py tests/test_qat_graph.py tests/test_qat_interop.py tests/test_graph_grad.py tests/test_qat_parity.py -q` — 308 passed.
- `mypy onnxsim/qat.py onnxsim/qat_graph.py` — clean.
- `ruff check` / `ruff format --check` — clean.
- `clang-format --dry-run --Werror` on all touched C++ files — clean.
- Fresh from-scratch C++ build (`-DONNXSIM_BUILTIN_ORT=OFF -DONNXSIM_TESTS=ON`), independently reproduced: `qat_entry_test`, `qat_graph_builder_test`, `qat_graph_parity_test`, and `graph_grad_test` all pass on freshly built binaries (verified byte-identical to what was actually built via file diff, and by binary mtime postdating every touched source file).
- Mutation-tested on both languages: reverting the Python fix makes the new regression tests fail with the original errors; reverting the C++ fix fails to compile (a test references a now-removed struct field).
- `scripts/make_qat_parity_fixtures.py`'s regenerated fixture is byte-identical (confirmed via checksum) — the all-float case is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_