### PR TITLE
axera: a legalizer for the AX650, earned from compiling Audio8

### DIFF
--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -52,6 +52,7 @@ on:
       - "tests/test_axera_mcode_structure.py"
       - "tests/test_axera_mcode_validator.py"
       - "tests/test_axera_op_coverage_report.py"
+      - "tests/test_axera_legalize.py"
 
 concurrency:
   group: axera-integration-${{ github.ref }}
@@ -119,7 +120,7 @@ jobs:
       - name: Run in-tree smoke tests
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py" "$GITHUB_WORKSPACE/tests/test_axera_legalize.py"
       - name: Run static Pulsar2 compatibility suite
         working-directory: ${{ runner.temp }}
         run: |

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -5344,6 +5344,82 @@ those from a checkpoint through `llm_build`, never from an ONNX export. And
 the **`com.microsoft` INT4 exports are a dead end** for this toolchain in the
 form they ship.
 
+## A legalizer for the AX650, and what compiling Audio8 taught it
+
+Op coverage says whether a graph's op *types* are on the vendor's list.
+The Audio8 codec decoder is the case that shows how far short of sufficient
+that is: after conversion and simplification it reaches **99.3% NPU-eligible**,
+and it still does not compile. `legalize.py` is where the difference lives --
+semantics-preserving rewrites that make a graph acceptable, each one added
+because a real `pulsar2 build` refused a real model without it.
+
+### Getting the decoder ready
+
+| stage | nodes | NPU-eligible |
+| --- | --- | --- |
+| as shipped (fp16, symbolic shapes) | 3,341 | 93.8% |
+| float32, batch and frames frozen, simplified | 871 | 99.3% |
+
+The blockers collapse from `Shape` (170), `Reciprocal` (29), `Range`, `Einsum`
+to a single op type. Shape arithmetic was never a real obstacle -- it only
+existed because the batch and frame count were symbolic, and folding it away
+is onnxsim's own job.
+
+**`float16_to_float32` is the first rule, and it is fiddlier than it sounds.**
+Constants live in three places: the initializer list, the `value` attribute of
+`Constant` nodes, and the `to` attribute of `Cast`. This decoder has 214
+initializers and **1,174 `Constant` nodes**, so converting only the
+initializers -- the obvious implementation -- leaves a graph that binds a
+single `Div` to both `float` and `float16`, which onnxruntime rejects outright.
+
+### Then the compiler's own fused ops take over
+
+What blocks this model is not an ONNX op at all. Pulsar2 pattern-matches the
+Snake activation `x + sin(alpha*x)**2 / alpha` -- 29 of them in the vocoder
+trunk -- into a **native `AxQuantizedSnake`** carrying per-channel alpha, and
+that op then fails to build at both ends of the size range:
+
+| frames | tensor | failure |
+| --- | --- | --- |
+| 110 | `(1, 384, 28160)` | `NoTilerException` -- no tiler for that length |
+| 8 | dim 2: 32 vs 1536 | `OpBuildException: broadcast dim 2 mismatch` |
+
+**`pow2_to_mul` answers it.** Rewriting `Pow(x, 2)` to `Mul(x, x)` is exact for
+floats, and it stops the matcher: after the rewrite `AxQuantizedSnake` appears
+**zero times** in the build log, and the build proceeds past it. The unfused
+`Sin`/`Mul`/`Div`/`Add` are each on the supported list. Confirmed
+semantics-preserving on the real decoder against onnxruntime -- 46 sites,
+maximum absolute difference 8.8e-7, correlation 1.00000000.
+
+That is the general point, and the reason a legalizer cannot be derived from
+an op list: **the op that blocked this model appears in no ONNX graph and on no
+support list, because the compiler invents it during fusion.**
+
+### The remaining blockers, and one rule the compiler undoes
+
+Each build gets strictly further, which is how you tell a legalizer is working:
+
+1. `AxQuantizedSnake` -- fixed by `pow2_to_mul`.
+2. `AxClip`, `min 0 max 4095`, `dtype.num_bits=16, lut.output_dtype.num_bits=32`
+   -- the clamp on codec token indices. This is the int64 `codes` input, and
+   the answer is not a rewrite but a cut: feeding the vocoder body its float
+   feature map instead of tokens sidesteps it. (Worth recording separately
+   that Pulsar2's frontend and PTQ *do* accept an int64 input; it is the
+   backend's Clip that refuses.)
+3. `AxQuantizedConv` with `padding=(54, 0)`, `dilation=9` -- the causal
+   convolutions.
+
+**`explicit_conv_padding` is the honest failure here.** Hoisting asymmetric
+padding into an explicit `Pad` node is a correct rewrite -- 16 sites, verified
+identical to 5.4e-7 -- and it does not help, because **Pulsar2 re-fuses `Pad`
+into `Conv`**: the next build reports the identical `padding=(54, 0)`. The rule
+is kept because it is right and cheap, and because knowing the frontend undoes
+it is worth more than not knowing. A rewrite that survives fusion would have to
+change the convolution itself, not its padding.
+
+So the decoder does not compile yet, and what stands between is now three named
+things rather than a percentage.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`

--- a/scripts/axera/legalize.py
+++ b/scripts/axera/legalize.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Rewrites that make an ONNX graph acceptable to Pulsar2 for the AX650N.
+
+Every rule here exists because a real `pulsar2 build` refused a real model
+without it, and each records which failure it answers. They are semantics-
+preserving: a legalized graph computes the same function, it is only spelled
+in a way the compiler can lower.
+
+This is deliberately separate from op *coverage* (`op_coverage.py`). Coverage
+asks whether the ONNX op types are on the vendor's list, which is necessary
+and, as the Audio8 codec decoder showed, nowhere near sufficient -- that graph
+reaches 99.3% eligible and still fails, on an op the compiler *fuses into
+existence itself*. A legalizer is how you act on that gap.
+
+Usage::
+
+    legalize.py in.onnx out.onnx            # apply every rule
+    legalize.py --rules pow2_to_mul in.onnx out.onnx
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+
+import numpy as np
+import onnx
+from onnx import AttributeProto, TensorProto, helper, numpy_helper
+
+
+def float16_to_float32(model):
+    """Retype an all-float16 graph to float32.
+
+    Pulsar2 takes float32. An fp16 export has its constants in three places,
+    and missing any one leaves a graph that mixes precisions: the initializer
+    list, the `value` attribute of `Constant` nodes, and the `to` attribute of
+    `Cast`. Converting only the initializers -- 214 of them in the Audio8
+    codec decoder, against 1,174 `Constant` nodes -- produces a model ONNX
+    Runtime rejects with "Type parameter (T) of Optype (Div) bound to
+    different types (tensor(float) and tensor(float16))".
+    """
+    changed = 0
+    for init in model.graph.initializer:
+        if init.data_type == TensorProto.FLOAT16:
+            arr = numpy_helper.to_array(init).astype(np.float32)
+            init.CopyFrom(numpy_helper.from_array(arr, init.name))
+            changed += 1
+    for node in model.graph.node:
+        for attr in node.attribute:
+            if (
+                node.op_type == "Cast"
+                and attr.name == "to"
+                and attr.i == TensorProto.FLOAT16
+            ):
+                attr.i = TensorProto.FLOAT
+                changed += 1
+            if (
+                attr.type == AttributeProto.TENSOR
+                and attr.t.data_type == TensorProto.FLOAT16
+            ):
+                arr = numpy_helper.to_array(attr.t).astype(np.float32)
+                attr.t.CopyFrom(numpy_helper.from_array(arr, attr.t.name))
+                changed += 1
+            if attr.type == AttributeProto.TENSORS:
+                for t in attr.tensors:
+                    if t.data_type == TensorProto.FLOAT16:
+                        arr = numpy_helper.to_array(t).astype(np.float32)
+                        t.CopyFrom(numpy_helper.from_array(arr, t.name))
+                        changed += 1
+    for value in (
+        list(model.graph.input)
+        + list(model.graph.output)
+        + list(model.graph.value_info)
+    ):
+        if value.type.tensor_type.elem_type == TensorProto.FLOAT16:
+            value.type.tensor_type.elem_type = TensorProto.FLOAT
+            changed += 1
+    return changed
+
+
+def _scalar_constant(model, name):
+    """The scalar value of `name` if it is a constant, else None."""
+    for init in model.graph.initializer:
+        if init.name == name:
+            arr = numpy_helper.to_array(init)
+            return float(arr.reshape(-1)[0]) if arr.size == 1 else None
+    for node in model.graph.node:
+        if node.op_type == "Constant" and node.output and node.output[0] == name:
+            for attr in node.attribute:
+                if attr.name == "value":
+                    arr = numpy_helper.to_array(attr.t)
+                    return float(arr.reshape(-1)[0]) if arr.size == 1 else None
+    return None
+
+
+def pow2_to_mul(model):
+    """`Pow(x, 2)` becomes `Mul(x, x)`.
+
+    Exact for floats, and one fewer transcendental op. It also stops Pulsar2
+    matching the Snake activation `x + sin(alpha*x)**2 / alpha`, which it
+    otherwise fuses into a native `AxQuantizedSnake` that then fails to build
+    at every size tried: `NoTilerException` on a `(1,384,28160)` tensor, and
+    `OpBuildException: broadcast dim 2: 32 1536 mismatch` on a small one. The
+    unfused `Sin`/`Mul`/`Div`/`Add` are each on the supported list.
+    """
+    changed = 0
+    for node in model.graph.node:
+        if node.op_type != "Pow" or len(node.input) != 2:
+            continue
+        if _scalar_constant(model, node.input[1]) != 2.0:
+            continue
+        base = node.input[0]
+        del node.input[:]
+        node.input.extend([base, base])
+        node.op_type = "Mul"
+        changed += 1
+    return changed
+
+
+def explicit_conv_padding(model):
+    """A convolution with asymmetric padding gets an explicit `Pad` instead.
+
+    The Audio8 vocoder's causal convolutions carry `pads=(54, 0)` -- all of it
+    on the left -- alongside `dilation=9`, and Pulsar2's backend refuses the
+    fused `AxQuantizedConv` for one. Hoisting the padding into a `Pad` node
+    leaves the convolution with symmetric (zero) padding, which is the form
+    every other convolution in the graph already has.
+
+    Semantics are unchanged: zero-padding explicitly and then convolving with
+    no padding is what the attribute means.
+    """
+    changed = 0
+    nodes = list(model.graph.node)
+    out = []
+    for node in nodes:
+        pads = None
+        for attr in node.attribute:
+            if attr.name == "pads":
+                pads = list(attr.ints)
+        if node.op_type != "Conv" or not pads or len(pads) % 2:
+            out.append(node)
+            continue
+        half = len(pads) // 2
+        begin, end = pads[:half], pads[half:]
+        if begin == end:
+            out.append(node)
+            continue
+        name = node.input[0] + f"_padded_{changed}"
+        full = [0, 0] + begin + [0, 0] + end
+        pads_init = numpy_helper.from_array(
+            np.array(full, np.int64), node.name + "_pads"
+        )
+        model.graph.initializer.append(pads_init)
+        out.append(
+            helper.make_node(
+                "Pad",
+                [node.input[0], pads_init.name],
+                [name],
+                name=node.name + "_explicit_pad",
+                mode="constant",
+            )
+        )
+        node.input[0] = name
+        for attr in node.attribute:
+            if attr.name == "pads":
+                del attr.ints[:]
+                attr.ints.extend([0] * len(pads))
+        out.append(node)
+        changed += 1
+    if changed:
+        del model.graph.node[:]
+        model.graph.node.extend(out)
+    return changed
+
+
+RULES = {
+    "float16_to_float32": float16_to_float32,
+    "pow2_to_mul": pow2_to_mul,
+    "explicit_conv_padding": explicit_conv_padding,
+}
+
+
+def legalize(model, rules=None):
+    """Apply the named rules in order; returns `{rule: sites changed}`."""
+    applied = collections.OrderedDict()
+    for name in rules or RULES:
+        applied[name] = RULES[name](model)
+    return applied
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input")
+    parser.add_argument("output")
+    parser.add_argument("--rules", nargs="*", choices=sorted(RULES))
+    args = parser.parse_args(argv)
+
+    model = onnx.load(args.input)
+    for name, n in legalize(model, args.rules).items():
+        print(f"  {name}: {n} sites")
+    onnx.save(
+        model,
+        args.output,
+        save_as_external_data=True,
+        location=args.output.rsplit("/", 1)[-1] + ".data",
+        size_threshold=1024,
+    )
+    print("wrote", args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_axera_legalize.py
+++ b/tests/test_axera_legalize.py
@@ -1,0 +1,184 @@
+"""AX650 legalization rewrites, checked offline.
+
+`scripts/axera/legalize.py` holds rewrites that make a graph acceptable to
+Pulsar2. Each exists because a real build refused a real model without it, so
+the tests here check the two properties that matter: the rewrite fires where
+it should, and it does not change what the graph computes.
+
+Neither needs Docker or a card.
+"""
+
+import os
+import sys
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import legalize  # noqa: E402
+
+
+def _snake_model(dtype=TensorProto.FLOAT, exponent_as_initializer=True):
+    """`x + sin(alpha*x)**2 / alpha` -- the Snake activation, spelled the way
+    a real neural-codec export spells it."""
+    np_dtype = np.float16 if dtype == TensorProto.FLOAT16 else np.float32
+    alpha = numpy_helper.from_array(np.array([2.0], np_dtype), "alpha")
+    two = numpy_helper.from_array(np.array(2.0, np_dtype), "two")
+    nodes = [
+        helper.make_node("Mul", ["x", "alpha"], ["ax"]),
+        helper.make_node("Sin", ["ax"], ["s"]),
+        helper.make_node("Pow", ["s", "two"], ["s2"]),
+        helper.make_node("Div", ["s2", "alpha"], ["d"]),
+        helper.make_node("Add", ["x", "d"], ["y"]),
+    ]
+    initializer = [alpha, two]
+    if not exponent_as_initializer:
+        initializer = [alpha]
+        nodes.insert(2, helper.make_node("Constant", [], ["two"], value=two))
+    graph = helper.make_graph(
+        nodes,
+        "snake",
+        [helper.make_tensor_value_info("x", dtype, [1, 4, 8])],
+        [helper.make_tensor_value_info("y", dtype, [1, 4, 8])],
+        initializer=initializer,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 10
+    return model
+
+
+def test_pow2_becomes_mul_and_computes_the_same_thing():
+    """`Pow(x, 2)` -> `Mul(x, x)` is exact, and it is what stops Pulsar2 fusing
+    a Snake activation into the native op that then fails to build."""
+    ort = __import__("onnxruntime")
+    before = _snake_model()
+    after = _snake_model()
+    assert legalize.pow2_to_mul(after) == 1
+    assert [n.op_type for n in after.graph.node].count("Pow") == 0
+    onnx.checker.check_model(after)
+
+    x = np.random.RandomState(0).randn(1, 4, 8).astype(np.float32)
+    runs = []
+    for model in (before, after):
+        session = ort.InferenceSession(
+            model.SerializeToString(), providers=["CPUExecutionProvider"]
+        )
+        runs.append(session.run(None, {"x": x})[0])
+    assert np.allclose(runs[0], runs[1], atol=1e-6), np.abs(runs[0] - runs[1]).max()
+
+
+def test_pow2_finds_the_exponent_however_it_is_stored():
+    """An export may put the exponent in an initializer or in a `Constant`
+    node; a rule that only looks in one place fires on half the graphs."""
+    for as_init in (True, False):
+        model = _snake_model(exponent_as_initializer=as_init)
+        assert legalize.pow2_to_mul(model) == 1, as_init
+
+
+def test_pow2_leaves_other_exponents_alone():
+    """Only the exponent 2 is exact as a self-multiply."""
+    model = _snake_model()
+    for init in model.graph.initializer:
+        if init.name == "two":
+            init.CopyFrom(numpy_helper.from_array(np.array(3.0, np.float32), "two"))
+    assert legalize.pow2_to_mul(model) == 0
+    assert [n.op_type for n in model.graph.node].count("Pow") == 1
+
+
+def test_float16_graph_is_retyped_everywhere_it_matters():
+    """Constants live in three places -- initializers, `Constant` attributes
+    and `Cast` targets -- and converting only the first leaves a graph that
+    mixes precisions inside a single op, which onnxruntime rejects outright."""
+    model = _snake_model(dtype=TensorProto.FLOAT16, exponent_as_initializer=False)
+    model.graph.node.append(
+        helper.make_node("Cast", ["y"], ["y16"], to=TensorProto.FLOAT16)
+    )
+    model.graph.output[0].name = "y16"
+
+    assert legalize.float16_to_float32(model) > 0
+    assert all(t.data_type != TensorProto.FLOAT16 for t in model.graph.initializer)
+    for node in model.graph.node:
+        for attr in node.attribute:
+            if attr.name == "value":
+                assert attr.t.data_type != TensorProto.FLOAT16
+            if node.op_type == "Cast" and attr.name == "to":
+                assert attr.i != TensorProto.FLOAT16
+    for value in list(model.graph.input) + list(model.graph.output):
+        assert value.type.tensor_type.elem_type != TensorProto.FLOAT16
+
+    ort = __import__("onnxruntime")
+    ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )  # loads, which the half-converted graph does not
+
+
+def _causal_conv_model():
+    """A convolution padded only on the left -- the causal form a streaming
+    codec uses, and the one Pulsar2's backend refuses."""
+    w = numpy_helper.from_array(
+        np.random.RandomState(0).randn(4, 4, 3).astype(np.float32), "w"
+    )
+    graph = helper.make_graph(
+        [
+            helper.make_node(
+                "Conv", ["x", "w"], ["y"], kernel_shape=[3], pads=[4, 0], dilations=[2]
+            )
+        ],
+        "causal",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4, 16])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4, 16])],
+        initializer=[w],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 10
+    return model
+
+
+def test_asymmetric_padding_is_hoisted_into_a_pad_node():
+    """Asymmetric `pads` become an explicit `Pad`, leaving the convolution
+    with the symmetric padding every other convolution already has."""
+    ort = __import__("onnxruntime")
+    before = _causal_conv_model()
+    after = _causal_conv_model()
+    assert legalize.explicit_conv_padding(after) == 1
+    assert [n.op_type for n in after.graph.node] == ["Pad", "Conv"]
+    conv = after.graph.node[1]
+    pads = next(a.ints for a in conv.attribute if a.name == "pads")
+    assert list(pads) == [0, 0]
+    onnx.checker.check_model(after)
+
+    x = np.random.RandomState(1).randn(1, 4, 16).astype(np.float32)
+    runs = [
+        __import__("onnxruntime")
+        .InferenceSession(m.SerializeToString(), providers=["CPUExecutionProvider"])
+        .run(None, {"x": x})[0]
+        for m in (before, after)
+    ]
+    assert np.allclose(runs[0], runs[1], atol=1e-5), np.abs(runs[0] - runs[1]).max()
+    assert ort is not None
+
+
+def test_symmetric_padding_is_left_alone():
+    """Only asymmetry needs hoisting; rewriting every convolution would add a
+    node per layer for nothing."""
+    model = _causal_conv_model()
+    for attr in model.graph.node[0].attribute:
+        if attr.name == "pads":
+            del attr.ints[:]
+            attr.ints.extend([2, 2])
+    assert legalize.explicit_conv_padding(model) == 0
+    assert [n.op_type for n in model.graph.node] == ["Conv"]
+
+
+def test_legalize_reports_what_each_rule_changed():
+    model = _snake_model(dtype=TensorProto.FLOAT16)
+    applied = legalize.legalize(model)
+    assert set(applied) == set(legalize.RULES)
+    assert applied["pow2_to_mul"] == 1
+    assert applied["float16_to_float32"] > 0


### PR DESCRIPTION
Op coverage says whether a graph's op *types* are on the vendor's list. The Audio8 codec decoder shows how far short of sufficient that is: after conversion and simplification it reaches **99.3% NPU-eligible** and still does not compile. `scripts/axera/legalize.py` is where the difference lives — semantics-preserving rewrites, each added because a real `pulsar2 build` refused a real model without it.

| rule | sites on the real decoder |
| --- | --- |
| `float16_to_float32` | 214 initializers + 1,174 `Constant` attrs + 57 `Cast` |
| `pow2_to_mul` | 46 |
| `explicit_conv_padding` | 16 |

**`float16_to_float32` is fiddlier than it sounds.** Constants live in three places: the initializer list, `Constant` nodes' `value` attributes, and `Cast` targets. Converting only the initializers — the obvious implementation — leaves a graph binding one `Div` to both `float` and `float16`, which onnxruntime rejects outright.

## The op that blocks it is one the compiler invents

Pulsar2 pattern-matches the Snake activation `x + sin(alpha*x)**2 / alpha` — 29 of them in the vocoder trunk — into a native **`AxQuantizedSnake`** with per-channel alpha, which then fails to build at *both* ends of the size range:

| frames | tensor | failure |
| --- | --- | --- |
| 110 | `(1, 384, 28160)` | `NoTilerException` — no tiler for that length |
| 8 | dim 2: 32 vs 1536 | `OpBuildException: broadcast dim 2 mismatch` |

**`pow2_to_mul` answers it.** `Pow(x, 2)` → `Mul(x, x)` is exact for floats and stops the matcher: afterwards `AxQuantizedSnake` appears **zero times** in the build log and the build proceeds past it. Verified semantics-preserving on the real decoder against onnxruntime — max abs diff **8.8e-7**, correlation **1.00000000**.

That is why a legalizer cannot be derived from an op list: **the op that blocked this model appears in no ONNX graph and on no support list, because the compiler invents it during fusion.**

## One rule the compiler undoes, kept deliberately

`explicit_conv_padding` hoists asymmetric `pads` into an explicit `Pad`. It is a correct rewrite (16 sites, identical to 5.4e-7) and **it does not help**: pulsar2 re-fuses `Pad` into `Conv`, and the next build reports the identical `padding=(54, 0)`. Kept because it is right and cheap, and because knowing the frontend undoes it is worth more than not knowing — a rewrite that survives fusion would have to change the convolution itself.

## Where the decoder stands

Each build gets strictly further, which is how you tell the legalizer is working:

1. `AxQuantizedSnake` → fixed by `pow2_to_mul`
2. `AxClip(0, 4095)`, `dtype.num_bits=16 / lut.output_dtype.num_bits=32` — the codec token-index clamp. Not a rewrite but a cut: feed the vocoder body its float feature map. (Separately worth recording: pulsar2's frontend and PTQ *do* accept an int64 input; it is the backend's Clip that refuses.)
3. `AxQuantizedConv` with `padding=(54,0)`, `dilation=9` — the causal convolutions.

**The decoder does not compile yet**, and what stands between is now three named things rather than a percentage.

Seven offline tests, wired into the existing no-hardware CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS