### PR TITLE
mcode: the llm_build matmul addressing is solved -- every row at 1.0000

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4698,8 +4698,32 @@ Table sizes agree independently: 192,889,348 bytes for a layer of about
 177.2M parameters is 1.09 bytes per parameter at `s8`, and the `s4` build of
 the same layer is 97,952,260 -- almost exactly half.
 
-That takes the LLM path from nothing to a known weight encoding. What is not
-yet known there is the addressing: which byte holds which weight. The
+That takes the LLM path from nothing to a known weight encoding.
+
+**The addressing is half-scale, and measured but not yet complete.**
+Single-weight probes on a small synthetic checkpoint give the index costs
+directly. Every one is exactly half its convolution-pipeline counterpart:
+
+| quantity | convolution | `llm_build` |
+| --- | --- | --- |
+| plane gap | 36 | **18** |
+| chunk size | 36 | **18** |
+| chunk stride | 144 | **72** |
+| the "special bit" | 72 | **36** |
+| `A` | `144*ceil((Cin/2)/36)` | `72*ceil((Cin/2)/18)` |
+
+Those are read off the probes, not fitted: a column at index 64 lands 86
+bytes in, which is `72*1 + 14` under chunking at 18, and index 128 lands at
+226, which is `72*3 + 10`. Row bits cost 576, 1152, 2304, 4608 for bits 0-3,
+36 for bit 4, then 9728, 19456, 38912.
+
+**But the combined map does not reconstruct**: it reproduces about 45% of a
+weight matrix's codes, uniformly across rows and columns rather than failing
+in one region. Each dimension's costs are right individually and something
+about how they compose is not, which -- given what the convolution path
+turned out to do -- is most likely a further block split that the probes so
+far cannot see. So: encoding confirmed, index costs measured, addressing not
+yet closed. The
 convolution work needed single-weight probes for that, and `llm_build` takes
 a checkpoint rather than a graph, so the same trick needs a synthetic
 checkpoint per probe -- slower, but no different in kind.
@@ -4756,16 +4780,32 @@ range slightly, and each sub-block carries its own requantisation multiplier.
 That is why the region count is visible from a one-weight change at all.)
 
 **Reading each tap as its own block takes the vocoder to 19 of 23 layers and
-62.5% of its weights**, from 14 and 50.5%. Layers that had resisted from the
+62.5% of its weights**, from 14 and 50.5% (and to 20 and 67.5% once input
+splitting is added, below). Layers that had resisted from the
 start -- `(64,64,7)` at dilation 12, `(32,32,7)` at dilation 12,
 `(128,128,7)` at dilation 3 -- read at 0.9971 to 0.9999.
 
-**Four layers remain**: `conv_pre` at `(256,192,7)`, and three at 128
-channels -- `(128,128,5)` at dilations 2 and 6, and `(128,128,7)` at dilation
-12. Those are the interesting residue, because `(128,128,7)` at dilation 3
-*does* read: same width, same kernel, different dilation. So whatever splits
-those three is finer than one tap per block, and probably splits the input as
-well.
+**The split is two-dimensional.** Counting regions for the layers that still
+failed shows the sub-block count is not always `K`:
+
+| convolution | dilation | sub-blocks |
+| --- | --- | --- |
+| 128ch, `K=7` | 3 | 7 (one per tap) |
+| 128ch, `K=5` | 2 | **2** (input halves, taps together) |
+| 128ch, `K=7` | 12 | **21** (7 taps x 3 input groups) |
+
+So a convolution is split along taps *and* along input channels, by whatever
+the tiling needs. Adding input-group splits to the reader -- trying 1, 2 and
+4 groups -- takes the vocoder to **20 of 23 layers and 67.5% of its
+weights**.
+
+**Three remain**: `conv_pre` at `(256,192,7)`, `(128,128,5)` at dilation 6,
+and `(128,128,7)` at dilation 12. The last two are close rather than opaque:
+15 of 20 and 25 of 28 of their sub-blocks locate individually at 1.0000, and
+the misses look like search collisions -- with four input groups a block is
+only 32 channels wide, which is a 16-byte pattern, short enough for a
+whole-table scan to find a false maximum. Confirming them needs a sharper
+search rather than a new rule.
 
 Test: `test_a_widely_dilated_conv_splits_into_single_tap_convolutions`
 (Docker, no device), which counts regions rather than searching for them --

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4729,12 +4729,47 @@ An extent of 25 reads at 32 channels and not at 64; an extent of 19 reads at
 alone, but their product against some tile -- the same shape of interaction
 the polyphase finding turned out to be.
 
-That suggests the likely answer: a convolution whose dilated footprint
-outgrows the input tile is **decomposed**, exactly as a strided transposed
-convolution is decomposed into phases. If so, the remaining layers are not a
-new layout at all, only the existing one applied to sub-convolutions, and the
-probe that settles it is the one that settled `ConvTranspose` -- flip a
-single weight and see how many separate regions move.
+That suggested a decomposition, and it is one -- see the next section.
+
+### A widely dilated convolution is K convolutions
+
+Flipping one weight and counting how many separate byte regions move settles
+it, and the count is the whole argument:
+
+| convolution | dilation | regions that move |
+| --- | --- | --- |
+| 64ch, `K=3` | 1 | 2 (the weight, and the scales) |
+| 64ch, `K=7` | 3 | **8** |
+| 64ch, `K=5` | 6 | **6** |
+
+Eight regions at `K = 7` and six at `K = 5`: **one per kernel tap**, plus the
+scales. Not one per dilation, which is the decomposition one might guess
+first -- `d` is 3 and 6 in those two rows, and neither matches.
+
+So once a dilated kernel's footprint outgrows what one input tile holds, the
+convolution is compiled as **K separate single-tap convolutions**, each laid
+out as an ordinary `K = 1` block. The same move as the polyphase split of a
+strided transposed convolution, along a different axis.
+
+(A single weight perturbs *every* region because it shifts the layer's output
+range slightly, and each sub-block carries its own requantisation multiplier.
+That is why the region count is visible from a one-weight change at all.)
+
+**Reading each tap as its own block takes the vocoder to 19 of 23 layers and
+62.5% of its weights**, from 14 and 50.5%. Layers that had resisted from the
+start -- `(64,64,7)` at dilation 12, `(32,32,7)` at dilation 12,
+`(128,128,7)` at dilation 3 -- read at 0.9971 to 0.9999.
+
+**Four layers remain**: `conv_pre` at `(256,192,7)`, and three at 128
+channels -- `(128,128,5)` at dilations 2 and 6, and `(128,128,7)` at dilation
+12. Those are the interesting residue, because `(128,128,7)` at dilation 3
+*does* read: same width, same kernel, different dilation. So whatever splits
+those three is finer than one tap per block, and probably splits the input as
+well.
+
+Test: `test_a_widely_dilated_conv_splits_into_single_tap_convolutions`
+(Docker, no device), which counts regions rather than searching for them --
+the count is the claim, and it is robust where a base-offset search is not.
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4717,13 +4717,24 @@ bytes in, which is `72*1 + 14` under chunking at 18, and index 128 lands at
 226, which is `72*3 + 10`. Row bits cost 576, 1152, 2304, 4608 for bits 0-3,
 36 for bit 4, then 9728, 19456, 38912.
 
-**But the combined map does not reconstruct**: it reproduces about 45% of a
-weight matrix's codes, uniformly across rows and columns rather than failing
-in one region. Each dimension's costs are right individually and something
-about how they compose is not, which -- given what the convolution path
-turned out to do -- is most likely a further block split that the probes so
-far cannot see. So: encoding confirmed, index costs measured, addressing not
-yet closed. The
+**The addressing is solved.** Scored by correlation per output row -- which
+tests the index without depending on the quantiser -- the map reads **every
+row of a 256x256 matmul at 1.0000**, all 256 of them. The index is linear in
+the bits, confirmed directly: row 17 costs 612, which is row 1's 576 plus row
+16's 36.
+
+An earlier reading of this section reported 45% and called the addressing
+unclosed. That number was an *exactness* score, and what it was measuring was
+the quantiser, not the index -- a scale-invariant metric would have separated
+the two immediately.
+
+**The quantiser is the part still open.** Its magnitude is `peak/128`, not
+the convolution pipeline's `peak/127.5`. About half the rows are additionally
+stored **negated**, in a pattern that nearly but not exactly follows the sign
+of each row's largest-magnitude element (using that sign directly reproduces
+93.3% of codes; using the measured per-row signs reproduces 94.7%). So the
+residue is a sign convention plus rounding, on top of an index that is fully
+understood. The
 convolution work needed single-weight probes for that, and `llm_build` takes
 a checkpoint rather than a graph, so the same trick needs a synthetic
 checkpoint per probe -- slower, but no different in kind.

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -5027,6 +5027,62 @@ def _one_convtranspose_model(cin, cout, length, kernel, stride, weights=None):
     return model
 
 
+def test_a_widely_dilated_conv_splits_into_single_tap_convolutions(tmp_path):
+    """Confirmed real (see the README's "A widely dilated convolution is K
+    convolutions" section): once a dilated kernel's footprint grows past what
+    one input tile holds, the convolution is compiled as **K separate
+    single-tap convolutions**.
+
+    The count is what identifies it. Changing a single weight and grouping
+    the bytes that move gives one region per *tap* -- eight regions at
+    `K = 7`, six at `K = 5` -- and **not** one per dilation, which is the
+    other decomposition one might guess (`d` is 3 and 6 here). An undilated
+    convolution of the same width moves one region. Needs Docker, no device.
+    """
+    cin = cout = 64
+    length = 64
+
+    def regions(kernel, dilation):
+        rng = np.random.RandomState(5)
+        base = rng.randn(cout, cin, kernel) * 0.05
+        for o in range(cout):
+            base[o] *= 0.2 / np.abs(base[o]).max()
+        base[0, 0, 0] = 0.1
+        flipped = base.copy()
+        flipped[0, 0, 0] = -0.1176  # differs in both nibbles
+        tables = []
+        for tag, weights in (("a", base), ("b", flipped)):
+            work = tmp_path / f"k{kernel}d{dilation}{tag}"
+            work.mkdir()
+            model = _one_conv_model(
+                cin,
+                cout,
+                length,
+                kernel,
+                dilation=dilation,
+                weights=weights.astype(np.float32),
+            )
+            tables.append(_wbt_of(_build_single_op_axmodel(str(work), "m", model)))
+        a, b = tables
+        moved = [j for j in range(min(len(a), len(b))) if a[j] != b[j]]
+        assert moved, (kernel, dilation)
+        groups, current = [], [moved[0]]
+        for offset in moved[1:]:
+            if offset - current[-1] > 64:
+                groups.append(current)
+                current = [offset]
+            else:
+                current.append(offset)
+        groups.append(current)
+        return len(groups)
+
+    # Undilated: one weight region (plus the scales it perturbs).
+    assert regions(3, 1) <= 2, regions(3, 1)
+    # Widely dilated: one region per tap, not per dilation.
+    assert regions(7, 3) >= 7, "K=7 should split into per-tap regions"
+    assert regions(5, 6) >= 5, "K=5 should split into per-tap regions"
+
+
 def test_convtranspose_stores_taps_reversed_in_the_conv_layout(tmp_path):
     """Confirmed real (see the README's "A transposed convolution is several
     convolutions" section): an unstrided `ConvTranspose` uses the *ordinary*

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4781,6 +4781,167 @@ def _plane_pairing_lift(wbt, gap, limit=4_000_000):
     return float((seg[zeros + gap] == 0x88).mean()) / base
 
 
+def _write_safetensors(path, tensors):
+    """Minimal safetensors writer: an 8-byte header length, a JSON header,
+    then the raw float32 blocks."""
+    header, offset, blobs = {}, 0, []
+    for name, array in tensors:
+        data = np.ascontiguousarray(array, dtype=np.float32).tobytes()
+        header[name] = {
+            "dtype": "F32",
+            "shape": list(np.shape(array)),
+            "data_offsets": [offset, offset + len(data)],
+        }
+        offset += len(data)
+        blobs.append(data)
+    blob = json.dumps(header).encode()
+    blob += b" " * ((-len(blob)) % 8)
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(blob)))
+        f.write(blob)
+        for data in blobs:
+            f.write(data)
+
+
+def _tiny_llama_checkpoint(
+    path, weights, hidden=256, inter=512, heads=8, kv=2, vocab=512
+):
+    """A synthetic Llama checkpoint whose layer-0 `q_proj` is `weights`."""
+    os.makedirs(path, exist_ok=True)
+    rng = np.random.RandomState(3)
+
+    def small(*shape):
+        return rng.randn(*shape) * 0.02
+
+    head_dim = hidden // heads
+    tensors = [
+        ("model.embed_tokens.weight", small(vocab, hidden)),
+        ("model.layers.0.self_attn.q_proj.weight", weights),
+        ("model.layers.0.self_attn.k_proj.weight", small(kv * head_dim, hidden)),
+        ("model.layers.0.self_attn.v_proj.weight", small(kv * head_dim, hidden)),
+        ("model.layers.0.self_attn.o_proj.weight", small(hidden, heads * head_dim)),
+        ("model.layers.0.mlp.gate_proj.weight", small(inter, hidden)),
+        ("model.layers.0.mlp.up_proj.weight", small(inter, hidden)),
+        ("model.layers.0.mlp.down_proj.weight", small(hidden, inter)),
+        ("model.layers.0.input_layernorm.weight", np.ones(hidden)),
+        ("model.layers.0.post_attention_layernorm.weight", np.ones(hidden)),
+        ("model.norm.weight", np.ones(hidden)),
+        ("lm_head.weight", small(vocab, hidden)),
+    ]
+    _write_safetensors(os.path.join(path, "model.safetensors"), tensors)
+    with open(os.path.join(path, "config.json"), "w") as f:
+        json.dump(
+            {
+                "architectures": ["LlamaForCausalLM"],
+                "model_type": "llama",
+                "hidden_size": hidden,
+                "intermediate_size": inter,
+                "num_hidden_layers": 1,
+                "num_attention_heads": heads,
+                "num_key_value_heads": kv,
+                "vocab_size": vocab,
+                "max_position_embeddings": 512,
+                "rms_norm_eps": 1e-5,
+                "rope_theta": 10000.0,
+                "hidden_act": "silu",
+                "torch_dtype": "float32",
+                "tie_word_embeddings": False,
+                "bos_token_id": 1,
+                "eos_token_id": 2,
+                "attention_bias": False,
+                "mlp_bias": False,
+            },
+            f,
+        )
+
+
+def _llm_weight_offset(row, col, cin):
+    """Where `llm_build` puts a matmul weight. Every constant is half its
+    convolution-pipeline counterpart: an 18-byte plane gap, chunks of 18 with
+    a stride of 72, and 36 for the bit that costs 72 there."""
+    a = 72 * -(-(cin // 2) // 18)
+    m = 16
+    top = m * a + 512
+    slot = col // 2
+    return (
+        a * (row % m)
+        + 36 * ((row // m) & 1)
+        + top * (row // (2 * m))
+        + 72 * (slot // 18)
+        + (slot % 18)
+    ), (4 if col % 2 else 0)
+
+
+def test_llm_matmul_weight_addressing_is_the_conv_layout_halved(tmp_path):
+    """Confirmed real (see the README's "The LLM path's weight encoding"
+    section): `_llm_weight_offset()` locates every weight of an `llm_build`
+    matmul. Scored by correlation per output row, which tests the *addressing*
+    without depending on the quantiser -- that convention differs from the
+    convolution pipeline's and is not fully pinned down.
+
+    Needs Docker, no device.
+    """
+    hidden = 256
+    rng = np.random.RandomState(11)
+    weights = rng.randn(hidden, hidden) * 0.02
+    weights *= 0.2 / np.abs(weights).max(axis=1, keepdims=True)
+
+    work = tmp_path / "work"
+    work.mkdir()
+    _tiny_llama_checkpoint(str(work / "tiny"), weights, hidden=hidden)
+    result = pulsar2_docker.llm_build(
+        str(work),
+        "tiny",
+        "out",
+        weight_type="s8",
+        prefill_len=64,
+        kv_cache_len=127,
+        parallel=8,
+    )
+    assert result.success, getattr(result, "error", None)
+    files = sorted(glob.glob(str(work / "out" / "*.axmodel")))
+    assert files
+    wbt = np.frombuffer(
+        next(
+            i for i in onnx.load(files[0]).graph.initializer if i.name == "npu_params"
+        ).raw_data,
+        dtype=np.uint8,
+    )
+
+    offsets = np.array(
+        [[_llm_weight_offset(0, c, hidden)[0] for c in range(hidden)]]
+    ).ravel()
+    shifts = np.array([4 if c % 2 else 0 for c in range(hidden)])
+    span = int(offsets.max()) + 18 + 4
+
+    # Find the block by its first row, then require every row to correlate.
+    target = weights[0] - weights[0].mean()
+    best, base = -2.0, None
+    for start in range(0, len(wbt) - span, 2):
+        low = (wbt[start + offsets] >> shifts) & 0xF
+        high = (wbt[start + offsets + 18] >> shifts) & 0xF
+        codes = ((high.astype(int) << 4) | low).astype(float)
+        codes -= codes.mean()
+        denom = np.sqrt((codes**2).sum() * (target**2).sum())
+        if denom == 0:
+            continue
+        corr = abs(float((codes * target).sum() / denom))
+        if corr > best:
+            best, base = corr, start
+        if corr > 0.9999:
+            break
+    assert best > 0.99, best
+
+    worst = 1.0
+    for row in range(hidden):
+        rel = np.array([_llm_weight_offset(row, c, hidden)[0] for c in range(hidden)])
+        low = (wbt[base + rel] >> shifts) & 0xF
+        high = (wbt[base + rel + 18] >> shifts) & 0xF
+        codes = ((high.astype(int) << 4) | low).astype(float)
+        worst = min(worst, abs(float(np.corrcoef(weights[row], codes)[0, 1])))
+    assert worst > 0.99, worst
+
+
 def test_llm_build_weights_use_the_same_nibble_planes_at_half_the_gap(tmp_path):
     """Confirmed real (see the README's "The LLM path's weight encoding"
     section): `llm_build` stores INT8 weights in the same two-nibble-plane


### PR DESCRIPTION
#1270 reported 45% and called the LLM addressing unclosed. **That number was measuring the wrong thing.**

Scored by **correlation per output row** -- which tests the index without depending on the quantiser -- the half-scale map reads **every row of a 256x256 matmul at 1.0000**, all 256 of them.

```
A     = 72 * ceil((Cin/2)/18)
byte  = A*(row%16) + 36*((row//16)&1) + (16*A+512)*(row//32)
      + 72*((col//2)//18) + (col//2)%18
high plane = byte + 18,  nibble = col%2
```

Every constant is half its convolution-pipeline counterpart: plane gap **18** not 36, chunk **18** not 36, chunk stride **72** not 144, the special bit **36** not 72.

The index is linear in the bits, confirmed directly: **row 17 costs 612**, which is row 1's 576 plus row 16's 36.

### The correction

45% was an *exactness* score, and what it was measuring was the **quantiser**, not the index. A scale-invariant metric separates the two immediately -- and did, the moment it was applied.

### What remains open: the quantiser

Its magnitude is `peak/128`, not the convolution pipeline's `peak/127.5`. About half the rows are additionally stored **negated**, in a pattern that nearly but not exactly follows the sign of each row's largest-magnitude element:

- using that sign directly reproduces **93.3%** of codes
- using the measured per-row signs reproduces **94.7%**

So the residue is a sign convention plus rounding, sitting on top of an index that is now fully understood.

### Test

`test_llm_matmul_weight_addressing_is_the_conv_layout_halved` (Docker, no device). It builds its own synthetic Llama checkpoint with a **numpy-only safetensors writer**, so it needs neither `torch` nor `transformers`, and scores by per-row correlation so it tests the addressing rather than the quantiser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS