### PR TITLE
Extend Z3-based formal verification to more passes, quantization, and a coverage report

### DIFF
--- a/scripts/formal_verify_coverage.py
+++ b/scripts/formal_verify_coverage.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Report how many of onnxsim's registered optimizer passes have a Z3
+soundness proof under ``tests/test_formal_verify_*.py``.
+
+This is a distinct metric from the C++ line/branch coverage the
+``coverage.yml`` workflow already produces (via gcovr): that measures how
+much of a pass's *code* executes when the test suite runs, regardless of
+whether any test proves the pass's rewrite is actually sound. This script
+instead measures how many of the *passes themselves* -- named rewrite
+rules registered with onnxoptimizer -- have a hand-written Z3 proof at all,
+against the full universe of passes ``onnxsim --list-default-optimizers``
+and ``--list-other-optimizers`` report.
+
+Usage: ``python scripts/formal_verify_coverage.py`` (needs the built
+``onnxsim_cpp2py_export`` extension importable, same as running the tests).
+"""
+
+import glob
+import os
+
+import onnxsim.onnxsim_cpp2py_export as C
+
+_TESTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "tests")
+
+# test_formal_verify_*.py files in this family that verify a property shared
+# across ONNX ops onnxsim's quantization relies on, rather than one of
+# onnxsim's own optimizer passes (see each such file's own module
+# docstring) -- these don't correspond to a pass name and aren't counted
+# against the pass universe below.
+_NOT_A_PASS = {"quantize_round_trip"}
+
+
+def _proved_pass_names():
+    proved = set()
+    for path in glob.glob(os.path.join(_TESTS_DIR, "test_formal_verify_*.py")):
+        name = os.path.basename(path)[len("test_formal_verify_") : -len(".py")]
+        if name not in _NOT_A_PASS:
+            proved.add(name)
+    return proved
+
+
+def main():
+    default_passes = set(C._list_optimizers())
+    other_passes = set(C._list_other_optimizers())
+    all_passes = default_passes | other_passes
+    proved = _proved_pass_names()
+
+    unknown = proved - all_passes
+    if unknown:
+        raise SystemExit(
+            "test_formal_verify_*.py names a pass onnxsim doesn't register "
+            f"(stale after a rename?): {sorted(unknown)}"
+        )
+
+    proved_default = proved & default_passes
+    proved_other = proved & other_passes
+    unproved_default = sorted(default_passes - proved)
+
+    print(
+        f"Default (on-by-default) passes: {len(proved_default)}/{len(default_passes)} proved"
+    )
+    print(
+        f"Other (opt-in) passes:          {len(proved_other)}/{len(other_passes)} proved"
+    )
+    print(
+        f"All registered passes:          {len(proved)}/{len(all_passes)} proved "
+        f"({100 * len(proved) / len(all_passes):.1f}%)"
+    )
+    print()
+    print("Proved:")
+    for name in sorted(proved):
+        print(f"  {name}")
+    print()
+    print(f"Not yet proved, on by default ({len(unproved_default)}):")
+    for name in unproved_default:
+        print(f"  {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/_formal_verify_common.py
+++ b/tests/_formal_verify_common.py
@@ -52,6 +52,41 @@ def simplify_isolated(model, *pass_names, check_n=3):
     return sim_model, collections.Counter(n.op_type for n in sim_model.graph.node)
 
 
+def simplify_isolated_extra(model, *pass_names, check_n=3):
+    """Like ``simplify_isolated``, but for opt-in ("other") passes -- ones not
+    part of the default set, which must be named via ``extra_optimizers`` to
+    run at all (see ``onnxsim --list-other-optimizers``). Every default pass
+    is skipped, so only the named opt-in pass(es) run.
+    """
+    names = set(pass_names)
+    all_other = set(C._list_other_optimizers())
+    unknown = names - all_other
+    assert not unknown, f"not an opt-in onnxsim optimizer pass: {sorted(unknown)}"
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=check_n,
+        extra_optimizers=sorted(names),
+        skipped_optimizers=sorted(C._list_optimizers()),
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    return sim_model, collections.Counter(n.op_type for n in sim_model.graph.node)
+
+
+def producer(model, output_name):
+    """The node that produces ``output_name`` in ``model``'s graph.
+
+    Isolating one opt-in pass via ``simplify_isolated_extra`` runs it without
+    its usual companion dead-code pass (``eliminate_deadend`` is a default
+    pass, skipped here like every other one) -- so a rewrite that leaves its
+    old input dangling (rather than deleting it outright) can leave a second,
+    dead copy of the rewrite's own output type sitting unused elsewhere in
+    the graph. A raw ``Counter`` of op types then overcounts; walking
+    backward from a real graph output instead finds the live computation
+    regardless of what dead code is also lying around.
+    """
+    return next(n for n in model.graph.node if output_name in n.output)
+
+
 def prove(claim, msg="rewrite is not a sound equivalence"):
     """Prove ``claim`` valid.
 

--- a/tests/test_formal_verify_eliminate_nop_transpose.py
+++ b/tests/test_formal_verify_eliminate_nop_transpose.py
@@ -1,0 +1,79 @@
+"""Formal check for EliminateNopTranspose (eliminate_nop_transpose.h).
+
+The rewrite requires the ``perm`` attribute to be *present* -- a Transpose
+with no ``perm`` attribute (whose ONNX default semantics reverse every axis,
+which only happens to be a no-op for rank <= 1) is never matched by this
+pass at all, regardless of rank -- and to be exactly the identity
+permutation ``[0, 1, ..., n-1]`` (``is_nop_transpose``). It then rewires
+every use of the Transpose's output directly to its input
+(``tryReplacingAllUsesWith``), the same rewiring EliminateIdentity uses.
+
+Soundness is the special case of fuse_consecutive_transposes' own
+permutation algebra (see test_formal_verify_fuse_consecutive_transposes.py)
+where perm is the identity: scattering a symbolic index through the
+identity permutation returns that index unchanged, so an uninterpreted
+tensor read at the "transposed" index equals the read at the original
+index, for every index -- a genuine universal proof, not a finite sample.
+"""
+
+from _formal_verify_common import prove, simplify_isolated, z3
+from onnx import parser
+
+_RANK = 3
+_IDENTITY_PERM = list(range(_RANK))
+
+
+def _scatter(idx, perm):
+    # transpose(T, perm)[idx] reads T at the index built by scattering idx
+    # through perm: result[perm[i]] = idx[i] (ONNX/numpy Transpose semantics).
+    out = [None] * len(perm)
+    for i, p in enumerate(perm):
+        out[p] = idx[i]
+    return out
+
+
+def test_eliminate_nop_transpose_is_sound():
+    tensor = z3.Function("tensor", *([z3.IntSort()] * _RANK), z3.RealSort())
+    j = [z3.Int(f"j{i}") for i in range(_RANK)]
+    prove(tensor(*_scatter(j, _IDENTITY_PERM)) == tensor(*j))
+
+
+def test_eliminate_nop_transpose_pass_matches():
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,3,4] X) => (float[2,3,4] Y)
+        {
+          t = Transpose<perm = [0, 1, 2]>(X)
+          Y = Relu(t)
+        }
+        """
+    )
+    _, ops = simplify_isolated(model, "eliminate_nop_transpose")
+    assert ops["Transpose"] == 0
+    assert ops["Relu"] == 1
+
+
+def test_eliminate_nop_transpose_declines_missing_perm():
+    # A Transpose with no perm attribute is never matched by this pass, even
+    # though ONNX's default (reverse every axis) happens to be a no-op here
+    # only for rank <= 1 -- eliminate_nop_transpose.h's own
+    # patternMatchPredicate requires hasAttribute(kperm) and does not
+    # special-case the missing-attribute default at all.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,3,4] X) => (float[4,3,2] Y)
+        {
+          Y = Transpose(X)
+        }
+        """
+    )
+    _, ops = simplify_isolated(model, "eliminate_nop_transpose")
+    assert ops["Transpose"] == 1

--- a/tests/test_formal_verify_fuse_matmul_add_bias_into_gemm.py
+++ b/tests/test_formal_verify_fuse_matmul_add_bias_into_gemm.py
@@ -1,0 +1,114 @@
+"""Formal check for FuseMatMulAddBiasIntoGemm (fuse_matmul_add_bias_into_gemm.h).
+
+The rewrite fires only on ``Add(MatMul(A, B), C)`` -- MatMul strictly as the
+Add's *first* operand (``CheckKind(node, kAdd, 0, kMatMul)``);
+``Add(C, MatMul(A, B))`` is never matched, even though addition is
+commutative, because the pass never checks the second operand.
+``runTransform`` additionally requires both MatMul operands to be rank-2
+with statically known relevant dims, and the bias ``C`` to broadcast against
+the (N, M) output the same way ONNX Gemm's own ``C`` broadcasts -- 1-D
+matching M, or 2-D with a leading dim of 1 or N. The rewrite replaces the
+matched Add node with a new ``Gemm(A, B, C, alpha=1, beta=1, transA=0,
+transB=0)``; the original MatMul is left dangling (0 uses) rather than
+destroyed outright -- a separate dead-code pass (eliminate_deadend) removes
+it, so it is still present immediately after this pass runs in isolation.
+
+Soundness is close to definitional -- Gemm's own semantics are
+``alpha * A @ B + beta * C``, so with alpha=beta=1 this is exactly
+``A @ B + C`` -- but it is worth proving explicitly rather than asserting by
+inspection: a 1-off in which operand supplies alpha/beta/transA/transB, or a
+wrong operand order, would silently compute something else. This proves it
+as a real arithmetic identity over a small concrete matrix shape (2x3 @ 3x2,
+1-D bias broadcasting over rows), which exercises the summation and the
+broadcast rule without needing to reason about a symbolic-rank
+generalization.
+"""
+
+import numpy as np
+import onnx
+from _formal_verify_common import prove, simplify_isolated, z3
+from onnx import parser
+
+
+def test_fuse_matmul_add_bias_into_gemm_is_sound():
+    # A = 2x3, B = 3x2, C = bias of length 2 (broadcasts over A's 2 rows).
+    A = [[z3.Real(f"a{i}{k}") for k in range(3)] for i in range(2)]
+    B = [[z3.Real(f"b{k}{j}") for j in range(2)] for k in range(3)]
+    C = [z3.Real(f"c{j}") for j in range(2)]
+
+    def dot(i, j):
+        return sum(A[i][k] * B[k][j] for k in range(3))
+
+    alpha, beta = 1, 1
+    matmul_then_add = [[dot(i, j) + C[j] for j in range(2)] for i in range(2)]
+    gemm = [[alpha * dot(i, j) + beta * C[j] for j in range(2)] for i in range(2)]
+
+    claim = z3.And(
+        *[matmul_then_add[i][j] == gemm[i][j] for i in range(2) for j in range(2)]
+    )
+    prove(claim)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def test_fuse_matmul_add_bias_into_gemm_pass_matches():
+    rng = np.random.default_rng(0)
+    W = rng.standard_normal((16, 8))
+    B = rng.standard_normal(8)
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4,16] X) => (float[4,8] Y)
+        {
+          mm = MatMul(X, W)
+          Y = Add(mm, B)
+        }
+        """
+    )
+    model.graph.initializer.extend([_f32(W, "W"), _f32(B, "B")])
+    sim_model, ops = simplify_isolated(model, "fuse_matmul_add_bias_into_gemm")
+    assert ops["Gemm"] == 1
+    # Add is destroyed (it's the matched node); MatMul is left dangling
+    # (0 uses) rather than destroyed -- see the module docstring.
+    assert ops["Add"] == 0
+    assert ops["MatMul"] == 1
+
+    gemm_node = next(n for n in sim_model.graph.node if n.op_type == "Gemm")
+    attrs = {a.name: a for a in gemm_node.attribute}
+    # The exact attribute values just proven sound above -- alpha=beta=1
+    # (Gemm's own defaults) and no transpose, either explicitly set or left
+    # at ONNX's default.
+    assert attrs.get("alpha") is None or attrs["alpha"].f == 1.0
+    assert attrs.get("beta") is None or attrs["beta"].f == 1.0
+    assert attrs.get("transA") is None or attrs["transA"].i == 0
+    assert attrs.get("transB") is None or attrs["transB"].i == 0
+
+
+def test_fuse_matmul_add_bias_into_gemm_declines_swapped_operand_order():
+    # Add(bias, MatMul(...)) -- bias as the *first* operand -- is never
+    # matched: the predicate only checks Add's operand 0 for a MatMul.
+    rng = np.random.default_rng(0)
+    W = rng.standard_normal((16, 8))
+    B = rng.standard_normal(8)
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4,16] X) => (float[4,8] Y)
+        {
+          mm = MatMul(X, W)
+          Y = Add(B, mm)
+        }
+        """
+    )
+    model.graph.initializer.extend([_f32(W, "W"), _f32(B, "B")])
+    _, ops = simplify_isolated(model, "fuse_matmul_add_bias_into_gemm")
+    assert ops["Gemm"] == 0
+    assert ops["MatMul"] == 1

--- a/tests/test_formal_verify_fuse_matmul_add_bias_into_gemm_batched.py
+++ b/tests/test_formal_verify_fuse_matmul_add_bias_into_gemm_batched.py
@@ -1,0 +1,128 @@
+"""Formal check for FuseMatMulAddBiasIntoGemmBatched (opt-in; onnxsim's own
+``onnxsim/passes/fuse_matmul_add_bias_into_gemm_batched.h``), the batched
+(rank >= 3) sibling of the default ``fuse_matmul_add_bias_into_gemm``
+already proved in test_formal_verify_fuse_matmul_add_bias_into_gemm.py.
+
+It matches ``Add(MatMul(X, W), bias)`` **in either operand order**
+(``Add(bias, MatMul(X, W))`` too) -- unlike the non-batched sibling, which
+only matches MatMul as Add's first operand. X must be rank >= 3 with a
+static trailing (contraction) dim; the leading "batch" dims may be dynamic.
+W must be a constant rank-2 ``[K, N]``; bias must be exactly 1-D, ``[N]`` or
+``[1]``. The rewrite reshapes X to 2-D (``X2 = Reshape(X, [-1, K])``), runs
+a single ``Gemm(X2, W, bias, alpha=1, beta=1, transA=0, transB=0)``, and
+reshapes the result back to the original leading dims plus ``N``.
+
+Soundness combines two facts:
+
+1. Row-major ``Reshape`` never moves data, it only relabels a flat buffer's
+   index -- modeled here with an uninterpreted 1-D buffer function so both
+   X's ``[B, M, K]`` indexing and X2's ``[B*M, K]`` indexing are shown to
+   read the *identical* buffer element, for literally all integer indices
+   (this holds unconditionally, with no side condition needed -- it is pure
+   index arithmetic, the same flattening identity a C-order reshape always
+   satisfies).
+2. Gemm's row-wise formula is exactly MatMul-then-Add's per-row formula --
+   the same arithmetic identity already proved in
+   test_formal_verify_fuse_matmul_add_bias_into_gemm.py -- applied to the
+   flattened row ``b*M + m`` instead of a single un-batched row.
+"""
+
+import numpy as np
+import onnx
+from _formal_verify_common import prove, simplify_isolated_extra, z3
+from onnx import parser
+
+_K = 2  # concrete contraction dim -- enough to exercise the dot-product sum
+_N = 2  # concrete output-channel dim
+
+
+def test_fuse_matmul_add_bias_into_gemm_batched_is_sound():
+    buf = z3.Function("buf", z3.IntSort(), z3.RealSort())  # X's flat row-major buffer
+    W = [[z3.Real(f"w{k}{n}") for n in range(_N)] for k in range(_K)]
+    bias = [z3.Real(f"bias{n}") for n in range(_N)]
+    b, m, M = z3.Ints("b m M")
+
+    def x_at(bb, mm, k):
+        # X[b, m, k], read from X's own row-major flat buffer: shape [*, M, K].
+        return buf(bb * M * _K + mm * _K + k)
+
+    def x2_at(r, k):
+        # X2 = Reshape(X, [-1, K])'s row r -- the *same* buffer, no data moved.
+        return buf(r * _K + k)
+
+    def dot(row_at, n):
+        return sum(row_at(k) * W[k][n] for k in range(_K))
+
+    batched = [dot(lambda k: x_at(b, m, k), n) + bias[n] for n in range(_N)]
+    gemm_row = b * M + m
+    gemm = [dot(lambda k: x2_at(gemm_row, k), n) + bias[n] for n in range(_N)]
+
+    claim = z3.And(*[batched[n] == gemm[n] for n in range(_N)])
+    prove(claim)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def test_fuse_matmul_add_bias_into_gemm_batched_pass_matches():
+    rng = np.random.default_rng(0)
+    W = rng.standard_normal((8, 5))
+    B = rng.standard_normal(5)
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,3,8] X) => (float[2,3,5] Y)
+        {
+          mm = MatMul(X, W)
+          Y = Add(mm, B)
+        }
+        """
+    )
+    model.graph.initializer.extend([_f32(W, "W"), _f32(B, "B")])
+    sim_model, ops = simplify_isolated_extra(
+        model, "fuse_matmul_add_bias_into_gemm_batched"
+    )
+    assert ops["Gemm"] == 1
+    assert ops["Reshape"] == 2  # X flattened in, output un-flattened back out
+    # Add is destroyed (it's the matched node); MatMul is left dangling
+    # (0 uses) rather than destroyed -- the same pattern as the non-batched
+    # sibling pass (see test_formal_verify_fuse_matmul_add_bias_into_gemm.py).
+    assert ops["Add"] == 0
+    assert ops["MatMul"] == 1
+
+    gemm_node = next(n for n in sim_model.graph.node if n.op_type == "Gemm")
+    attrs = {a.name: a for a in gemm_node.attribute}
+    assert attrs.get("alpha") is None or attrs["alpha"].f == 1.0
+    assert attrs.get("beta") is None or attrs["beta"].f == 1.0
+    assert attrs.get("transA") is None or attrs["transA"].i == 0
+    assert attrs.get("transB") is None or attrs["transB"].i == 0
+
+
+def test_fuse_matmul_add_bias_into_gemm_batched_matches_swapped_operand_order():
+    # Unlike the non-batched fuse_matmul_add_bias_into_gemm (which only
+    # matches Add(MatMul(...), bias), not the swapped order), this pass
+    # matches Add(bias, MatMul(...)) too.
+    rng = np.random.default_rng(0)
+    W = rng.standard_normal((8, 5))
+    B = rng.standard_normal(5)
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,3,8] X) => (float[2,3,5] Y)
+        {
+          mm = MatMul(X, W)
+          Y = Add(B, mm)
+        }
+        """
+    )
+    model.graph.initializer.extend([_f32(W, "W"), _f32(B, "B")])
+    _, ops = simplify_isolated_extra(model, "fuse_matmul_add_bias_into_gemm_batched")
+    assert ops["Gemm"] == 1
+    assert ops["Add"] == 0

--- a/tests/test_formal_verify_fuse_matmul_into_conv.py
+++ b/tests/test_formal_verify_fuse_matmul_into_conv.py
@@ -1,0 +1,149 @@
+"""Formal check for FuseMatMulIntoConv (opt-in; onnxsim's own
+``onnxsim/passes/fuse_matmul_into_conv.h``): rewrites a bare ``MatMul(X, W)``
+(optionally with a bias ``Add`` in *either* operand order, or a
+``Gemm(X, W[, B])`` with ``alpha==1`` and, if biased, ``beta==1``) into a
+1-D ``Conv`` with ``kernel_shape=[1]``.
+
+The rewrite reshapes X to ``[-1, K, 1]`` (collapsing every leading dim into
+Conv's batch axis and appending a trailing size-1 spatial axis -- a pure
+reshape, no data movement), transposes W to ``[N, K]`` and unsqueezes it to
+``[N, K, 1]`` (a Conv weight ``[Cout, Cin, kernel=1]``), and reshapes the
+Conv's output back. Bias, if present, must be exactly ``[N]`` or ``[1]``
+(expanded to ``[N]`` if ``[1]``, since Conv's bias has no broadcast rule).
+
+Soundness combines two already-established facts and one new one:
+
+1. Reshape only relabels a flat buffer -- the same argument as
+   test_formal_verify_fuse_matmul_add_bias_into_gemm_batched.py, here even
+   simpler: the appended spatial axis has size 1, so it contributes a zero
+   offset and the trailing ``[..., 1]`` reshape reads the identical element
+   X's own ``[batch, K]`` indexing would.
+2. A Conv with ``kernel_shape=[1]`` has no sliding window and no zero-fill
+   boundary to reason about at all -- unlike
+   test_formal_verify_fuse_pad_into_conv.py's general Conv model, this
+   pass's own reshape guarantees exactly one spatial position, so it is
+   exactly a per-position matrix-vector product.
+3. That matrix-vector product is exactly MatMul(X, W) + bias, the same
+   arithmetic identity already proved in
+   test_formal_verify_fuse_matmul_add_bias_into_gemm.py.
+
+A biased match rewires Add's uses to the new Conv chain but does not delete
+the now-unused original MatMul node outright; isolating this one pass (no
+eliminate_deadend alongside it, unlike a real ``simplify()`` call) then lets
+that dangling MatMul get matched by this same pass's own bare-MatMul rule on
+a later fixed-point iteration, producing a second, entirely dead Conv chain
+nothing reads. The differential checks below trace forward from the graph's
+real output instead of counting op types, so that harmless artifact of
+testing one pass in isolation doesn't make the check about the wrong node.
+"""
+
+import numpy as np
+import onnx
+from _formal_verify_common import producer, prove, simplify_isolated_extra, z3
+from onnx import parser
+
+_K = 2  # concrete contraction dim -- enough to exercise the dot-product sum
+_N = 2  # concrete output-channel (Cout) dim
+
+
+def test_fuse_matmul_into_conv_is_sound():
+    buf = z3.Function("buf", z3.IntSort(), z3.RealSort())  # X's flat row-major buffer
+    # Conv weight W2[n, k] = W[k, n] (the pass's own weight transpose).
+    W2 = [[z3.Real(f"w{n}{k}") for k in range(_K)] for n in range(_N)]
+    bias = [z3.Real(f"bias{n}") for n in range(_N)]
+    batch = z3.Int("batch")
+
+    def x_flat(bb, k):
+        # X's own row-major layout, logically [batch, K].
+        return buf(bb * _K + k)
+
+    def x_conv(bb, k):
+        # X2 = Reshape(X, [-1, K, 1]): the trailing size-1 spatial axis has
+        # stride 1 but only ever holds index 0, so it contributes nothing --
+        # the same flat buffer element as x_flat.
+        return buf(bb * _K * 1 + k * 1 + 0)
+
+    def conv_out(bb, n):
+        # Conv, kernel_shape=[1], group=1, one spatial position: a plain
+        # per-position matrix-vector product -- no window, no zero-fill.
+        return sum(W2[n][k] * x_conv(bb, k) for k in range(_K)) + bias[n]
+
+    def matmul_add_out(bb, n):
+        return sum(x_flat(bb, k) * W2[n][k] for k in range(_K)) + bias[n]
+
+    claim = z3.And(*[conv_out(batch, n) == matmul_add_out(batch, n) for n in range(_N)])
+    prove(claim)
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def test_fuse_matmul_into_conv_pass_matches():
+    rng = np.random.default_rng(0)
+    W = rng.standard_normal((16, 8))
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4,16] X) => (float[4,8] Y)
+        {
+          Y = MatMul(X, W)
+        }
+        """
+    )
+    model.graph.initializer.extend([_f32(W, "W")])
+    sim_model, ops = simplify_isolated_extra(model, "fuse_matmul_into_conv")
+    assert ops["MatMul"] == 0
+
+    # Y's producer is the final un-flattening Reshape; its input is Conv's
+    # output. kernel_shape is never set as an explicit Conv attribute here --
+    # it's left implicit, inferred (by any ONNX-conformant runtime) from the
+    # weight tensor's own shape, which is what this checks instead.
+    reshape_node = producer(sim_model, "Y")
+    assert reshape_node.op_type == "Reshape"
+    conv_node = producer(sim_model, reshape_node.input[0])
+    assert conv_node.op_type == "Conv"
+    by_name = {
+        init.name: onnx.numpy_helper.to_array(init)
+        for init in sim_model.graph.initializer
+    }
+    conv_weight = by_name[conv_node.input[1]]
+    assert conv_weight.shape == (8, 16, 1)  # [Cout, Cin, kernel=1]
+
+
+def test_fuse_matmul_into_conv_matches_swapped_bias_operand_order():
+    # Unlike the non-batched fuse_matmul_add_bias_into_gemm (which only
+    # matches Add(MatMul(...), bias)), this pass matches
+    # Add(bias, MatMul(...)) too.
+    rng = np.random.default_rng(0)
+    W = rng.standard_normal((16, 8))
+    B = rng.standard_normal(8)
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4,16] X) => (float[4,8] Y)
+        {
+          mm = MatMul(X, W)
+          Y = Add(B, mm)
+        }
+        """
+    )
+    model.graph.initializer.extend([_f32(W, "W"), _f32(B, "B")])
+    sim_model, ops = simplify_isolated_extra(model, "fuse_matmul_into_conv")
+    assert ops["Add"] == 0
+
+    # Trace from Y (not a raw op-type count): isolating this one pass, with
+    # its usual eliminate_deadend companion skipped, leaves the original
+    # (now-unused) MatMul's own separate Conv-fusion lying around as dead
+    # code alongside the live one Y actually depends on.
+    reshape_node = producer(sim_model, "Y")
+    assert reshape_node.op_type == "Reshape"
+    conv_node = producer(sim_model, reshape_node.input[0])
+    assert conv_node.op_type == "Conv"
+    assert "B" in conv_node.input

--- a/tests/test_formal_verify_fuse_pad_into_conv.py
+++ b/tests/test_formal_verify_fuse_pad_into_conv.py
@@ -1,0 +1,101 @@
+"""Formal check for FusePadIntoConv (fuse_pad_into_conv.h).
+
+The rewrite requires the preceding Pad to use ``mode="constant"`` with a
+value of exactly 0, no padding on the N/C axes, non-negative pad amounts,
+and ``auto_pad`` absent or ``"NOTSET"`` -- all side conditions guarding the
+same underlying assumption: the Pad node contributes only *zero-fill* on the
+*spatial* axes. Under that assumption it merges the Pad's begin/end amounts
+into Conv's own ``pads`` attribute elementwise (additively -- a pre-existing
+nonzero Conv ``pads`` is not replaced, it is added to), for every spatial
+axis, and rewires Conv's input directly to Pad's input.
+
+Soundness (per spatial axis, since axes are independent): convolving with a
+constant-0 Pad in front is the same zero-fill window read as convolving with
+combined pads directly, because both scenarios read a sample at the same
+absolute input position and return 0 in exactly the same out-of-bounds
+cases. Modeling that shared zero-fill rule once (``_read`` below) and
+instantiating it for both the two-step (Pad then Conv-with-original-pads)
+and single-step (Conv-with-combined-pads) formulas turns the pass's "add the
+pad amounts" claim into an arithmetic identity Z3 can check outright. This
+proves the per-output-element value formula for one spatial axis; the
+matching output *length* is separate (and simpler) integer arithmetic --
+both scenarios sum the same two pad amounts into the convolution's total
+padding -- and isn't re-derived here.
+"""
+
+import numpy as np
+import onnx
+from _formal_verify_common import prove, simplify_isolated, z3
+from onnx import parser
+
+_KERNEL_SIZE = 3
+
+
+def _read(x, length, idx):
+    # Zero-fill boundary condition shared by Pad (mode="constant", value=0)
+    # and by a Conv's own implicit zero-fill outside its input, for a
+    # symbolic 1-D input of the given length.
+    return z3.If(z3.And(idx >= 0, idx < length), x(idx), z3.RealVal(0))
+
+
+def test_fuse_pad_into_conv_is_sound():
+    x = z3.Function("x", z3.IntSort(), z3.RealSort())
+    length, pad_begin, conv_pad_begin, p = z3.Ints("length pad_begin conv_pad_begin p")
+    domain = z3.And(length > 0, pad_begin >= 0, conv_pad_begin >= 0)
+
+    def conv_at(read_at, pad_begin_amount, position):
+        return sum(
+            read_at(position - pad_begin_amount + k) for k in range(_KERNEL_SIZE)
+        )
+
+    def padded_read(j):
+        return _read(x, length, j - pad_begin)
+
+    def direct_read(j):
+        return _read(x, length, j)
+
+    # Two-step: Pad(X, pad_begin) materializes a zero-padded array; Conv then
+    # applies its own (pre-existing) conv_pad_begin against *that* array.
+    two_step = conv_at(padded_read, conv_pad_begin, p)
+    # Single-step: fuse_pad_into_conv's own formula -- combined pad is the
+    # elementwise sum -- applied directly against X.
+    direct = conv_at(direct_read, pad_begin + conv_pad_begin, p)
+
+    prove(z3.Implies(domain, two_step == direct))
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def test_fuse_pad_into_conv_pass_matches_with_existing_conv_pads():
+    # Conv already declares its own nonzero `pads` here (unlike this repo's
+    # existing test_fuse_pad_into_conv in test_fusion_patterns.py, which
+    # leaves Conv's pads at the all-zero default) -- this specifically
+    # exercises fuse_pad_into_conv.h's additive-merge branch rather than the
+    # zero-plus-zero case.
+    W = np.random.default_rng(0).standard_normal((8, 3, 3, 3))
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[1,3,16,16] X) => (float[1,8,18,18] Y)
+        <int64[8] node_pads = {0, 0, 1, 1, 0, 0, 1, 1}>
+        {
+          p = Pad<mode = "constant">(X, node_pads)
+          Y = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(p, W)
+        }
+        """
+    )
+    model.graph.initializer.extend([_f32(W, "W")])
+    sim_model, ops = simplify_isolated(model, "fuse_pad_into_conv")
+    assert ops["Pad"] == 0
+    assert ops["Conv"] == 1
+
+    conv_node = next(n for n in sim_model.graph.node if n.op_type == "Conv")
+    pads = next(a.ints for a in conv_node.attribute if a.name == "pads")
+    # Elementwise sum of the Pad node's spatial pads and Conv's own
+    # pre-existing pads -- fuse_pad_into_conv.h's own additive-merge formula.
+    assert list(pads) == [2, 2, 2, 2]

--- a/tests/test_formal_verify_quantize_round_trip.py
+++ b/tests/test_formal_verify_quantize_round_trip.py
@@ -1,0 +1,91 @@
+"""Formal check for the uniform-affine quantize/dequantize round trip.
+
+``onnxsim.calibration.quantize_static`` (and every other uniform-affine
+scheme in this repo) inserts a standard ONNX QuantizeLinear/DequantizeLinear
+pair around each quantized tensor::
+
+    q  = saturate(round(x / scale) + zero_point)
+    x' = (q - zero_point) * scale
+
+This is the first of two lemmas needed for a formal (not sampled)
+worst-case error bound on a quantized model: the round-trip bound proved
+here, and a follow-up MAC-composition lemma (not yet in this repo) that
+combines per-element round-trip bounds into an end-to-end bound for a
+quantized MatMul/Conv/Gemm.
+
+Unlike the other tests in this file family (which each isolate one of
+onnxsim's own optimizer rewrites via ``skipped_optimizers``), this one
+isolates a property of two *ONNX* operators onnxsim's quantization relies
+on but does not implement itself -- there is no onnxsim pass to isolate
+here, so the differential check instead runs the two ops through
+onnxruntime directly.
+
+Soundness only needs one fact about ``round``: it returns *some* integer
+within 0.5 of its argument -- true for round-half-to-even (ONNX's
+documented tie-breaking rule) and for every other correct
+nearest-integer rounding rule, since the tie-breaking choice only matters
+for exact half-integers, where either neighbor is still within the bound.
+Modeling ``round(v)`` this way, rather than picking one specific tie rule,
+proves the bound for any of them at once.
+
+The proof assumes no saturation (the quantized code stays in range):
+saturation clips to a fixed code and can introduce unbounded error by
+construction -- a real, separate failure mode of a too-narrow calibration
+range, not something ``scale / 2`` ever bounds -- so it is an explicit side
+condition here, not silently ignored.
+"""
+
+import numpy as np
+import pytest
+from _formal_verify_common import prove, z3
+from onnx import parser
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def test_quantize_round_trip_is_sound():
+    x, scale, zero_point = z3.Reals("x scale zero_point")
+    n = z3.Int("n")  # round(x / scale): *some* integer within 0.5 of x/scale.
+    half = z3.RealVal(1) / 2
+
+    hypotheses = z3.And(
+        scale > 0,
+        n - x / scale <= half,
+        x / scale - n <= half,
+    )
+    # Not saturated: the quantized code is exactly n + zero_point (no clip),
+    # so dequantizing recovers n * scale -- zero_point cancels exactly.
+    quantized_code = n + zero_point
+    dequantized = (quantized_code - zero_point) * scale
+
+    error = x - dequantized
+    prove(z3.Implies(hypotheses, z3.And(error <= scale / 2, -error <= scale / 2)))
+
+
+def test_quantize_round_trip_matches_onnxruntime():
+    # Differential check: run the real QuantizeLinear/DequantizeLinear pair
+    # (the ops onnxsim's own quantize_static inserts) through onnxruntime,
+    # and confirm every element's round-trip error is within scale/2, for a
+    # scale/zero_point/input range chosen so nothing saturates -- matching
+    # the proof's own side condition.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[1000] X) => (float[1000] Y)
+        <float scale = {0.1}, int8 zero_point = {0}>
+        {
+          q = QuantizeLinear(X, scale, zero_point)
+          Y = DequantizeLinear(q, scale, zero_point)
+        }
+        """
+    )
+    sess = ort.InferenceSession(model.SerializeToString())
+    rng = np.random.default_rng(0)
+    # int8 range is [-128, 127]; keep |X / scale| well clear of that so
+    # nothing saturates.
+    x = (rng.random(1000).astype(np.float32) - 0.5) * 10.0  # in [-5, 5)
+    (y,) = sess.run(None, {"X": x})
+    np.testing.assert_array_less(np.abs(x - y), 0.1 / 2 + 1e-6)


### PR DESCRIPTION
## Summary

Follow-up to the merged #1272 (`eliminate_identity`, `fuse_consecutive_transposes`, `fuse_bn_into_conv`), extending the same translation-validation architecture — a hand-written Z3 proof that a rewrite's algebra is sound, plus a differential check that the compiled pass agrees with it on a concrete model:

- **Three more default passes**: `eliminate_nop_transpose` (the identity-permutation special case, plus a check that a *missing* `perm` attribute is never touched), `fuse_matmul_add_bias_into_gemm` (`MatMul+Add ≡ Gemm(α=1,β=1)`, including the operand-order side condition), `fuse_pad_into_conv` (the zero-fill-shift identity behind "pads add elementwise," specifically exercising a Conv that already has its own nonzero `pads`).
- **Two opt-in passes** (`onnxsim/passes/`, not vendored onnxoptimizer): `fuse_matmul_into_conv` and `fuse_matmul_add_bias_into_gemm_batched`. Both needed a new `simplify_isolated_extra` helper (opt-in passes need `extra_optimizers`, not just `skipped_optimizers`), and both proofs reuse the `fuse_matmul_add_bias_into_gemm` lemma composed with a new one: row-major `Reshape` never moves data, it only relabels a flat buffer's index.
- **A quantization error bound**: proves `|x − dequantize(quantize(x))| ≤ scale/2` for ONNX's `QuantizeLinear`/`DequantizeLinear` formula — the base fact every uniform-affine scheme in this repo depends on. `round()` is modeled abstractly (any nearest-integer rule, not just round-half-to-even) with saturation as an explicit side condition. No onnxsim pass to isolate here, so the differential check runs the real ops through onnxruntime directly.
- **A proof-coverage report** (`scripts/formal_verify_coverage.py`): compares `tests/test_formal_verify_*.py` against onnxsim's full registered pass list. Currently 8/106 registered passes proved (6/40 default, 2/66 opt-in).

Every proof has a negative control confirming it isn't vacuous (a deliberately wrong formula/bound gets a real Z3 counterexample), and every differential check was run against the real compiled extension — which caught real gaps in my own assumptions along the way: the original `MatMul` node is left dangling rather than destroyed by `fuse_matmul_add_bias_into_gemm{,_batched}`; Conv's `kernel_shape` isn't set as an explicit attribute by `fuse_matmul_into_conv` (it's inferred from the weight tensor's shape); and isolating one opt-in pass without its usual `eliminate_deadend` companion leaves dead code that a naive op-count assertion would miscount (fixed with a `producer()` helper that traces from the graph's real output instead).

## Test plan

- [x] `pytest tests/test_formal_verify_*.py tests/test_fusion_patterns.py` — 81 passed
- [x] `ruff check` / `ruff format --check` — clean (two pre-existing, unrelated findings on `master` already)
- [x] `mypy` — clean
- [x] Manual negative controls for each new proof (wrong sign/order/bound → real Z3 counterexample)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYPkPSuY9aARnGkHCpVzLV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYPkPSuY9aARnGkHCpVzLV)_