### PR TITLE
mcode: the llm_build weight encoding -- same nibble planes, half the gap

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4572,23 +4572,46 @@ each -- which at 512 MACs/cycle demands roughly **3.8 GHz**. Even a generous
 1.5 GHz gives about 1.5 TOPS per core, so the pair can offer perhaps 2 to 3
 TOPS: a useful 20-30% on top of the NPU, not a doubling.
 
-**Where the gap actually is: clock.** The NPU sustains **4,949 MAC/cycle**
-across its three cores (measured, stable across shapes). At that rate,
-18 TOPS requires
+**Where the gap actually is: array utilisation, not clock.** The NPU
+sustains **4,949 MAC/cycle** across its cores, measured and stable across
+shapes.
 
-    18e12 / (2 * 4949) = 1.82 GHz
+The clock no longer has to be guessed. A `profile=True` build writes a
+`trace.json` whose events carry durations, and comparing their span against
+the same build's `max_cycle` gives the toolchain's own conversion:
 
-and the implied clock measured here is **854-949 MHz** -- almost exactly
-half. So the rating is consistent with the same silicon at roughly twice the
-clock this card runs at, and the card idles at 75 C in an M.2 slot. The
-shortfall looks like clock and thermal headroom rather than lost efficiency,
-which also fits the earlier finding that the NPU executes essentially the
-cycle count its own compiler predicts.
+| graph | max_cycle | trace span | nominal |
+| --- | --- | --- | --- |
+| 1024ch 16x16 | 3,905,355 | 3906.3 us | 999.8 MHz |
+| 256ch 64x64 | 3,831,460 | 3832.7 us | 999.7 MHz |
+| 512ch 32x32 | 3,704,778 | 3706.5 us | 999.5 MHz |
 
-That is a hypothesis about *why*, not a measurement: AXCL exposes no NPU
-frequency (`axcl-smi info --npu` reports usage and an engine version, no
-clock), so the 1.82 GHz figure is inferred from the rating and the measured
-MAC rate, not read from the hardware.
+The compiler emits exactly one cycle per nanosecond, so its **nominal NPU
+clock is 1.0 GHz**. Measured against real device time the same builds give
+854 to 949 MHz, so the hardware runs at **85-95% of nominal** -- close to it,
+not at half of something larger.
+
+That settles the arithmetic. At 1.0 GHz, 18 TOPS requires
+
+    18e12 / (2 * 1.0e9) = 9,000 MAC/cycle
+
+and the hardware sustains 4,949, or **55%** of it. The kernel log names
+sixteen execution units (`EU[0]` through `EU[15]`), and 9,000 over 16 is 562
+per unit -- consistent with a 512-MAC unit per EU and a rating that assumes
+the whole array busy.
+
+So the distance to 18 TOPS is how much of the array a real convolution keeps
+fed, not clock and not the DSPs. An earlier draft of this section proposed a
+1.82 GHz rated clock with this card running at half; the trace says
+otherwise and that reading was wrong.
+
+**What is still not directly readable** is the hardware's instantaneous
+frequency: AXCL exposes no NPU clock (`axcl-smi info --npu` gives usage and
+an engine version; `set --freq` sets the *CPU*, offering 1200/1400/1700 MHz),
+the device kernel log prints none, and no `AX_SYS_*` clock getter is exported
+even though `AX_NPU_CLK_ID` exists in the headers. The 1.0 GHz above is the
+compiler's nominal, and the 854-949 MHz is measured effective throughput --
+between them there is no room for a large hidden clock deficit.
 
 **So: using the DSPs is possible but would need firmware written from
 scratch with a toolchain that is not part of this stack, and by the numbers

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4658,6 +4658,48 @@ vocoder.
 Test: `test_convtranspose_stores_taps_reversed_in_the_conv_layout` (Docker,
 no device), which checks every code and that dropping the reversal breaks it.
 
+### The LLM path's weight encoding
+
+Everything decoded so far is `pulsar2 build` output. `llm_build` is a
+different compiler entry point, and its weight tables had never been looked
+at -- coverage there was zero. They are not a different format.
+
+**The tell is the zero weight.** In the two-nibble-plane INT8 encoding an
+all-zero weight reads `0x00` in the low plane and `0x88` in the high one, so
+a real plane gap makes `0x00` at some offset predict `0x88` a fixed distance
+later. Scanning gaps 1 to 64 over a layer's `npu_params`:
+
+| model | best gap | P(`0x88` at j+gap given `0x00` at j) | lift |
+| --- | --- | --- | --- |
+| synthetic 4096-hidden, `s8` | **18** | 0.52 | **12.3x** |
+| SmolLM2-135M, `s8` | **18** | 0.21 | **7.9x** |
+| synthetic 4096-hidden, `s4` | 64 | 0.005 | 0.06x |
+
+So `llm_build` uses **the same two-nibble-plane INT8 encoding, with the
+planes 18 bytes apart** rather than the convolution pipeline's 36 -- half the
+plane, and the same idea. Two independent models agree on 18, with 17 and 19
+as shoulders, so the fine structure may not be a single fixed stride.
+
+**The `s4` build is what makes this an encoding claim rather than a
+coincidence.** Four-bit weights need only one nibble, so there is no second
+plane to pair with, and indeed no gap anywhere from 1 to 64 shows any lift at
+all -- the best is 0.06x, i.e. *less* than chance. The pairing appears
+exactly when the format says it should and vanishes exactly when it should.
+
+Table sizes agree independently: 192,889,348 bytes for a layer of about
+177.2M parameters is 1.09 bytes per parameter at `s8`, and the `s4` build of
+the same layer is 97,952,260 -- almost exactly half.
+
+That takes the LLM path from nothing to a known weight encoding. What is not
+yet known there is the addressing: which byte holds which weight. The
+convolution work needed single-weight probes for that, and `llm_build` takes
+a checkpoint rather than a graph, so the same trick needs a synthetic
+checkpoint per probe -- slower, but no different in kind.
+
+Test: `test_llm_build_weights_use_the_same_nibble_planes_at_half_the_gap`
+(Docker, no device), which checks the peak at 18, that it beats the
+convolution pipeline's 36, and that `s4` shows nothing.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4485,10 +4485,9 @@ again:
 | 128-channel dilated layers | 128 works undilated, so the two rules interact |
 | dilation 6 and 12 at 64 channels | 32 channels handles both, so it interacts with width |
 
-That is still only **7.1% of the vocoder's weights**, because the three
-transposed convolutions and `conv_pre` hold most of them. The honest summary
-is that the vocoder's *small* layers are now fully readable and its *large*
-ones are not.
+That was 7.1% of the vocoder's weights, because the three transposed
+convolutions and `conv_pre` hold most of them. The transposed ones are now
+readable too -- see the next section, which takes it to 47.5%.
 
 Test: `test_dilation_changes_the_weight_layout` (Docker, no device), which
 checks both rules against their own builds and that the undilated rule does
@@ -4617,6 +4616,47 @@ between them there is no room for a large hidden clock deficit.
 scratch with a toolchain that is not part of this stack, and by the numbers
 it buys a fraction of what the rating implies. The rating's missing factor is
 much better explained by clock.**
+
+### A transposed convolution is several convolutions
+
+The three `ConvTranspose` upsamplers hold most of the vocoder's weights and
+none of them read. They are not stored in a layout of their own.
+
+**Unstrided, it is the ordinary conv layout with two adjustments.** ONNX
+orders a `ConvTranspose` weight `(Cin, Cout, K)` rather than
+`(Cout, Cin, K)`, and dimension 0 behaves as the *input* channel exactly as
+`i` does for a convolution -- weights `(0,0,0)` and `(1,0,0)` land in the
+same byte, different nibbles. The taps are then stored **reversed**: with
+`K = 4` at 32 channels, `k = 3` sits at byte 0, `k = 2` at 16, `k = 1` at 32
+and `k = 0` at 156, which is slot 48 chunked at 36 into `144 + 12`. Reading
+`(Cout, Cin, K)` with `k' = K-1-k` reproduces every code.
+
+**Strided, it is split into `stride` separate convolutions.** At stride 2 the
+taps do not stay together: `k = 0` and `k = 2` land 16 bytes apart while
+`k = 1` sits in an entirely different region. That is polyphase
+decomposition -- a stride-`s` transposed convolution compiled as `s` ordinary
+convolutions of `K/s` taps each, which is the standard way to implement one.
+
+**All twenty phases of the vocoder's three upsamplers locate**, at 0.9997 to
+0.9999:
+
+| layer | stride | phases | located |
+| --- | --- | --- | --- |
+| `(256, 128, 16)` | 8 | 8 x 2 taps | 8/8 |
+| `(128, 64, 16)` | 8 | 8 x 2 taps | 8/8 |
+| `(64, 32, 8)` | 4 | 4 x 2 taps | 4/4 |
+
+**The vocoder goes from 10 to 13 of 23 layers, and from 7.1% to 47.5% of its
+weights.** Three layers carried forty points of coverage, which is what
+happens when the unread ones are the big ones.
+
+What remains is `conv_pre` at 192 input channels, and the dilated layers at
+128 channels and at dilations 6 and 12 -- the same width-and-dilation
+interaction noted before, now the only thing between here and a fully read
+vocoder.
+
+Test: `test_convtranspose_stores_taps_reversed_in_the_conv_layout` (Docker,
+no device), which checks every code and that dropping the reversal breaks it.
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4763,6 +4763,71 @@ def test_int8_throughput_reaches_a_useful_fraction_of_the_rating(tmp_path):
     assert tops > 5.0, (tops, stats)
 
 
+def _plane_pairing_lift(wbt, gap, limit=4_000_000):
+    """How much more often a zero low-nibble byte is followed `gap` bytes
+    later by `0x88`, relative to how often `0x88` occurs at all.
+
+    In the two-nibble-plane INT8 encoding an all-zero weight reads `0x00` in
+    the low plane and `0x88` in the high one, so a real plane gap shows a
+    large lift and a wrong one shows about 1.0.
+    """
+    seg = np.frombuffer(wbt[: min(len(wbt), limit)], dtype=np.uint8)
+    base = float((seg == 0x88).mean())
+    if base == 0:
+        return 0.0
+    zeros = np.nonzero(seg[: len(seg) - gap] == 0x00)[0]
+    if len(zeros) < 1000:
+        return 0.0
+    return float((seg[zeros + gap] == 0x88).mean()) / base
+
+
+def test_llm_build_weights_use_the_same_nibble_planes_at_half_the_gap(tmp_path):
+    """Confirmed real (see the README's "The LLM path's weight encoding"
+    section): `llm_build` stores INT8 weights in the same two-nibble-plane
+    form the convolution pipeline uses, but with the planes **18** bytes
+    apart rather than 36.
+
+    The `s4` build is the control that makes this an encoding claim rather
+    than a coincidence: four-bit weights need only one nibble, so they show
+    no pairing at any gap. Needs Docker, no device.
+    """
+    ckpt = _cached_hf_checkpoint("HuggingFaceTB/SmolLM2-135M")
+    if ckpt is None:
+        pytest.skip("HuggingFaceTB/SmolLM2-135M is not in the local HuggingFace cache")
+    work = tmp_path / "work"
+    work.mkdir()
+    shutil.copytree(ckpt, work / "SmolLM2-135M", symlinks=False)
+
+    lifts = {}
+    for weight_type in ("s8", "s4"):
+        result = pulsar2_docker.llm_build(
+            str(work),
+            "SmolLM2-135M",
+            f"out_{weight_type}",
+            weight_type=weight_type,
+            prefill_len=512,
+            kv_cache_len=1023,
+            parallel=8,
+        )
+        assert result.success, (weight_type, getattr(result, "error", None))
+        layer = sorted(glob.glob(str(work / f"out_{weight_type}" / "*_l0_*.axmodel")))
+        assert layer, weight_type
+        wbt = bytes(
+            next(
+                i
+                for i in onnx.load(layer[0]).graph.initializer
+                if i.name == "npu_params"
+            ).raw_data
+        )
+        lifts[weight_type] = {g: _plane_pairing_lift(wbt, g) for g in (17, 18, 19, 36)}
+
+    # s8: a clear peak at 18, and *not* at the convolution pipeline's 36.
+    assert lifts["s8"][18] > 4.0, lifts["s8"]
+    assert lifts["s8"][18] > lifts["s8"][36], lifts["s8"]
+    # s4: four-bit weights occupy one nibble, so nothing pairs anywhere.
+    assert max(lifts["s4"].values()) < 2.0, lifts["s4"]
+
+
 def test_llm_build_offers_an_int4_weight_path_the_cnn_path_lacks(tmp_path):
     """Confirmed real (see the README's "Where the INT4 path actually is"
     section): `pulsar2 llm_build` accepts `-w s4`, and the resulting model is

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4930,6 +4930,76 @@ def _weight1d_offset_wide(o, i, k, cin, cout, kernel, top):
     ), (4 if i % 2 else 0)
 
 
+def _one_convtranspose_model(cin, cout, length, kernel, stride, weights=None):
+    """A 1-D transposed convolution. ONNX orders its weight `(Cin, Cout, K)`,
+    the opposite of `Conv`."""
+    rng = np.random.RandomState(0)
+    values = (rng.randn(cin, cout, kernel) * 0.05) if weights is None else weights
+    weight = numpy_helper.from_array(np.asarray(values, dtype=np.float32), "w")
+    node = helper.make_node(
+        "ConvTranspose",
+        ["x", "w"],
+        ["y"],
+        name="convt",
+        kernel_shape=[kernel],
+        strides=[stride],
+        pads=[(kernel - stride) // 2] * 2,
+    )
+    graph = helper.make_graph(
+        [node],
+        "one_convt",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, cin, length])],
+        [
+            helper.make_tensor_value_info(
+                "y", TensorProto.FLOAT, [1, cout, length * stride]
+            )
+        ],
+        [weight],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_convtranspose_stores_taps_reversed_in_the_conv_layout(tmp_path):
+    """Confirmed real (see the README's "A transposed convolution is several
+    convolutions" section): an unstrided `ConvTranspose` uses the *ordinary*
+    convolution weight layout, with two adjustments -- ONNX's `(Cin, Cout, K)`
+    weight maps straight on (dimension 0 behaves as input channels), and the
+    kernel taps are stored **reversed**.
+
+    Getting the reversal wrong is not obvious from a correlation, so this
+    checks every code. Needs Docker, no device.
+    """
+    cin = cout = 32
+    kernel, length = 4, 32
+    rng = np.random.RandomState(5)
+    weights = rng.randn(cin, cout, kernel) * 0.05
+    for i in range(cin):
+        weights[i] *= 0.2 / np.abs(weights[i]).max()
+    weights = weights.astype(np.float32)
+
+    work = tmp_path / "s1"
+    work.mkdir()
+    model = _one_convtranspose_model(cin, cout, length, kernel, 1, weights=weights)
+    wbt = _wbt_of(_build_single_op_axmodel(str(work), "m", model))
+
+    # (Cin, Cout, K) -> the conv layout's (o, i, k), taps reversed.
+    as_conv = np.swapaxes(weights, 0, 1)[:, :, ::-1].copy()
+    got = np.zeros(as_conv.shape, dtype=int)
+    for o in range(cout):
+        for i in range(cin):
+            for k in range(kernel):
+                off, shift = _weight_offset(o, i, k, cin, cout, kernel)
+                got[o, i, k] = (((wbt[off + _WBT_PLANE_GAP] >> shift) & 0xF) << 4) | (
+                    (wbt[off] >> shift) & 0xF
+                )
+    assert (got == _quantize_conv_weights(as_conv)).all()
+    # Without the reversal it does not read.
+    assert not (got == _quantize_conv_weights(np.swapaxes(weights, 0, 1))).all()
+
+
 def test_dilation_changes_the_weight_layout(tmp_path):
     """Confirmed real (see the README's "Dilation reorders the weights"
     section): a dilated convolution stores its weights in a *different*


### PR DESCRIPTION
Everything decoded so far is `pulsar2 build` output. `llm_build` is a different compiler entry point and its weight tables had never been looked at -- coverage there was **zero**. They turn out not to be a different format.

### The tell is the zero weight

In the two-nibble-plane INT8 encoding an all-zero weight reads `0x00` in the low plane and `0x88` in the high one. So a real plane gap makes `0x00` at some offset predict `0x88` a fixed distance later. Scanning gaps 1 to 64 over a layer's `npu_params`:

| model | best gap | P(`0x88` at j+gap given `0x00` at j) | lift |
| --- | --- | --- | --- |
| synthetic 4096-hidden, `s8` | **18** | 0.52 | **12.3x** |
| SmolLM2-135M, `s8` | **18** | 0.21 | **7.9x** |
| synthetic 4096-hidden, `s4` | 64 | 0.005 | 0.06x |

So `llm_build` uses **the same two-nibble-plane INT8 encoding, with the planes 18 bytes apart** rather than the convolution pipeline's 36 -- half the plane, same idea. Two independent models agree on 18, with 17 and 19 as shoulders, so the fine structure may not be a single fixed stride.

### The `s4` build is what makes this an encoding claim

Four-bit weights need only one nibble, so there is no second plane to pair with -- and indeed **no gap anywhere from 1 to 64 shows any lift at all**, the best being 0.06x, i.e. *less* than chance.

The pairing appears exactly when the format says it should, and vanishes exactly when it should.

### Table sizes agree independently

192,889,348 bytes for a layer of about 177.2M parameters is **1.09 bytes per parameter** at `s8`, and the `s4` build of the same layer is 97,952,260 -- almost exactly half.

### What is still unknown there

The **addressing**: which byte holds which weight. The convolution work needed single-weight probes for that, and `llm_build` takes a checkpoint rather than a graph, so the same trick needs a synthetic checkpoint per probe -- slower, but no different in kind.

### Test

`test_llm_build_weights_use_the_same_nibble_planes_at_half_the_gap` (Docker, no device) -- checks the peak at 18, that it beats the convolution pipeline's 36, and that `s4` shows nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS