### PR TITLE
Don't fold a rank>=2 value out of flat propagated shape data

### DIFF
--- a/onnxsim/partial_shape_eval.cpp
+++ b/onnxsim/partial_shape_eval.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "constant_folding.h"
@@ -429,6 +430,49 @@ std::map<std::string, onnxsim::SymTensor> EvaluateGraphSymbolicValues(
   return onnxsim::EvaluateSymbolicValues(vg);
 }
 
+// ModelProto-flavoured CollectRankUnsafeDataValues (declared further down,
+// next to the Graph-native folder) -- see that function's comment for what
+// "rank unsafe" means and why the mark has to be carried forward. Rank comes
+// from the model's type map rather than a Value's own sizes(), and a name
+// missing from that map counts as "rank not proven", i.e. unsafe.
+std::unordered_set<std::string> CollectRankUnsafeDataValuesOnModel(
+    const onnx::GraphProto& graph,
+    const std::unordered_map<std::string, const onnx::TypeProto*>& type_map,
+    const onnx::shape_inference::DataValueMap& data_map) {
+  std::unordered_set<std::string> unsafe;
+  auto rank_is_modelled = [&type_map](const std::string& name) {
+    auto iter = type_map.find(name);
+    if (iter == type_map.end() || !iter->second->has_tensor_type()) {
+      return false;
+    }
+    const auto& tensor_type = iter->second->tensor_type();
+    return tensor_type.has_shape() && tensor_type.shape().dim_size() <= 1;
+  };
+  // A GraphProto's nodes are required to be in topological order, so one pass
+  // over them propagates the mark completely.
+  for (const auto& node : graph.node()) {
+    bool tainted = false;
+    for (const std::string& in : node.input()) {
+      if (data_map.count(in) == 0) {
+        continue;
+      }
+      if (unsafe.count(in) != 0 || !rank_is_modelled(in)) {
+        tainted = true;
+        break;
+      }
+    }
+    for (const std::string& out : node.output()) {
+      if (data_map.count(out) == 0) {
+        continue;
+      }
+      if (tainted || !rank_is_modelled(out)) {
+        unsafe.insert(out);
+      }
+    }
+  }
+  return unsafe;
+}
+
 // Partial shape evaluation (issue #139) via ONNX data propagation.
 //
 // The plain constant folder only folds a node when *all* of its inputs are
@@ -561,6 +605,11 @@ void _EvalPartialShape(onnx::ModelProto& model) {
 
   const auto type_map = BuildTypeMap(model);
 
+  // Values whose propagated data must not be trusted -- see
+  // CollectRankUnsafeDataValues' own comment.
+  const std::unordered_set<std::string> rank_unsafe =
+      CollectRankUnsafeDataValuesOnModel(model.graph(), type_map, data_map);
+
   // Maps the output of a foldable node to the constant tensor it produces. Each
   // such node is rewritten into a `Constant` node holding this value.
   std::unordered_map<std::string, onnx::TensorProto> folded_values;
@@ -574,6 +623,9 @@ void _EvalPartialShape(onnx::ModelProto& model) {
     const std::string& output = node.output(0);
     auto data_iter = data_map.find(output);
     if (data_iter == data_map.end()) {
+      continue;
+    }
+    if (rank_unsafe.count(output) != 0) {
       continue;
     }
 
@@ -657,6 +709,9 @@ void _EvalPartialShape(onnx::ModelProto& model) {
     if (data_iter == data_map.end()) {
       continue;
     }
+    if (rank_unsafe.count(node.input(1)) != 0) {
+      continue;
+    }
     const onnx::TensorShapeProto& shape_value = data_iter->second;
     if (shape_value.dim_size() == 0) {
       continue;
@@ -727,6 +782,12 @@ void _EvalPartialShape(onnx::ModelProto& model) {
       int64_t element_count = 1;
       for (int64_t d : dims) element_count *= d;
       if (element_count != static_cast<int64_t>(flat.size())) continue;
+      // SymTensor models a rank-0 scalar or a rank-1 vector and nothing else
+      // (sym_value_eval.h), and its evaluators say so -- EvalSlice is "rank-1
+      // data, axis 0 only", Transpose is evaluated as the identity. Same
+      // reasoning as CollectRankUnsafeDataValues: a flat element sequence must
+      // not be reinterpreted under a rank >= 2 output's dims (issue #1284).
+      if (dims.size() > 1) continue;
       onnx::TensorProto tp;
       tp.set_data_type(elem_type);
       for (int64_t d : dims) tp.add_dims(d);
@@ -844,6 +905,68 @@ void _EvalPartialShape(onnx::ModelProto& model) {
   }
 }
 
+// Values whose ONNX-propagated data is meaningless because the propagation ran
+// on a tensor of a rank it does not model (onnxsim issue #1284).
+//
+// Data propagation carries a value as a `TensorShapeProto` -- a flat sequence
+// with no rank of its own -- because it exists to resolve *shape* scaffolding,
+// which is rank <= 1 by nature. Every `PartialDataPropagationFunction` is
+// written for that form: `Slice`'s says outright "Only supports axis = 0 since
+// the data comes from Shape", and `DataPropagationContextImpl::getInputData`
+// refuses to seed data from an initializer of rank >= 2 for the same reason.
+//
+// Nothing enforces that on a value produced *inside* the propagation, though.
+// Let a rank >= 2 tensor in -- e.g. the `[3, 2]` pads matrix in the
+// `Concat -> Reshape([-1, 2]) -> Slice(steps=-1) -> Transpose -> Reshape([-1])`
+// construction PyTorch emits for `F.pad` -- and the propagators silently read
+// its flat entries as a rank-1 element order: that `Slice` must reverse the 3
+// rows, but the propagator reverses all 6 flat entries. The value is still
+// "fully known", just wrong, and it keeps propagating to everything downstream,
+// so an element-count check on the folded node alone does not catch it.
+//
+// So mark a value's propagated data unusable when the value's own rank is not
+// provably <= 1, and carry that mark forward through any node that consumed a
+// marked value's data. `Shape(x)` and friends are unaffected: `x` carries no
+// propagated data of its own, so a rank-4 activation feeding a `Shape` marks
+// nothing -- which is the whole point of this pass (issue #139).
+std::unordered_set<std::string> CollectRankUnsafeDataValues(
+    const std::vector<onnx::Node*>& node_ptrs,
+    const onnx::shape_inference::DataValueMap& data_map) {
+  std::unordered_set<std::string> unsafe;
+  // A rank onnx's own data propagation models: a rank-0 scalar or a rank-1
+  // vector, and only when shape inference actually proved which.
+  auto rank_is_modelled = [](const onnx::Value* v) {
+    return v->has_sizes() && v->sizes().size() <= 1;
+  };
+  // node_ptrs is in topological order, so a producer is always visited before
+  // its consumers and one pass suffices.
+  for (const onnx::Node* node : node_ptrs) {
+    bool tainted = false;
+    for (const onnx::Value* in : node->inputs()) {
+      const std::string& name = in->uniqueName();
+      // Only an input that actually carries propagated data can taint this
+      // node's output; an ordinary activation input cannot.
+      if (data_map.count(name) == 0) {
+        continue;
+      }
+      if (unsafe.count(name) != 0 || !rank_is_modelled(in)) {
+        tainted = true;
+        break;
+      }
+    }
+    for (const onnx::Value* out : node->outputs()) {
+      const std::string& name = out->uniqueName();
+      if (data_map.count(name) == 0) {
+        continue;
+      }
+      if (tainted || !rank_is_modelled(out)) {
+        unsafe.insert(name);
+      }
+    }
+  }
+  return unsafe;
+}
+
 // Graph-native counterpart of _EvalPartialShape: same two rewrites (fold a
 // fully-known shape-family output to a Constant; materialize a Reshape's
 // shape input as a Constant with a single -1 slot when everything else is
@@ -900,6 +1023,11 @@ bool _EvalPartialShapeOnGraph(
     }
   }
 
+  // Values whose propagated data must not be trusted -- see
+  // CollectRankUnsafeDataValues' own comment.
+  const std::unordered_set<std::string> rank_unsafe =
+      CollectRankUnsafeDataValues(node_ptrs, data_map);
+
   // Maps the output of a foldable node to the constant tensor it produces.
   std::unordered_map<std::string, onnx::Tensor> folded_values;
   for (onnx::Node* node : node_ptrs) {
@@ -907,6 +1035,7 @@ bool _EvalPartialShapeOnGraph(
     onnx::Value* out = node->outputs()[0];
     auto data_iter = data_map.find(out->uniqueName());
     if (data_iter == data_map.end()) continue;
+    if (rank_unsafe.count(out->uniqueName())) continue;
 
     const onnx::TensorShapeProto& value = data_iter->second;
     bool fully_known = true;
@@ -966,6 +1095,7 @@ bool _EvalPartialShapeOnGraph(
     if (folded_values.count(node->outputs()[0]->uniqueName())) continue;
     auto data_iter = data_map.find(node->inputs()[1]->uniqueName());
     if (data_iter == data_map.end()) continue;
+    if (rank_unsafe.count(node->inputs()[1]->uniqueName())) continue;
     const onnx::TensorShapeProto& shape_value = data_iter->second;
     if (shape_value.dim_size() == 0) continue;
     int unknown = 0;
@@ -1034,6 +1164,12 @@ bool _EvalPartialShapeOnGraph(
       int64_t element_count = 1;
       for (int64_t d : dims) element_count *= d;
       if (element_count != static_cast<int64_t>(flat.size())) continue;
+      // SymTensor models a rank-0 scalar or a rank-1 vector and nothing else
+      // (sym_value_eval.h), and its evaluators say so -- EvalSlice is "rank-1
+      // data, axis 0 only", Transpose is evaluated as the identity. Same
+      // reasoning as CollectRankUnsafeDataValues: a flat element sequence must
+      // not be reinterpreted under a rank >= 2 output's dims (issue #1284).
+      if (dims.size() > 1) continue;
       onnx::Tensor t;
       t.elem_type() = elem_type;
       t.sizes() = dims;

--- a/tests/test_partial_shape_eval_rank.py
+++ b/tests/test_partial_shape_eval_rank.py
@@ -1,0 +1,202 @@
+"""Partial shape evaluation must not fold a rank>=2 value from flat shape data.
+
+Regression tests for onnxsim issue #1284.
+
+``_EvalPartialShape`` / ``_EvalPartialShapeOnGraph``
+(onnxsim/partial_shape_eval.cpp) fold a node whose value ONNX's *data
+propagation* -- or onnxsim's own ``SymTensor`` evaluator -- managed to resolve.
+Both of those represent a value as a **flat sequence with no rank of its own**:
+data propagation uses a ``TensorShapeProto`` (a shape vector), and every ONNX
+``PartialDataPropagationFunction`` is written for that rank<=1 form (``Slice``'s
+own says "Only supports axis = 0 since the data comes from Shape", and
+``DataPropagationContextImpl::getInputData`` only converts a rank-0/rank-1
+initializer); ``SymTensor`` is likewise a scalar or a vector and nothing else
+(``EvalSlice``: "rank-1 data, axis 0 only"; ``Transpose`` is evaluated as the
+identity, which only holds at rank <= 1).
+
+The folder used to accept such a sequence for an output of *any* rank as long as
+the element count matched, which silently reinterprets a rank-1 element order as
+a rank-N one. The graph below -- the pads construction PyTorch emits for
+``F.pad``, which NNSmith reproduces -- is exactly that case: a rank-2 ``[3, 2]``
+``Slice`` with ``steps=-1`` reverses the 3 *rows*, but the propagator reverses
+all 6 flat entries, so the ``Pad`` downstream pads the wrong sides and every
+value derived from it changes.
+
+These tests use only the ``onnx`` Python API, so they run without torch.
+"""
+
+import numpy as np
+import onnx
+from onnx import numpy_helper, parser
+from onnx.reference import ReferenceEvaluator
+
+import onnxsim
+
+# The sentinel PyTorch's ``F.pad`` export writes as the reversing Slice's `ends`.
+# Any value below ``-numel`` triggered the bug; this is the one real exports use.
+_INT64_END_SENTINEL = -9223372036854775807
+
+
+def _model(body, initializer=(), opset=17, ir_version=8):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _pads_chain_initializers(torch_pad):
+    """The constants of the ``F.pad`` pads construction.
+
+    ``torch_pad`` is torch's own padding list -- ``(before, after)`` per axis,
+    last axis first -- which the chain rearranges into ONNX ``Pad``'s
+    ``[before..., after...]`` layout. It must cover every axis of the tensor
+    being padded, which is when torch emits the empty ``ConstantOfShape``
+    below (its zero-fill is what pads a shorter list out to full rank).
+    """
+    return [
+        numpy_helper.from_array(np.array([0], np.int64), "cos_in"),
+        numpy_helper.from_array(np.array(torch_pad, np.int64), "torch_pad"),
+        numpy_helper.from_array(np.array([-1, 2], np.int64), "sh_m1_2"),
+        numpy_helper.from_array(np.array([-1], np.int64), "sl_starts"),
+        numpy_helper.from_array(np.array([_INT64_END_SENTINEL], np.int64), "sl_ends"),
+        numpy_helper.from_array(np.array([0], np.int64), "sl_axes"),
+        numpy_helper.from_array(np.array([-1], np.int64), "sl_steps"),
+        numpy_helper.from_array(np.array([-1], np.int64), "sh_m1"),
+    ]
+
+
+# Reused as a text fragment so callers can interpolate it like the rest of the
+# body (see CLAUDE.md's note on reusable node sequences).
+_PADS_CHAIN = """
+  cos = ConstantOfShape <value = int64[1] {0}> (cos_in)
+  cc0 = Concat <axis = 0> (torch_pad, cos)
+  rows = Reshape (cc0, sh_m1_2)
+  rev = Slice (rows, sl_starts, sl_ends, sl_axes, sl_steps)
+  cols = Transpose <perm = [1, 0]> (rev)
+  flat = Reshape (cols, sh_m1)
+  pads = Cast <to = 7> (flat)
+"""
+
+
+def _run(model, feeds):
+    return ReferenceEvaluator(model).run(None, feeds)
+
+
+def test_reversing_slice_on_rank2_is_folded_correctly():
+    # The pads chain on its own: `pads` is entirely constant, so simplify()
+    # folds it away -- but it must fold to the value the graph actually
+    # computes, not to a flat reversal of it.
+    model = _model(
+        f"""
+        g (float[1] dummy) => (int64[6] pads, float[1] keep)
+        {{
+        {_PADS_CHAIN}
+          keep = Identity (dummy)
+        }}
+        """,
+        initializer=_pads_chain_initializers((1, 2, 0, 0, 0, 0)),
+    )
+    onnx.checker.check_model(model)
+    feeds = {"dummy": np.zeros(1, np.float32)}
+
+    expected = _run(model, feeds)[0]
+    # ONNX Pad's [before_axis0.., after_axis0..] for a rank-3 tensor padded on
+    # its last axis only -- what torch's `F.pad(x, (1, 2))` means. Reversing
+    # the flat sequence instead of the 3 rows (the bug) yields the *reversed*
+    # (2, 1) padding, [0, 0, 2, 0, 0, 1], which is why the mismatch is a shift
+    # rather than a crash: the element count is right, the values are not.
+    assert expected.tolist() == [0, 0, 1, 0, 0, 2]
+
+    sim, ok = onnxsim.simplify(model, check_n=3)
+
+    assert ok
+    assert "Slice" not in [n.op_type for n in sim.graph.node]
+    np.testing.assert_array_equal(_run(sim, feeds)[0], expected)
+
+
+def test_pad_trilu_chain_survives_simplification():
+    # onnxsim issue #1284: the wrongly folded pads reach a `Pad`, so `Trilu`
+    # sees a differently-shaped tensor and every value downstream of the
+    # Sigmoid/Mul/Cos chain moves -- by up to 0.36 on the reported graph, far
+    # outside `Cos`'s own [-1, 1] range being compared at rtol 1e-4.
+    model = _model(
+        f"""
+        g (float[1,2,3] data, float[3] side) => (float[1,2,6] out)
+        {{
+        {_PADS_CHAIN}
+          padded = Pad <mode = "constant"> (data, pads, pad_value)
+          upper = Trilu <upper = 1> (padded, trilu_k)
+          gate = Sigmoid (upper)
+          scale = Concat <axis = 0> (side, weight)
+          scaled = Mul (gate, scale)
+          out = Cos (scaled)
+        }}
+        """,
+        initializer=_pads_chain_initializers((1, 2, 0, 0, 0, 0))
+        + [
+            numpy_helper.from_array(np.array(0.0, np.float32), "pad_value"),
+            numpy_helper.from_array(np.array(0, np.int64), "trilu_k"),
+            numpy_helper.from_array(np.array([0.5, 1.5, 2.5], np.float32), "weight"),
+        ],
+    )
+    onnx.checker.check_model(model)
+
+    sim, ok = onnxsim.simplify(model, check_n=5)
+    assert ok
+
+    rng = np.random.RandomState(0)
+    for _ in range(5):
+        feeds = {
+            "data": rng.randn(1, 2, 3).astype(np.float32),
+            "side": rng.randn(3).astype(np.float32),
+        }
+        np.testing.assert_allclose(
+            _run(sim, feeds)[0], _run(model, feeds)[0], rtol=1e-4, atol=1e-5
+        )
+
+
+def test_rank1_shape_scaffolding_is_still_folded():
+    # The rank<=1 case the folder exists for must keep working: a reversing
+    # Slice straight off a rank-1 Concat is exactly what data propagation
+    # models, and it still folds (and folds correctly).
+    model = _model(
+        """
+        g (float[1] dummy) => (int64[6] rev, float[1] keep)
+        {
+          cos = ConstantOfShape <value = int64[1] {0}> (cos_in)
+          cc0 = Concat <axis = 0> (flat_values, cos)
+          rev = Slice (cc0, sl_starts, sl_ends, sl_axes, sl_steps)
+          keep = Identity (dummy)
+        }
+        """,
+        initializer=[
+            numpy_helper.from_array(np.array([0], np.int64), "cos_in"),
+            numpy_helper.from_array(
+                np.array([12, 0, -65487, 0, 45, 0], np.int64), "flat_values"
+            ),
+            numpy_helper.from_array(np.array([-1], np.int64), "sl_starts"),
+            numpy_helper.from_array(
+                np.array([_INT64_END_SENTINEL], np.int64), "sl_ends"
+            ),
+            numpy_helper.from_array(np.array([0], np.int64), "sl_axes"),
+            numpy_helper.from_array(np.array([-1], np.int64), "sl_steps"),
+        ],
+    )
+    onnx.checker.check_model(model)
+    feeds = {"dummy": np.zeros(1, np.float32)}
+
+    expected = _run(model, feeds)[0]
+    assert expected.tolist() == [0, 45, 0, -65487, 0, 12]
+
+    sim, ok = onnxsim.simplify(model, check_n=3)
+
+    assert ok
+    assert "Slice" not in [n.op_type for n in sim.graph.node]
+    np.testing.assert_array_equal(_run(sim, feeds)[0], expected)


### PR DESCRIPTION
## The bug

`simplify()` changed a model's numeric output on an NNSmith-generated graph: a `Cos` moved by up to **0.36**, well outside its own `[-1, 1]` range, so this was a real discrepancy rather than float noise.

It is **not an optimizer pass**. The mismatch survives `skipped_optimizers=<all 61>`, and disappears only with `skip_constant_folding=True`. The culprit is `_EvalPartialShape` / `_EvalPartialShapeOnGraph` (`onnxsim/partial_shape_eval.cpp`), which run as part of constant folding.

## Root cause

Those two fold a node whose value ONNX's *data propagation* resolved. Data propagation carries a value as a `TensorShapeProto` — **a flat sequence with no rank of its own** — because it exists to resolve *shape* scaffolding, which is rank ≤ 1 by nature. Every ONNX `PartialDataPropagationFunction` is written for that form: `Slice`'s says outright *"Only supports axis = 0 since the data comes from Shape"*, and `DataPropagationContextImpl::getInputData` refuses to seed data from an initializer of rank ≥ 2 for the same reason.

Nothing enforced that on a value produced *inside* the propagation. The pads construction PyTorch emits for `F.pad` — which NNSmith reproduces, and which is exactly the `Reshape`/`Slice`/`Transpose`/`Cast` chain in the issue's node listing —

```
Concat -> Reshape([-1, 2]) -> Slice(starts=[-1], ends=INT64_MIN+1, axes=[0], steps=[-1])
       -> Transpose(perm=[1,0]) -> Reshape([-1]) -> Cast(int64)   ==> Pad's `pads`
```

puts a rank-2 `[3, 2]` tensor through it. That `Slice` must reverse the 3 **rows**; the propagator reverses all **6 flat entries**. The folder's only guard was that the element count matched — which it does — so the wrong value was baked in as a `Constant`:

```
true : [0, 0, 1, 0, 0, 2]     # pad the last axis by (1, 2)
baked: [0, 0, 2, 0, 0, 1]     # pad it by (2, 1)
```

The downstream `Pad` then pads the wrong sides, `Trilu`'s diagonal lands elsewhere, and every value derived from it through `Sigmoid`/`Mul`/`Cos` moves — the 0.36 in the report.

The trigger is narrow, which is why this survived: it needs `ends < -numel` (real `F.pad` exports write `INT64_MIN + 1`) *and* an element count that happens to match, so the bad value is accepted instead of discarded.

## The fix

Mark a value's propagated data unusable when its own rank is not provably ≤ 1, and **carry the mark forward** through any node that consumed a marked value's data. The forward carry matters: an element-count check on the folded node alone does not catch it, because the corruption keeps propagating into rank-1 values downstream (one of the reproducers below fails exactly that way).

- `Shape(x)` and friends are unaffected — `x` carries no propagated data of its own, so a rank-4 activation feeding a `Shape` marks nothing. That is the whole point of the pass (#139).
- Genuinely constant rank ≥ 2 values are unaffected — the ordinary executor-based constant folder still folds them.

The same reinterpretation is possible through onnxsim's own `SymTensor` evaluator, which likewise models only a rank-0 scalar or a rank-1 vector (`EvalSlice` is *"rank-1 data, axis 0 only"*; `Transpose` is evaluated as the identity, true only at rank ≤ 1), so its two folding sites get the matching rank guard.

## Verification

- The NNSmith model that first reproduced this: `onnxsim model.onnx out.onnx 5` reported `Tensor v6_0 changes after optimization. The max diff is 0.740234375.` before, and passes `check_n` after. Re-running the fuzzer on that seed now reports `ok`.
- A parameter sweep over the reversing `Slice`'s `ends` (28 points, spanning the `-numel` boundary where the bug switches on) is correct at every point after the fix; 6 structural variants of the chain all pass.
- New `tests/test_partial_shape_eval_rank.py` — built with `onnx.parser` per `CLAUDE.md`. Confirmed to **fail on the unfixed build** with exactly the reported symptom (`Tensor out changes after optimization. The max diff is 0.221...`) and pass after. `test_rank1_shape_scaffolding_is_still_folded` guards against the fix over-restricting.
- `tests/test_symexpr_kv_cache_consistency.py` (which exercises this folder directly), `test_simple.py`, `test_constant_fold_determinism.py`, `test_fusion_patterns.py`, `test_moved_optimizer_passes.py`, `test_model_info.py`, `test_pruning.py`, `test_python_api.py` and others all pass. `ruff check` / `ruff format --check` and `clang-format --dry-run --Werror` are clean on the touched files.

Closes #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015f3Ag1UkFHiY2KUXyjRfAw

---
_Generated by [Claude Code](https://claude.ai/code/session_015f3Ag1UkFHiY2KUXyjRfAw)_