### PR TITLE
Add CI coverage for onnx-finetune's actual training path

### DIFF
--- a/.github/workflows/onnx-finetune-training.yml
+++ b/.github/workflows/onnx-finetune-training.yml
@@ -117,10 +117,20 @@ jobs:
           # wheel-install step has a documented setuptools/distutils bug (see
           # README.md) whose own documented workaround -- pointing PYTHONPATH
           # at that directory -- is what this workflow does instead.
+          #
+          # --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5: ORT
+          # v1.19.2 vendors google_nsync, whose CMakeLists.txt declares
+          # `cmake_minimum_required(VERSION 3.5)` -- support for which CMake
+          # itself has since dropped entirely ("Compatibility with CMake <
+          # 3.5 has been removed from CMake"). `pip install cmake` always
+          # resolves to the latest release, so this isn't optional even
+          # though ORT's own source needs no other change; it's exactly the
+          # workaround CMake's own error message names.
           python3 tools/ci_build/build.py \
             --build_dir build --config Release --parallel \
             --skip_tests --allow_running_as_root \
-            --build_shared_lib --enable_training --enable_pybind
+            --build_shared_lib --enable_training --enable_pybind \
+            --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5
           df -h
 
       - name: Stage curated ORT dist (lib + python bindings)

--- a/.github/workflows/onnx-finetune-training.yml
+++ b/.github/workflows/onnx-finetune-training.yml
@@ -1,0 +1,163 @@
+name: onnx-finetune training path
+
+# tools/onnx-finetune's actual training path (scripts/generate_artifacts.py +
+# the onnx-finetune C++ binary, see ../../tools/onnx-finetune/README.md) needs
+# a training-enabled ONNX Runtime built from source -- ~20-40 minutes cold,
+# unlike onnx-finetune-lora.yml's graph-surgery-only jobs, which run against a
+# plain `pip install onnxruntime`. Kept in a separate workflow (rather than a
+# third job in onnx-finetune-lora.yml) so its cache/trigger tuning doesn't
+# leak into that file's fast/cheap jobs.
+#
+# Cost is why this does not gate every PR that touches tools/onnx-finetune/**
+# (that's already covered, cheaply, by onnx-finetune-lora.yml). It runs
+# weekly, on demand, and on pull requests that touch the training path
+# itself -- src/main.cpp, CMakeLists.txt, or the scripts the toy end-to-end
+# example actually exercises. Mirrors big-endian.yml's trigger shape.
+#
+# ONNX Runtime here is pinned to v1.19.2 (matching tools/onnx-finetune/README.md),
+# deliberately NOT the v1.29.0 this repo's own standalone C++/WASM build uses
+# (third_party/onnxruntime-1.29.0, cmake/build_ort.cmake, rust.yml's
+# `onnxruntime-src-1.29.0` cache) -- that build is not training-enabled, is
+# assembled fully out-of-tree via ExternalProject_Add, and nobody has verified
+# onnx-finetune still builds against 1.29.0's newer/less-stable training API
+# surface. Bumping onnx-finetune's ORT version is a separate task.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC (weekly)
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tools/onnx-finetune/src/**"
+      - "tools/onnx-finetune/CMakeLists.txt"
+      - "tools/onnx-finetune/scripts/generate_artifacts.py"
+      - "tools/onnx-finetune/scripts/make_toy_model.py"
+      - "tools/onnx-finetune/scripts/make_synthetic_data.py"
+      - "tools/onnx-finetune/tests/test_training_e2e.py"
+      - ".github/workflows/onnx-finetune-training.yml"
+
+concurrency:
+  group: onnx-finetune-training-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ORT_SRC_DIR: ${{ github.workspace }}/third_party/onnxruntime-1.19.2
+  ORT_DIST_DIR: ${{ github.workspace }}/ort-dist # curated, cache-friendly
+
+jobs:
+  training-e2e:
+    name: build ORT (training) + onnx-finetune toy end-to-end
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      # 1. ONNX Runtime source (with submodules: protobuf, abseil, onnx, ...).
+      # Headers only need this tree, regardless of whether the build below
+      # runs or is skipped by a dist-cache hit -- CMakeLists.txt's
+      # ORT_SOURCE_DIR include dirs (include/onnxruntime/core/session,
+      # orttraining/orttraining/training_api/include) live here, not in the
+      # build output.
+      - name: Cache ONNX Runtime source (v1.19.2)
+        id: cache-ort-src
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.ORT_SRC_DIR }}
+          key: onnxruntime-src-1.19.2
+
+      - name: Clone ONNX Runtime source (v1.19.2)
+        if: steps.cache-ort-src.outputs.cache-hit != 'true'
+        run: |
+          git clone --branch v1.19.2 --depth 1 \
+            https://github.com/microsoft/onnxruntime.git "${{ env.ORT_SRC_DIR }}"
+          cd "${{ env.ORT_SRC_DIR }}"
+          git submodule update --init --recursive --depth 1
+
+      # 2. Curated build output only: libonnxruntime.so (+ its versioned
+      # symlinks) and the compiled Python training package -- NOT the full
+      # build/ tree (object files, CMakeFiles, etc. for protobuf+abseil+onnx+
+      # ORT built from source can be many GB; GitHub's cache budget is a
+      # shared 10GB/repo LRU pool that rust.yml's sccache + its own
+      # onnxruntime-src-1.29.0 cache already draw on). Only libonnxruntime.so
+      # is needed to satisfy CMakeLists.txt's
+      # `find_library(... PATHS ${ORT_BUILD_DIR} REQUIRED NO_DEFAULT_PATH)`;
+      # it doesn't need the rest of the build tree.
+      #
+      # Trailing "-v1" is a manual cache-bust switch: bump it if these staged
+      # contents or the build flags below change without the ORT version
+      # itself changing.
+      - name: Cache curated ONNX Runtime build output (lib + python bindings)
+        id: cache-ort-dist
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.ORT_DIST_DIR }}
+          key: onnxruntime-dist-1.19.2-training-pybind-ubuntu-24.04-v1
+
+      - name: Build ONNX Runtime (training + pybind, one build serves both consumers)
+        if: steps.cache-ort-dist.outputs.cache-hit != 'true'
+        working-directory: ${{ env.ORT_SRC_DIR }}
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install cmake numpy packaging
+          df -h
+          # --enable_training is a superset of --enable_training_apis (what
+          # the C++-only build needs), so this one build satisfies both
+          # generate_artifacts.py (via --enable_pybind) and the onnx-finetune
+          # C++ binary. --build_wheel is deliberately omitted: --enable_pybind
+          # alone already populates build/Release/build/lib/, and the
+          # wheel-install step has a documented setuptools/distutils bug (see
+          # README.md) whose own documented workaround -- pointing PYTHONPATH
+          # at that directory -- is what this workflow does instead.
+          python3 tools/ci_build/build.py \
+            --build_dir build --config Release --parallel \
+            --skip_tests --allow_running_as_root \
+            --build_shared_lib --enable_training --enable_pybind
+          df -h
+
+      - name: Stage curated ORT dist (lib + python bindings)
+        if: steps.cache-ort-dist.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "${{ env.ORT_DIST_DIR }}/lib" "${{ env.ORT_DIST_DIR }}/python"
+          # -P preserves symlinks (libonnxruntime.so -> libonnxruntime.so.1 ->
+          # libonnxruntime.so.1.19.2); actions/cache tars the directory so
+          # symlinks survive the round trip.
+          cp -P "${{ env.ORT_SRC_DIR }}"/build/Release/libonnxruntime.so* \
+            "${{ env.ORT_DIST_DIR }}/lib/"
+          cp -r "${{ env.ORT_SRC_DIR }}"/build/Release/build/lib/. \
+            "${{ env.ORT_DIST_DIR }}/python/"
+          du -sh "${{ env.ORT_DIST_DIR }}"
+
+      # 3. Build the onnx-finetune C++ binary against ORT_SRC_DIR (headers,
+      # always present from step 1) + ORT_DIST_DIR/lib (libonnxruntime.so,
+      # from either the cache or the fresh build+stage above).
+      - name: Configure and build onnx-finetune
+        run: |
+          cmake -B tools/onnx-finetune/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DORT_SOURCE_DIR="${{ env.ORT_SRC_DIR }}" \
+            -DORT_BUILD_DIR="${{ env.ORT_DIST_DIR }}/lib"
+          cmake --build tools/onnx-finetune/build --parallel
+
+      # 4. Run the toy end-to-end test. generate_artifacts.py needs the
+      # training python bindings via PYTHONPATH (see README's troubleshooting
+      # note on the setuptools/distutils wheel-install bug -- this sidesteps
+      # it entirely by never installing a wheel); the eval half of the test
+      # imports a *plain* pip-installed onnxruntime, verifying the README's
+      # claim that finetuned.onnx loads fine outside a training build.
+      - name: Install plain onnxruntime + pytest (for evaluating finetuned.onnx)
+        run: pip install onnx numpy onnxruntime pytest
+
+      - name: pytest tools/onnx-finetune/tests/test_training_e2e.py
+        env:
+          ONNX_FINETUNE_BIN: ${{ github.workspace }}/tools/onnx-finetune/build/onnx-finetune
+          ORT_TRAINING_PYTHONPATH: ${{ env.ORT_DIST_DIR }}/python
+        run: pytest tools/onnx-finetune/tests/test_training_e2e.py -v

--- a/.github/workflows/onnx-finetune-training.yml
+++ b/.github/workflows/onnx-finetune-training.yml
@@ -190,7 +190,14 @@ jobs:
       # from either the cache or the fresh build+stage above).
       - name: Configure and build onnx-finetune
         run: |
-          cmake -B tools/onnx-finetune/build \
+          # -S is required: without it, `cmake -B tools/onnx-finetune/build`
+          # defaults the *source* directory to the current working directory
+          # (the repo root), configuring onnxsim's own root CMakeLists.txt
+          # (which add_subdirectory()s third_party/onnx, not present here
+          # since this job checks out with submodules: false) instead of
+          # tools/onnx-finetune/CMakeLists.txt -- caught by the first real
+          # run reaching this step, after the ORT build itself completed.
+          cmake -S tools/onnx-finetune -B tools/onnx-finetune/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DORT_SOURCE_DIR="${{ env.ORT_SRC_DIR }}" \
             -DORT_BUILD_DIR="${{ env.ORT_DIST_DIR }}/lib"

--- a/.github/workflows/onnx-finetune-training.yml
+++ b/.github/workflows/onnx-finetune-training.yml
@@ -102,6 +102,25 @@ jobs:
           path: ${{ env.ORT_DIST_DIR }}
           key: onnxruntime-dist-1.19.2-training-pybind-ubuntu-24.04-v1
 
+      # ORT v1.19.2 fetches eigen from a GitLab commit-archive URL with a
+      # pinned SHA1 hash; GitLab's archive generator is not byte-stable over
+      # the ~1.5 years since this ORT release, so that hash now legitimately
+      # mismatches what GitLab serves (verified: this is the *same* commit,
+      # just re-archived differently -- not a compromised or wrong source).
+      # A plain git clone of that exact commit sidesteps the flaky archive
+      # entirely; --use_preinstalled_eigen/--eigen_path (real build.py flags,
+      # confirmed against ORT's own source -- they map straight to
+      # -Donnxruntime_USE_PREINSTALLED_EIGEN=ON -Deigen_SOURCE_PATH=<path>)
+      # is what tells build.py to use it instead of FetchContent's own
+      # download. Other vendored deps use the same URL+hash pattern but are
+      # GitHub-hosted, which has not shown this problem here -- fix only
+      # what has actually failed, not every dependency speculatively.
+      - name: Fetch eigen via git (GitLab's archive endpoint isn't hash-stable long-term)
+        if: steps.cache-ort-dist.outputs.cache-hit != 'true'
+        run: |
+          git clone https://gitlab.com/libeigen/eigen.git "${{ runner.temp }}/eigen"
+          git -C "${{ runner.temp }}/eigen" checkout e7248b26a1ed53fa030c5c459f7ea095dfd276ac
+
       - name: Build ONNX Runtime (training + pybind, one build serves both consumers)
         if: steps.cache-ort-dist.outputs.cache-hit != 'true'
         working-directory: ${{ env.ORT_SRC_DIR }}
@@ -126,11 +145,14 @@ jobs:
           # resolves to the latest release, so this isn't optional even
           # though ORT's own source needs no other change; it's exactly the
           # workaround CMake's own error message names.
+          #
+          # --use_preinstalled_eigen/--eigen_path: see the step above.
           python3 tools/ci_build/build.py \
             --build_dir build --config Release --parallel \
             --skip_tests --allow_running_as_root \
             --build_shared_lib --enable_training --enable_pybind \
-            --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5
+            --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            --use_preinstalled_eigen --eigen_path "${{ runner.temp }}/eigen"
           df -h
 
       - name: Stage curated ORT dist (lib + python bindings)

--- a/.github/workflows/onnx-finetune-training.yml
+++ b/.github/workflows/onnx-finetune-training.yml
@@ -14,13 +14,24 @@ name: onnx-finetune training path
 # itself -- src/main.cpp, CMakeLists.txt, or the scripts the toy end-to-end
 # example actually exercises. Mirrors big-endian.yml's trigger shape.
 #
-# ONNX Runtime here is pinned to v1.19.2 (matching tools/onnx-finetune/README.md),
-# deliberately NOT the v1.29.0 this repo's own standalone C++/WASM build uses
-# (third_party/onnxruntime-1.29.0, cmake/build_ort.cmake, rust.yml's
-# `onnxruntime-src-1.29.0` cache) -- that build is not training-enabled, is
-# assembled fully out-of-tree via ExternalProject_Add, and nobody has verified
-# onnx-finetune still builds against 1.29.0's newer/less-stable training API
-# surface. Bumping onnx-finetune's ORT version is a separate task.
+# ONNX Runtime here is v1.29.0 -- the same version this repo's own standalone
+# C++/WASM build already uses (third_party/onnxruntime-1.29.0,
+# cmake/build_ort.cmake, rust.yml's `onnxruntime-src-1.29.0` cache), rather
+# than tools/onnx-finetune/README.md's documented v1.19.2. That reverses an
+# earlier decision to stay on v1.19.2 as "the version actually documented and
+# presumably dev-tested" -- reversed after the first two real CI runs against
+# v1.19.2 both failed on version-specific bit-rot (a vendored dependency,
+# google_nsync, needing a pre-3.5 CMake compatibility mode CMake itself has
+# since dropped; a second vendored dependency, eigen, fetched from a GitLab
+# archive URL whose pinned hash no longer matches what GitLab serves) that
+# v1.29.0's own dependency updates have already fixed upstream (google_nsync
+# is no longer a dependency at all; eigen now comes from a GitHub mirror
+# instead of GitLab). Converging on one ORT version across the repo, reusing
+# what's already proven to build here, and dodging both failures already hit
+# outweighed staying pinned to what the README happens to say. The one risk
+# this doesn't remove: nobody has verified onnx-finetune's training-API usage
+# (generate_artifacts.py, main.cpp) still matches v1.29.0's API shape --
+# that's exactly what this job's own toy end-to-end run tests.
 
 on:
   schedule:
@@ -44,7 +55,7 @@ permissions:
   contents: read
 
 env:
-  ORT_SRC_DIR: ${{ github.workspace }}/third_party/onnxruntime-1.19.2
+  ORT_SRC_DIR: ${{ github.workspace }}/third_party/onnxruntime-1.29.0
   ORT_DIST_DIR: ${{ github.workspace }}/ort-dist # curated, cache-friendly
 
 jobs:
@@ -67,17 +78,25 @@ jobs:
       # ORT_SOURCE_DIR include dirs (include/onnxruntime/core/session,
       # orttraining/orttraining/training_api/include) live here, not in the
       # build output.
-      - name: Cache ONNX Runtime source (v1.19.2)
+      #
+      # Deliberately a separate cache key from rust.yml's own
+      # `onnxruntime-src-1.29.0` (same version, different path/consumer):
+      # that cache is populated by onnxsim-sys's own build script under
+      # different assumptions (e.g. whether submodules are initialized), and
+      # a cache is first-writer-wins with no way to tell "hit but shaped
+      # differently" from "hit and complete" -- not worth the risk for a
+      # source clone that costs under a minute cold.
+      - name: Cache ONNX Runtime source (v1.29.0)
         id: cache-ort-src
         uses: actions/cache@v6
         with:
           path: ${{ env.ORT_SRC_DIR }}
-          key: onnxruntime-src-1.19.2
+          key: onnxruntime-src-1.29.0-training
 
-      - name: Clone ONNX Runtime source (v1.19.2)
+      - name: Clone ONNX Runtime source (v1.29.0)
         if: steps.cache-ort-src.outputs.cache-hit != 'true'
         run: |
-          git clone --branch v1.19.2 --depth 1 \
+          git clone --branch v1.29.0 --depth 1 \
             https://github.com/microsoft/onnxruntime.git "${{ env.ORT_SRC_DIR }}"
           cd "${{ env.ORT_SRC_DIR }}"
           git submodule update --init --recursive --depth 1
@@ -100,26 +119,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.ORT_DIST_DIR }}
-          key: onnxruntime-dist-1.19.2-training-pybind-ubuntu-24.04-v1
-
-      # ORT v1.19.2 fetches eigen from a GitLab commit-archive URL with a
-      # pinned SHA1 hash; GitLab's archive generator is not byte-stable over
-      # the ~1.5 years since this ORT release, so that hash now legitimately
-      # mismatches what GitLab serves (verified: this is the *same* commit,
-      # just re-archived differently -- not a compromised or wrong source).
-      # A plain git clone of that exact commit sidesteps the flaky archive
-      # entirely; --use_preinstalled_eigen/--eigen_path (real build.py flags,
-      # confirmed against ORT's own source -- they map straight to
-      # -Donnxruntime_USE_PREINSTALLED_EIGEN=ON -Deigen_SOURCE_PATH=<path>)
-      # is what tells build.py to use it instead of FetchContent's own
-      # download. Other vendored deps use the same URL+hash pattern but are
-      # GitHub-hosted, which has not shown this problem here -- fix only
-      # what has actually failed, not every dependency speculatively.
-      - name: Fetch eigen via git (GitLab's archive endpoint isn't hash-stable long-term)
-        if: steps.cache-ort-dist.outputs.cache-hit != 'true'
-        run: |
-          git clone https://gitlab.com/libeigen/eigen.git "${{ runner.temp }}/eigen"
-          git -C "${{ runner.temp }}/eigen" checkout e7248b26a1ed53fa030c5c459f7ea095dfd276ac
+          key: onnxruntime-dist-1.29.0-training-pybind-ubuntu-24.04-v1
 
       - name: Build ONNX Runtime (training + pybind, one build serves both consumers)
         if: steps.cache-ort-dist.outputs.cache-hit != 'true'
@@ -128,31 +128,34 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install cmake numpy packaging
           df -h
-          # --enable_training is a superset of --enable_training_apis (what
-          # the C++-only build needs), so this one build satisfies both
-          # generate_artifacts.py (via --enable_pybind) and the onnx-finetune
-          # C++ binary. --build_wheel is deliberately omitted: --enable_pybind
-          # alone already populates build/Release/build/lib/, and the
-          # wheel-install step has a documented setuptools/distutils bug (see
-          # README.md) whose own documented workaround -- pointing PYTHONPATH
-          # at that directory -- is what this workflow does instead.
+          # --enable_training_apis is passed explicitly alongside
+          # --enable_training rather than relied on as an implication: v1.19.2's
+          # generated CMake command line showed -Donnxruntime_ENABLE_TRAINING_APIS=ON
+          # even with only --enable_training on the Python side, but that's a
+          # CMakeLists.txt-level default, not something confirmed in
+          # v1.29.0's own build_args.py -- passing both removes the ambiguity
+          # rather than trusting an implication across a version this hasn't
+          # been exercised against before.
           #
-          # --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5: ORT
-          # v1.19.2 vendors google_nsync, whose CMakeLists.txt declares
-          # `cmake_minimum_required(VERSION 3.5)` -- support for which CMake
-          # itself has since dropped entirely ("Compatibility with CMake <
-          # 3.5 has been removed from CMake"). `pip install cmake` always
-          # resolves to the latest release, so this isn't optional even
-          # though ORT's own source needs no other change; it's exactly the
-          # workaround CMake's own error message names.
+          # --enable_pybind (not --build_wheel): this one build still needs to
+          # serve both generate_artifacts.py and the onnx-finetune C++ binary.
+          # The exact output directory for the compiled Python package is
+          # discovered below via `find` rather than hardcoded, since the
+          # v1.19.2 README's "build/Release/build/lib/" path was itself never
+          # independently confirmed, let alone assumed safe to carry into an
+          # unexercised version.
           #
-          # --use_preinstalled_eigen/--eigen_path: see the step above.
+          # --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5: kept as
+          # defensive insurance. It was needed on v1.19.2 because of
+          # google_nsync's pre-3.5 cmake_minimum_required; google_nsync is
+          # gone from v1.29.0's dependency list, but this flag is a no-op if
+          # nothing needs it and cheap insurance if some other still-vendored
+          # dependency turns out to have the same issue.
           python3 tools/ci_build/build.py \
             --build_dir build --config Release --parallel \
             --skip_tests --allow_running_as_root \
-            --build_shared_lib --enable_training --enable_pybind \
-            --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            --use_preinstalled_eigen --eigen_path "${{ runner.temp }}/eigen"
+            --build_shared_lib --enable_training --enable_training_apis --enable_pybind \
+            --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5
           df -h
 
       - name: Stage curated ORT dist (lib + python bindings)
@@ -160,12 +163,26 @@ jobs:
         run: |
           mkdir -p "${{ env.ORT_DIST_DIR }}/lib" "${{ env.ORT_DIST_DIR }}/python"
           # -P preserves symlinks (libonnxruntime.so -> libonnxruntime.so.1 ->
-          # libonnxruntime.so.1.19.2); actions/cache tars the directory so
+          # libonnxruntime.so.1.29.0); actions/cache tars the directory so
           # symlinks survive the round trip.
           cp -P "${{ env.ORT_SRC_DIR }}"/build/Release/libonnxruntime.so* \
             "${{ env.ORT_DIST_DIR }}/lib/"
-          cp -r "${{ env.ORT_SRC_DIR }}"/build/Release/build/lib/. \
-            "${{ env.ORT_DIST_DIR }}/python/"
+          # Discover the compiled Python package directory rather than
+          # assuming a fixed path (see the build step's comment). Searching
+          # for a directory named "onnxruntime" would be too loose -- that
+          # name appears throughout the C++ source tree too -- so this
+          # searches for the exact file generate_artifacts.py actually
+          # needs (onnxruntime/training/__init__.py) and derives the
+          # package's parent directory from wherever that turns up.
+          TRAINING_INIT=$(find "${{ env.ORT_SRC_DIR }}/build" -type f -path "*/onnxruntime/training/__init__.py" | head -1)
+          if [ -z "$TRAINING_INIT" ]; then
+            echo "::error::could not find a built onnxruntime.training package under ${{ env.ORT_SRC_DIR }}/build"
+            find "${{ env.ORT_SRC_DIR }}/build" -maxdepth 8 -type d -iname "onnxruntime"
+            exit 1
+          fi
+          PY_PARENT_DIR=$(dirname "$(dirname "$(dirname "$TRAINING_INIT")")")
+          echo "found onnxruntime.training under: $PY_PARENT_DIR"
+          cp -r "$PY_PARENT_DIR/onnxruntime" "${{ env.ORT_DIST_DIR }}/python/onnxruntime"
           du -sh "${{ env.ORT_DIST_DIR }}"
 
       # 3. Build the onnx-finetune C++ binary against ORT_SRC_DIR (headers,
@@ -180,11 +197,10 @@ jobs:
           cmake --build tools/onnx-finetune/build --parallel
 
       # 4. Run the toy end-to-end test. generate_artifacts.py needs the
-      # training python bindings via PYTHONPATH (see README's troubleshooting
-      # note on the setuptools/distutils wheel-install bug -- this sidesteps
-      # it entirely by never installing a wheel); the eval half of the test
-      # imports a *plain* pip-installed onnxruntime, verifying the README's
-      # claim that finetuned.onnx loads fine outside a training build.
+      # training python bindings via PYTHONPATH pointed at the discovered
+      # package's parent directory; the eval half of the test imports a
+      # *plain* pip-installed onnxruntime, verifying the README's claim that
+      # finetuned.onnx loads fine outside a training build.
       - name: Install plain onnxruntime + pytest (for evaluating finetuned.onnx)
         run: pip install onnx numpy onnxruntime pytest
 

--- a/tools/onnx-finetune/README.md
+++ b/tools/onnx-finetune/README.md
@@ -33,7 +33,7 @@ API or `onnxruntime.training.artifacts`. You need to build ONNX Runtime from
 source with training enabled, once:
 
 ```sh
-git clone --branch v1.19.2 https://github.com/microsoft/onnxruntime.git
+git clone --branch v1.29.0 https://github.com/microsoft/onnxruntime.git
 cd onnxruntime
 git submodule update --init --recursive
 

--- a/tools/onnx-finetune/tests/test_training_e2e.py
+++ b/tools/onnx-finetune/tests/test_training_e2e.py
@@ -1,0 +1,134 @@
+"""End-to-end test of onnx-finetune's actual training path: the half
+test_lora.py's own docstring says it deliberately does not cover, because it
+needs a training-enabled onnxruntime build (see ../README.md). This is that
+coverage -- it runs the README's own toy end-to-end example for real:
+scripts/generate_artifacts.py (needs onnxruntime.training.artifacts) followed
+by the onnx-finetune C++ binary's actual train loop.
+
+Skipped, with a reason, unless the environment provides a training-enabled
+ONNX Runtime build -- see .github/workflows/onnx-finetune-training.yml, the
+only place that sets ONNX_FINETUNE_BIN/ORT_TRAINING_PYTHONPATH today. Under
+the plain-onnxruntime jobs in onnx-finetune-lora.yml this shows as SKIPPED
+rather than simply not existing, so the coverage boundary stays visible there
+too.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnxruntime
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+ONNX_FINETUNE_BIN = os.environ.get("ONNX_FINETUNE_BIN")
+ORT_TRAINING_PYTHONPATH = os.environ.get("ORT_TRAINING_PYTHONPATH")
+
+pytestmark = pytest.mark.skipif(
+    not ONNX_FINETUNE_BIN or not ORT_TRAINING_PYTHONPATH,
+    reason=(
+        "needs a training-enabled ONNX Runtime build; set ONNX_FINETUNE_BIN and "
+        "ORT_TRAINING_PYTHONPATH (see tools/onnx-finetune/README.md and "
+        ".github/workflows/onnx-finetune-training.yml)"
+    ),
+)
+
+INPUT_DIM = 4
+TARGET_DIM = 1
+NUM_SAMPLES = 2048
+
+_LOSS_RE = re.compile(r"loss ([\d.]+)")
+
+
+def _run(script, *args, env=None):
+    subprocess.run([sys.executable, str(SCRIPTS / script), *args], check=True, env=env)
+
+
+def test_toy_mlp_loss_drops_and_finetuned_model_is_usable(tmp_path):
+    toy_model = tmp_path / "toy_model.onnx"
+    train_input = tmp_path / "train_input.bin"
+    train_target = tmp_path / "train_target.bin"
+    artifacts_dir = tmp_path / "artifacts"
+    finetuned_model = tmp_path / "finetuned.onnx"
+
+    _run("make_toy_model.py", "-o", str(toy_model))
+    _run(
+        "make_synthetic_data.py",
+        "--num-samples",
+        str(NUM_SAMPLES),
+        "--input-out",
+        str(train_input),
+        "--target-out",
+        str(train_target),
+    )
+
+    # generate_artifacts.py needs onnxruntime.training, which this test's
+    # own process does not import (see module docstring) -- only the
+    # subprocess gets the training-enabled PYTHONPATH.
+    artifacts_env = {**os.environ, "PYTHONPATH": ORT_TRAINING_PYTHONPATH}
+    _run(
+        "generate_artifacts.py",
+        str(toy_model),
+        "-o",
+        str(artifacts_dir),
+        env=artifacts_env,
+    )
+
+    result = subprocess.run(
+        [
+            ONNX_FINETUNE_BIN,
+            "--artifacts-dir",
+            str(artifacts_dir),
+            "--train-input",
+            str(train_input),
+            "--train-target",
+            str(train_target),
+            "--input-dim",
+            str(INPUT_DIM),
+            "--target-dim",
+            str(TARGET_DIM),
+            "--num-samples",
+            str(NUM_SAMPLES),
+            "--batch-size",
+            "32",
+            "--epochs",
+            "20",
+            "--lr",
+            "0.01",
+            "--output-model",
+            str(finetuned_model),
+            "--output-names",
+            "output",
+            "--log-every",
+            "20",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    # Secondary check: the tool's own reported loss trend.
+    losses = [float(m) for m in _LOSS_RE.findall(result.stdout)]
+    assert losses, f"no loss values parsed from onnx-finetune output:\n{result.stdout}"
+    assert losses[0] > 1.0, (
+        f"first loss {losses[0]} lower than expected for an untrained model"
+    )
+    assert losses[-1] < losses[0] * 0.1, (
+        f"loss did not drop as expected: first={losses[0]} last={losses[-1]}"
+    )
+
+    # Primary check, independent of the tool's own log: evaluate the
+    # exported model with a *plain* onnxruntime install (this is the process's
+    # own import, never given the training PYTHONPATH -- see module docstring)
+    # against the raw synthetic data, proving both the numeric claim and the
+    # README's "loads with any onnxruntime build" claim in one step.
+    x = np.fromfile(train_input, dtype=np.float32).reshape(NUM_SAMPLES, INPUT_DIM)
+    y = np.fromfile(train_target, dtype=np.float32).reshape(NUM_SAMPLES, TARGET_DIM)
+    session = onnxruntime.InferenceSession(str(finetuned_model))
+    (pred,) = session.run(["output"], {"input": x})
+    mse = float(np.mean((pred - y) ** 2))
+    assert mse < 0.05, f"finetuned model's MSE against training data too high: {mse}"


### PR DESCRIPTION
## The gap

`tools/onnx-finetune/` is a complete, separate integration with ONNX Runtime's own on-device training API (`onnxruntime.training.artifacts` for gradient-graph generation, ORT's native C++ training API for the actual train loop), plus a LoRA/QLoRA/native-adapter-export layer on top. It's genuinely distinct from this repo's own hand-rolled `graph_grad`/`qat.py` fine-tuning system — it provides real capability that isn't replicated elsewhere (rank-decomposition adapters, QLoRA on an NF4 base, ORT's native `.onnx_adapter` swap-in-place format).

**`generate_artifacts.py` and the `onnx-finetune` C++ binary's actual train loop — the tool's entire reason to exist — have never been exercised by CI.** The only existing workflow, `onnx-finetune-lora.yml`, runs `pytest tools/onnx-finetune/tests -v` against a plain `pip install onnxruntime`, and `test_lora.py`'s own module docstring says explicitly it covers "pure graph-surgery correctness... unlike generate_artifacts.py/onnx-finetune itself, which need a training-enabled onnxruntime build." No workflow in the repo builds ONNX Runtime with training enabled.

## What this adds

**`.github/workflows/onnx-finetune-training.yml`** (new, separate from `onnx-finetune-lora.yml` since a cold run is a genuine 20-40 minute from-source ORT build vs. that file's ~2-minute `pip install`s):

- Builds ONNX Runtime **v1.29.0** — the same version already vendored elsewhere in this repo (`third_party/onnxruntime-1.29.0`, `cmake/build_ort.cmake`, `rust.yml`'s `onnxruntime-src-1.29.0` cache), converging on one ORT version rather than pinning a second one. (This started at v1.19.2, matching `tools/onnx-finetune/README.md`'s documented version — see "Version history" below for why it moved.)
- Builds with `--enable_training --enable_training_apis --enable_pybind` — one build serves both `generate_artifacts.py` (via a discovered path to the compiled Python package, injected through `PYTHONPATH`) and the C++ binary.
- Caches the ORT source and a **curated** slice of the build output (just `libonnxruntime.so*` + the compiled Python training package, not the full multi-GB build tree) separately, following the `id`/`cache-hit` idiom already used in `coverage.yml`/`pyodide-wasm.yml`.
- Runs the README's own "toy end-to-end example": `make_toy_model.py` → `make_synthetic_data.py` → `generate_artifacts.py` → the `onnx-finetune` binary → a new pytest that checks both the tool's own logged loss trend and, independently, evaluates the exported model with a **plain, non-training** `onnxruntime` install against the synthetic targets (MSE assertion).
- **Trigger**: weekly schedule + `workflow_dispatch` + `pull_request` narrowed to just the files that define the training path itself, modeled on `big-endian.yml`'s trigger shape. Deliberately not broadly PR-gated: this repo's GitHub Actions cache is a shared 10GB/repo LRU pool `rust.yml` already draws on heavily.

**`tools/onnx-finetune/tests/test_training_e2e.py`** (new): follows `test_lora.py`'s conventions. Skips cleanly with an explicit reason when `ONNX_FINETUNE_BIN`/`ORT_TRAINING_PYTHONPATH` aren't set — so the *existing* cheap jobs now show this test as `SKIPPED` with that reason, keeping the coverage boundary visible even where it doesn't run.

## Version history on this PR (v1.19.2 → v1.29.0)

The PR started targeting v1.19.2, matching the README. The first two real CI runs against it both failed on version-specific bit-rot, fixed one at a time:
1. `google_nsync` (a vendored dependency) needs `cmake_minimum_required(VERSION 3.5)`, support for which CMake itself has since dropped entirely.
2. `eigen` (another vendored dependency) is fetched from a GitLab commit-archive URL with a pinned SHA1 hash that no longer matches what GitLab serves — same commit, differently re-archived over the ~1.5 years since this ORT release.

Checking ONNX Runtime's actual v1.29.0 source showed both are already fixed upstream (`google_nsync` is no longer a dependency at all; `eigen` now comes from a GitHub mirror instead of GitLab) — and v1.29.0 is the version already vendored elsewhere in this repo. Switched rather than continuing to patch v1.19.2 one bit-rotted dependency at a time. `README.md`'s documented git-clone instructions updated to match; `tools/onnx-finetune/wasm/`'s own separate v1.19.2 references are untouched (a different, separate build this PR doesn't cover).

## What this deliberately doesn't do

- Doesn't touch `tools/onnx-finetune/wasm/` — a separate build, out of scope here.
- Doesn't add this job to branch-protection required status checks (repo-settings decision, not something a workflow file can make) — flagging here since its duration is cache-dependent and variable.
- Uses a looser MSE threshold (`< 0.05`) than the README's literal `< 0.001` claim, paired with a stricter loss-trend check, to absorb CPU-kernel nondeterminism risk across future runner images without ever having observed real CI variance yet.

## Verification

- `pytest tools/onnx-finetune/tests -v` — 7 passed (all existing LoRA/QLoRA tests, untouched), 1 skipped (the new test, with the expected reason string).
- `ruff check` / `ruff format --check` on the new test file — clean.
- Every CLI argument/flag/seed the new test relies on was verified against the actual source, not assumed from the README. `--cmake_extra_defines`, `--use_preinstalled_eigen`/`--eigen_path` (later removed once no longer needed), and the `build_args.py` flag surface for v1.29.0 were all checked against ONNX Runtime's own source before use, not guessed.
- The real training build + toy end-to-end run needs GitHub's actual runners (not practical to replicate a 20-40 min from-source build in this environment) — actively being driven to green via real CI runs, fixing each real failure as it surfaces rather than guessing ahead of time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC