### PR TITLE
axera: per-ONNX-op coverage, and the TopK it was silently missing

### DIFF
--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -51,6 +51,7 @@ on:
       - "tests/test_axera_quantonnx.py"
       - "tests/test_axera_mcode_structure.py"
       - "tests/test_axera_mcode_validator.py"
+      - "tests/test_axera_op_coverage_report.py"
 
 concurrency:
   group: axera-integration-${{ github.ref }}
@@ -118,7 +119,7 @@ jobs:
       - name: Run in-tree smoke tests
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py"
       - name: Run static Pulsar2 compatibility suite
         working-directory: ${{ runner.temp }}
         run: |

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -5273,6 +5273,77 @@ slots that move between builds hold allocator output. An interpreter that
 produced numbers would be inventing them. `check` answers the question that
 can be answered honestly: could the runtime load and walk this?
 
+## Per-ONNX-op coverage, and what it caught
+
+`op_coverage.py` classifies every operator in the ai.onnx default domain
+against Axera's published support list, and counts a model's nodes by whether
+the NPU can take them. Neither needs Docker or a card.
+
+| classification | ops | share of ai.onnx |
+| --- | --- | --- |
+| NPU-eligible | 83 | 41.1% |
+| confirmed broken on real hardware | 6 | 3.0% |
+| CPU-only by construction | 21 | 10.4% |
+| not on the vendor's list | 92 | 45.5% |
+
+**The audit paid for itself immediately.** Axera's list spells the op `Topk`;
+ONNX's operator is `TopK`. A list entry that is not a real ONNX op name can
+never match a node, so every `TopK` in every graph was being classified
+unsupported -- while the real-hardware op sweep had *already built a `TopK`
+node successfully*. It was a misclassification, not a missing capability, and
+nothing downstream could have noticed: the heuristic and the sweep never
+compared notes. Both spellings are now in the list, and a test asserts that the
+only entries which are not ai.onnx names are the vendor's own fused ops
+(`InverseSigmoid`, `Silu`, `SpatialTransformer`), named explicitly.
+
+That is the general hazard with a scraped support list, and it is worth
+stating: **an entry that matches nothing fails silently and in the safe
+direction**, so it shows up as a model being less compatible than it is,
+never as an error.
+
+### Audio8: which parts could run on an AX650, measured
+
+The Audio8 TTS/ASR packages (`tests/test_audio8.py`) are a useful test of that
+table against real, awkward graphs -- ORT deployment exports full of
+`com.microsoft` contrib ops, INT4 weight-only quantization and KV caches.
+Counting their nodes, without downloading their weights:
+
+| graph | nodes | NPU-eligible |
+| --- | --- | --- |
+| `codec_decoder_fp16` (TTS vocoder) | 3,341 | 94.0% |
+| `codec_encoder_fp16` | 4,916 | 93.7% |
+| `slow_ar_int8` | 16,426 | 91.8% |
+| `fast_ar_int8` | 1,116 | 91.5% |
+| `lm_cache_decode_int4` | 943 | 92.3% |
+| `llm_kv_cpu_fp32_int4` | 6,651 | 89.5% |
+| `genai_int4_qwen/model` | 299 | 34.8% |
+
+61 distinct op types across all of them, 47 NPU-eligible. The 14 that are not
+fall into three groups, and the distinction matters more than the percentage:
+
+* **`com.microsoft` contrib ops** -- `MatMulNBits` (546 nodes),
+  `SkipSimplifiedLayerNormalization`, `GroupQueryAttention`,
+  `GatherBlockQuantized`. These are ONNX Runtime's own, with no ai.onnx
+  equivalent in the graph. Pulsar2 will not take them, and no simplification
+  turns them back into standard ops.
+* **ORT dynamic-quantization plumbing** -- `MatMulInteger` (240),
+  `DynamicQuantizeLinear` (140), `DequantizeLinear`. Not a real obstacle so
+  much as the wrong starting point: the NPU quantizes for itself, so the
+  float export is what to feed it.
+* **Ordinary ONNX ops the list lacks** -- and `Shape` alone is 2,293 nodes,
+  with `Range`, `Neg`, `Reciprocal`, `Trilu`, `Einsum` behind it. Shape
+  arithmetic is exactly what constant-folding removes once the input shapes
+  are fixed, which is onnxsim's own job.
+
+So the honest read is not one verdict but three. The **codec decoder is the
+promising target**: it is a convolutional vocoder at 94% eligible, the same
+shape of model as the Piper decoder this project already compiled and ran on
+an AX650N to produce audible speech. The **autoregressive halves are not an
+ONNX problem at all** -- they are transformer decoders, and Axera compiles
+those from a checkpoint through `llm_build`, never from an ONNX export. And
+the **`com.microsoft` INT4 exports are a dead end** for this toolchain in the
+form they ship.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/op_coverage.py
+++ b/scripts/axera/op_coverage.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Per-ONNX-op coverage for the Axera AX650 NPU, and per-model op usage.
+
+Two questions this answers without a compiler or a card:
+
+1. **Of the ai.onnx operator set, how much can the AX650 take?** Every schema
+   in the default domain is classified against `pulsar2_ops`: NPU-eligible,
+   confirmed broken on real hardware, CPU-only by construction (control flow,
+   sequences, strings), or simply not on the vendor's list.
+2. **For a given model, which of its ops are eligible?** Node counts by op
+   type, so "89% of nodes" and "the six op types blocking it" are separate
+   numbers -- they usually tell very different stories.
+
+Usage::
+
+    op_coverage.py                          # the ai.onnx table
+    op_coverage.py model.onnx [more.onnx]   # plus per-model usage
+    op_coverage.py --csv coverage.csv model.onnx
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import os
+import sys
+
+import onnx
+import onnx.defs
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pulsar2_ops  # noqa: E402
+
+#: Entries of ``AX650_SUPPORTED_OPS`` that are Pulsar2-native op names rather
+#: than ai.onnx ones. They are not typos; they name fused or vendor ops the
+#: compiler accepts, and they will never match a node in a standard graph.
+VENDOR_NATIVE = frozenset({"InverseSigmoid", "Silu", "SpatialTransformer"})
+
+#: Classifications, most specific first.
+ELIGIBLE = "npu"
+BROKEN = "broken"
+CPU_ONLY = "cpu-only"
+UNLISTED = "unlisted"
+
+
+def classify(op_type):
+    """How the AX650 heuristic treats one ai.onnx op type."""
+    if op_type in pulsar2_ops.AX650_CONFIRMED_BROKEN_OPS:
+        return BROKEN
+    if op_type in pulsar2_ops.AX650_SUPPORTED_OPS:
+        return ELIGIBLE
+    if op_type in pulsar2_ops.CPU_ONLY_OPS:
+        return CPU_ONLY
+    return UNLISTED
+
+
+def onnx_op_types():
+    """Every op type in the default (ai.onnx) domain."""
+    return sorted({s.name for s in onnx.defs.get_all_schemas() if s.domain == ""})
+
+
+def coverage_table():
+    """`{classification: [op types]}` over the whole ai.onnx operator set."""
+    out = collections.defaultdict(list)
+    for op in onnx_op_types():
+        out[classify(op)].append(op)
+    return dict(out)
+
+
+def model_usage(path):
+    """`(node count, {(domain, op_type): count})` for one model, without
+    loading its weights -- op types do not depend on them, and these graphs
+    routinely carry hundreds of megabytes of external data."""
+    model = onnx.load(path, load_external_data=False)
+    counts = collections.Counter(
+        (node.domain or "", node.op_type) for node in model.graph.node
+    )
+    return sum(counts.values()), counts
+
+
+def summarise(path):
+    """`(total nodes, eligible nodes, {label: count} for the rest)`."""
+    total, counts = model_usage(path)
+    eligible, blocked = 0, collections.Counter()
+    for (domain, op_type), n in counts.items():
+        if domain == "" and classify(op_type) == ELIGIBLE:
+            eligible += n
+        else:
+            blocked[f"{domain + '.' if domain else ''}{op_type}"] += n
+    return total, eligible, blocked
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("models", nargs="*", help="ONNX models to inventory")
+    parser.add_argument("--csv", help="write the per-op table here")
+    args = parser.parse_args(argv)
+
+    table = coverage_table()
+    total_ops = sum(len(v) for v in table.values())
+    print(f"ai.onnx operator set: {total_ops} op types")
+    for label in (ELIGIBLE, BROKEN, CPU_ONLY, UNLISTED):
+        ops = table.get(label, [])
+        print(f"  {label:9s} {len(ops):4d}  {100 * len(ops) / total_ops:5.1f}%")
+    extra = sorted(set(pulsar2_ops.AX650_SUPPORTED_OPS) - set(onnx_op_types()))
+    print(f"  vendor-native entries (never match a standard node): {extra}")
+
+    if args.csv:
+        with open(args.csv, "w", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(["op_type", "classification"])
+            for op in onnx_op_types():
+                writer.writerow([op, classify(op)])
+        print(f"wrote {args.csv}")
+
+    for path in args.models:
+        total, eligible, blocked = summarise(path)
+        share = 100 * eligible / total if total else 0.0
+        print(f"\n{os.path.basename(path)}: {total} nodes, {share:.1f}% eligible")
+        for op, n in blocked.most_common(12):
+            print(f"    {op:48s} {n:6d}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/axera/pulsar2_ops.py
+++ b/scripts/axera/pulsar2_ops.py
@@ -255,7 +255,13 @@ AX650_SUPPORTED_OPS: frozenset = frozenset(
         "Swish",
         "Tanh",
         "Tile",
+        # Axera's own list spells it "Topk"; ONNX's operator is "TopK". Both
+        # are here because the vendor spelling matches no node in a real graph
+        # -- and the real-hardware op sweep built a "TopK" node successfully
+        # (see the README's "Systematic op coverage" section), so treating one
+        # as unsupported was a misclassification, not a missing capability.
         "Topk",
+        "TopK",
         "Transpose",
         "Unsqueeze",
         "Where",

--- a/tests/test_axera_op_coverage_report.py
+++ b/tests/test_axera_op_coverage_report.py
@@ -1,0 +1,111 @@
+"""Per-ONNX-op coverage for the AX650, checked offline.
+
+`scripts/axera/op_coverage.py` classifies every op in the ai.onnx default
+domain against the vendor's published support list, and counts a model's nodes
+by whether the NPU can take them. Neither needs Docker or a card, so unlike
+the rest of the Axera suite this runs on a stock CI runner.
+
+The check that earns its keep is the first one: an entry in the support list
+that is not a real ONNX op name matches nothing, so it silently understates
+coverage. That is not hypothetical -- `TopK` was on the list spelled `Topk`,
+and the real-hardware sweep had already built a `TopK` node successfully.
+"""
+
+import os
+import sys
+
+import numpy as np
+import onnx
+import onnx.defs
+from onnx import TensorProto, helper, numpy_helper
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import op_coverage  # noqa: E402
+import pulsar2_ops  # noqa: E402
+
+
+def test_every_supported_op_is_a_real_onnx_op_or_a_named_vendor_one():
+    """A support-list entry that is not an ai.onnx op name can never match a
+    node, so it costs coverage silently. The only entries allowed to do that
+    are the vendor's own fused ops, named explicitly."""
+    onnx_ops = set(op_coverage.onnx_op_types())
+    stray = set(pulsar2_ops.AX650_SUPPORTED_OPS) - onnx_ops
+    assert stray <= op_coverage.VENDOR_NATIVE | {"Topk"}, stray
+
+
+def test_topk_is_matched_under_its_onnx_spelling():
+    """Axera's list spells it `Topk`; ONNX's operator is `TopK`. The
+    real-hardware sweep built a `TopK` node, so classifying one as unsupported
+    was a misclassification rather than a missing capability."""
+    assert "TopK" in pulsar2_ops.AX650_SUPPORTED_OPS
+    assert op_coverage.classify("TopK") == op_coverage.ELIGIBLE
+    assert not pulsar2_ops.unsupported_on_ax650(
+        helper.make_model(
+            helper.make_graph(
+                [helper.make_node("TopK", ["x", "k"], ["v", "i"], largest=1, sorted=1)],
+                "g",
+                [
+                    helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 8]),
+                    helper.make_tensor_value_info("k", TensorProto.INT64, [1]),
+                ],
+                [
+                    helper.make_tensor_value_info("v", TensorProto.FLOAT, [1, 3]),
+                    helper.make_tensor_value_info("i", TensorProto.INT64, [1, 3]),
+                ],
+            ),
+            opset_imports=[helper.make_opsetid("", 17)],
+        )
+    )
+
+
+def test_the_table_partitions_the_whole_operator_set():
+    """Every ai.onnx op lands in exactly one bucket, and the buckets add up."""
+    ops = op_coverage.onnx_op_types()
+    table = op_coverage.coverage_table()
+    assert sum(len(v) for v in table.values()) == len(ops)
+    seen = [op for bucket in table.values() for op in bucket]
+    assert sorted(seen) == ops
+    assert len(set(seen)) == len(seen)
+    # The NPU takes a substantial minority of ONNX; a sweeping claim either way
+    # would be wrong, and this pins which.
+    assert 0.3 < len(table[op_coverage.ELIGIBLE]) / len(ops) < 0.6
+
+
+def test_model_usage_counts_nodes_without_loading_weights(tmp_path):
+    """Op types do not depend on weights, and these graphs routinely carry
+    hundreds of megabytes of external data, so the inventory must not need
+    them."""
+    weight = numpy_helper.from_array(np.zeros((4, 4, 3, 3), np.float32), "w")
+    graph = helper.make_graph(
+        [
+            helper.make_node(
+                "Conv", ["x", "w"], ["c"], kernel_shape=[3, 3], pads=[1] * 4
+            ),
+            helper.make_node("Relu", ["c"], ["r"]),
+            helper.make_node("Shape", ["r"], ["s"]),
+        ],
+        "g",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4, 8, 8])],
+        [helper.make_tensor_value_info("s", TensorProto.INT64, [4])],
+        initializer=[weight],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    path = str(tmp_path / "m.onnx")
+    onnx.save(
+        model,
+        path,
+        save_as_external_data=True,
+        location="m.onnx.data",
+        size_threshold=0,
+    )
+    os.remove(str(tmp_path / "m.onnx.data"))  # the weights are gone; ops remain
+
+    total, eligible, blocked = op_coverage.summarise(path)
+    assert total == 3
+    assert eligible == 2  # Conv and Relu
+    assert dict(blocked) == {"Shape": 1}


### PR DESCRIPTION
`scripts/axera/op_coverage.py` classifies every operator in the ai.onnx default domain against Axera's published support list, and counts a model's nodes by whether the NPU can take them. Neither needs Docker or a card, so both run in the existing no-hardware CI job.

| classification | ops | share of ai.onnx |
| --- | --- | --- |
| NPU-eligible | 83 | 41.1% |
| confirmed broken on real hardware | 6 | 3.0% |
| CPU-only by construction | 21 | 10.4% |
| not on the vendor's list | 92 | 45.5% |

## The audit paid for itself immediately

Axera's list spells the op **`Topk`**; ONNX's operator is **`TopK`**. A list entry that is not a real ONNX op name can never match a node, so every `TopK` in every graph was being classified unsupported — while the real-hardware op sweep had **already built a `TopK` node successfully**. A misclassification, not a missing capability, and nothing downstream could have noticed: the heuristic and the sweep never compared notes.

Both spellings are now in the list, and a test asserts that the only entries which are not ai.onnx names are the vendor's own fused ops (`InverseSigmoid`, `Silu`, `SpatialTransformer`), named explicitly. The general hazard is worth stating: **an entry that matches nothing fails silently and in the safe direction** — it shows up as a model being less compatible than it is, never as an error.

## Audio8, measured against the table

The Audio8 TTS/ASR packages (`tests/test_audio8.py`) are a good test of that table against real, awkward graphs. Counting their nodes, without downloading their weights:

| graph | nodes | NPU-eligible |
| --- | --- | --- |
| `codec_decoder_fp16` (TTS vocoder) | 3,341 | **94.0%** |
| `codec_encoder_fp16` | 4,916 | 93.7% |
| `slow_ar_int8` | 16,426 | 91.8% |
| `lm_cache_decode_int4` | 943 | 92.3% |
| `llm_kv_cpu_fp32_int4` | 6,651 | 89.5% |
| `genai_int4_qwen/model` | 299 | 34.8% |

61 distinct op types, 47 NPU-eligible. The 14 that are not split three ways, and the distinction matters more than the percentage:

- **`com.microsoft` contrib ops** — `MatMulNBits` (546 nodes), `SkipSimplifiedLayerNormalization`, `GroupQueryAttention`, `GatherBlockQuantized`. No ai.onnx equivalent in the graph; no simplification turns them back into standard ops.
- **ORT dynamic-quantization plumbing** — `MatMulInteger` (240), `DynamicQuantizeLinear` (140). Not an obstacle so much as the wrong starting point: the NPU quantizes for itself, so the float export is what to feed it.
- **Ordinary ONNX ops the list lacks** — `Shape` alone is **2,293 nodes**, with `Range`, `Neg`, `Reciprocal`, `Trilu`, `Einsum` behind it. Shape arithmetic is exactly what constant-folding removes once input shapes are fixed, which is onnxsim's own job.

So the read is three verdicts, not one: the **codec decoder is the promising target** (a convolutional vocoder at 94%, the same shape of model as the Piper decoder this project already compiled and ran on an AX650N to produce audible speech); the **autoregressive halves are not an ONNX problem at all** (transformer decoders, which Axera compiles from a checkpoint via `llm_build`); and the **`com.microsoft` INT4 exports are a dead end** for this toolchain in the form they ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS