### PR TITLE
Don't report a false "changes after optimization" for matching NaNs

### DIFF
--- a/onnxsim/model_checking.py
+++ b/onnxsim/model_checking.py
@@ -124,6 +124,19 @@ def _custom_default_domain_ops(model: onnx.ModelProto) -> Set[str]:
     return custom_ops
 
 
+def _has_one_sided_nan(a: np.ndarray, b: np.ndarray) -> bool:
+    """True if a NaN sits in one array where the other holds a non-NaN value.
+
+    Used only to explain a reported mismatch: ``np.max(np.abs(a - b))`` is NaN
+    whenever either side has one, so the printed "max diff" cannot by itself
+    distinguish a real NaN-vs-number regression from the both-sides-NaN case
+    that ``compare`` deliberately tolerates.
+    """
+    if a.dtype.kind not in "fc" or b.dtype.kind not in "fc":
+        return False  # integer/bool outputs cannot hold NaN
+    return bool(np.any(np.isnan(a) != np.isnan(b)))
+
+
 def compare(
     model_opt: Union[str, bytes, onnx.ModelProto],
     model_ori: Union[str, onnx.ModelProto],
@@ -153,6 +166,10 @@ def compare(
         (correct) op reordering accumulates floating-point error beyond the
         default -- see the RF-DETR XLarge case in ``scripts/rfdetr``.
     :param atol: Absolute tolerance for ``numpy.allclose`` (see ``rtol``).
+        Outputs are compared with ``equal_nan=True``: a NaN the original model
+        already produces for a given random input (a Div by zero, say) is not
+        counted as a change when the simplified model produces a NaN in the
+        same position. A NaN on only one side remains a mismatch.
     :param input_fill: How to fill the generated test inputs when ``input_data``
         is not given. One of ``"random"`` (uniform ``[0, 1)``, the default),
         ``"ones"``, ``"zeros"`` or ``"arange"`` (``0, 1, 2, ...`` in row-major
@@ -329,13 +346,33 @@ def compare(
         res_opt = forward(trial_opt, inputs, custom_lib)
 
         for name in res_opt.keys():
-            if not np.allclose(res_opt[name], res_ori[name], rtol=rtol, atol=atol):
+            # equal_nan=True: a NaN produced at the same position by *both*
+            # models is not evidence that anything changed -- it just means the
+            # model itself is undefined at this (random) input, e.g. a Div by
+            # zero. Without it, NaN != NaN made such inputs report a bogus
+            # "changes after optimization" (GitHub issue #1285). It only ever
+            # equates NaN with NaN: a NaN in one output where the other holds a
+            # number is still a mismatch, and so is +Inf vs -Inf or Inf vs any
+            # finite value (np.allclose compares infinities exactly by default,
+            # which is already the behaviour we want for them).
+            if not np.allclose(
+                res_opt[name], res_ori[name], rtol=rtol, atol=atol, equal_nan=True
+            ):
                 if verbose:
                     print(
                         "Tensor {} changes after optimization. The max diff is {}.".format(
                             name, np.max(np.abs(res_opt[name] - res_ori[name]))
                         )
                     )
+                    if _has_one_sided_nan(res_opt[name], res_ori[name]):
+                        # The max diff is NaN in this case, which reads exactly
+                        # like the (now tolerated) both-sides-NaN case. Say
+                        # which one it actually is.
+                        print(
+                            "(The max diff is NaN because NaN appears in one "
+                            "model's output where the other's is a number. "
+                            "Matching NaNs on both sides are not reported.)"
+                        )
                     print("After optimization:")
                     print(res_opt[name])
                     print("Before optimization:")

--- a/tests/test_model_checking.py
+++ b/tests/test_model_checking.py
@@ -1,6 +1,9 @@
-"""Tests for ``onnxsim.model_checking``, particularly the Random* op seed
-pinning added for models like VOICEVOX's predict_sing_f0.onnx (see below).
+"""Tests for ``onnxsim.model_checking``: the Random* op seed pinning added for
+models like VOICEVOX's predict_sing_f0.onnx (see below), and the NaN handling of
+the output comparison itself (GitHub issue #1285).
 """
+
+import copy
 
 import numpy as np
 import onnx
@@ -152,3 +155,175 @@ def test_compare_unaffected_for_plain_models(monkeypatch):
     assert compare(model, model, n_times=1) is True
     # No Random* ops -> the exact model objects are forwarded, no seeded copy.
     assert all(m is model for m in calls)
+
+
+# --------------------------------------------------------------------------- #
+# compare(): NaN on both sides is not a change (GitHub issue #1285)
+# --------------------------------------------------------------------------- #
+def _div_model() -> onnx.ModelProto:
+    # Two separate inputs (rather than Div(x, x)) so that no optimizer pass can
+    # rewrite the division away and change what the check actually compares.
+    return _model(
+        """
+        g (float[3] x, float[3] z) => (float[3] y)
+        {
+          y = Div(x, z)
+        }
+        """
+    )
+
+
+# 0 / 0 -> NaN in the first position, ordinary numbers in the other two.
+_DIV_BY_ZERO_INPUT = {
+    "x": np.array([0.0, 1.0, 2.0], dtype=np.float32),
+    "z": np.array([0.0, 1.0, 4.0], dtype=np.float32),
+}
+
+
+def _named(model: onnx.ModelProto, name: str) -> onnx.ModelProto:
+    model = copy.deepcopy(model)
+    model.graph.name = name
+    return model
+
+
+def _fake_backend(outputs):
+    """A backend returning a per-model canned output, keyed by graph name.
+
+    Lets a test pin exactly what "the original model" and "the simplified
+    model" each returned, which is the only thing ``compare`` looks at.
+    """
+
+    def run_model(model, inputs, **kwargs):
+        return {"y": outputs[model.graph.name]}
+
+    return run_model
+
+
+def _compare_fake(monkeypatch, ori, opt, verbose=True):
+    monkeypatch.setattr(
+        model_checking.backend,
+        "run_model",
+        _fake_backend(
+            {
+                "ori": np.array(ori, dtype=np.float32),
+                "opt": np.array(opt, dtype=np.float32),
+            }
+        ),
+    )
+    model = _div_model()
+    return compare(
+        _named(model, "opt"),
+        _named(model, "ori"),
+        n_times=1,
+        input_data=_DIV_BY_ZERO_INPUT,
+        verbose=verbose,
+    )
+
+
+def test_div_by_zero_model_really_produces_nan():
+    # Guards the premise of the tests below: were this model to stop producing
+    # a NaN, they would start passing vacuously.
+    res = model_checking.backend.run_model(_div_model(), _DIV_BY_ZERO_INPUT)
+    assert np.isnan(res["y"][0])
+    assert not np.isnan(res["y"][1:]).any()
+
+
+def test_compare_tolerates_nan_produced_by_both_models():
+    # The original model is already undefined (0 / 0) at this input, so an
+    # equally-NaN output from the simplified model says nothing about
+    # simplification and must not be reported as a change. Before the fix,
+    # NaN != NaN made this print "The max diff is nan." and return False.
+    model = _div_model()
+    assert compare(model, model, n_times=1, input_data=_DIV_BY_ZERO_INPUT) is True
+
+
+def test_simplify_check_passes_for_model_whose_output_is_nan():
+    # End-to-end: simplify(..., check_n=1) reports success rather than the
+    # false "Check failed" of issue #1285.
+    import onnxsim
+
+    _, check_ok = onnxsim.simplify(
+        _div_model(), check_n=1, input_data=_DIV_BY_ZERO_INPUT
+    )
+    assert check_ok is True
+
+
+def test_compare_still_catches_nan_on_one_side_only(monkeypatch):
+    # What the fix must stay sensitive to: a NaN where the original model
+    # returned a number is a genuine regression.
+    assert (
+        _compare_fake(
+            monkeypatch, ori=[1.0, 2.0, 3.0], opt=[1.0, np.nan, 3.0], verbose=False
+        )
+        is False
+    )
+
+
+def test_compare_still_catches_number_where_original_was_nan(monkeypatch):
+    # ... and the mirror image: the simplified model inventing a number where
+    # the original was undefined is just as much a change.
+    assert (
+        _compare_fake(
+            monkeypatch, ori=[1.0, np.nan, 3.0], opt=[1.0, 2.0, 3.0], verbose=False
+        )
+        is False
+    )
+
+
+def test_compare_still_catches_plain_numeric_difference(monkeypatch):
+    # equal_nan must not have loosened the ordinary finite comparison.
+    assert (
+        _compare_fake(
+            monkeypatch, ori=[1.0, 2.0, 3.0], opt=[1.0, 2.5, 3.0], verbose=False
+        )
+        is False
+    )
+
+
+def test_compare_tolerates_matching_infinities(monkeypatch):
+    # np.allclose compares infinities exactly on its own; 1 / 0 -> +Inf on both
+    # sides is as much a property of the model as a matching NaN is.
+    assert (
+        _compare_fake(
+            monkeypatch,
+            ori=[np.inf, -np.inf, 3.0],
+            opt=[np.inf, -np.inf, 3.0],
+        )
+        is True
+    )
+
+
+def test_compare_still_catches_flipped_infinity_sign(monkeypatch):
+    assert (
+        _compare_fake(
+            monkeypatch, ori=[np.inf, 2.0, 3.0], opt=[-np.inf, 2.0, 3.0], verbose=False
+        )
+        is False
+    )
+
+
+def test_compare_explains_a_one_sided_nan_in_its_report(monkeypatch, capsys):
+    # "The max diff is nan." on its own reads exactly like the tolerated
+    # both-sides-NaN case, which is what made issue #1285 confusing to read.
+    _compare_fake(monkeypatch, ori=[1.0, 2.0, 3.0], opt=[1.0, np.nan, 3.0])
+    assert "NaN appears in one model's output" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# _has_one_sided_nan
+# --------------------------------------------------------------------------- #
+def test_has_one_sided_nan():
+    nan = np.array([1.0, np.nan], dtype=np.float32)
+    num = np.array([1.0, 2.0], dtype=np.float32)
+    assert model_checking._has_one_sided_nan(nan, num)
+    assert model_checking._has_one_sided_nan(num, nan)
+    assert not model_checking._has_one_sided_nan(nan, nan)
+    assert not model_checking._has_one_sided_nan(num, num)
+
+
+def test_has_one_sided_nan_false_for_non_float_outputs():
+    # np.isnan raises on integer/bool arrays; they cannot hold a NaN anyway.
+    ints = np.array([1, 2], dtype=np.int64)
+    bools = np.array([True, False])
+    assert not model_checking._has_one_sided_nan(ints, ints)
+    assert not model_checking._has_one_sided_nan(bools, bools)


### PR DESCRIPTION
Closes #1285.

## The problem

`model_checking.compare()` compared the original and simplified outputs with plain `np.allclose(res_opt[name], res_ori[name], rtol=rtol, atol=atol)`. `np.allclose`'s `equal_nan` defaults to `False`, so when a `check_n` trial's random input made the **original** (unsimplified) model itself produce a NaN — a `Div` by zero, say — the simplified model's equally-undefined NaN in the same position was reported as changed:

```
Checking 0/3...
Tensor v12_0 changes after optimization. The max diff is nan.
```

Both sides are equally undefined at that input, so nothing about `simplify()`'s correctness can be concluded from it — yet it was reported exactly like a genuine numeric regression.

## The fix

Pass `equal_nan=True`. Verified against numpy directly rather than assumed: it equates NaN **only** with NaN, so the cases that matter are all still caught —

| original | simplified | reported as a change? |
| --- | --- | --- |
| NaN | NaN (same position) | no (this is the fix) |
| number | NaN | yes |
| NaN | number | yes |
| +Inf | +Inf | no |
| +Inf | -Inf | yes |
| Inf | any finite value | yes |
| 2.0 | 2.5 | yes |

`Inf` needs no separate handling: `np.allclose` already compares infinities exactly, which is exactly the behaviour wanted for them (a `1 / 0 -> +Inf` on both sides is as much a property of the model as a matching NaN is). So the change is the one keyword, nothing more.

One follow-on: `np.max(np.abs(a - b))` is NaN whenever *either* side has one, so a real NaN-vs-number mismatch still prints "The max diff is nan.", which now reads exactly like the tolerated case. The verbose report gets one extra line saying which of the two it actually is.

## Tests

`tests/test_model_checking.py` gains a section built on a small `Div(x, z)` model fed `x = [0, 1, 2]`, `z = [0, 1, 4]`, so its output is NaN in the first position and ordinary numbers in the other two (`onnx.parser` text form, per the house style in `CLAUDE.md`):

- `test_div_by_zero_model_really_produces_nan` — guards the premise, so the rest can't pass vacuously.
- `test_compare_tolerates_nan_produced_by_both_models` and `test_simplify_check_passes_for_model_whose_output_is_nan` — the regression itself, at the `compare()` level and end-to-end through `simplify(..., check_n=1)`.
- `test_compare_still_catches_nan_on_one_side_only`, `..._number_where_original_was_nan`, `..._plain_numeric_difference`, `..._flipped_infinity_sign` — the check must not have gone blind to real bugs.
- `test_compare_tolerates_matching_infinities`, plus unit tests for the new `_has_one_sided_nan` helper and the report line.

Checked that the two NaN-tolerance tests fail on the unfixed code while every "still catches a real mismatch" test passes both before and after, so they are testing what they claim to.

`pytest tests/test_model_checking.py` → 20 passed (the run also emits onnx's own `RuntimeWarning: invalid value encountered in divide`, confirming the real NaN path is exercised). `tests/test_backend.py` and `tests/test_model_info.py` → 71 passed, 7 skipped. `ruff check` and `ruff format --check` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015f3Ag1UkFHiY2KUXyjRfAw

---
_Generated by [Claude Code](https://claude.ai/code/session_015f3Ag1UkFHiY2KUXyjRfAw)_