### PR TITLE
Port LoRA block auto-discovery (discover_lora_blocks) to C++

### DIFF
--- a/onnxsim/lora_entry.cpp
+++ b/onnxsim/lora_entry.cpp
@@ -1219,6 +1219,131 @@ void RefuseUnsupported(const std::vector<onnx::NodeProto>& nodes) {
 }
 
 // ---------------------------------------------------------------------------
+// Block discovery -- faithful ports of qat.py's _liveness_cuts and
+// _primary_graph_input, the two helpers lora.py's discover_lora_blocks
+// calls. See lora_entry.h's DiscoverLoraBlocks for the argument summary and
+// qat.py's own docstrings (read in full before touching either function
+// below) for the actual liveness argument -- it is not re-derived here.
+// ---------------------------------------------------------------------------
+
+// Every index at which `graph` narrows to a single live activation, paired
+// with the tensor that survives it -- index -1 meaning "before the first
+// node". A faithful port of qat.py::_liveness_cuts; see that function's
+// docstring for why this is the whole of boundary discovery. `primary_input`
+// is the one graph input kept in the live set (ordinarily
+// PrimaryGraphInput(graph)'s result, or "" for a graph with none); every
+// other graph input is excluded from liveness entirely, exactly as
+// _liveness_cuts documents.
+std::vector<std::pair<int, std::string>> LivenessCuts(
+    const onnx::GraphProto& graph, const std::string& primary_input) {
+  std::set<std::string> initializers;
+  for (const onnx::TensorProto& t : graph.initializer()) {
+    initializers.insert(t.name());
+  }
+  std::set<std::string> graph_inputs;
+  for (const onnx::ValueInfoProto& input : graph.input()) {
+    if (initializers.count(input.name()) == 0) {
+      graph_inputs.insert(input.name());
+    }
+  }
+  std::set<std::string> ignored;
+  for (const std::string& name : graph_inputs) {
+    if (name != primary_input) ignored.insert(name);
+  }
+
+  // A tensor is live until its last consumer; a graph output is live past
+  // the end of the graph, so it is never dropped before the final gap.
+  const int node_count = graph.node_size();
+  std::map<std::string, int> last_use;
+  for (int index = 0; index < node_count; ++index) {
+    for (const std::string& name : graph.node(index).input()) {
+      if (!name.empty() && initializers.count(name) == 0 &&
+          ignored.count(name) == 0) {
+        last_use[name] = index;
+      }
+    }
+  }
+  for (const onnx::ValueInfoProto& out : graph.output()) {
+    if (!out.name().empty() && initializers.count(out.name()) == 0 &&
+        ignored.count(out.name()) == 0) {
+      last_use[out.name()] = node_count;
+    }
+  }
+  auto last_use_of = [&last_use](const std::string& name) -> int {
+    const auto it = last_use.find(name);
+    return it == last_use.end() ? -1 : it->second;
+  };
+
+  std::vector<std::pair<int, std::string>> cuts;
+  std::set<std::string> live;
+  for (const std::string& name : graph_inputs) {
+    if (ignored.count(name) == 0 && last_use_of(name) > -1) live.insert(name);
+  }
+  if (live.size() == 1) cuts.emplace_back(-1, *live.begin());
+
+  for (int index = 0; index < node_count; ++index) {
+    for (const std::string& name : graph.node(index).output()) {
+      if (!name.empty() && ignored.count(name) == 0 &&
+          last_use_of(name) > index) {
+        live.insert(name);
+      }
+    }
+    std::set<std::string> still_live;
+    for (const std::string& name : live) {
+      if (last_use_of(name) > index) still_live.insert(name);
+    }
+    live = std::move(still_live);
+    if (live.size() == 1) cuts.emplace_back(index, *live.begin());
+  }
+  return cuts;
+}
+
+// The graph input the most nodes depend on -- the main activation path,
+// empty when `graph` has no non-initializer input. A faithful port of
+// qat.py::_primary_graph_input; see that function's docstring for why "reach
+// the most nodes" is the right heuristic and why getting it wrong costs
+// block granularity, not correctness. Ties go to the earlier graph input.
+std::string PrimaryGraphInput(const onnx::GraphProto& graph) {
+  std::set<std::string> initializers;
+  for (const onnx::TensorProto& t : graph.initializer()) {
+    initializers.insert(t.name());
+  }
+  std::vector<std::string> candidates;
+  for (const onnx::ValueInfoProto& input : graph.input()) {
+    if (initializers.count(input.name()) == 0) {
+      candidates.push_back(input.name());
+    }
+  }
+  if (candidates.empty()) return "";
+
+  std::string best_name = candidates[0];
+  int64_t best_reach = -1;
+  for (const std::string& name : candidates) {
+    std::set<std::string> reached{name};
+    int64_t count = 0;
+    for (const onnx::NodeProto& node : graph.node()) {
+      bool depends = false;
+      for (const std::string& in : node.input()) {
+        if (!in.empty() && reached.count(in) != 0) {
+          depends = true;
+          break;
+        }
+      }
+      if (!depends) continue;
+      ++count;
+      for (const std::string& out : node.output()) {
+        if (!out.empty()) reached.insert(out);
+      }
+    }
+    if (count > best_reach) {
+      best_name = name;
+      best_reach = count;
+    }
+  }
+  return best_name;
+}
+
+// ---------------------------------------------------------------------------
 // Shapes -- mirrors qat_entry.cpp's StaticDims/FloatShapeInfo/
 // InferFloatShapes/ElemTypeOr/SetValueInfo/BlockShapes.
 // ---------------------------------------------------------------------------
@@ -1524,6 +1649,115 @@ LoraInjectionResult InjectLora(const onnx::ModelProto& model,
 
   onnx::checker::check_model(result.model);
   return result;
+}
+
+std::vector<LoraBlock> DiscoverLoraBlocks(
+    const onnx::ModelProto& injected_model, const LoraAdapter& adapter,
+    int64_t max_targets_per_block) {
+  if (max_targets_per_block < 1) {
+    throw std::invalid_argument("max_targets_per_block must be at least 1");
+  }
+
+  const onnx::GraphProto& graph = injected_model.graph();
+  const std::vector<std::pair<int, std::string>> cuts =
+      LivenessCuts(graph, PrimaryGraphInput(graph));
+  std::set<std::string> target_outputs;
+  for (const LoraTarget& t : adapter.targets)
+    target_outputs.insert(t.node_output);
+
+  // Walk consecutive cut pairs exactly as lora.py's discover_lora_blocks
+  // does: `start` is the cut a pending block began at (unset only when
+  // `cuts` itself is empty, which skips this loop entirely), `count` how
+  // many of `adapter`'s own target outputs have accumulated into it since.
+  std::vector<std::pair<std::string, std::string>> pairs;
+  bool have_start = !cuts.empty();
+  std::pair<int, std::string> start;
+  if (have_start) start = cuts.front();
+  int64_t count = 0;
+
+  for (size_t i = 0; i + 1 < cuts.size(); ++i) {
+    const std::pair<int, std::string>& previous = cuts[i];
+    const std::pair<int, std::string>& current = cuts[i + 1];
+    bool gap = false;
+    for (int index = previous.first + 1; index <= current.first; ++index) {
+      if (SupportedOps().count(graph.node(index).op_type()) == 0) {
+        gap = true;
+        break;
+      }
+    }
+    if (gap) {
+      // A gap. Close whatever was pending before it and reopen after.
+      if (have_start && count > 0 && start.first < previous.first) {
+        pairs.emplace_back(start.second, previous.second);
+      }
+      start = current;
+      have_start = true;
+      count = 0;
+      continue;
+    }
+    if (!have_start) {
+      start = previous;
+      have_start = true;
+    }
+    for (int index = previous.first + 1; index <= current.first; ++index) {
+      for (const std::string& out : graph.node(index).output()) {
+        if (target_outputs.count(out) != 0) ++count;
+      }
+    }
+    if (count >= max_targets_per_block) {
+      pairs.emplace_back(start.second, current.second);
+      start = current;
+      count = 0;
+    }
+  }
+  if (have_start && count > 0 && !cuts.empty() &&
+      start.first < cuts.back().first) {
+    pairs.emplace_back(start.second, cuts.back().second);
+  }
+
+  std::vector<LoraBlock> blocks;
+  for (const auto& pair : pairs) {
+    BlockSlice slice;
+    try {
+      slice = SliceBlock(graph, pair.first, pair.second);
+    } catch (const std::invalid_argument&) {
+      // Defensive, matching discover_lora_blocks: the span construction
+      // above already guarantees a non-empty, block_output_name-producing
+      // slice.
+      continue;
+    }
+    std::set<std::string> block_outputs;
+    for (const onnx::NodeProto& node : slice.nodes) {
+      for (const std::string& out : node.output()) {
+        if (!out.empty()) block_outputs.insert(out);
+      }
+    }
+    std::vector<std::string> block_targets;
+    for (const LoraTarget& t : adapter.targets) {
+      if (block_outputs.count(t.node_output) != 0) {
+        block_targets.push_back(t.node_output);
+      }
+    }
+    // Structurally unreachable given how `pairs` was built above -- every
+    // pair spans at least one node whose output is a target -- but kept for
+    // symmetry with discover_lora_blocks's own defensive check.
+    if (block_targets.empty()) continue;
+
+    std::set<std::string> op_type_set;
+    for (const onnx::NodeProto& node : slice.nodes) {
+      op_type_set.insert(node.op_type());
+    }
+
+    LoraBlock block;
+    block.input_name = pair.first;
+    block.output_name = pair.second;
+    block.target_outputs = std::move(block_targets);
+    block.external_inputs = slice.externals;  // already sorted
+    block.op_types.assign(op_type_set.begin(), op_type_set.end());
+    block.num_nodes = static_cast<int64_t>(slice.nodes.size());
+    blocks.push_back(std::move(block));
+  }
+  return blocks;
 }
 
 // A finding worth recording here rather than only in a commit message:

--- a/onnxsim/lora_entry.h
+++ b/onnxsim/lora_entry.h
@@ -191,6 +191,79 @@ LoraInjectionResult InjectLora(const onnx::ModelProto& model,
                                const InjectLoraOptions& options = {});
 
 // ---------------------------------------------------------------------------
+// DiscoverLoraBlocks -- the C++ port of onnxsim/lora.py's
+// discover_lora_blocks, which itself reuses onnxsim/qat.py's
+// _liveness_cuts/_primary_graph_input
+// ---------------------------------------------------------------------------
+
+// One trainable block DiscoverLoraBlocks found, named the way a caller would
+// name one for BuildLoraStepGraph by hand. Mirrors lora.py's LoraBlock field
+// for field.
+struct LoraBlock {
+  std::string input_name;
+  std::string output_name;
+  std::vector<std::string> target_outputs;   // never empty
+  std::vector<std::string> external_inputs;  // sorted, input_name included
+  std::vector<std::string> op_types;         // deduplicated, sorted
+  int64_t num_nodes = 0;
+};
+
+// Partitions `injected_model` into a sequence of blocks BuildLoraStepGraph
+// can train, without a caller naming a single block_input_name/
+// block_output_name pair by hand -- the C++ port of lora.py's own
+// discover_lora_blocks, which itself reuses qat.py's _liveness_cuts /
+// _primary_graph_input verbatim (ported here as the same-named
+// anonymous-namespace helpers in lora_entry.cpp). Those two functions'
+// docstrings carry the actual argument and are not repeated here, on this
+// header's own standing policy of one place to update when a derivation
+// changes -- but in one sentence: a slice is trainable iff it is
+// **differentiable** (every op inside is in graph_grad::SupportedOps()) and
+// **self-contained** (the graph narrows to exactly one live tensor at both
+// of its boundaries, so cutting it out there severs nothing else still in
+// use). _liveness_cuts finds every such boundary by a liveness argument, not
+// by recognizing architectures -- initializers and every non-primary graph
+// input are excluded from the live set, so a second input (an attention
+// mask, say) never suppresses a cut the way it would if it were counted as
+// an ordinary activation; _primary_graph_input picks which input keeps that
+// power, by reachability, ties going to the earlier input. Neither can see a
+// tensor computed purely from initializers for what it is -- such a tensor
+// is counted as an ordinary live activation and so suppresses cuts across
+// its own live range -- but that is conservative (fewer, larger blocks, or
+// none), not incorrect.
+//
+// This walks consecutive cut pairs in graph order, treats any node in a span
+// whose op type is not in SupportedOps() as a hard gap that closes whatever
+// block was pending and reopens after it, and otherwise accumulates that
+// span's node outputs that are one of `adapter`'s own
+// LoraTarget::node_output tensors -- the same tensor InjectLora restored the
+// original node's name to -- closing a block once that running count
+// reaches `max_targets_per_block`. A final pending block, if any, is closed
+// against the last cut once the walk ends.
+//
+// This does NOT call FoldFrozenPrefixes: like lora.py's own
+// discover_lora_blocks, it has no notion of "frozen", so it treats every
+// unsupported op as a hard gap even where BuildLoraStepGraph could in
+// principle train through it by capturing it as a block-external constant
+// (an NF4 dequant chain's Cast, say -- see BuildLoraStepGraph's own comment
+// on why SliceBlock captures rather than folds it). That is conservative,
+// not incorrect: run this against an apply_qlora-composed model and it may
+// propose fewer or smaller blocks than a hand-named BuildLoraStepGraph call
+// could actually train; it never proposes one that cannot train.
+//
+// Throws std::invalid_argument when `max_targets_per_block < 1`, message
+// mirroring lora.py's own ValueError ("max_targets_per_block must be at
+// least 1"). Boundaries are found in `injected_model`'s own graph -- the one
+// BuildLoraStepGraph differentiates -- so pass the model InjectLora/
+// apply_qlora produced, not the original float model.
+//
+// Returns the blocks in graph order, possibly empty. Consecutive blocks need
+// not be adjacent: a gap between two of them is a region nothing here can
+// train.
+std::vector<LoraBlock> DiscoverLoraBlocks(
+    const onnx::ModelProto& injected_model, const LoraAdapter& adapter,
+    int64_t max_targets_per_block = 2);
+
+// ---------------------------------------------------------------------------
 // BuildLoraStepGraph -- the C++ port of the graph-building half of
 // onnxsim/lora.py's _build_lora_step_graph / _train_lora_block
 // ---------------------------------------------------------------------------

--- a/onnxsim/lora_entry_test.cpp
+++ b/onnxsim/lora_entry_test.cpp
@@ -587,6 +587,190 @@ void AlphaAddsAScaleInitializerAndAMulNode() {
 }
 
 // ---------------------------------------------------------------------------
+// DiscoverLoraBlocks
+// ---------------------------------------------------------------------------
+
+// A LoraAdapter whose targets carry only `node_output` -- the only field
+// DiscoverLoraBlocks reads. The other LoraTarget fields (weight_name,
+// op_type, lora_a_name/lora_b_name, rank) are irrelevant to it, exactly as
+// lora.py's own discover_lora_blocks only ever touches LoraTarget.node_output.
+LoraAdapter AdapterFor(const std::vector<std::string>& target_outputs) {
+  LoraAdapter adapter;
+  for (const std::string& name : target_outputs) {
+    LoraTarget t;
+    t.node_output = name;
+    adapter.targets.push_back(t);
+  }
+  return adapter;
+}
+
+// X -> MatMul(X, W1) -> H -> MatMul(H, W2) -> Y. A straight-line chain with
+// no gap: MatMul is in graph_grad::SupportedOps() throughout.
+onnx::ModelProto TwoMatMulChainModel() {
+  onnx::ModelProto model;
+  onnx::GraphProto* graph = model.mutable_graph();
+  graph->set_name("two_matmul_chain");
+  AddBatchedInput(graph, "X", kK);
+  AddOutput(graph, "Y", kN);
+  *graph->add_node() = MakeNode("MatMul", {"X", "W1"}, {"H"});
+  *graph->add_node() = MakeNode("MatMul", {"H", "W2"}, {"Y"});
+  *graph->add_initializer() =
+      FloatTensor("W1", {kK, kK}, std::vector<float>(kK * kK, 0.1f));
+  *graph->add_initializer() =
+      FloatTensor("W2", {kK, kN}, std::vector<float>(kK * kN, 0.1f));
+  Finish(&model);
+  return model;
+}
+
+// X -> MatMul(X, W1) -> H -> Elu(H) -> R -> MatMul(R, W2) -> Y. Elu has no
+// graph_grad rule (see UndifferentiableModel above), so a candidate span
+// crossing it is a hard gap even though both MatMuls on either side are
+// individually differentiable.
+onnx::ModelProto MatMulEluMatMulModel() {
+  onnx::ModelProto model;
+  onnx::GraphProto* graph = model.mutable_graph();
+  graph->set_name("matmul_elu_matmul");
+  AddBatchedInput(graph, "X", kK);
+  AddOutput(graph, "Y", kN);
+  *graph->add_node() = MakeNode("MatMul", {"X", "W1"}, {"H"});
+  *graph->add_node() = MakeNode("Elu", {"H"}, {"R"});
+  *graph->add_node() = MakeNode("MatMul", {"R", "W2"}, {"Y"});
+  *graph->add_initializer() =
+      FloatTensor("W1", {kK, kK}, std::vector<float>(kK * kK, 0.1f));
+  *graph->add_initializer() =
+      FloatTensor("W2", {kK, kN}, std::vector<float>(kK * kN, 0.1f));
+  Finish(&model);
+  return model;
+}
+
+// X -> MatMul(X, W1) -> A and X -> MatMul(X, W2) -> B, with both A and B
+// graph outputs: a fork that never narrows back to a single live tensor
+// after the very first cut (the model's own input X).
+onnx::ModelProto NonReconvergingBranchModel() {
+  onnx::ModelProto model;
+  onnx::GraphProto* graph = model.mutable_graph();
+  graph->set_name("non_reconverging_branch");
+  AddBatchedInput(graph, "X", kK);
+  AddOutput(graph, "A", kN);
+  AddOutput(graph, "B", kN);
+  *graph->add_node() = MakeNode("MatMul", {"X", "W1"}, {"A"});
+  *graph->add_node() = MakeNode("MatMul", {"X", "W2"}, {"B"});
+  *graph->add_initializer() =
+      FloatTensor("W1", {kK, kN}, std::vector<float>(kK * kN, 0.1f));
+  *graph->add_initializer() =
+      FloatTensor("W2", {kK, kN}, std::vector<float>(kK * kN, 0.1f));
+  Finish(&model);
+  return model;
+}
+
+void TwoAdapterTargetsMergeIntoOneBlockUnderTheDefaultMaxTargetsPerBlock() {
+  const onnx::ModelProto model = TwoMatMulChainModel();
+  const LoraAdapter adapter = AdapterFor({"H", "Y"});
+
+  const std::vector<LoraBlock> blocks = DiscoverLoraBlocks(model, adapter, 2);
+  CheckEqual(static_cast<int64_t>(blocks.size()), 1,
+             "both injected-adapter targets merge into a single block");
+  if (blocks.size() == 1) {
+    CheckEqual(blocks[0].input_name, "X", "the merged block's input");
+    CheckEqual(blocks[0].output_name, "Y", "the merged block's output");
+    CheckEqual(static_cast<int64_t>(blocks[0].target_outputs.size()), 2,
+               "both H and Y fall inside the merged block");
+    Check(blocks[0].target_outputs[0] == "H" &&
+              blocks[0].target_outputs[1] == "Y",
+          "target_outputs is in graph order");
+    CheckEqual(blocks[0].num_nodes, 2,
+               "the merged block contains both MatMuls");
+    CheckEqual(static_cast<int64_t>(blocks[0].op_types.size()), 1,
+               "op_types is deduplicated to the one op type present");
+    CheckEqual(blocks[0].op_types[0], "MatMul", "the block's only op type");
+    Check(!blocks[0].external_inputs.empty() &&
+              blocks[0].external_inputs[0] == "X",
+          "external_inputs includes the block's own input");
+  }
+}
+
+void MaxTargetsPerBlockOneGivesOneBlockPerAdapterTarget() {
+  const onnx::ModelProto model = TwoMatMulChainModel();
+  const LoraAdapter adapter = AdapterFor({"H", "Y"});
+
+  const std::vector<LoraBlock> blocks = DiscoverLoraBlocks(model, adapter, 1);
+  CheckEqual(static_cast<int64_t>(blocks.size()), 2,
+             "max_targets_per_block=1 gives one block per adapter target "
+             "instead of merging them");
+  if (blocks.size() == 2) {
+    CheckEqual(blocks[0].input_name, "X", "the first block's input");
+    CheckEqual(blocks[0].output_name, "H", "the first block's output");
+    CheckEqual(static_cast<int64_t>(blocks[0].target_outputs.size()), 1,
+               "the first block has exactly one target");
+    CheckEqual(blocks[0].target_outputs[0], "H", "the first block's target");
+
+    CheckEqual(blocks[1].input_name, "H", "the second block's input");
+    CheckEqual(blocks[1].output_name, "Y", "the second block's output");
+    CheckEqual(static_cast<int64_t>(blocks[1].target_outputs.size()), 1,
+               "the second block has exactly one target");
+    CheckEqual(blocks[1].target_outputs[0], "Y", "the second block's target");
+  }
+}
+
+void AnUnsupportedOpSplitsWhatWouldOtherwiseBeOneBlockIntoTwo() {
+  const onnx::ModelProto model = MatMulEluMatMulModel();
+  const LoraAdapter adapter = AdapterFor({"H", "Y"});
+
+  // max_targets_per_block=2 merges H and Y into one block on a chain with no
+  // gap (the previous test) -- here Elu (no graph_grad rule) forces a split
+  // regardless of max_targets_per_block, and nothing spans it.
+  const std::vector<LoraBlock> blocks = DiscoverLoraBlocks(model, adapter, 2);
+  CheckEqual(static_cast<int64_t>(blocks.size()), 2,
+             "the unsupported Elu splits the chain into two blocks");
+  if (blocks.size() == 2) {
+    CheckEqual(blocks[0].input_name, "X", "the first block's input");
+    CheckEqual(blocks[0].output_name, "H",
+               "the first block ends right before the gap");
+    CheckEqual(blocks[1].input_name, "R",
+               "the second block starts right after the gap");
+    CheckEqual(blocks[1].output_name, "Y", "the second block's output");
+  }
+  for (const LoraBlock& block : blocks) {
+    for (const std::string& op : block.op_types) {
+      Check(op != "Elu", "no block contains the unsupported Elu");
+    }
+  }
+}
+
+void ASpanWithNoAdapterTargetInsideItIsNeverProposedAsABlock() {
+  const onnx::ModelProto model = TwoMatMulChainModel();
+  const LoraAdapter adapter = AdapterFor({"NotAnyNodesOutput"});
+
+  const std::vector<LoraBlock> blocks = DiscoverLoraBlocks(model, adapter, 2);
+  Check(blocks.empty(),
+        "a graph with none of the adapter's target outputs proposes no "
+        "block at all");
+}
+
+void NonPositiveMaxTargetsPerBlockIsRefused() {
+  const onnx::ModelProto model = TwoMatMulChainModel();
+  const LoraAdapter adapter = AdapterFor({"H", "Y"});
+  CheckThrows<std::invalid_argument>(
+      [&]() { DiscoverLoraBlocks(model, adapter, 0); },
+      "max_targets_per_block must be at least 1",
+      "max_targets_per_block=0 is refused");
+  CheckThrows<std::invalid_argument>(
+      [&]() { DiscoverLoraBlocks(model, adapter, -1); },
+      "max_targets_per_block must be at least 1",
+      "a negative max_targets_per_block is refused");
+}
+
+void ANonReconvergingBranchYieldsNoBlocksWithoutCrashing() {
+  const onnx::ModelProto model = NonReconvergingBranchModel();
+  const LoraAdapter adapter = AdapterFor({"A", "B"});
+
+  const std::vector<LoraBlock> blocks = DiscoverLoraBlocks(model, adapter, 2);
+  Check(blocks.empty(),
+        "a fork that never narrows back to one live tensor yields no "
+        "blocks rather than crashing");
+}
+
+// ---------------------------------------------------------------------------
 // BuildLoraStepGraph
 // ---------------------------------------------------------------------------
 
@@ -973,6 +1157,13 @@ int main() {
   ANon1x1ConvIsNotInjected();
   RestrictTargetNamesLimitsInjectionToTheNamedWeights();
   AlphaAddsAScaleInitializerAndAMulNode();
+
+  TwoAdapterTargetsMergeIntoOneBlockUnderTheDefaultMaxTargetsPerBlock();
+  MaxTargetsPerBlockOneGivesOneBlockPerAdapterTarget();
+  AnUnsupportedOpSplitsWhatWouldOtherwiseBeOneBlockIntoTwo();
+  ASpanWithNoAdapterTargetInsideItIsNeverProposedAsABlock();
+  NonPositiveMaxTargetsPerBlockIsRefused();
+  ANonReconvergingBranchYieldsNoBlocksWithoutCrashing();
 
   AnInjectedMatMulProducesAStepGraphTheCheckerAccepts();
   InitialStateSeedsTheAdapterFromItsCurrentValueAndZeroesTheMoments();


### PR DESCRIPTION
## Summary

`onnxsim/lora_entry.h`'s own top comment flagged block auto-discovery as the one deliberately-deferred item from the LoRA C++ port (#1291): the driving loop (inject → build step graph → train → write back) was ported, but a caller still had to name `block_input_name`/`block_output_name` by hand. This closes that gap.

- Adds `DiscoverLoraBlocks` (+ `LoraBlock`) to `lora_entry.h`/`.cpp`, a faithful port of `onnxsim/lora.py`'s `discover_lora_blocks`, which itself reuses `onnxsim/qat.py`'s `_liveness_cuts`/`_primary_graph_input` verbatim. Those two helpers are ported into `lora_entry.cpp`'s anonymous namespace as `LivenessCuts`/`PrimaryGraphInput`, structured exactly like their Python counterparts (a liveness argument, not pattern matching): the graph narrows to exactly one live tensor at each cut point, so a slice between two cuts is self-contained.
- The discovery loop walks consecutive liveness-cut pairs, treats any node whose `op_type` is outside `graph_grad::SupportedOps()` as a hard gap, and closes a block once `max_targets_per_block` of the adapter's own target outputs have accumulated into the pending span -- calling the existing `SliceBlock` for each resulting `(input, output)` pair, exactly as the Python calls `qat._slice_block`.
- Deliberately excludes any WASM/embind wiring: the browser already has its own JS-native discovery (`scripts/convertmodel/lora_blocks.mjs`, built on `qat_blocks.mjs`'s `livenessCuts`/`primaryGraphInput`, shipped in #1291) -- a separate reimplementation, matching how QAT's own browser discovery works (QAT's `discover_qat_blocks` itself has no C++ port either, only a JS-native one). This PR is the pure C++ port only, for parity/testability and any future non-browser C++ consumer.
- 6 new `lora_entry_test.cpp` cases: merging two adapter targets into one block under `max_targets_per_block=2`; one block per target under `max_targets_per_block=1`; an unsupported op splitting what would otherwise be one block into two; a graph with no adapter target proposing no block; `max_targets_per_block <= 0` being refused; and a never-reconverging branch yielding an empty block list without crashing.

## Test plan

- `cmake -DONNXSIM_BUILTIN_ORT=OFF -DONNXSIM_TESTS=ON -DCMAKE_BUILD_TYPE=Release` (per `CLAUDE.md`: the wheel build never compiles ONNX Runtime, and neither does this) -- built and ran `lora_entry_test` (all pass, including the 6 new cases), `qat_entry_test` and `graph_grad_test` (both unmodified, verified as a sanity check for header collisions -- both pass).
- `clang-format --dry-run --Werror` on all three touched files -- clean.
- `git diff --stat` against `master` -- only `onnxsim/lora_entry.h`, `onnxsim/lora_entry.cpp`, `onnxsim/lora_entry_test.cpp` changed; nothing under `scripts/convertmodel/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn8htRWMsPoRBuGNAWj6nC)_