### PR TITLE
Add Z3-based translation validation for three optimizer rewrites

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
       # a master-branch push from a pull request inside the manylinux container.
       CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2 ONNXSIM_RELEASE GITHUB_EVENT_NAME GITHUB_REF
       CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
-      CIBW_TEST_REQUIRES: pytest flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26 sympy onnx-shape-inference onnxslim onnx_safetensors
+      CIBW_TEST_REQUIRES: pytest flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26 sympy onnx-shape-inference onnxslim onnx_safetensors z3-solver
       CIBW_BEFORE_TEST: pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu/
       CIBW_TEST_COMMAND: pytest -v ${{ matrix.pytest_args }} {project}/tests && onnxsim -h && onnxsim --list-default-optimizers
       # Only build on Python 3 and skip 32-bit or musl builds

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,13 @@ jobs:
       # a master-branch push from a pull request inside the manylinux container.
       CIBW_ENVIRONMENT_PASS_LINUX: CI SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN ACTIONS_CACHE_SERVICE_V2 ONNXSIM_RELEASE GITHUB_EVENT_NAME GITHUB_REF
       CIBW_BEFORE_BUILD: "python3 -m pip install --break-system-packages cmake ninja setuptools sccache nanobind"
-      CIBW_TEST_REQUIRES: pytest flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26 sympy onnx-shape-inference onnxslim onnx_safetensors z3-solver
+      # z3-solver's own wheels for linux/aarch64 require manylinux_2_38 (a newer
+      # glibc than this job's manylinux_2_28 image provides), so pip falls back
+      # to building it from source there and that build fails -- omit it only
+      # on that one matrix leg; ubuntu-24.04 (manylinux_2_27 wheel) and
+      # macos-15 (macosx_13_0 wheel, matching CIBW_ENVIRONMENT's
+      # MACOSX_DEPLOYMENT_TARGET below) both have compatible prebuilt wheels.
+      CIBW_TEST_REQUIRES: pytest flake8 onnxruntime onnxscript==0.6.2 timm==1.0.26 sympy onnx-shape-inference onnxslim onnx_safetensors${{ matrix.os != 'ubuntu-24.04-arm' && ' z3-solver' || '' }}
       CIBW_BEFORE_TEST: pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu/
       CIBW_TEST_COMMAND: pytest -v ${{ matrix.pytest_args }} {project}/tests && onnxsim -h && onnxsim --list-default-optimizers
       # Only build on Python 3 and skip 32-bit or musl builds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,13 @@ shape-inference = ["onnx-shape-inference"]
 # Needed by onnxsim.profile_plot.plot_node_reduction() / --node-reduction-plot,
 # which renders the "NodeCount" events in a simplify(..., profile=...) trace.
 plot = ["matplotlib"]
+# z3-solver backs tests/_formal_verify_common.py's translation-validation tests
+# (tests/test_formal_verify_*.py): each targeted optimizer rewrite gets a
+# hand-written Z3 proof that its documented algebra is a sound equivalence,
+# plus a differential check that the compiled pass, run in isolation, agrees
+# with that same algebra on concrete models. Unrelated to onnxsim's own
+# ONNX-to-ONNX pipeline; those tests are skipped (not failed) without it.
+verify = ["z3-solver"]
 # Needed by onnxsim.export_transformers_model(), which calls
 # optimum.exporters.onnx.main_export to turn a Hugging Face transformers model
 # into ONNX before simplifying it. Heavy and unrelated to onnxsim's own

--- a/tests/_formal_verify_common.py
+++ b/tests/_formal_verify_common.py
@@ -25,14 +25,14 @@ these tests are skipped, not failed, when it isn't installed.
 
 import collections
 
+import onnxsim.onnxsim_cpp2py_export as C
 import pytest
+
+import onnxsim
 
 z3 = pytest.importorskip(
     "z3", reason="formal verification tests need the 'verify' extra (z3-solver)"
 )
-
-import onnxsim
-import onnxsim.onnxsim_cpp2py_export as C
 
 
 def isolate(*pass_names):

--- a/tests/_formal_verify_common.py
+++ b/tests/_formal_verify_common.py
@@ -1,0 +1,66 @@
+"""Shared helpers for the formal-verification tests (tests/test_formal_verify_*.py).
+
+Each targeted optimizer rewrite gets two independent checks:
+
+1. A hand-written Z3 proof (``prove`` below) that the rewrite's documented
+   algebra is a sound equivalence -- e.g. that composing two Transpose
+   permutations the way fuse_consecutive_transposes.h does is equivalent to
+   applying both in sequence, for every index and every tensor value, not
+   just a finite sample.
+2. A differential check (``simplify_isolated`` below) that the actual
+   compiled pass, run alone via ``skipped_optimizers``, produces output
+   consistent with that same algebra on a concrete model.
+
+(1) alone only proves the hand-written *spec* is sound; there is no way to
+symbolically execute onnxsim's C++ pass code itself from Python (no per-pass
+hook is exposed across the nanobind boundary -- only whole-model
+``optimize()`` is). (2) narrows that gap by validating the compiled pass
+against the same spec on concrete numbers. Neither replaces onnxsim's own
+random-sampling ``--check`` (see onnxsim/model_checking.py), which still runs
+alongside via ``simplify_isolated``'s own ``check_n``.
+
+z3-solver backs this and is an optional dependency (the ``verify`` extra):
+these tests are skipped, not failed, when it isn't installed.
+"""
+
+import collections
+
+import pytest
+
+z3 = pytest.importorskip(
+    "z3", reason="formal verification tests need the 'verify' extra (z3-solver)"
+)
+
+import onnxsim
+import onnxsim.onnxsim_cpp2py_export as C
+
+
+def isolate(*pass_names):
+    """``skipped_optimizers`` value that leaves only the named default passes active."""
+    names = set(pass_names)
+    all_default = set(C._list_optimizers())
+    unknown = names - all_default
+    assert not unknown, f"not a default onnxsim optimizer pass: {sorted(unknown)}"
+    return sorted(all_default - names)
+
+
+def simplify_isolated(model, *pass_names, check_n=3):
+    sim_model, check_ok = onnxsim.simplify(
+        model, check_n=check_n, skipped_optimizers=isolate(*pass_names)
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    return sim_model, collections.Counter(n.op_type for n in sim_model.graph.node)
+
+
+def prove(claim, msg="rewrite is not a sound equivalence"):
+    """Prove ``claim`` valid.
+
+    Mirrors z3's own ``prove()`` helper (free variables in ``claim`` are
+    implicitly universally quantified: ``claim`` is valid iff its negation is
+    unsatisfiable), but raises with the counterexample instead of printing it,
+    so a broken proof fails the test with a useful message.
+    """
+    solver = z3.Solver()
+    solver.add(z3.Not(claim))
+    result = solver.check()
+    assert result == z3.unsat, f"{msg}: counterexample {solver.model()}"

--- a/tests/test_formal_verify_eliminate_identity.py
+++ b/tests/test_formal_verify_eliminate_identity.py
@@ -13,9 +13,8 @@ instead of just restating ``x == x``: the proof holds for every possible
 consumer, not only the one this file happens to test against.
 """
 
-from onnx import parser
-
 from _formal_verify_common import prove, simplify_isolated, z3
+from onnx import parser
 
 
 def test_eliminate_identity_is_sound():

--- a/tests/test_formal_verify_eliminate_identity.py
+++ b/tests/test_formal_verify_eliminate_identity.py
@@ -1,0 +1,48 @@
+"""Formal check for EliminateIdentity (eliminate_identity.h).
+
+The rewrite deletes ``a = Identity(x)`` and rewires every use of ``a``
+directly to ``x`` (``patternMatchPredicate`` matches an Identity node;
+``runTransform`` calls ``tryReplacingAllUsesWith(node->output(), node->input())``).
+Soundness needs two facts: Identity's own semantics (``a == x``), and that
+ONNX's dataflow graph model has no notion of node identity beyond the values
+it produces/consumes -- so *any* downstream computation over ``a`` gets the
+same result over ``x``. Modeling the downstream computation as an arbitrary
+uninterpreted function (rather than the one concrete consumer used in the
+differential check below) is what makes this a real soundness argument
+instead of just restating ``x == x``: the proof holds for every possible
+consumer, not only the one this file happens to test against.
+"""
+
+from onnx import parser
+
+from _formal_verify_common import prove, simplify_isolated, z3
+
+
+def test_eliminate_identity_is_sound():
+    x = z3.Real("x")
+    a = z3.Real("a")
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+
+    identity_semantics = a == x
+    prove(z3.Implies(identity_semantics, consumer(a) == consumer(x)))
+
+
+def test_eliminate_identity_pass_matches():
+    # Differential check: the actual compiled pass, run alone, removes the
+    # Identity node and rewires its consumer directly to X.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4,8] X) => (float[4,8] Y)
+        {
+          a = Identity(X)
+          Y = Relu(a)
+        }
+        """
+    )
+    _, ops = simplify_isolated(model, "eliminate_identity")
+    assert ops["Identity"] == 0
+    assert ops["Relu"] == 1

--- a/tests/test_formal_verify_fuse_bn_into_conv.py
+++ b/tests/test_formal_verify_fuse_bn_into_conv.py
@@ -31,9 +31,8 @@ identity directly instead of reasoning about an opaque sqrt symbol.
 
 import numpy as np
 import onnx
-from onnx import parser
-
 from _formal_verify_common import prove, simplify_isolated, z3
+from onnx import parser
 
 
 def test_fuse_bn_into_conv_is_sound():

--- a/tests/test_formal_verify_fuse_bn_into_conv.py
+++ b/tests/test_formal_verify_fuse_bn_into_conv.py
@@ -1,0 +1,111 @@
+"""Formal check for FuseBNIntoConv (fuse_bn_into_conv.h).
+
+The rewrite folds BatchNormalization's affine transform into the preceding
+Conv's weight/bias::
+
+    new_W = W * s
+    new_b = (B - mean) * s + bias
+    s     = scale / sqrt(var + eps)
+
+where ``B`` is the Conv's own pre-existing bias, or 0 if it had none. This
+exact formula is also what ``tests/test_fusion_patterns.py``'s
+``test_fuse_conv_bn_into_conv_double`` validates numerically against the
+compiled pass in float64.
+
+Two independent facts make the fusion sound, combined here into one real
+(non-floating-point) arithmetic identity per output element:
+
+1. Conv is linear in its weights for a fixed input, so scaling every weight
+   by ``s`` scales the pre-BN output by ``s`` (modeled below with a 2-tap dot
+   product -- enough taps to exercise linearity/distributivity, not just a
+   single-weight special case).
+2. BN's own affine transform, expanded algebraically, is exactly
+   ``s * conv_out + (B - mean) * s + bias``.
+
+``sqrt`` is modeled as a real variable ``sq`` constrained by
+``sq * sq == var + eps`` and ``sq > 0`` -- the same side condition
+fuse_bn_into_conv.h's own division relies on -- rather than as an
+uninterpreted function, so Z3's real (nonlinear) arithmetic can discharge the
+identity directly instead of reasoning about an opaque sqrt symbol.
+"""
+
+import numpy as np
+import onnx
+from onnx import parser
+
+from _formal_verify_common import prove, simplify_isolated, z3
+
+
+def test_fuse_bn_into_conv_is_sound():
+    w0, w1, x0, x1, B = z3.Reals("w0 w1 x0 x1 B")
+    scale, bias, mean, var, eps = z3.Reals("scale bias mean var eps")
+    sq, s = z3.Reals("sq s")
+
+    conv_out = w0 * x0 + w1 * x1 + B  # Conv(x, W) + B
+
+    side_conditions = z3.And(
+        sq * sq == var + eps,
+        sq > 0,
+        s * sq == scale,  # s == scale / sq, kept polynomial (no division)
+    )
+
+    original = (conv_out - mean) * s + bias  # BatchNormalization, in terms of s
+    fused_conv_out = (w0 * s) * x0 + (w1 * s) * x1  # Conv(x, W * s), no bias
+    fused_bias = (B - mean) * s + bias
+    fused = fused_conv_out + fused_bias
+
+    prove(z3.Implies(side_conditions, original == fused))
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def test_fuse_bn_into_conv_pass_matches():
+    rng = np.random.default_rng(0)
+    W = rng.standard_normal((8, 3, 3, 3))
+    scale = rng.random(8) + 0.5
+    bias = rng.standard_normal(8)
+    mean = rng.standard_normal(8)
+    var = rng.random(8) + 0.5
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[1,3,16,16] X) => (float[1,8,16,16] Y)
+        {
+          c = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(X, W)
+          Y = BatchNormalization(c, scale, bias, mean, var)
+        }
+        """
+    )
+    model.graph.initializer.extend(
+        [
+            _f32(W, "W"),
+            _f32(scale, "scale"),
+            _f32(bias, "bias"),
+            _f32(mean, "mean"),
+            _f32(var, "var"),
+        ]
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_bn_into_conv")
+    assert ops["BatchNormalization"] == 0
+    assert ops["Conv"] == 1
+
+    conv_node = next(n for n in sim_model.graph.node if n.op_type == "Conv")
+    by_name = {
+        init.name: onnx.numpy_helper.to_array(init)
+        for init in sim_model.graph.initializer
+    }
+    fused_w = by_name[conv_node.input[1]]
+    fused_b = by_name[conv_node.input[2]]
+
+    # The exact formula just proven sound above, computed independently with
+    # numpy (eps matches fuse_bn_into_conv.h's hardcoded default of 1e-5).
+    s = scale / np.sqrt(var + 1e-5)
+    expected_w = W * s.reshape(-1, 1, 1, 1)
+    expected_b = (0.0 - mean) * s + bias
+    np.testing.assert_allclose(fused_w, expected_w, rtol=1e-4, atol=1e-6)
+    np.testing.assert_allclose(fused_b, expected_b, rtol=1e-4, atol=1e-6)

--- a/tests/test_formal_verify_fuse_consecutive_transposes.py
+++ b/tests/test_formal_verify_fuse_consecutive_transposes.py
@@ -15,9 +15,8 @@ applied in sequence -- for every rank-4 index, a genuine universal proof
 quantified), not just a finite sample of concrete indices.
 """
 
-from onnx import parser
-
 from _formal_verify_common import prove, simplify_isolated, z3
+from onnx import parser
 
 _RANK = 4
 _T1 = [1, 0, 2, 3]  # inner transpose (applied first): swap axes 0 and 1

--- a/tests/test_formal_verify_fuse_consecutive_transposes.py
+++ b/tests/test_formal_verify_fuse_consecutive_transposes.py
@@ -1,0 +1,71 @@
+"""Formal check for FuseConsecutiveTransposes (fuse_consecutive_transposes.h).
+
+Two consecutive Transpose nodes collapse into one whose perm is
+``compose_transposes(t1, t2)[i] = t1[t2[i]]``, where ``t1`` is the earlier
+(inner) transpose's perm and ``t2`` the later (outer) one's -- see that
+function in fuse_consecutive_transposes.h, reproduced exactly (not just
+approximated) in ``_compose_transposes`` below.
+
+Soundness here is pure permutation algebra, independent of tensor shape or
+dtype: modeling the tensor as an uninterpreted function from a symbolic
+integer index tuple to a real value lets Z3 prove the fused single transpose
+reads the exact same value at every index as the two original transposes
+applied in sequence -- for every rank-4 index, a genuine universal proof
+(free variables in a Z3 validity check are implicitly universally
+quantified), not just a finite sample of concrete indices.
+"""
+
+from onnx import parser
+
+from _formal_verify_common import prove, simplify_isolated, z3
+
+_RANK = 4
+_T1 = [1, 0, 2, 3]  # inner transpose (applied first): swap axes 0 and 1
+_T2 = [0, 2, 1, 3]  # outer transpose (applied second): swap axes 1 and 2
+
+
+def _compose_transposes(t1, t2):
+    # Mirrors fuse_consecutive_transposes.h's own compose_transposes exactly.
+    return [t1[t2[i]] for i in range(len(t1))]
+
+
+def _scatter(idx, perm):
+    # transpose(T, perm)[idx] reads T at the index built by scattering idx
+    # through perm: result[perm[i]] = idx[i] (ONNX/numpy Transpose semantics:
+    # output.dims[i] = input.dims[perm[i]]).
+    out = [None] * len(perm)
+    for i, p in enumerate(perm):
+        out[p] = idx[i]
+    return out
+
+
+def test_fuse_consecutive_transposes_is_sound():
+    tf = _compose_transposes(_T1, _T2)
+
+    tensor = z3.Function("tensor", *([z3.IntSort()] * _RANK), z3.RealSort())
+    j = [z3.Int(f"j{i}") for i in range(_RANK)]
+
+    two_step = tensor(*_scatter(_scatter(j, _T2), _T1))
+    fused = tensor(*_scatter(j, tf))
+    prove(two_step == fused)
+
+
+def test_fuse_consecutive_transposes_pass_matches():
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,3,4,5] X) => (float[3,4,2,5] Y)
+        {{
+          t = Transpose<perm = {_T1}>(X)
+          Y = Transpose<perm = {_T2}>(t)
+        }}
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_transposes")
+    assert ops["Transpose"] == 1
+    fused_node = next(n for n in sim_model.graph.node if n.op_type == "Transpose")
+    perm = next(a.ints for a in fused_node.attribute if a.name == "perm")
+    assert list(perm) == _compose_transposes(_T1, _T2)


### PR DESCRIPTION
Each of eliminate_identity, fuse_consecutive_transposes, and
fuse_bn_into_conv gets a hand-written Z3 proof that its documented
rewrite algebra is a sound equivalence, plus a differential check
(skipped_optimizers isolates the single pass) that the compiled
pass's actual output on a concrete model agrees with that same
algebra. This narrows the gap versus onnxsim's existing --check,
which only samples random inputs rather than proving equivalence.

z3-solver is gated behind a new optional `verify` extra so these
tests are skipped, not failed, without it; CI installs it via
CIBW_TEST_REQUIRES.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QYPkPSuY9aARnGkHCpVzLV