### PR TITLE
BatchNormalization and InstanceNormalization's gradients

### DIFF
--- a/docs/qat.md
+++ b/docs/qat.md
@@ -215,7 +215,7 @@ Each stage is independently shippable and independently useful.
    pass here could do: every gradient in the repo is hand-derived for one
    fixed shape, which is exactly why `brecq.py` is capped at a linear chain.
    So `graph_grad.py` came first -- `build_backward` walks a forward slice in
-   reverse and emits the gradient as ordinary ONNX nodes, 21 op rules, each
+   reverse and emits the gradient as ordinary ONNX nodes, 27 op rules, each
    checked against central finite differences, its emission pinned to
    `qat_graph.EP_FRIENDLY_OPS`. It is a rule table and a reverse walk, not an
    autograd framework: the ONNX graph is already the tape.
@@ -422,10 +422,11 @@ learn scales and got a model whose scales are untouched has no way to tell
 that from a run where learning them did not help.
 
 Operator coverage is the same constraint it is under QAT, and it is still the
-binding one on a real model: `graph_grad.SUPPORTED_OPS` is 23 rules
-(`LayerNormalization` among them since this branch, and `Conv` since a later
-one), so a normalization -- or a convolution -- in the middle of a block is
-now more nodes in the slice rather than a boundary between blocks. On a CNN
+binding one on a real model: `graph_grad.SUPPORTED_OPS` is 27 rules
+(`LayerNormalization`, `BatchNormalization` and `InstanceNormalization` among
+them, and `Conv` since a later one), so a normalization -- or a convolution --
+in the middle of a block is now more nodes in the slice rather than a
+boundary between blocks. On a CNN
 that is the difference between blocks carved *around* every convolution and
 blocks that contain them, and the convolution's own weight trains too. The
 whole default ONNX domain is 202 operators.

--- a/onnxsim/graph_grad.cpp
+++ b/onnxsim/graph_grad.cpp
@@ -1399,6 +1399,189 @@ std::vector<OptStr> GradLayerNormalization(Backward& ctx,
   return grads;
 }
 
+std::vector<OptStr> GradBatchNormalization(Backward& ctx,
+                                           const onnx::NodeProto& node,
+                                           const std::string& g) {
+  // Five gradients, in inference mode (training_mode omitted or 0, the
+  // opset-17 default). mean/var are the node's own *inputs* here, fixed
+  // per-channel numbers rather than reductions of x, so unlike
+  // GradLayerNormalization dx does not depend on every other element in its
+  // group -- see _grad_batch_normalization in graph_grad.py for the
+  // derivation and for why training_mode=1 needs no check in this rule at
+  // all (the spec requires it to carry three outputs, so BuildBackward's own
+  // single-output check refuses it before this rule ever runs). This is a
+  // transcription of the Python, node for node.
+  const std::string& x = node.input(0);
+  const std::string& scale = node.input(1);
+  const std::string& bias = node.input(2);
+  const std::string& mean = node.input(3);
+  const std::string& var = node.input(4);
+  const std::string name = Quoted(node.output(0));
+  const Shape x_shape = ctx.ShapeOf(x);
+  const int64_t rank = static_cast<int64_t>(x_shape.size());
+  if (rank < 2) {
+    throw UnsupportedOpError(
+        "BatchNormalization needs a batch and a channel axis, got input "
+        "shape " +
+        ShapeStr(x_shape) + " (node " + name + ")");
+  }
+  const int64_t channels = x_shape[1];
+  const std::vector<std::pair<std::string, std::string>> operands = {
+      {"scale", scale}, {"B", bias}, {"mean", mean}, {"var", var}};
+  for (const auto& [label, tensor] : operands) {
+    const Shape shape = ctx.ShapeOf(tensor);
+    if (shape.size() != 1 || shape[0] != channels) {
+      throw UnsupportedOpError(
+          "BatchNormalization's " + label + " has shape " + ShapeStr(shape) +
+          ", not (" + std::to_string(channels) + ",) (node " + name + ")");
+    }
+  }
+  const float eps = AttrFloat(node, "epsilon", 1e-5f);
+
+  Shape bshape{1, channels};
+  for (int64_t i = 2; i < rank; ++i) bshape.push_back(1);
+
+  const std::string mean_shape_const = ctx.b().ConstInt64(bshape, "shape");
+  const std::string mean_b =
+      ctx.b().Op("Reshape", {mean, mean_shape_const}, "reshape");
+  const std::string xc = ctx.b().Sub(x, mean_b);
+
+  const std::string one = ctx.b().Const(1.0f);
+  const std::string var_shape_const = ctx.b().ConstInt64(bshape, "shape");
+  const std::string var_b =
+      ctx.b().Op("Reshape", {var, var_shape_const}, "reshape");
+  const std::string eps_const = ctx.b().Const(eps);
+  const std::string shifted = ctx.b().Add(var_b, eps_const);
+  const std::string deviation = ctx.b().Sqrt(shifted);
+  const std::string inv = ctx.b().Div(one, deviation);
+  const std::string xhat = ctx.b().Mul(xc, inv);
+
+  const std::string scale_shape_const = ctx.b().ConstInt64(bshape, "shape");
+  const std::string scale_b =
+      ctx.b().Op("Reshape", {scale, scale_shape_const}, "reshape");
+  const std::string gs = ctx.b().Mul(g, scale_b);
+  const std::string dx = ctx.b().Mul(gs, inv);
+
+  Shape channel_axes{0};
+  for (int64_t i = 2; i < rank; ++i) channel_axes.push_back(i);
+
+  const std::string g_xhat = ctx.b().Mul(g, xhat);
+  const std::string dscale_axes = ctx.b().ConstInt64(channel_axes, "axes");
+  const std::string dscale = ctx.b().Op("ReduceSum", {g_xhat, dscale_axes},
+                                        {IntAttr("keepdims", 0)}, "reducesum");
+
+  const std::string dbias_axes = ctx.b().ConstInt64(channel_axes, "axes");
+  const std::string dbias = ctx.b().Op("ReduceSum", {g, dbias_axes},
+                                       {IntAttr("keepdims", 0)}, "reducesum");
+
+  const std::string dmean_axes = ctx.b().ConstInt64(channel_axes, "axes");
+  const std::string dx_summed = ctx.b().Op(
+      "ReduceSum", {dx, dmean_axes}, {IntAttr("keepdims", 0)}, "reducesum");
+  const std::string dmean = ctx.b().Op("Neg", {dx_summed}, "neg");
+
+  // dvar = -0.5 * sum(dx * xhat * inv): dx * xhat alone is only inv^2 (one
+  // factor from each), so this needs one more multiply by inv to reach the
+  // inv^3 the chain rule through sqrt actually produces -- see the Python
+  // docstring's note on exactly this point.
+  const std::string dx_xhat = ctx.b().Mul(dx, xhat);
+  const std::string dx_xhat_inv = ctx.b().Mul(dx_xhat, inv);
+  const std::string dvar_axes = ctx.b().ConstInt64(channel_axes, "axes");
+  const std::string dvar_summed =
+      ctx.b().Op("ReduceSum", {dx_xhat_inv, dvar_axes},
+                 {IntAttr("keepdims", 0)}, "reducesum");
+  const std::string neg_half = ctx.b().Const(-0.5f);
+  const std::string dvar = ctx.b().Mul(dvar_summed, neg_half);
+
+  return {dx, dscale, dbias, dmean, dvar};
+}
+
+std::vector<OptStr> GradInstanceNormalization(Backward& ctx,
+                                              const onnx::NodeProto& node,
+                                              const std::string& g) {
+  // Three gradients. Same coupling as GradLayerNormalization -- mean and
+  // variance are computed from x itself, so every element's gradient depends
+  // on every other element in its group through them -- but the group is one
+  // (batch, channel) pair, reduced over the spatial axes [2, rank) only,
+  // rather than a suffix of axes named by an axis attribute
+  // (InstanceNormalization has none; the channel axis is always 1). scale/B
+  // are one entry per channel, GradBatchNormalization's broadcast rather
+  // than layer-norm's, so scale is reshaped to [1, C, 1, ..., 1] the same
+  // way before use. See _grad_instance_normalization in graph_grad.py for
+  // the full derivation; this is a transcription of it, node for node.
+  const std::string& x = node.input(0);
+  const std::string& scale = node.input(1);
+  const std::string& bias = node.input(2);
+  const std::string name = Quoted(node.output(0));
+  const Shape x_shape = ctx.ShapeOf(x);
+  const int64_t rank = static_cast<int64_t>(x_shape.size());
+  if (rank < 3) {
+    throw UnsupportedOpError(
+        "InstanceNormalization needs at least one spatial dimension, got "
+        "input shape " +
+        ShapeStr(x_shape) + " (node " + name + ")");
+  }
+  const int64_t channels = x_shape[1];
+  const std::vector<std::pair<std::string, std::string>> operands = {
+      {"scale", scale}, {"B", bias}};
+  for (const auto& [label, tensor] : operands) {
+    const Shape shape = ctx.ShapeOf(tensor);
+    if (shape.size() != 1 || shape[0] != channels) {
+      throw UnsupportedOpError(
+          "InstanceNormalization's " + label + " has shape " + ShapeStr(shape) +
+          ", not (" + std::to_string(channels) + ",) (node " + name + ")");
+    }
+  }
+  const float eps = AttrFloat(node, "epsilon", 1e-5f);
+
+  Shape spatial_axes;
+  for (int64_t i = 2; i < rank; ++i) spatial_axes.push_back(i);
+  const std::vector<onnx::AttributeProto> reduce_attrs = {
+      IntsAttr("axes", spatial_axes), IntAttr("keepdims", 1)};
+
+  Shape bshape{1, channels};
+  for (int64_t i = 2; i < rank; ++i) bshape.push_back(1);
+  const std::string scale_shape_const = ctx.b().ConstInt64(bshape, "shape");
+  const std::string scale_b =
+      ctx.b().Op("Reshape", {scale, scale_shape_const}, "reshape");
+
+  const std::string mu =
+      ctx.b().Op("ReduceMean", {x}, reduce_attrs, "reducemean");
+  const std::string xc = ctx.b().Sub(x, mu);
+  const std::string xc_squared = ctx.b().Mul(xc, xc);
+  const std::string var =
+      ctx.b().Op("ReduceMean", {xc_squared}, reduce_attrs, "reducemean");
+  const std::string one = ctx.b().Const(1.0f);
+  const std::string eps_const = ctx.b().Const(eps);
+  const std::string shifted = ctx.b().Add(var, eps_const);
+  const std::string deviation = ctx.b().Sqrt(shifted);
+  const std::string inv = ctx.b().Div(one, deviation);
+  const std::string xhat = ctx.b().Mul(xc, inv);
+
+  const std::string gs = ctx.b().Mul(g, scale_b);
+  const std::string mean_gs =
+      ctx.b().Op("ReduceMean", {gs}, reduce_attrs, "reducemean");
+  const std::string gs_xhat = ctx.b().Mul(gs, xhat);
+  const std::string mean_gs_xhat =
+      ctx.b().Op("ReduceMean", {gs_xhat}, reduce_attrs, "reducemean");
+  const std::string centred = ctx.b().Sub(gs, mean_gs);
+  const std::string correction = ctx.b().Mul(xhat, mean_gs_xhat);
+  const std::string inner = ctx.b().Sub(centred, correction);
+  const std::string dx = ctx.b().Mul(inv, inner);
+
+  const std::string g_xhat = ctx.b().Mul(g, xhat);
+  Shape channel_axes{0};
+  channel_axes.insert(channel_axes.end(), spatial_axes.begin(),
+                      spatial_axes.end());
+  const std::string dscale_axes = ctx.b().ConstInt64(channel_axes, "axes");
+  const std::string dscale = ctx.b().Op("ReduceSum", {g_xhat, dscale_axes},
+                                        {IntAttr("keepdims", 0)}, "reducesum");
+  const std::string dbias_axes = ctx.b().ConstInt64(channel_axes, "axes");
+  const std::string dbias = ctx.b().Op("ReduceSum", {g, dbias_axes},
+                                       {IntAttr("keepdims", 0)}, "reducesum");
+
+  return {dx, dscale, dbias};
+}
+
 std::vector<OptStr> GradClip(Backward& ctx, const onnx::NodeProto& node,
                              const std::string& g) {
   // Pass the gradient through where the input was *strictly* inside the
@@ -1516,6 +1699,7 @@ const std::map<std::string, Rule>& Rules() {
       new std::map<std::string, Rule>{
           {"Add", &GradAdd},
           {"AveragePool", &GradAveragePool},
+          {"BatchNormalization", &GradBatchNormalization},
           {"Clip", &GradClip},
           {"Conv", &GradConv},
           {"Div", &GradDiv},
@@ -1524,6 +1708,7 @@ const std::map<std::string, Rule>& Rules() {
           {"Gather", &GradGather},
           {"Gemm", &GradGemm},
           {"Identity", &GradIdentity},
+          {"InstanceNormalization", &GradInstanceNormalization},
           {"LayerNormalization", &GradLayerNormalization},
           {"MatMul", &GradMatMul},
           {"MaxPool", &GradMaxPool},
@@ -1568,6 +1753,9 @@ const std::set<std::string>& BackwardOps() {
   // set says why that is not a loosening either, and the EP_FRIENDLY_OPS note
   // in qat_graph.py records what a Conv/ConvTranspose membership would have
   // cost instead.
+  // GradBatchNormalization and GradInstanceNormalization needed nothing from
+  // this set at all -- every op their gradients use was already here for
+  // GradLayerNormalization or the elementwise rules.
   static const std::set<std::string>* ops = new std::set<std::string>{
       "Add",     "Cast",   "Div", "Exp",      "Gather",     "Greater",
       "Less",    "MatMul", "Mul", "Neg",      "ReduceMean", "ReduceSum",

--- a/onnxsim/graph_grad.py
+++ b/onnxsim/graph_grad.py
@@ -115,6 +115,15 @@ BACKWARD_OPS = frozenset(
 # axis, a constant int64 index, and no dependence of the *index* on any
 # runtime value.
 
+# :func:`_grad_batch_normalization` and :func:`_grad_instance_normalization`
+# needed nothing from this set at all: every op their gradients use --
+# ``Sub``, ``Div``, ``Mul``, ``Add``, ``Sqrt``, ``Reshape`` (for the
+# per-channel broadcast, in place of ``Expand``), ``ReduceSum``/``ReduceMean``
+# and ``Neg`` -- was already here for :func:`_grad_layer_normalization` or the
+# elementwise rules. Worth recording precisely because it is the exception to
+# every other note in this block, which each admitted one specific op for one
+# specific rule.
+
 
 class UnsupportedOpError(ValueError):
     """Raised for a node whose op type has no VJP rule.
@@ -1327,6 +1336,201 @@ def _grad_layer_normalization(
     return grads
 
 
+def _grad_batch_normalization(
+    ctx: _Backward, node: onnx.NodeProto, g: str
+) -> List[Optional[str]]:
+    """``BatchNormalization``'s five gradients, in inference mode.
+
+    A step graph never runs this op with ``training_mode=1``: this repo's
+    fine-tuning graphs fake-quantize and reconstruct against *fixed* running
+    statistics, they do not re-estimate a mean and variance from the current
+    minibatch the way live training would. A ``training_mode=1`` node is
+    refused anyway, but not by a check in this rule -- the spec requires it
+    to have three outputs (``Y``, ``running_mean``, ``running_var``), so
+    :func:`build_backward`'s own single-output check refuses it before this
+    rule ever runs, the same way :func:`_grad_maxpool`'s docstring explains
+    ``MaxPool``'s optional ``Indices`` output needs no rule-specific check of
+    its own. What is left, at the opset-17 default (``training_mode``
+    omitted or 0), is per the spec::
+
+        xc   = x - mean            inv = 1 / sqrt(var + eps)
+        xhat = xc * inv            y   = xhat * scale + B
+
+    with ``mean``/``var`` the node's own *inputs* -- fixed per-channel
+    numbers, not reductions of ``x``. That is the whole difference from
+    :func:`_grad_layer_normalization`: there, ``mean``/``var`` are computed
+    from ``x`` itself, so every output element's gradient depends on every
+    other element through them; here they do not depend on ``x`` at all, so
+    differentiating through them is nothing more than differentiating
+    through two more per-channel constants, each appearing exactly where the
+    forward above shows::
+
+        dx     = g * scale * inv
+        dscale = sum_{n, spatial} (g * xhat)
+        db     = sum_{n, spatial} g
+        dmean  = -sum_{n, spatial} (g * scale * inv)  = -sum_{n, spatial}(dx)
+        dvar   = -0.5 * sum_{n, spatial} (g * scale * xc * inv^3)
+               = -0.5 * sum_{n, spatial} (dx * xhat * inv)
+
+    the last two reusing ``dx`` (``g * scale * inv``, already needed for
+    ``x``'s own gradient) and ``xhat`` (already needed for ``dscale``)
+    instead of recomputing either -- ``dx * xhat`` alone is only ``inv^2``
+    (one factor from each), so ``dvar`` needs one more multiply by ``inv``
+    to reach the ``inv^3`` the chain rule through ``sqrt`` actually produces.
+
+    **The broadcast.** ``scale``, ``B``, ``mean`` and ``var`` are all
+    ``[C]`` and broadcast against axis 1 specifically, not against ``x``'s
+    trailing axes the way :meth:`_Backward.reduce_to` (built for ordinary
+    numpy-style broadcasting -- every ``Add``/``Mul``/``Sub`` rule's own
+    case) undoes. Reshaping ``scale`` and ``mean`` to ``[1, C, 1, ..., 1]``
+    once, up front, turns their use in the forward arithmetic above into an
+    ordinary broadcast; going the other way, the four channel-shaped
+    gradients are each one ``ReduceSum`` over every axis but 1 with
+    ``keepdims=0``, producing the ``[C]`` shape directly -- the same move
+    :func:`_grad_conv` makes for its own bias gradient, generalized from
+    "batch and the spatial axes" to "every axis but the channel one", which
+    is also right when there are no spatial axes at all (``x`` rank 2, just
+    batch and channel): the reduction is then over the batch axis alone.
+    """
+    x = node.input[0]
+    scale, bias = node.input[1], node.input[2]
+    mean, var = node.input[3], node.input[4]
+    name = node.output[0]
+    x_shape = ctx.shape(x)
+    rank = len(x_shape)
+    if rank < 2:
+        raise UnsupportedOpError(
+            f"BatchNormalization needs a batch and a channel axis, got "
+            f"input shape {x_shape} (node {name!r})"
+        )
+    channels = int(x_shape[1])
+    for label, tensor in (
+        ("scale", scale),
+        ("B", bias),
+        ("mean", mean),
+        ("var", var),
+    ):
+        shape = ctx.shape(tensor)
+        if tuple(shape) != (channels,):
+            raise UnsupportedOpError(
+                f"BatchNormalization's {label} has shape {tuple(shape)}, not "
+                f"({channels},) (node {name!r})"
+            )
+    eps = float(_attr(node, "epsilon", 1e-5))
+
+    bshape = (1, channels) + (1,) * (rank - 2)
+
+    def bcast(t: str) -> str:
+        return ctx.b.op("Reshape", [t, ctx.int64_const(bshape, "shape")])
+
+    xc = ctx.b.sub(x, bcast(mean))
+    inv = ctx.b.div(
+        ctx.b.const(1.0), ctx.b.sqrt(ctx.b.add(bcast(var), ctx.b.const(eps)))
+    )
+    xhat = ctx.b.mul(xc, inv)
+
+    gs = ctx.b.mul(g, bcast(scale))
+    dx = ctx.b.mul(gs, inv)
+
+    channel_axes = [0] + list(range(2, rank))
+
+    def reduce_channel(t: str) -> str:
+        return ctx.b.op(
+            "ReduceSum", [t, ctx.int64_const(channel_axes, "axes")], keepdims=0
+        )
+
+    dscale = reduce_channel(ctx.b.mul(g, xhat))
+    dbias = reduce_channel(g)
+    dmean = ctx.b.op("Neg", [reduce_channel(dx)])
+    dvar = ctx.b.mul(
+        reduce_channel(ctx.b.mul(ctx.b.mul(dx, xhat), inv)), ctx.b.const(-0.5)
+    )
+
+    return [dx, dscale, dbias, dmean, dvar]
+
+
+def _grad_instance_normalization(
+    ctx: _Backward, node: onnx.NodeProto, g: str
+) -> List[Optional[str]]:
+    """``InstanceNormalization``'s three gradients.
+
+    Same coupling as :func:`_grad_layer_normalization` -- mean and variance
+    are computed from ``x`` itself, so every element's gradient depends on
+    every other element in its group through them -- but a different group:
+    one ``(batch, channel)`` pair, reduced over the spatial axes ``[2,
+    rank)`` only, rather than a suffix of axes named by an ``axis``
+    attribute (``InstanceNormalization`` has none; the channel axis is
+    always 1, per the spec). Per the ONNX doc::
+
+        mu   = mean_spatial(x)      xc  = x - mu
+        var  = mean_spatial(xc^2)   inv = 1 / sqrt(var + eps)
+        xhat = xc * inv             y   = xhat * scale + B
+
+    with ``scale``/``B`` one entry per channel, broadcasting against every
+    batch element and every spatial position --
+    :func:`_grad_batch_normalization`'s broadcast, not layer-norm's, so
+    ``scale`` is reshaped to ``[1, C, 1, ..., 1]`` the same way before use.
+    Past that reshape, ``dx`` is exactly layer-norm's own ``dx`` with
+    ``axes`` set to the spatial ones, and ``dscale``/``db`` are batch-norm's
+    channel-reduced ``ReduceSum``, over batch and spatial together this time
+    since neither of those is the channel axis.
+
+    A rank below 3 -- no spatial axis at all -- is refused: the reduction
+    would then be over an empty axis list, which ``ReduceMean`` treats as
+    "reduce every axis" rather than "reduce none", silently changing what
+    "instance" means. That is exactly the kind of behaviour
+    :class:`UnsupportedOpError` exists to catch at build time instead of
+    risking.
+    """
+    x, scale, bias = node.input[0], node.input[1], node.input[2]
+    name = node.output[0]
+    x_shape = ctx.shape(x)
+    rank = len(x_shape)
+    if rank < 3:
+        raise UnsupportedOpError(
+            f"InstanceNormalization needs at least one spatial dimension, "
+            f"got input shape {x_shape} (node {name!r})"
+        )
+    channels = int(x_shape[1])
+    for label, tensor in (("scale", scale), ("B", bias)):
+        shape = ctx.shape(tensor)
+        if tuple(shape) != (channels,):
+            raise UnsupportedOpError(
+                f"InstanceNormalization's {label} has shape {tuple(shape)}, "
+                f"not ({channels},) (node {name!r})"
+            )
+    eps = float(_attr(node, "epsilon", 1e-5))
+    spatial_axes = list(range(2, rank))
+    bshape = (1, channels) + (1,) * (rank - 2)
+    scale_b = ctx.b.op("Reshape", [scale, ctx.int64_const(bshape, "shape")])
+
+    mu = ctx.b.op("ReduceMean", [x], axes=spatial_axes, keepdims=1)
+    xc = ctx.b.sub(x, mu)
+    var = ctx.b.op("ReduceMean", [ctx.b.mul(xc, xc)], axes=spatial_axes, keepdims=1)
+    inv = ctx.b.div(ctx.b.const(1.0), ctx.b.sqrt(ctx.b.add(var, ctx.b.const(eps))))
+    xhat = ctx.b.mul(xc, inv)
+
+    gs = ctx.b.mul(g, scale_b)
+    mean_gs = ctx.b.op("ReduceMean", [gs], axes=spatial_axes, keepdims=1)
+    mean_gs_xhat = ctx.b.op(
+        "ReduceMean", [ctx.b.mul(gs, xhat)], axes=spatial_axes, keepdims=1
+    )
+    dx = ctx.b.mul(
+        inv, ctx.b.sub(ctx.b.sub(gs, mean_gs), ctx.b.mul(xhat, mean_gs_xhat))
+    )
+
+    channel_axes = [0] + spatial_axes
+
+    def reduce_channel(t: str) -> str:
+        return ctx.b.op(
+            "ReduceSum", [t, ctx.int64_const(channel_axes, "axes")], keepdims=0
+        )
+
+    dscale = reduce_channel(ctx.b.mul(g, xhat))
+    dbias = reduce_channel(g)
+    return [dx, dscale, dbias]
+
+
 def _grad_clip(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
     """Pass the gradient through where the input was strictly inside the
     bounds, zero it elsewhere.
@@ -1464,6 +1668,7 @@ def _grad_gather(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[
 _RULES: Dict[str, Rule] = {
     "Add": _grad_add,
     "AveragePool": _grad_averagepool,
+    "BatchNormalization": _grad_batch_normalization,
     "Clip": _grad_clip,
     "Conv": _grad_conv,
     "Div": _grad_div,
@@ -1472,6 +1677,7 @@ _RULES: Dict[str, Rule] = {
     "Gather": _grad_gather,
     "Gemm": _grad_gemm,
     "Identity": _grad_identity,
+    "InstanceNormalization": _grad_instance_normalization,
     "LayerNormalization": _grad_layer_normalization,
     "MatMul": _grad_matmul,
     "MaxPool": _grad_maxpool,

--- a/onnxsim/graph_grad_test.cpp
+++ b/onnxsim/graph_grad_test.cpp
@@ -221,6 +221,29 @@ Shapes LayerNormShapes() {
   return {{"X", {2, 3, 4}}, {"S", {4}}, {"Bn", {4}}, {"Y", {2, 3, 4}}};
 }
 
+// A fused BatchNormalization in inference mode -- mean/var are fixed
+// per-channel inputs here rather than reductions of X, so this is the only
+// slice whose Neg comes from a reduction result rather than from GradSub.
+std::vector<onnx::NodeProto> BatchNormSlice() {
+  return {Node("BatchNormalization", {"X", "S", "Bn", "Mn", "Vr"}, {"Y"})};
+}
+
+Shapes BatchNormShapes() {
+  return {{"X", {2, 3, 4, 4}}, {"S", {3}},  {"Bn", {3}},
+          {"Mn", {3}},         {"Vr", {3}}, {"Y", {2, 3, 4, 4}}};
+}
+
+// InstanceNormalization -- mean/var computed from X itself like LayerNorm,
+// but over the spatial axes only, with a per-channel scale/B that (like
+// BatchNormalization's) needs reshaping before it broadcasts against X.
+std::vector<onnx::NodeProto> InstanceNormSlice() {
+  return {Node("InstanceNormalization", {"X", "S", "Bn"}, {"Y"})};
+}
+
+Shapes InstanceNormShapes() {
+  return {{"X", {2, 3, 4, 4}}, {"S", {3}}, {"Bn", {3}}, {"Y", {2, 3, 4, 4}}};
+}
+
 // A convolution with a bias -- the rule with a weight tensor to
 // differentiate, and (along with MaxPool/AveragePool below) one whose
 // emission depends on arithmetic (the index tables) rather than only on the
@@ -262,6 +285,7 @@ Shapes PoolShapes() {
 void TheSupportedOpsAreExactlyThePythonRuleTable() {
   const std::set<std::string> expected = {"Add",
                                           "AveragePool",
+                                          "BatchNormalization",
                                           "Clip",
                                           "Conv",
                                           "Div",
@@ -270,6 +294,7 @@ void TheSupportedOpsAreExactlyThePythonRuleTable() {
                                           "Gather",
                                           "Gemm",
                                           "Identity",
+                                          "InstanceNormalization",
                                           "LayerNormalization",
                                           "MatMul",
                                           "MaxPool",
@@ -323,6 +348,8 @@ void TheEmittedBackwardStaysInsideTheOperatorAllowlist() {
       {TranscendentalSlice(), TranscendentalShapes(), {"A"}},
       {GemmSlice(), GemmShapes(), {"A", "W", "Cb"}},
       {LayerNormSlice(), LayerNormShapes(), {"X", "S", "Bn"}},
+      {BatchNormSlice(), BatchNormShapes(), {"X", "S", "Bn", "Mn", "Vr"}},
+      {InstanceNormSlice(), InstanceNormShapes(), {"X", "S", "Bn"}},
       {ConvSlice(), ConvShapes(), {"X", "Wc", "Bc"}},
       {PoolSlice(), PoolShapes(), {"X"}},
   };
@@ -550,6 +577,170 @@ void TheLayerNormRuleEmitsTheSameNodesInTheSameOrderAsThePython() {
           "a LayerNorm without a bias should emit two nodes fewer");
     Check(grads.size() == 2 && grads.count("Bn") == 0,
           "a LayerNorm without a bias has no third gradient");
+  }
+}
+
+// If this fails, the C++ BatchNormalization rule has drifted from
+// _grad_batch_normalization in graph_grad.py -- pinned the same way and for
+// the same reason as the LayerNorm rule above.
+void TheBatchNormRuleEmitsTheSameNodesInTheSameOrderAsThePython() {
+  GraphBuilder b("bw_");
+  const std::map<std::string, std::string> grads =
+      BuildBackward(b, BatchNormSlice(), BatchNormShapes(), {{"Y", "dY"}},
+                    {"X", "S", "Bn", "Mn", "Vr"});
+  // mean reshaped to [1, C, 1, 1] and subtracted (xc); var reshaped, +eps,
+  // sqrt, inv; xhat = xc * inv; scale reshaped, gs = g * scale, dx = gs *
+  // inv; g * xhat reduced over every axis but 1 for dscale; g reduced the
+  // same way for db; dx reduced and negated for dmean; dx * xhat * inv
+  // reduced and scaled by -0.5 for dvar (one more multiply by inv than
+  // dscale's numerator needed, since the chain rule through sqrt produces
+  // inv^3 rather than inv^2 -- see the Python docstring's note on this).
+  const std::vector<std::string> expected = {
+      "Reshape", "Sub",       "Reshape",   "Add",       "Sqrt",
+      "Div",     "Mul",       "Reshape",   "Mul",       "Mul",
+      "Mul",     "ReduceSum", "ReduceSum", "ReduceSum", "Neg",
+      "Mul",     "Mul",       "ReduceSum", "Mul"};
+  Check(OpTypes(b) == expected,
+        "the BatchNormalization rule should emit graph_grad.py's nodes in "
+        "its order");
+  Check(b.nodes().size() == expected.size() &&
+            grads.at("X") == b.nodes()[9].output(0),
+        "dX should be the Mul(gs, inv) that closes the dx expression");
+  Check(grads.at("S") == b.nodes()[11].output(0),
+        "dscale should be the ReduceSum over g * xhat");
+  Check(grads.at("Bn") == b.nodes()[12].output(0),
+        "db should be the ReduceSum over g alone");
+  Check(grads.at("Mn") == b.nodes()[14].output(0),
+        "dmean should be the Neg of the reduced dx");
+  Check(grads.at("Vr") == b.nodes().back().output(0),
+        "dvar should be the last thing emitted");
+  // Three broadcast shapes ([1, C, 1, 1] for mean, var and scale), the 1.0
+  // numerator, epsilon, four reduce-axes lists (dscale/db/dmean/dvar) and
+  // -0.5 -- ten initializers, none shared between uses, the same
+  // one-initializer-per-call discipline GraphBuilder.const/int64_const
+  // follow in the Python.
+  Check(b.initializer().size() == 10, "the rule emits ten initializers");
+  const std::set<std::string> emitted = OpTypeSet(b);
+  Check(emitted.count("Conv") == 0 && emitted.count("MatMul") == 0 &&
+            emitted.count("Expand") == 0,
+        "BatchNormalization's gradient needs no weight and no matmul, and "
+        "the per-channel broadcast is a Reshape plus an ordinary Mul rather "
+        "than an Expand");
+}
+
+// The InstanceNormalization analogue of the BatchNormalization pin above.
+void TheInstanceNormRuleEmitsTheSameNodesInTheSameOrderAsThePython() {
+  GraphBuilder b("bw_");
+  const std::map<std::string, std::string> grads =
+      BuildBackward(b, InstanceNormSlice(), InstanceNormShapes(), {{"Y", "dY"}},
+                    {"X", "S", "Bn"});
+  // scale reshaped to [1, C, 1, 1] up front; mu, xc, xc^2, var (both
+  // ReduceMeans over the spatial axes only), var+eps, sqrt, inv, xhat --
+  // exactly LayerNorm's own sequence with the reduced axes changed; then gs,
+  // mean(gs), gs*xhat, mean(gs*xhat), the two mean terms subtracted off and
+  // dx; finally g*xhat and g reduced over batch and spatial together for
+  // dscale/db.
+  const std::vector<std::string> expected = {
+      "Reshape",    "ReduceMean", "Sub",        "Mul",       "ReduceMean",
+      "Add",        "Sqrt",       "Div",        "Mul",       "Mul",
+      "ReduceMean", "Mul",        "ReduceMean", "Sub",       "Mul",
+      "Sub",        "Mul",        "Mul",        "ReduceSum", "ReduceSum"};
+  Check(OpTypes(b) == expected,
+        "the InstanceNormalization rule should emit graph_grad.py's nodes "
+        "in its order");
+  Check(b.nodes().size() == expected.size() &&
+            grads.at("X") == b.nodes()[16].output(0),
+        "dX should be the Mul(inv, ...) that closes the dx expression");
+  Check(grads.at("S") == b.nodes()[18].output(0),
+        "dscale should be the ReduceSum over g * xhat");
+  Check(grads.at("Bn") == b.nodes().back().output(0),
+        "db should be the last thing emitted");
+  Check(b.initializer().size() == 5,
+        "the rule emits five initializers: the [1, C, 1, 1] broadcast "
+        "shape, the 1.0 numerator, epsilon, and the two reduce-axes lists");
+  const std::set<std::string> emitted = OpTypeSet(b);
+  Check(emitted.count("Expand") == 0 && emitted.count("Conv") == 0 &&
+            emitted.count("MatMul") == 0,
+        "InstanceNormalization's gradient needs no weight, no matmul and no "
+        "Expand");
+}
+
+// If this fails, a BatchNormalization whose rank or per-channel operand
+// shapes don't add up would be differentiated against a geometry it
+// invented -- the same hazard APoolGeometryThatDoesNotResolveIsRefused
+// checks for MaxPool/AveragePool.
+void ABatchNormGeometryThatDoesNotAddUpIsRefused() {
+  {
+    // No batch or channel axis at all.
+    const Shapes shapes = {{"X", {3}},  {"S", {3}},  {"Bn", {3}},
+                           {"Mn", {3}}, {"Vr", {3}}, {"Y", {3}}};
+    GraphBuilder b;
+    CheckThrows<UnsupportedOpError>(
+        [&] {
+          BuildBackward(b, BatchNormSlice(), shapes, {{"Y", "dY"}}, {"X"});
+        },
+        "channel axis",
+        "BatchNormalization with no batch or channel axis is refused");
+  }
+  {
+    // scale's shape does not match X's channel count.
+    const Shapes shapes = {{"X", {1, 3, 4, 4}}, {"S", {2}},
+                           {"Bn", {3}},         {"Mn", {3}},
+                           {"Vr", {3}},         {"Y", {1, 3, 4, 4}}};
+    GraphBuilder b;
+    CheckThrows<UnsupportedOpError>(
+        [&] {
+          BuildBackward(b, BatchNormSlice(), shapes, {{"Y", "dY"}}, {"X"});
+        },
+        "scale has shape",
+        "BatchNormalization with a mismatched scale is refused");
+  }
+  {
+    // training_mode=1 -- refused by BuildBackward's own single-output check
+    // before this rule ever runs, since the spec requires three outputs
+    // whenever training_mode=1. There is no spec-conformant one-output
+    // training_mode=1 graph to construct, which is exactly why this rule
+    // carries no training_mode check of its own -- see the rule's comment.
+    const Shapes shapes = {
+        {"X", {1, 2, 3, 3}}, {"S", {2}},          {"Bn", {2}}, {"Mn", {2}},
+        {"Vr", {2}},         {"Y", {1, 2, 3, 3}}, {"RM", {2}}, {"RV", {2}}};
+    GraphBuilder b;
+    CheckThrows<UnsupportedOpError>(
+        [&] {
+          BuildBackward(
+              b,
+              {Node("BatchNormalization", {"X", "S", "Bn", "Mn", "Vr"},
+                    {"Y", "RM", "RV"}, {IntAttr("training_mode", 1)})},
+              shapes, {{"Y", "dY"}}, {"X"});
+        },
+        "3 outputs", "BatchNormalization with training_mode=1 is refused");
+  }
+}
+
+// The InstanceNormalization analogue of the refusals above.
+void AnInstanceNormGeometryThatDoesNotAddUpIsRefused() {
+  {
+    // No spatial axis at all (rank 2: batch and channel only).
+    const Shapes shapes = {
+        {"X", {4, 3}}, {"S", {3}}, {"Bn", {3}}, {"Y", {4, 3}}};
+    GraphBuilder b;
+    CheckThrows<UnsupportedOpError>(
+        [&] {
+          BuildBackward(b, InstanceNormSlice(), shapes, {{"Y", "dY"}}, {"X"});
+        },
+        "spatial dimension",
+        "InstanceNormalization with no spatial axis is refused");
+  }
+  {
+    const Shapes shapes = {
+        {"X", {1, 3, 4, 4}}, {"S", {2}}, {"Bn", {3}}, {"Y", {1, 3, 4, 4}}};
+    GraphBuilder b;
+    CheckThrows<UnsupportedOpError>(
+        [&] {
+          BuildBackward(b, InstanceNormSlice(), shapes, {{"Y", "dY"}}, {"X"});
+        },
+        "scale has shape",
+        "InstanceNormalization with a mismatched scale is refused");
   }
 }
 
@@ -1090,6 +1281,10 @@ int main() {
   ReducedAxesComeFromTheAttributeWhenThereIsOne();
   ABroadcastGradientIsSummedBackToTheOperandShape();
   TheLayerNormRuleEmitsTheSameNodesInTheSameOrderAsThePython();
+  TheBatchNormRuleEmitsTheSameNodesInTheSameOrderAsThePython();
+  TheInstanceNormRuleEmitsTheSameNodesInTheSameOrderAsThePython();
+  ABatchNormGeometryThatDoesNotAddUpIsRefused();
+  AnInstanceNormGeometryThatDoesNotAddUpIsRefused();
   TheConvRuleEmitsTheSameNodesInTheSameOrderAsThePython();
   TheConvIndexTablesAreTheOnesTheGeometryImplies();
   AConvWhoseGeometryDoesNotAddUpIsRefused();

--- a/onnxsim/qat_parity_fixtures.txt
+++ b/onnxsim/qat_parity_fixtures.txt
@@ -3,7 +3,7 @@
 # Asserted against onnxsim/qat_graph.py (tests/test_qat_parity.py) and
 # against onnxsim/qat_graph_builder.cpp (onnxsim/qat_graph_parity_test.cpp).
 ops Abs,Add,Cast,Clip,Div,Exp,Gather,Greater,Less,MatMul,Mul,Neg,Pow,ReduceMean,ReduceSum,Reshape,Sigmoid,Sign,Sqrt,Sub,Transpose
-rules Add,AveragePool,Clip,Conv,Div,Erf,Exp,Gather,Gemm,Identity,LayerNormalization,MatMul,MaxPool,Mul,Neg,ReduceMean,ReduceSum,Relu,Reshape,Sigmoid,Softmax,Sqrt,Sub,Tanh,Transpose
+rules Add,AveragePool,BatchNormalization,Clip,Conv,Div,Erf,Exp,Gather,Gemm,Identity,InstanceNormalization,LayerNormalization,MatMul,MaxPool,Mul,Neg,ReduceMean,ReduceSum,Relu,Reshape,Sigmoid,Softmax,Sqrt,Sub,Tanh,Transpose
 backward_ops Add,Cast,Div,Exp,Gather,Greater,Less,MatMul,Mul,Neg,ReduceMean,ReduceSum,Reshape,Sqrt,Sub,Transpose
 model_text <ir_version: 10, opset_import: ["" : 21]>
 model_text g (float[4,32] X) => (float[4,32] Y) {

--- a/scripts/convertmodel/qat_blocks.mjs
+++ b/scripts/convertmodel/qat_blocks.mjs
@@ -57,6 +57,7 @@ import { fields, decode } from "./macs.mjs";
 export const DIFFERENTIABLE_OPS = new Set([
   "Add",
   "AveragePool",
+  "BatchNormalization",
   "Clip",
   "Conv",
   "Div",
@@ -65,6 +66,7 @@ export const DIFFERENTIABLE_OPS = new Set([
   "Gather",
   "Gemm",
   "Identity",
+  "InstanceNormalization",
   "LayerNormalization",
   "MatMul",
   "MaxPool",

--- a/tests/test_graph_grad.py
+++ b/tests/test_graph_grad.py
@@ -764,6 +764,95 @@ _CASES = {
         """,
         None,
     ),
+    # BatchNormalization, inference mode (training_mode omitted, the opset-17
+    # default): mean/var are the node's own *inputs*, fixed per-channel
+    # numbers rather than reductions of X, so unlike LayerNormalization dX
+    # does not depend on every other element in its group -- see
+    # _grad_batch_normalization for the derivation. V is kept positive
+    # (variance) via _positive, the same way sqrt's own case does.
+    "batch_norm": (
+        """
+        g (float[2,3,4,4] X, float[3] S, float[3] Bs, float[3] M, float[3] V)
+            => (float[2,3,4,4] Y) {
+          Y = BatchNormalization(X, S, Bs, M, V)
+        }
+        """,
+        {"V": _positive},
+    ),
+    # A non-trivial channel count together with a different spatial rank (one
+    # spatial axis instead of two), to catch a rule that hardcoded "axis 1 of
+    # 4" rather than reading the rank generically.
+    "batch_norm_channel_count": (
+        """
+        g (float[2,5,7] X, float[5] S, float[5] Bs, float[5] M, float[5] V)
+            => (float[2,5,7] Y) {
+          Y = BatchNormalization(X, S, Bs, M, V)
+        }
+        """,
+        {"V": _positive},
+    ),
+    # Rank 2 -- batch and channel only, no spatial axis at all. The
+    # broadcast/reduce subtlety this exercises: dscale/db/dmean/dvar's
+    # ReduceSum then has only the batch axis to sum over, not "batch and
+    # spatial", and a rule that assumed a spatial axis exists (e.g. hardcoded
+    # axes=[0, 2, 3]) would break here instead of merely computing a
+    # differently-shaped right answer.
+    "batch_norm_no_spatial": (
+        """
+        g (float[4,3] X, float[3] S, float[3] Bs, float[3] M, float[3] V)
+            => (float[4,3] Y) {
+          Y = BatchNormalization(X, S, Bs, M, V)
+        }
+        """,
+        {"V": _positive},
+    ),
+    "batch_norm_epsilon": (
+        """
+        g (float[2,3,4,4] X, float[3] S, float[3] Bs, float[3] M, float[3] V)
+            => (float[2,3,4,4] Y) {
+          Y = BatchNormalization <epsilon = 0.01> (X, S, Bs, M, V)
+        }
+        """,
+        {"V": _positive},
+    ),
+    # InstanceNormalization: mean/var computed from X itself, like
+    # LayerNormalization, but over the spatial axes only -- see
+    # _grad_instance_normalization. No override needed: X is continuous
+    # random data, so its per-(batch, channel) spatial variance is never
+    # exactly zero.
+    "instance_norm": (
+        """
+        g (float[2,3,4,4] X, float[3] S, float[3] Bs) => (float[2,3,4,4] Y) {
+          Y = InstanceNormalization(X, S, Bs)
+        }
+        """,
+        None,
+    ),
+    "instance_norm_channel_count": (
+        """
+        g (float[2,5,3,3] X, float[5] S, float[5] Bs) => (float[2,5,3,3] Y) {
+          Y = InstanceNormalization(X, S, Bs)
+        }
+        """,
+        None,
+    ),
+    # The minimum rank this rule accepts: one spatial axis (rank 3 total).
+    "instance_norm_1d_spatial": (
+        """
+        g (float[2,3,5] X, float[3] S, float[3] Bs) => (float[2,3,5] Y) {
+          Y = InstanceNormalization(X, S, Bs)
+        }
+        """,
+        None,
+    ),
+    "instance_norm_epsilon": (
+        """
+        g (float[2,3,4,4] X, float[3] S, float[3] Bs) => (float[2,3,4,4] Y) {
+          Y = InstanceNormalization <epsilon = 0.001> (X, S, Bs)
+        }
+        """,
+        None,
+    ),
     "clip": (
         """
         g (float[3,4] A) => (float[3,4] Y)
@@ -1561,6 +1650,174 @@ def test_a_pool_with_a_window_that_is_entirely_padding_is_refused(op):
             {"A": [1, 1, 1], "Y": [1, 1, 3]},
             {"Y": "dY"},
             ["A"],
+        )
+
+
+@pytest.mark.parametrize(
+    "body,fragment",
+    [
+        (
+            """
+            g (float[3] X, float[3] S, float[3] Bs, float[3] M, float[3] V)
+                => (float[3] Y) {
+              Y = BatchNormalization(X, S, Bs, M, V)
+            }
+            """,
+            "channel axis",
+        ),
+        (
+            """
+            g (float[1,3,4,4] X, float[2] S, float[3] Bs, float[3] M, float[3] V)
+                => (float[1,3,4,4] Y) {
+              Y = BatchNormalization(X, S, Bs, M, V)
+            }
+            """,
+            "scale has shape",
+        ),
+        (
+            """
+            g (float[1,3,4,4] X, float[3] S, float[2] Bs, float[3] M, float[3] V)
+                => (float[1,3,4,4] Y) {
+              Y = BatchNormalization(X, S, Bs, M, V)
+            }
+            """,
+            "B has shape",
+        ),
+        (
+            """
+            g (float[1,3,4,4] X, float[3] S, float[3] Bs, float[2] M, float[3] V)
+                => (float[1,3,4,4] Y) {
+              Y = BatchNormalization(X, S, Bs, M, V)
+            }
+            """,
+            "mean has shape",
+        ),
+        (
+            """
+            g (float[1,3,4,4] X, float[3] S, float[3] Bs, float[3] M, float[2] V)
+                => (float[1,3,4,4] Y) {
+              Y = BatchNormalization(X, S, Bs, M, V)
+            }
+            """,
+            "var has shape",
+        ),
+    ],
+    ids=[
+        "no_batch_or_channel_axis",
+        "scale_shape_mismatch",
+        "bias_shape_mismatch",
+        "mean_shape_mismatch",
+        "var_shape_mismatch",
+    ],
+)
+def test_a_batch_norm_this_rule_cannot_invert_is_refused(body, fragment):
+    """A ``BatchNormalization`` whose rank or per-channel operand shapes
+    don't add up is refused by name -- the same discipline
+    :func:`_conv_geometry`/:func:`_pool_geometry` are held to.
+
+    ``training_mode=1`` gets no case here: per the spec it always comes with
+    three declared outputs, so it is already refused by
+    :func:`build_backward`'s own single-output check (see
+    :func:`test_a_maxpools_indices_output_is_refused` for the same shape of
+    refusal on ``MaxPool``'s ``Indices``), and there is no spec-conformant
+    graph left to construct that would reach a training_mode-specific check
+    in the rule itself.
+    """
+    model = _model(body)
+    shapes = {
+        value.name: [d.dim_value for d in value.type.tensor_type.shape.dim]
+        for value in list(model.graph.input) + list(model.graph.output)
+    }
+    with pytest.raises(graph_grad.UnsupportedOpError, match=fragment):
+        graph_grad.build_backward(
+            qat_graph.GraphBuilder(),
+            list(model.graph.node),
+            shapes,
+            {"Y": "dY"},
+            ["X"],
+        )
+
+
+def test_a_batch_norms_training_mode_output_is_refused():
+    """``training_mode=1`` -- computing batch statistics live rather than
+    taking fixed running ones -- is refused the same way ``MaxPool``'s
+    ``Indices`` output is: the spec requires three outputs
+    (``Y``, ``running_mean``, ``running_var``) whenever ``training_mode=1``,
+    so :func:`build_backward`'s own single-output check refuses it before
+    :func:`onnxsim.graph_grad._grad_batch_normalization` ever runs.
+    """
+    model = onnx.parser.parse_model(
+        f"{_HEADER}\n"
+        """
+        g (float[1,2,3,3] X, float[2] S, float[2] Bs, float[2] M, float[2] V)
+            => (float[1,2,3,3] Y, float[2] RM, float[2] RV) {
+          Y, RM, RV = BatchNormalization <training_mode = 1> (X, S, Bs, M, V)
+        }
+        """
+    )
+    with pytest.raises(graph_grad.UnsupportedOpError, match="3 outputs"):
+        graph_grad.build_backward(
+            qat_graph.GraphBuilder(),
+            list(model.graph.node),
+            {
+                "X": [1, 2, 3, 3],
+                "S": [2],
+                "Bs": [2],
+                "M": [2],
+                "V": [2],
+                "Y": [1, 2, 3, 3],
+            },
+            {"Y": "dY"},
+            ["X"],
+        )
+
+
+@pytest.mark.parametrize(
+    "body,fragment",
+    [
+        (
+            """
+            g (float[4,3] X, float[3] S, float[3] Bs) => (float[4,3] Y) {
+              Y = InstanceNormalization(X, S, Bs)
+            }
+            """,
+            "spatial dimension",
+        ),
+        (
+            """
+            g (float[1,3,4,4] X, float[2] S, float[3] Bs) => (float[1,3,4,4] Y) {
+              Y = InstanceNormalization(X, S, Bs)
+            }
+            """,
+            "scale has shape",
+        ),
+        (
+            """
+            g (float[1,3,4,4] X, float[3] S, float[2] Bs) => (float[1,3,4,4] Y) {
+              Y = InstanceNormalization(X, S, Bs)
+            }
+            """,
+            "B has shape",
+        ),
+    ],
+    ids=["no_spatial_axis", "scale_shape_mismatch", "bias_shape_mismatch"],
+)
+def test_an_instance_norm_this_rule_cannot_invert_is_refused(body, fragment):
+    """The ``InstanceNormalization`` analogue of the ``BatchNormalization``
+    refusals above: a rank with no spatial axis at all, or a ``scale``/``B``
+    that does not have one entry per channel."""
+    model = _model(body)
+    shapes = {
+        value.name: [d.dim_value for d in value.type.tensor_type.shape.dim]
+        for value in list(model.graph.input) + list(model.graph.output)
+    }
+    with pytest.raises(graph_grad.UnsupportedOpError, match=fragment):
+        graph_grad.build_backward(
+            qat_graph.GraphBuilder(),
+            list(model.graph.node),
+            shapes,
+            {"Y": "dY"},
+            ["X"],
         )
 
 


### PR DESCRIPTION
## What this does

Adds VJP rules for `BatchNormalization` and `InstanceNormalization` to `graph_grad`, in both the Python emitter and its C++ port. `Conv`, pooling, and now normalization are the ops a real CNN puts around a convolution — this closes the last of that immediate neighborhood. `SUPPORTED_OPS` grows 25 → 27; `BACKWARD_OPS` (16 ops) is **unchanged** — both rules reuse only ops already there (`Sub`/`Div`/`Mul`/`Add`/`Sqrt`/`Reshape`/`ReduceSum`/`ReduceMean`/`Neg`), so no new execution-provider coverage question needed answering.

**`BatchNormalization`** is inference mode only (`training_mode=0`/omitted, the opset-17 default — verified against the actual ONNX schema: `since_version=15`, five required inputs, `training_mode=1` is the only case with extra outputs). `mean`/`var` are node *inputs* (running statistics), not values computed from `x`, which makes this a substantially simpler gradient than `LayerNormalization`'s: no "every element's gradient depends on every other element via the mean/variance it helped compute." It's closer in shape to `_grad_reduce`'s broadcast-via-constant-multiply than to `_grad_layer_normalization`.

**`InstanceNormalization`** fit the `LayerNormalization` pattern closely enough to include rather than scope out: mean/variance computed from `x` itself, but over spatial axes instead of feature axes.

**A real bug found and fixed via the finite-difference discipline this module insists on.** The first `dvar` derivation used `dx * xhat` (only `inv²`) instead of `dx * xhat * inv` (`inv³`, what the chain rule through `sqrt` actually produces) — caught by an ad hoc float64 FD check before any test was written, then mutation-tested: reverting the fix makes 8 tests fail with the wrong-by-a-factor-of-`inv` error, confirming the tests actually pin the right math rather than whatever the code happened to compute.

**Refused, not guessed at:** rank mismatches, and `scale`/`B`/`mean`/`var` shapes that don't match the channel dimension. `training_mode=1` is already refused by `build_backward`'s existing single-output check (the same precedent as `MaxPool`'s optional `Indices` output) rather than needing a rule-specific check.

## Parity

`onnxsim/graph_grad.cpp` mirrors both rules node-for-node (`GradBatchNormalization`/`GradInstanceNormalization`), registered in the C++ rules map — verified against the actual Python emission order/names via direct introspection before transcribing (19 nodes/10 initializers for BatchNorm, 20 nodes/5 for InstanceNorm), not reconstructed from the docstring. `onnxsim/qat_parity_fixtures.txt` regenerated (byte-identical to the source commit's, confirmed by re-running the generator against latest master). `docs/qat.md`'s two rule-count mentions corrected (found already stale before this PR — updated straight to the accurate post-merge count).

**The browser panel's hand-kept rule table** (`scripts/convertmodel/qat_blocks.mjs`'s `DIFFERENTIABLE_OPS`, pinned against `qat_parity_fixtures.txt`'s `rules` line by a test #1259 just wired into PR CI after catching exactly this kind of drift on #1256/#1257) needed the same two names added — done here, verified via `npm run test:qat-blocks` (11 checks) and `npm run test:qat-finetune` (23 checks), both green.

## Verification

- `pytest tests/test_graph_grad.py tests/test_qat_parity.py tests/test_qat.py tests/test_qat_graph.py tests/test_qat_interop.py -q` — 333 passed.
- `mypy onnxsim/graph_grad.py`, `ruff check`/`ruff format --check` — clean.
- `clang-format --dry-run --Werror` on all touched C++ files — clean.
- `npm run test:qat-blocks` / `npm run test:qat-finetune` (scripts/convertmodel) — 11 + 23 checks, green.
- Fresh from-scratch C++ build (`-DONNXSIM_BUILTIN_ORT=OFF -DONNXSIM_TESTS=ON`) on the final merged state (post-#1261): `graph_grad_test`, `qat_graph_parity_test`, `qat_entry_test`, and `qat_graph_builder_test` all pass on freshly built binaries (mtime postdating every touched source file).

New Python cases: plain/channel-count/no-spatial-axis-broadcast/epsilon variants for both ops, plus 8 refusal-path tests (rank and shape-mismatch variants for `scale`/`B`/`mean`/`var`, and the `training_mode=1` refusal). New C++ tests mirror the same pinned node-sequences and refusals, and update `TheSupportedOpsAreExactlyThePythonRuleTable`'s pinned set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_