### PR TITLE
Add Z3 proofs for the GatherND and GridSample rewrite passes

### DIFF
--- a/tests/test_formal_verify_rewrite_gathernd_to_gather.py
+++ b/tests/test_formal_verify_rewrite_gathernd_to_gather.py
@@ -1,0 +1,80 @@
+"""Formal check for RewriteGatherNDToGather (opt-in; onnxsim's own
+``onnxsim/passes/rewrite_gathernd_to_gather.h``): rewrites
+``GatherND(data, indices, batch_dims=b)`` into a flatten + plain ``Gather``.
+
+This proof covers the ``batch_dims=0`` case with the ``k`` indexed axes
+merged into one: ``data`` (rank ``r``, axes ``[0, k)`` statically sized) is
+reshaped to ``flat_data = Reshape(data, [-1, *data.shape[k:]])``; each index
+column ``j`` is normalized (``idx_j < 0 ? idx_j + dim_j : idx_j`` --
+``GatherND``, like ``Gather``, allows negative per-axis indices) and the
+normalized columns combined into one flat row index by row-major strides,
+``combined = sum(idx_j_norm * mult_j)`` with ``mult_j = prod(dims[j+1:k])``;
+finally ``output = Gather(flat_data, combined, axis=0)``. The general
+``batch_dims > 0`` case additionally adds a per-batch-row offset, not
+re-derived here -- see that file's own header comment for the full
+derivation; the differential check below only exercises ``batch_dims=0``.
+
+Soundness is the same "reshape only relabels a flat buffer" argument as
+test_formal_verify_fuse_matmul_add_bias_into_gemm_batched.py, here merging
+the first ``k`` axes (rather than arbitrary leading batch dims) with a
+trailing free axis ``t`` preserved: proving
+``data[i0, i1, t] == flat_data[i0*D1 + i1, t]`` for ``k=2`` is exactly the
+same "compare two row-major flat-buffer offsets" argument, an
+unconditional index identity independent of dimension sizes -- normalizing
+each index column to be non-negative *before* combining it with strides is
+what makes ``i0``/``i1`` valid row-major sub-indices in the first place
+(combining raw negative indices with strides is not the same arithmetic
+at all: e.g. index -1 into a size-3 axis must normalize to 2 before being
+multiplied by a stride, not stay -1), which the differential check below
+confirms empirically by exercising negative indices in both columns
+against the real compiled pass, rather than by trying to state "wrong
+arithmetic gives a wrong answer" as its own Z3 claim.
+"""
+
+import numpy as np
+import onnx
+from _formal_verify_common import prove, simplify_isolated_extra, z3
+from onnx import parser
+
+
+def test_rewrite_gathernd_to_gather_reshape_is_sound():
+    # data: logically rank 3, shape (D0, D1, D2); the pass merges axes 0,1.
+    buf = z3.Function("buf", z3.IntSort(), z3.RealSort())  # data's flat buffer
+    D1, D2 = z3.Ints("D1 D2")
+    i0, i1, t = z3.Ints("i0 i1 t")
+
+    def data_at(a, b, c):
+        return buf(a * D1 * D2 + b * D2 + c)
+
+    def flat_data_at(row, c):
+        return buf(row * D2 + c)
+
+    combined = i0 * D1 + i1
+    prove(data_at(i0, i1, t) == flat_data_at(combined, t))
+
+
+def _i64(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.int64), name)
+
+
+def test_rewrite_gathernd_to_gather_pass_matches_negative_indices():
+    # indices deliberately includes a negative value in both columns
+    # (axis 0 has size 3, so -1 normalizes to 2; axis 1 has size 4, so -1
+    # normalizes to 3) -- exercising NormalizeIndex against the real
+    # compiled pass, not just the reshape lemma above.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[3,4,2] data) => (float[2,2] Y)
+        <int64[2,2] indices = {0, 1, -1, -1}>
+        {
+          Y = GatherND(data, indices)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated_extra(model, "rewrite_gathernd_to_gather")
+    assert ops["GatherND"] == 0
+    assert ops["Gather"] == 1

--- a/tests/test_formal_verify_rewrite_gridsample_to_gather.py
+++ b/tests/test_formal_verify_rewrite_gridsample_to_gather.py
@@ -1,0 +1,103 @@
+"""Formal check for RewriteGridSampleToGather (opt-in; onnxsim's own
+``onnxsim/passes/rewrite_gridsample_to_gather.h``), restricted here to
+``mode="nearest", padding_mode="zeros"`` -- the tractable case; bilinear
+interpolation and the reflection/border padding modes are not covered (see
+scoping note below).
+
+For nearest+zeros, the rewrite (after denormalizing the grid's [-1, 1]
+coordinates to pixel coordinates ``coordx``/``coordy`` -- an
+``align_corners``-dependent arithmetic step this proof does not re-derive,
+scoped out the same way test_formal_verify_fuse_pad_into_conv.py scopes out
+output-length arithmetic) computes, per output pixel::
+
+    xr = Round(coordx); yr = Round(coordy)          # rewrite_gridsample_to_gather.h:552-553
+    ix = Cast(Clip(xr, 0, W-1)); iy = Cast(Clip(yr, 0, H-1))   # BuildIndex, :406-407
+    gathered = X[iy, ix]                             # GatherPixel, always in-bounds
+    valid = (0 <= xr <= W-1) and (0 <= yr <= H-1)     # InRange, :412-413 -- tested
+                                                       # against the *rounded* xr/yr,
+                                                       # not the pre-round coordinate
+    result = gathered * valid
+
+Soundness: this is exactly the same zero-fill boundary rule as
+test_formal_verify_fuse_pad_into_conv.py's own ``_read`` helper (clip for
+the lookup, but test validity separately), just in two dimensions and with
+``round`` in place of a pad-shift. That the validity test uses the
+*rounded* coordinate ``xr``/``yr`` -- not the raw pre-round coordinate --
+is exactly what makes clip-then-mask reproduce true zero-fill sampling:
+had it tested the raw coordinate instead, a coordinate like -0.3 (which
+rounds to the valid index 0) would be masked to zero even though its
+nearest pixel is in-bounds. Modeling ``round`` the same way as
+test_formal_verify_quantize_round_trip.py (some integer within 0.5 of its
+argument, not one specific tie rule) and reusing
+test_formal_verify_fuse_pad_into_conv.py's zero-fill-vs-clip proof
+structure turns "clip-then-mask equals true zero-fill nearest sampling"
+into a direct case-split Z3 can check.
+"""
+
+import numpy as np
+import onnx
+from _formal_verify_common import prove, simplify_isolated_extra, z3
+from onnx import parser
+
+
+def test_rewrite_gridsample_to_gather_nearest_zeros_is_sound():
+    X = z3.Function("X", z3.IntSort(), z3.IntSort(), z3.RealSort())
+    H, W = z3.Ints("H W")
+    coordx, coordy = z3.Reals("coordx coordy")
+    nx, ny = z3.Ints("nx ny")  # Round(coordx), Round(coordy)
+    half = z3.RealVal(1) / 2
+
+    domain = z3.And(
+        H > 0,
+        W > 0,
+        nx - coordx <= half,
+        coordx - nx <= half,
+        ny - coordy <= half,
+        coordy - ny <= half,
+    )
+
+    def clip(v, hi):
+        return z3.If(v < 0, 0, z3.If(v > hi, hi, v))
+
+    ix = clip(nx, W - 1)
+    iy = clip(ny, H - 1)
+    valid = z3.And(nx >= 0, nx <= W - 1, ny >= 0, ny <= H - 1)
+    result = z3.If(valid, X(iy, ix), z3.RealVal(0))
+
+    # The zero-fill target: read X at the rounded index directly, zero if
+    # either axis is out of [0, dim).
+    zero_fill = z3.If(
+        z3.And(ny >= 0, ny < H, nx >= 0, nx < W), X(ny, nx), z3.RealVal(0)
+    )
+
+    prove(z3.Implies(domain, result == zero_fill))
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(np.asarray(array, dtype=np.float32), name)
+
+
+def test_rewrite_gridsample_to_gather_pass_matches():
+    # X is 4x4; grid mixes in-range normalized coordinates (0.0 -> the
+    # image center) with clearly out-of-range ones (+-3.0, well outside
+    # [-1, 1]) so the differential check (via simplify_isolated_extra's own
+    # check_n, which randomizes X) exercises both the plain-gather branch
+    # and the zero-fill branch against the real compiled pass.
+    grid = np.array(
+        [[[[0.0, 0.0], [3.0, 0.0]], [[-3.0, -3.0], [0.5, -0.5]]]], dtype=np.float32
+    )
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 16]
+        >
+        g (float[1,1,4,4] X) => (float[1,1,2,2] Y)
+        {
+          Y = GridSample<mode = "nearest", padding_mode = "zeros", align_corners = 0>(X, grid)
+        }
+        """
+    )
+    model.graph.initializer.append(_f32(grid, "grid"))
+    sim_model, ops = simplify_isolated_extra(model, "rewrite_gridsample_to_gather")
+    assert ops["GridSample"] == 0


### PR DESCRIPTION
## Summary

Two more opt-in onnxsim passes (`onnxsim/passes/`), both index-remapping rewrites onto a plain `Gather`:

- **`rewrite_gathernd_to_gather`** (`batch_dims=0` case): proves the pass's row-major-stride axis merge is a pure flat-buffer relabeling — the same "reshape never moves data" argument used for the batched Gemm fusion proof (#1281), now merging the `k` indexed axes instead of leading batch dims. The differential check exercises negative indices in both merged columns against the real compiled pass, since `NormalizeIndex` must run *before* the stride combination — combining raw negative indices with strides is not equivalent arithmetic, a point better shown empirically than as its own Z3 claim.
- **`rewrite_gridsample_to_gather`** (`mode=nearest`, `padding_mode=zeros`): proves clip-for-lookup-but-mask-separately reproduces true zero-fill sampling — the same zero-fill boundary argument as `fuse_pad_into_conv`'s own proof, in two dimensions. Reading the actual source (rather than trusting a paraphrase) was load-bearing here: the validity mask is tested against the *rounded* coordinate, not the raw pre-round one, which is what makes a coordinate like `-0.3` (rounding to the valid index `0`) correctly read that pixel instead of being masked to zero. Bilinear interpolation and the border/reflection padding modes are out of scope.

Both negative controls (a wrong stride order; testing the mask against the raw coordinate instead of the rounded one) get real Z3 counterexamples — the raw-coordinate one reproduces exactly the `-0.3`-rounds-to-`0` boundary case reasoned through by hand while verifying against the source.

Coverage: 10/106 registered passes now proved (was 8).

## Test plan

- [x] `pytest tests/test_formal_verify_*.py tests/test_fusion_patterns.py` — 87 passed
- [x] `ruff check` / `ruff format --check onnxsim tests` — clean (two pre-existing, unrelated findings on `master` already)
- [x] Manual negative controls for both new proofs (wrong stride order; raw-vs-rounded coordinate mask → real Z3 counterexamples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYPkPSuY9aARnGkHCpVzLV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYPkPSuY9aARnGkHCpVzLV)_