### PR TITLE
mcode: a transposed convolution is several convolutions -- vocoder coverage 7.1% to 47.5%

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4572,23 +4572,46 @@ each -- which at 512 MACs/cycle demands roughly **3.8 GHz**. Even a generous
 1.5 GHz gives about 1.5 TOPS per core, so the pair can offer perhaps 2 to 3
 TOPS: a useful 20-30% on top of the NPU, not a doubling.
 
-**Where the gap actually is: clock.** The NPU sustains **4,949 MAC/cycle**
-across its three cores (measured, stable across shapes). At that rate,
-18 TOPS requires
+**Where the gap actually is: array utilisation, not clock.** The NPU
+sustains **4,949 MAC/cycle** across its cores, measured and stable across
+shapes.
 
-    18e12 / (2 * 4949) = 1.82 GHz
+The clock no longer has to be guessed. A `profile=True` build writes a
+`trace.json` whose events carry durations, and comparing their span against
+the same build's `max_cycle` gives the toolchain's own conversion:
 
-and the implied clock measured here is **854-949 MHz** -- almost exactly
-half. So the rating is consistent with the same silicon at roughly twice the
-clock this card runs at, and the card idles at 75 C in an M.2 slot. The
-shortfall looks like clock and thermal headroom rather than lost efficiency,
-which also fits the earlier finding that the NPU executes essentially the
-cycle count its own compiler predicts.
+| graph | max_cycle | trace span | nominal |
+| --- | --- | --- | --- |
+| 1024ch 16x16 | 3,905,355 | 3906.3 us | 999.8 MHz |
+| 256ch 64x64 | 3,831,460 | 3832.7 us | 999.7 MHz |
+| 512ch 32x32 | 3,704,778 | 3706.5 us | 999.5 MHz |
 
-That is a hypothesis about *why*, not a measurement: AXCL exposes no NPU
-frequency (`axcl-smi info --npu` reports usage and an engine version, no
-clock), so the 1.82 GHz figure is inferred from the rating and the measured
-MAC rate, not read from the hardware.
+The compiler emits exactly one cycle per nanosecond, so its **nominal NPU
+clock is 1.0 GHz**. Measured against real device time the same builds give
+854 to 949 MHz, so the hardware runs at **85-95% of nominal** -- close to it,
+not at half of something larger.
+
+That settles the arithmetic. At 1.0 GHz, 18 TOPS requires
+
+    18e12 / (2 * 1.0e9) = 9,000 MAC/cycle
+
+and the hardware sustains 4,949, or **55%** of it. The kernel log names
+sixteen execution units (`EU[0]` through `EU[15]`), and 9,000 over 16 is 562
+per unit -- consistent with a 512-MAC unit per EU and a rating that assumes
+the whole array busy.
+
+So the distance to 18 TOPS is how much of the array a real convolution keeps
+fed, not clock and not the DSPs. An earlier draft of this section proposed a
+1.82 GHz rated clock with this card running at half; the trace says
+otherwise and that reading was wrong.
+
+**What is still not directly readable** is the hardware's instantaneous
+frequency: AXCL exposes no NPU clock (`axcl-smi info --npu` gives usage and
+an engine version; `set --freq` sets the *CPU*, offering 1200/1400/1700 MHz),
+the device kernel log prints none, and no `AX_SYS_*` clock getter is exported
+even though `AX_NPU_CLK_ID` exists in the headers. The 1.0 GHz above is the
+compiler's nominal, and the 854-949 MHz is measured effective throughput --
+between them there is no room for a large hidden clock deficit.
 
 **So: using the DSPs is possible but would need firmware written from
 scratch with a toolchain that is not part of this stack, and by the numbers

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4485,10 +4485,9 @@ again:
 | 128-channel dilated layers | 128 works undilated, so the two rules interact |
 | dilation 6 and 12 at 64 channels | 32 channels handles both, so it interacts with width |
 
-That is still only **7.1% of the vocoder's weights**, because the three
-transposed convolutions and `conv_pre` hold most of them. The honest summary
-is that the vocoder's *small* layers are now fully readable and its *large*
-ones are not.
+That was 7.1% of the vocoder's weights, because the three transposed
+convolutions and `conv_pre` hold most of them. The transposed ones are now
+readable too -- see the next section, which takes it to 47.5%.
 
 Test: `test_dilation_changes_the_weight_layout` (Docker, no device), which
 checks both rules against their own builds and that the undilated rule does
@@ -4617,6 +4616,47 @@ between them there is no room for a large hidden clock deficit.
 scratch with a toolchain that is not part of this stack, and by the numbers
 it buys a fraction of what the rating implies. The rating's missing factor is
 much better explained by clock.**
+
+### A transposed convolution is several convolutions
+
+The three `ConvTranspose` upsamplers hold most of the vocoder's weights and
+none of them read. They are not stored in a layout of their own.
+
+**Unstrided, it is the ordinary conv layout with two adjustments.** ONNX
+orders a `ConvTranspose` weight `(Cin, Cout, K)` rather than
+`(Cout, Cin, K)`, and dimension 0 behaves as the *input* channel exactly as
+`i` does for a convolution -- weights `(0,0,0)` and `(1,0,0)` land in the
+same byte, different nibbles. The taps are then stored **reversed**: with
+`K = 4` at 32 channels, `k = 3` sits at byte 0, `k = 2` at 16, `k = 1` at 32
+and `k = 0` at 156, which is slot 48 chunked at 36 into `144 + 12`. Reading
+`(Cout, Cin, K)` with `k' = K-1-k` reproduces every code.
+
+**Strided, it is split into `stride` separate convolutions.** At stride 2 the
+taps do not stay together: `k = 0` and `k = 2` land 16 bytes apart while
+`k = 1` sits in an entirely different region. That is polyphase
+decomposition -- a stride-`s` transposed convolution compiled as `s` ordinary
+convolutions of `K/s` taps each, which is the standard way to implement one.
+
+**All twenty phases of the vocoder's three upsamplers locate**, at 0.9997 to
+0.9999:
+
+| layer | stride | phases | located |
+| --- | --- | --- | --- |
+| `(256, 128, 16)` | 8 | 8 x 2 taps | 8/8 |
+| `(128, 64, 16)` | 8 | 8 x 2 taps | 8/8 |
+| `(64, 32, 8)` | 4 | 4 x 2 taps | 4/4 |
+
+**The vocoder goes from 10 to 13 of 23 layers, and from 7.1% to 47.5% of its
+weights.** Three layers carried forty points of coverage, which is what
+happens when the unread ones are the big ones.
+
+What remains is `conv_pre` at 192 input channels, and the dilated layers at
+128 channels and at dilations 6 and 12 -- the same width-and-dilation
+interaction noted before, now the only thing between here and a fully read
+vocoder.
+
+Test: `test_convtranspose_stores_taps_reversed_in_the_conv_layout` (Docker,
+no device), which checks every code and that dropping the reversal breaks it.
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4930,6 +4930,76 @@ def _weight1d_offset_wide(o, i, k, cin, cout, kernel, top):
     ), (4 if i % 2 else 0)
 
 
+def _one_convtranspose_model(cin, cout, length, kernel, stride, weights=None):
+    """A 1-D transposed convolution. ONNX orders its weight `(Cin, Cout, K)`,
+    the opposite of `Conv`."""
+    rng = np.random.RandomState(0)
+    values = (rng.randn(cin, cout, kernel) * 0.05) if weights is None else weights
+    weight = numpy_helper.from_array(np.asarray(values, dtype=np.float32), "w")
+    node = helper.make_node(
+        "ConvTranspose",
+        ["x", "w"],
+        ["y"],
+        name="convt",
+        kernel_shape=[kernel],
+        strides=[stride],
+        pads=[(kernel - stride) // 2] * 2,
+    )
+    graph = helper.make_graph(
+        [node],
+        "one_convt",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, cin, length])],
+        [
+            helper.make_tensor_value_info(
+                "y", TensorProto.FLOAT, [1, cout, length * stride]
+            )
+        ],
+        [weight],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_convtranspose_stores_taps_reversed_in_the_conv_layout(tmp_path):
+    """Confirmed real (see the README's "A transposed convolution is several
+    convolutions" section): an unstrided `ConvTranspose` uses the *ordinary*
+    convolution weight layout, with two adjustments -- ONNX's `(Cin, Cout, K)`
+    weight maps straight on (dimension 0 behaves as input channels), and the
+    kernel taps are stored **reversed**.
+
+    Getting the reversal wrong is not obvious from a correlation, so this
+    checks every code. Needs Docker, no device.
+    """
+    cin = cout = 32
+    kernel, length = 4, 32
+    rng = np.random.RandomState(5)
+    weights = rng.randn(cin, cout, kernel) * 0.05
+    for i in range(cin):
+        weights[i] *= 0.2 / np.abs(weights[i]).max()
+    weights = weights.astype(np.float32)
+
+    work = tmp_path / "s1"
+    work.mkdir()
+    model = _one_convtranspose_model(cin, cout, length, kernel, 1, weights=weights)
+    wbt = _wbt_of(_build_single_op_axmodel(str(work), "m", model))
+
+    # (Cin, Cout, K) -> the conv layout's (o, i, k), taps reversed.
+    as_conv = np.swapaxes(weights, 0, 1)[:, :, ::-1].copy()
+    got = np.zeros(as_conv.shape, dtype=int)
+    for o in range(cout):
+        for i in range(cin):
+            for k in range(kernel):
+                off, shift = _weight_offset(o, i, k, cin, cout, kernel)
+                got[o, i, k] = (((wbt[off + _WBT_PLANE_GAP] >> shift) & 0xF) << 4) | (
+                    (wbt[off] >> shift) & 0xF
+                )
+    assert (got == _quantize_conv_weights(as_conv)).all()
+    # Without the reversal it does not read.
+    assert not (got == _quantize_conv_weights(np.swapaxes(weights, 0, 1))).all()
+
+
 def test_dilation_changes_the_weight_layout(tmp_path):
     """Confirmed real (see the README's "Dilation reorders the weights"
     section): a dilated convolution stores its weights in a *different*


### PR DESCRIPTION
The three `ConvTranspose` upsamplers hold most of the vocoder's weights and none of them read (#1258). They turn out not to have a layout of their own.

### Unstrided: the ordinary conv layout with two adjustments

ONNX orders a `ConvTranspose` weight `(Cin, Cout, K)` rather than `(Cout, Cin, K)`, and dimension 0 behaves as the **input** channel exactly as `i` does for a convolution -- weights `(0,0,0)` and `(1,0,0)` land in the same byte, different nibbles.

The taps are then stored **reversed**. With `K = 4` at 32 channels: `k = 3` sits at byte 0, `k = 2` at 16, `k = 1` at 32, and `k = 0` at 156 -- which is slot 48 chunked at 36 into `144 + 12`. Reading `(Cout, Cin, K)` with `k' = K-1-k` reproduces **every code**.

### Strided: split into `stride` separate convolutions

At stride 2 the taps do not stay together: `k = 0` and `k = 2` land 16 bytes apart while `k = 1` sits in an entirely different region.

That is **polyphase decomposition** -- a stride-`s` transposed convolution compiled as `s` ordinary convolutions of `K/s` taps each, which is the standard way to implement one.

### All twenty phases of the vocoder's upsamplers locate

at 0.9997 to 0.9999:

| layer | stride | phases | located |
| --- | --- | --- | --- |
| `(256, 128, 16)` | 8 | 8 x 2 taps | **8/8** |
| `(128, 64, 16)` | 8 | 8 x 2 taps | **8/8** |
| `(64, 32, 8)` | 4 | 4 x 2 taps | **4/4** |

### Coverage

**The vocoder goes from 10 to 13 of 23 layers, and from 7.1% to 47.5% of its weights.** Three layers carried forty points of coverage -- which is what happens when the unread ones are the big ones.

What remains is `conv_pre` at 192 input channels, and the dilated layers at 128 channels and at dilations 6 and 12 -- the same width-and-dilation interaction noted in #1258, now the only thing between here and a fully read vocoder.

### Test

`test_convtranspose_stores_taps_reversed_in_the_conv_layout` (Docker, no device) -- checks every code, and that dropping the tap reversal breaks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS