### PR TITLE
Fix heap corruption in InferMatMul for rank-1 x rank-1 MatMul (#1275)

### DIFF
--- a/onnxsim/sym_shape_infer.cpp
+++ b/onnxsim/sym_shape_infer.cpp
@@ -251,10 +251,16 @@ class ShapeInferer {
     SymShape a_batch(la.begin(), la.end() - 2);
     SymShape b_batch(lb.begin(), lb.end() - 2);
     SymShape out = BroadcastShapes({&a_batch, &b_batch});
+    // M's position is fixed once the batch dims are laid down; erase it there
+    // (rather than at out.end() - 2) so a_vec's erase is still correct after
+    // b_vec's pop_back has already shortened `out` -- e.g. both inputs rank-1
+    // (a plain dot product), where out.end() - 2 would underflow before
+    // begin() once N has already been popped.
+    const std::size_t m_pos = out.size();
     out.push_back(la[la.size() - 2]);  // M
     out.push_back(lb[lb.size() - 1]);  // N
     if (b_vec) out.pop_back();
-    if (a_vec) out.erase(out.end() - 2);
+    if (a_vec) out.erase(out.begin() + static_cast<std::ptrdiff_t>(m_pos));
     return out;
   }
 

--- a/onnxsim/sym_shape_infer_test.cpp
+++ b/onnxsim/sym_shape_infer_test.cpp
@@ -286,6 +286,28 @@ int main() {
     assert(ShapeIs("se", {"seq", "seq"}));
   }
 
+  // === MatMul rank-1 operand handling (onnxsim issue #1275) ================
+  // numpy matmul promotes a rank-1 lhs/rhs with a leading/trailing 1, then
+  // strips it back out of the result. Getting the "strip" step wrong for the
+  // rank-1 x rank-1 case (both promoted dims removed, leaving a 0-D scalar)
+  // used to erase past the front of the output vector.
+  {
+    ShapeGraph g;
+    g.value_info["v"] = {SymExpr(768)};
+    g.value_info["m"] = {SymExpr(768), SymExpr(1000)};
+    g.node = {
+        // rank-1 x rank-1 (dot product): self-MatMul is the exact shape NNSmith
+        // generated for issue #1275 -- both promoted dims are stripped, so the
+        // result is a 0-D scalar.
+        N("MatMul", {"v", "v"}, {"dot"}),
+        N("MatMul", {"v", "m"}, {"vm"}),  // rank-1 x rank-2 -> [1000]
+    };
+    const auto r = onnxsim::InferSymbolicShapes(g);
+    g_result = &r;
+    assert(ShapeIs("dot", {}));
+    assert(ShapeIs("vm", {"1000"}));
+  }
+
   std::cout << "sym_shape_infer_test: all assertions passed\n";
   return 0;
 }


### PR DESCRIPTION
## Summary

- Fixes #1275: `simplify()` segfaulting / heap-corrupting (`free(): invalid pointer`) on a graph containing `MatMul(x, x)` where `x` is a 1-D tensor (a self-matmul dot product).
- Root cause: `InferMatMul` in `onnxsim/sym_shape_infer.cpp` promotes a rank-1 operand with a leading/trailing `1` (numpy matmul semantics), then strips those back out of the result. When **both** operands are rank-1, `if (b_vec) out.pop_back();` already shrinks `out` to size 1, so the following `if (a_vec) out.erase(out.end() - 2);` computes an iterator *before* `begin()` — an out-of-bounds `vector::erase` that corrupts the heap. The corruption doesn't crash there; it silently trashes heap metadata that only aborts later, in an unrelated destructor, matching the issue's confusing "`free(): invalid pointer` deep inside `~ShapeInferer`" symptom.
- Fix: compute the fixed index of the `M` dimension once (right after laying down the broadcast batch dims), and erase at that index instead of assuming it's always at `out.end() - 2`. This keeps the erase correct whether or not `N` was already popped.
- Adds a regression test to `onnxsim/sym_shape_infer_test.cpp` covering the rank-1 x rank-1 (dot product) and rank-1 x rank-2 cases. Verified this test reproduces a heap-buffer-overflow (via ASan) at the exact reported crash site against the pre-fix code, and passes cleanly against the fix.

## Root cause detail

Reproduced the exact model from the issue by regenerating it with NNSmith (`scripts/_nnsmith_gen.py mgen.seed=1 mgen.max_nodes=20`, from PR #1274's fuzzer branch) — the resulting node list matches the issue's report byte-for-byte, including the `MatMul(/Concat_1_output_0, /Concat_1_output_0)` node where `/Concat_1_output_0` is rank-1.

Under AddressSanitizer, `onnxsim.simplify(model, check_n=0)` on this model reliably shows:
```
SUMMARY: AddressSanitizer: SEGV ... in std::_Rb_tree<...>::_M_erase(...)
    #13 ... in InferMatMul onnxsim/sym_shape_infer.cpp:257
    #14 ... in Infer onnxsim/sym_shape_infer.cpp:187
    #15 ... in Run onnxsim/sym_shape_infer.cpp:99
```
confirming the crash is a downstream symptom of the out-of-bounds `vector::erase` in `InferMatMul`, not a bug in whatever container happens to get destroyed next.

## Test plan

- [x] Reproduced the crash (`free(): invalid pointer` / `Fatal Python error: Aborted`) with the exact NNSmith-generated model from the issue, on an unmodified build.
- [x] Reproduced under AddressSanitizer, pinpointing the out-of-bounds `vector::erase` in `InferMatMul` at `sym_shape_infer.cpp:257`.
- [x] After the fix: same model + ASan build runs clean, and `onnxsim.simplify(model, check_n=3)` completes and passes its own random-input equivalence check.
- [x] Standalone `sym_shape_infer_test.cpp` (`g++ -std=c++17 -fsanitize=address,undefined sym_expr.cpp sym_value_eval.cpp sym_shape_infer.cpp sym_shape_infer_test.cpp`) passes with the fix; confirmed the new test case fails (ASan heap-buffer-overflow, same line as the reported crash) against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrZy9zU3jUkde5tLaLo57L

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrZy9zU3jUkde5tLaLo57L)_