### PR TITLE
mcode: correction — the requantisation multiplier IS linear and writable within a range

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -4318,9 +4318,12 @@ activation scales, decoded" below: **a compiled model's convolution weights
 can be replaced by any set that preserves each output channel's peak, and the
 whole layer may now be rescaled freely** -- the output activation scale is
 writable, so a uniform 3x rescale reproduces the new convolution at 0.99975
-where it used to saturate. What still blocks arbitrary weights is one thing,
-now precisely identified: the per-channel requantisation multiplier is not
-rewritable as a float32, because the datapath does not read it as one.
+where it used to saturate. What still blocks arbitrary weights is
+narrower than it was: the per-channel requantisation multiplier is a real
+linear multiplier and is writable, but only within roughly +/-10% before
+individual channels start to break, so new weights must keep each output
+channel's peak close to its original *relative* to the others. A uniform
+rescale of the whole layer is free, because the output scale absorbs it.
 
 Test: `test_per_channel_weight_scales_sit_just_past_the_weight_block`
 (Docker, no device).
@@ -4994,29 +4997,39 @@ weights can be **rescaled**, which is precisely what saturated before: tripling
 every weight and tripling the output scale reproduces the new convolution at
 0.99975, where the old table's fixed output scale would have clipped it.
 
-**And the same run refutes something this file had assumed.** The per-channel
-float32 array next to the weight block is proportional to
-`x_scale * (peak[o]/127.5) / y_scale` -- that much still holds exactly, and the
-measured constant matches `x_scale/y_scale` to eight digits. But it is **not
-consumed as a linear multiplier**. Scaling it on the device:
+**The per-channel multiplier is writable too, over a limited range.** It is
+the float32 array next to the weight block, proportional to
+`x_scale * (peak[o]/127.5) / y_scale` -- and the measured constant matches
+`x_scale/y_scale` to eight digits. Scaling it and measuring each channel's
+least-squares slope against the CPU reference:
 
-| edit | correlation | amplitude |
+| factor | median slope | worst channel, slope/factor |
 | --- | --- | --- |
-| untouched | 0.99975 | 0.990 |
-| `y_scale` x2 | 0.99975 | 1.980 |
-| multiplier x0.5 | 0.302 | 1.197 |
-| multiplier x2 | 0.515 | **1.197** |
+| 0.95 | 0.952 | 0.92 .. 1.07 |
+| 1.05 | 1.043 | 0.93 .. 1.06 |
+| 1.10 | 1.090 | 0.87 .. 1.12 |
+| 1.25 | 1.230 | 0.71 .. 1.21 |
+| 0.50 | 0.541 | **-0.31 .. 1.20** |
 
-Halving and doubling it produce *the same* amplitude. No linear factor does
-that. The array is read -- corrupting it clearly damages the output -- but
-whatever the datapath takes from those four bytes is not their float32 value,
-which is what you would see if it reads a fixed-point mantissa and shift out
-of the same word. Rewriting that array had never actually been tested; it does
-not work, and the earlier plan of "rewrite weights, multipliers and scales
-together" was resting on it.
+Within a few percent it is an ordinary linear multiplier. Past about 25% the
+per-channel error grows until channels start breaking outright -- at 0.5x one
+channel's slope is *negative*, its output inverted -- and at 2x the output
+saturates.
 
-Test: `test_output_scale_is_rewritable_but_the_multiplier_is_not` (Docker and
-device).
+**A correction, and the measurement error behind it.** An earlier pass here
+concluded this array was "not consumed as a linear multiplier", on the
+evidence that scaling it by 0.5 and by 2 produced *the same* output amplitude
+(1.197 both times), which no linear factor can do. That observation was real
+and the inference from it was wrong. Amplitude is the maximum of 32 quantised
+samples, so it is set by whichever channel blew up, and at both factors that
+happened to be the same magnitude. Per-channel slopes -- 32 numbers instead of
+one, and a fit instead of a maximum -- show a clean linear multiplier with a
+few channels broken. The lesson is narrow and worth keeping: a single
+whole-tensor statistic cannot tell "the mechanism is different" from "most of
+it worked and a little of it broke".
+
+Test: `test_output_scale_and_multiplier_are_both_writable_within_a_range`
+(Docker and device).
 
 ### Held out: a second vocoder, and why the splits must be walked
 

--- a/tests/test_axera_mcode_structure.py
+++ b/tests/test_axera_mcode_structure.py
@@ -4677,19 +4677,23 @@ def _patch_scale_and_multiplier(axmodel, out_path, weights, y_factor, m_factor):
     return out_path
 
 
-def test_output_scale_is_rewritable_but_the_multiplier_is_not(tmp_path):
+def test_output_scale_and_multiplier_are_both_writable_within_a_range(tmp_path):
     """Confirmed real on an AX650N (see the README's "The activation scales,
-    decoded" section): the bfloat16 output scale in the mcode *is* the
-    dequantisation scale -- doubling it doubles the device's output exactly --
-    and that is what lets a layer's weights be rescaled, which saturated
-    before.
+    decoded" section).
 
-    The same run refutes something this file used to assume. The per-channel
-    float32 array next to the weight block is proportional to
-    `x_scale * (peak/127.5) / y_scale`, but it is **not consumed as a linear
-    multiplier**: scaling it by 0.5 and by 2 damages the output *by the same
-    amplitude*, which no linear factor can do. Rewriting it was never tested
-    before; it does not work.
+    Two things, measured as per-channel least-squares slopes against the CPU
+    reference rather than as amplitudes -- the maximum of 32 quantised samples
+    is far too coarse a statistic, and reading one led this file to the wrong
+    conclusion once already.
+
+    * The bfloat16 output scale in the mcode *is* the dequantisation scale:
+      doubling it doubles the device's output exactly, so a layer's weights
+      can be rescaled, which used to saturate.
+    * The per-channel float32 array next to the weight block *is* a linear
+      multiplier, and it is writable -- but only over a limited range. At
+      +/-5% every channel's slope tracks the factor to within a few percent;
+      at 0.5x or 2x individual channels break badly, some inverting sign, and
+      the output saturates.
 
     Needs Docker and a device.
     """
@@ -4715,58 +4719,69 @@ def test_output_scale_is_rewritable_but_the_multiplier_is_not(tmp_path):
         path = str(work / "ref.onnx")
         onnx.save(_one_conv_model(cin, cout, length, kernel, weights=w), path)
         session = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
-        return np.asarray(session.run(None, {"x": x})[0]).ravel()
+        return np.asarray(session.run(None, {"x": x})[0]).reshape(cout, length)
 
     def device(path):
         result = pulsar2_docker.run_on_device_with_inputs(
             path, {"x": x.tobytes()}, timeout=300
         )
         assert not result.error, result.error
-        return np.frombuffer(result.outputs[0], np.float32).ravel()
+        return np.frombuffer(result.outputs[0], np.float32).reshape(cout, length)
 
     ref = reference(weights)
-    amp = lambda a: float(np.abs(a).max() / np.abs(ref).max())  # noqa: E731
-    corr = lambda a: float(np.corrcoef(a, ref)[0, 1])  # noqa: E731
 
-    plain = device(axmodel)
-    assert corr(plain) > 0.99, corr(plain)
+    def slopes(path, against=ref):
+        got = device(path)
+        return (got * against).sum(1) / (against * against).sum(1)
 
-    # Doubling the stored output scale doubles the output, and nothing else.
-    doubled = device(
+    plain = slopes(axmodel)
+    assert abs(np.median(plain) - 1) < 0.02, np.median(plain)
+
+    # Doubling the stored output scale doubles the output, every channel.
+    doubled = slopes(
         _patch_scale_and_multiplier(
             axmodel, str(work / "y2.axmodel"), weights, 2.0, 1.0
         )
     )
-    assert corr(doubled) > 0.99, corr(doubled)
-    assert 1.9 < amp(doubled) / amp(plain) < 2.1, amp(doubled) / amp(plain)
+    assert abs(np.median(doubled) - 2) < 0.05, np.median(doubled)
 
-    # So a layer whose weights are rescaled can now be written, which is what
-    # saturated before: triple the weights, triple the output scale.
+    # So a rescaled layer can be written, which used to saturate.
     tripled = (weights * 3).astype(np.float32)
-    scaled = device(
+    scaled = slopes(
         _patch_scale_and_multiplier(
             axmodel, str(work / "w3.axmodel"), tripled, 3.0, 1.0
-        )
+        ),
+        against=reference(tripled),
     )
-    ref3 = reference(tripled)
-    assert float(np.corrcoef(scaled, ref3)[0, 1]) > 0.99, np.corrcoef(scaled, ref3)[
-        0, 1
-    ]
+    assert abs(np.median(scaled) - 1) < 0.05, np.median(scaled)
 
-    # The per-channel array is not a linear multiplier: halving and doubling
-    # it damage the output identically.
-    half = device(
+    # The multiplier is linear over a small range...
+    near = {}
+    for factor in (0.95, 1.05):
+        near[factor] = slopes(
+            _patch_scale_and_multiplier(
+                axmodel,
+                str(work / f"m{factor}.axmodel"),
+                weights,
+                1.0,
+                factor,
+            )
+        )
+        assert abs(np.median(near[factor]) / factor - 1) < 0.03, (
+            factor,
+            np.median(near[factor]),
+        )
+        assert (np.abs(near[factor] / factor - 1) < 0.15).all(), near[factor]
+
+    # ... and not beyond it: halving it makes channels disagree by an order of
+    # magnitude more, and at least one inverts.
+    far = slopes(
         _patch_scale_and_multiplier(
-            axmodel, str(work / "m05.axmodel"), weights, 1.0, 0.5
+            axmodel, str(work / "mhalf.axmodel"), weights, 1.0, 0.5
         )
     )
-    twice = device(
-        _patch_scale_and_multiplier(
-            axmodel, str(work / "m2.axmodel"), weights, 1.0, 2.0
-        )
-    )
-    assert corr(half) < 0.9 and corr(twice) < 0.9, (corr(half), corr(twice))
-    assert abs(amp(half) - amp(twice)) < 0.01 * amp(half), (amp(half), amp(twice))
+    spread = lambda v: float(np.std(v / np.median(v)))  # noqa: E731
+    assert spread(far) > 5 * spread(near[0.95]), (spread(far), spread(near[0.95]))
 
 
 def _quantize_llm_weights(weights):


### PR DESCRIPTION
**This corrects #1283, which I got wrong.**

That PR concluded the per-channel float32 array next to the weight block was *"not consumed as a linear multiplier"*, on the evidence that scaling it by 0.5 and by 2 produced **the same** output amplitude (1.197 both times) — which no linear factor can do. The observation was real. The inference from it was wrong.

Amplitude is the maximum of 32 quantised samples, so it is set by whichever channel blew up, and at both factors that happened to be the same magnitude. Measuring **each channel's least-squares slope** against the CPU reference — 32 numbers instead of one, a fit instead of a maximum — shows an ordinary linear multiplier with a few channels broken:

| factor | median slope | worst channel, slope/factor |
| --- | --- | --- |
| 0.95 | 0.952 | 0.92 .. 1.07 |
| 1.05 | 1.043 | 0.93 .. 1.06 |
| 1.10 | 1.090 | 0.87 .. 1.12 |
| 1.25 | 1.230 | 0.71 .. 1.21 |
| 0.50 | 0.541 | **−0.31** .. 1.20 |

Within a few percent it behaves as a multiplier. Past about 25% the per-channel error grows until channels break outright — at 0.5× one channel's output is *inverted* — and at 2× the output saturates.

**So the capability improves rather than narrows.** Convolution weights can be replaced by any set that keeps each output channel's peak within roughly 10% of its original *relative to the others*, and a uniform rescale of the whole layer is free, because the output scale absorbs it. Everything #1283 established about the bfloat16 activation scales stands — that part was verified per-channel and is unaffected.

The test is rewritten to assert the corrected behaviour and to measure slopes rather than amplitudes; it passes on the AX650N.

The lesson worth keeping is narrow: **a single whole-tensor statistic cannot distinguish "the mechanism is different" from "most of it worked and a little of it broke".**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS