### PR TITLE
mcode: the vocoder and a 4096-hidden matmul both read exactly -- 100.0%

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4884,12 +4884,12 @@ super-block covers 32 output channels, and the probe also moved four bytes at
 more per-channel float32 table, which the bias is the obvious candidate for
 and which no probe has yet moved.
 
-### Reading 90.6% of the vocoder, by discovering the geometry
+### Reading the whole vocoder, by discovering the geometry
 
 Exact-code coverage had stalled at 67.5% with three layers unread. The
 blocker was not the format -- it was that every search so far *assumed* a
-block's geometry and then looked for it. Two assumptions were wrong at once,
-and each hid the other.
+block's geometry and then looked for it. Three assumptions were wrong, and
+each one hid the next.
 
 **The first: that a block's input tile starts on a chunk boundary.** Slots are
 chunked 36 at a time with a 144-byte stride, and a search that lays a tile out
@@ -4907,14 +4907,23 @@ by exact bytes, then take the stride from where channel 1 sits, the odd offset
 from channel 16, and the super-block stride from channel 32, and only then
 verify every code of every output channel.
 
+**The third: that a layer splits its input channels one way.** It does not.
+The split is per **tap**. A byte-by-byte read of a widely dilated build showed
+its tap 0 ending at channel 31 -- with two slots of padding after it -- while
+every other tap of the same layer kept all 128 channels in one block. Choosing
+the split per tap rather than per layer is what closes the last two layers,
+and `conv_pre` wanted an uneven `32 + 160` that no uniform tiling would ever
+have proposed.
+
 | | layers at 100% | weights read |
 | --- | --- | --- |
 | assumed geometry | 20 of 23 | 67.5% |
-| **discovered geometry** | **20 of 23** | **90.6%** |
+| discovered geometry | 20 of 23 | 90.6% |
+| **+ per-tap splits** | **23 of 23** | **100.0%** |
 
-The layer count is the same and the weight count is not, which is the point:
-the earlier pass was scoring whole layers found or not found, and most of the
-"found" ones were only partly read.
+That is every one of the 1,661,152 weights of a real trained vocoder,
+predicted from the ONNX file alone and matched code for code -- transposed
+layers, dilated layers and all.
 
 The conventions it discovers are consistent, and worth stating because they
 are now measured rather than assumed:
@@ -4923,17 +4932,14 @@ are now measured rather than assumed:
   single slot space;
 * a **dilated** one is one block per tap, each tap padded up to a whole number
   of 144-byte chunks;
-* a **transposed** one is one block per polyphase, taps reversed.
+* a **transposed** one is one block per polyphase, taps reversed;
+* and any tap may split its input channels further, unevenly, independently of
+  its neighbours.
 
-**Three layers stay partial**, and they are the same three as before:
-`conv_pre` `(256,192,7)` at 64.3%, and the two 128-channel convolutions with
-the widest dilations (`K=5 d=6` at 75.0%, `K=7 d=12` at 89.3%). What is now
-known about them is that they are split further along the input axis, and not
-evenly: `conv_pre` reads exactly for its first 32 input channels at table
-offset 0, and the widely dilated pair put channels 0..31 in a block of their
-own with channels 32 onward in another. A 36-channel tile matched them at
-first -- until reading the table byte by byte showed the tile ending at
-channel 31 with two slots of padding after it.
+That last point is the one to carry forward. Every earlier failure to read a
+layer was a search looking for a layer-wide rule that does not exist: the
+allocator decides per tap, and the only way to know what it decided is to read
+it back out of the table.
 
 ### The LLM layout at 4096 hidden: 288-column blocks
 

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4941,23 +4941,27 @@ layer was a search looking for a layer-wide rule that does not exist: the
 allocator decides per tap, and the only way to know what it decided is to read
 it back out of the table.
 
-### The LLM layout at 4096 hidden: 288-column blocks
+### The LLM layout at 4096 hidden: column blocks, and all of them
 
 The `llm_build` addressing was solved at 256 hidden and scored 0.73 by
-correlation at 4096, which was recorded as a likely block split. With the
-quantiser now exact the question can be asked properly, and the answer is a
-column split with nothing else changed:
+correlation at 4096, which was recorded as a likely block split. It is a
+column split, and nothing else changes. Walking the table -- following columns
+until the codes stop matching, rather than assuming a width -- gives eight
+blocks:
 
-* one block holds **288 columns** -- read off the table by walking columns
-  until the codes stop matching, not inferred;
-* its row stride is **576**, which is exactly `72*ceil((288/2)/18)`, the same
-  formula that governs 256 hidden;
-* within one block **all 4096 rows** verify exactly, with the odd-register
-  offset at 36 and the super-block stride at 142336.
+| block | columns | width | row stride `a` | `72*ceil(w/2/18)` |
+| --- | --- | --- | --- | --- |
+| 1 | 0..287 | 288 | 576 | 576 |
+| 2..8 | 288..4095 | 544 each | 1152 | 1152 |
 
-So the row addressing was never the problem at 4096. 288 columns is 144 slots,
-eight chunks of 18 -- the widest a block can be and still have a row stride of
-576.
+Every block's row stride is the same `72*ceil((width/2)/18)` that governs 256
+hidden, every block sits `16*a + 512` bytes after the last -- the same `top`
+the conv layout uses -- and **all 4096 rows of every block verify exactly**.
+
+That is 16,777,216 codes of a 4096x4096 `q_proj`, **100.0% of them**, from the
+checkpoint alone. The row addressing was never the problem at 4096; the guess
+that 0.73 meant "the layout breaks at this width" was wrong, and the only
+thing that was actually unknown was where one block stops.
 
 ### The LLM path quantises differently, and here it is exactly
 

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4884,6 +4884,75 @@ super-block covers 32 output channels, and the probe also moved four bytes at
 more per-channel float32 table, which the bias is the obvious candidate for
 and which no probe has yet moved.
 
+### Reading 90.6% of the vocoder, by discovering the geometry
+
+Exact-code coverage had stalled at 67.5% with three layers unread. The
+blocker was not the format -- it was that every search so far *assumed* a
+block's geometry and then looked for it. Two assumptions were wrong at once,
+and each hid the other.
+
+**The first: that a block's input tile starts on a chunk boundary.** Slots are
+chunked 36 at a time with a 144-byte stride, and a search that lays a tile out
+contiguously from its own start is only right when the tile begins at a
+multiple of 36. In a packed layout tap `k` begins at slot `(Cin/2)*k`, which
+lands mid-chunk for almost every `k` -- so every tile that straddled a
+boundary was silently missed. Addressing each weight at its *absolute*
+intra-block slot and searching for the block base instead fixes it, and has
+the side benefit that one search now covers a whole block rather than a tile.
+
+**The second: that the member stride, the odd-register offset and the
+super-block stride follow the formula.** They usually do, but "usually" is not
+a criterion. So they are now read off the table: find output channel 0's block
+by exact bytes, then take the stride from where channel 1 sits, the odd offset
+from channel 16, and the super-block stride from channel 32, and only then
+verify every code of every output channel.
+
+| | layers at 100% | weights read |
+| --- | --- | --- |
+| assumed geometry | 20 of 23 | 67.5% |
+| **discovered geometry** | **20 of 23** | **90.6%** |
+
+The layer count is the same and the weight count is not, which is the point:
+the earlier pass was scoring whole layers found or not found, and most of the
+"found" ones were only partly read.
+
+The conventions it discovers are consistent, and worth stating because they
+are now measured rather than assumed:
+
+* an **undilated** convolution is one block, the whole kernel packed into a
+  single slot space;
+* a **dilated** one is one block per tap, each tap padded up to a whole number
+  of 144-byte chunks;
+* a **transposed** one is one block per polyphase, taps reversed.
+
+**Three layers stay partial**, and they are the same three as before:
+`conv_pre` `(256,192,7)` at 64.3%, and the two 128-channel convolutions with
+the widest dilations (`K=5 d=6` at 75.0%, `K=7 d=12` at 89.3%). What is now
+known about them is that they are split further along the input axis, and not
+evenly: `conv_pre` reads exactly for its first 32 input channels at table
+offset 0, and the widely dilated pair put channels 0..31 in a block of their
+own with channels 32 onward in another. A 36-channel tile matched them at
+first -- until reading the table byte by byte showed the tile ending at
+channel 31 with two slots of padding after it.
+
+### The LLM layout at 4096 hidden: 288-column blocks
+
+The `llm_build` addressing was solved at 256 hidden and scored 0.73 by
+correlation at 4096, which was recorded as a likely block split. With the
+quantiser now exact the question can be asked properly, and the answer is a
+column split with nothing else changed:
+
+* one block holds **288 columns** -- read off the table by walking columns
+  until the codes stop matching, not inferred;
+* its row stride is **576**, which is exactly `72*ceil((288/2)/18)`, the same
+  formula that governs 256 hidden;
+* within one block **all 4096 rows** verify exactly, with the odd-register
+  offset at 36 and the super-block stride at 142336.
+
+So the row addressing was never the problem at 4096. 288 columns is 144 slots,
+eight chunks of 18 -- the widest a block can be and still have a row stride of
+576.
+
 ### The LLM path quantises differently, and here it is exactly
 
 The convolution pipeline's quantiser was pinned down earlier: `scale =


### PR DESCRIPTION
Exact-code coverage had stalled at 67.5% with three vocoder layers unread. The blocker was never the format — every search so far **assumed** a block's geometry and then looked for it. Three assumptions were wrong, and each one hid the next.

**1. That a block's input tile starts on a chunk boundary.** Slots are chunked 36 at a time with a 144-byte stride, so laying a tile out contiguously from its own start is only right when the tile begins at a multiple of 36. In a packed layout tap `k` begins at slot `(Cin/2)*k`, which lands mid-chunk for almost every `k` — every straddling tile was silently missed. Addressing each weight at its *absolute* intra-block slot and searching for the block base fixes it, and one search now covers a whole block rather than a tile.

**2. That the member stride, odd-register offset and super-block stride follow the formula.** They usually do, but "usually" is not a criterion — so they are read off the table: find output channel 0's block by exact bytes, take the stride from channel 1, the odd offset from channel 16, the super-block stride from channel 32, and only then verify every code of every output channel.

**3. That a layer splits its input channels one way.** It does not — the split is per **tap**. A byte-by-byte read of a widely dilated build showed its tap 0 ending at channel 31, with two slots of padding after it, while every other tap of the same layer kept all 128 channels in one block. `conv_pre` wants an uneven `32 + 160` that no uniform tiling would ever have proposed.

| | layers at 100% | weights read |
| --- | --- | --- |
| assumed geometry | 20 of 23 | 67.5% |
| discovered geometry | 20 of 23 | 90.6% |
| **+ per-tap splits** | **23 of 23** | **100.0%** |

That is every one of the **1,661,152 weights of a real trained Piper vocoder**, predicted from the ONNX file alone and matched code for code — transposed layers, dilated layers and all.

**The same pass closes the LLM side.** `llm_build` addressing scored 0.73 by correlation at 4096 hidden, recorded as a likely block split. It is a column split and nothing else changes. Walking the table gives eight blocks — the first 288 columns wide, the other seven 544 — each with row stride `72*ceil((width/2)/18)`, each `16*a + 512` bytes after the last, and **all 4096 rows of every block exact**: 16,777,216 codes of a 4096×4096 `q_proj`, 100.0%, from the checkpoint alone.

**The point to carry forward:** every earlier failure to read a layer was a search looking for a layer-wide rule that does not exist. The allocator decides per tap, and the only way to know what it decided is to read it back out of the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS