### PR TITLE
Add Z3 formal-verification proofs for 8 more optimizer passes

### DIFF
--- a/tests/test_formal_verify_eliminate_deadend.py
+++ b/tests/test_formal_verify_eliminate_deadend.py
@@ -1,0 +1,297 @@
+"""Formal check for EliminateDeadEnd (eliminate_deadend.h).
+
+Like ``eliminate_duplicate_initializer.h`` (see
+``test_formal_verify_eliminate_duplicate_initializer.py``), this pass is a
+``FullGraphBasedPass`` (whole-graph analysis via ``runPass(Graph&)``), not a
+``PredicateBasedPass``. It has been referenced repeatedly by other tests in
+this suite (grep ``eliminate_deadend`` across ``tests/test_formal_verify_*``)
+as the pass that would normally sweep up a node a rewrite leaves dangling
+(0 uses) instead of destroying outright -- this file verifies that sweep
+itself.
+
+What it does, straight from the header: it walks the graph's nodes in
+**reverse** order and destroys any node with no uses at all -- checked via
+the cheap ``hasUsesInCurrentGraph()`` in the overwhelmingly common case, or
+the more expensive ``hasUses()`` (which also accounts for a value captured
+by a nested If/Loop/Scan subgraph body) only when
+``GraphMayHaveCapturedValues(graph)`` says the graph could possibly contain
+such a capturing op at all. The reverse order matters operationally: if node
+M is node N's only consumer and M itself turns out to have no uses, M is
+destroyed (dropping its inputs' use counts, including N's) *before* the
+sweep reaches N -- so a single ``runPass`` invocation can cascade-remove an
+entire chain of newly-dead nodes, not just directly-dead ones. See the
+module comment in ``_formal_verify_common.py`` and e.g.
+``test_formal_verify_eliminate_consecutive_idempotent_ops.py`` /
+``test_formal_verify_fuse_consecutive_slices.py`` for real examples of the
+"left dangling, eliminate_deadend would normally clean this up" pattern this
+pass exists to handle.
+
+Formal content, and why the proof here is intentionally thin (matching
+``eliminate_duplicate_initializer``'s precedent for a genuinely "thin,
+definitional" pass): this is not an algebraic identity about any operator's
+semantics -- it is a claim about graph reachability/dependency structure. A
+node whose output(s) are consumed by *nothing* -- no other node, no graph
+output, and (accounting for ``hasUses()``) no captured use inside a nested
+subgraph body either -- contributes nothing observable to what the graph
+computes, so removing it cannot change the result. This is modeled below as
+a small acyclic chain of named, uninterpreted-unary-function-defined values
+-- ``v1 = f1(input)``, ``v2 = f2(v1)``, graph output ``= f3(v2)`` -- plus a
+``dead = f4(v1)`` value that nothing downstream reads. The graph's output
+expression simply never mentions ``dead`` syntactically, so two versions of
+that expression -- one where ``dead``'s defining equation is additionally
+asserted to exist, one where it is not -- are trivially, syntactically
+identical; removing ``dead``'s definition (deleting the dead node) changes
+nothing about the output. This is really an observation about *syntactic*
+non-dependency rather than a nontrivial semantic derivation -- there is no
+operator algebra to prove here, unlike almost every other pass in this
+suite -- and that is expected and stated honestly, as
+``eliminate_duplicate_initializer``'s own docstring does for its own
+comparably thin claim. The negative control below (a deliberately wrong
+model where the output expression is made to actually reference ``dead``)
+confirms the "removing it changes nothing" argument is not vacuously true
+regardless of what is being removed. A second proof extends the same
+argument transitively to ``dead2 = f5(dead)`` -- a node that is only "dead"
+*because* ``dead`` itself is dead -- tying directly to the cascading
+reverse-iteration removal the real pass performs.
+
+Given how thin the algebra is, the real engineering content -- what the
+differential tests below actually exercise against the real compiled pass --
+is entirely in the reachability/dependency logic itself: that a single
+``runPass`` invocation removes a whole dead chain at once (the cascade case,
+confirmed empirically below to be the single most important behavior to
+verify, since a naive one-node-per-invocation removal would produce a
+weaker, order-dependent result), that a live chain is left untouched
+alongside a directly-dead node, that an all-live graph triggers no changes
+at all, and that a value captured only inside a nested If subgraph body is
+correctly *not* treated as dead even though it has no direct use in the
+outer graph's own node list.
+
+On single-invocation cascading, confirmed empirically (see this file's
+development notes) rather than assumed: ``EliminateDeadEnd`` is constructed
+with ``PassEfficiency::Complete`` (see the header), and
+``CountBasedPassAnalysis::fixedPointOptimizationNeeded()``
+(``pass.h``) only requests a repeat run for ``PassEfficiency::Partial``
+passes -- so with only ``eliminate_deadend`` active (as ``isolate()``
+arranges), ``FixedPointPassManager::run`` (``pass_manager.cc``) invokes
+``runPass`` on it exactly once. The cascade test below observing all three
+chained dead nodes gone after one ``simplify_isolated`` call is therefore
+real evidence of the reverse-iteration cascade the header describes, not an
+artifact of the pass being silently re-run by the fixed-point driver.
+
+On the captured-value case: confirmed empirically below that it is not too
+complex to construct via ``onnx.parser`` after all (the ``If`` node's
+attribute-graph syntax needs no trailing ``()`` after the ``<...>`` -- see
+``third_party/onnx/tests/cpp/parser_test.cc``'s ``IfNodeTest`` for the
+working grammar) -- so this file includes that case rather than skipping it.
+"""
+
+from _formal_verify_common import isolate, prove, simplify_isolated, z3
+from onnx import parser
+
+import onnxsim
+
+
+def _model(body, opset=16, ir_version=10):
+    return parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+
+
+def test_eliminate_deadend_is_sound():
+    f1 = z3.Function("f1", z3.RealSort(), z3.RealSort())
+    f2 = z3.Function("f2", z3.RealSort(), z3.RealSort())
+    f3 = z3.Function("f3", z3.RealSort(), z3.RealSort())
+    f4 = z3.Function("f4", z3.RealSort(), z3.RealSort())
+    inp = z3.Real("input")
+
+    # v1 = f1(input), v2 = f2(v1), output = f3(v2): a small acyclic chain the
+    # graph output actually depends on.
+    v1 = f1(inp)
+    v2 = f2(v1)
+    output = f3(v2)
+
+    # dead = f4(v1): a value defined from something live (v1), but nothing
+    # downstream reads dead itself -- it is a genuine dead end, not merely
+    # unreachable from the input.
+    dead = f4(v1)
+
+    # The claim: whether or not dead's defining equation is additionally
+    # asserted, the graph's output expression is unaffected. `output` simply
+    # never mentions `dead`/f4 syntactically, so this holds for any value of
+    # `dead` at all -- stated here as an implication so the hypothesis
+    # (dead's definition holding) is explicit, mirroring this suite's usual
+    # "Implies(hypothesis, claim)" shape even though the hypothesis does no
+    # work in discharging it.
+    prove(z3.Implies(dead == f4(v1), output == f3(f2(f1(inp)))))
+
+
+def test_eliminate_deadend_is_sound_cascade():
+    # The cascade case: dead2 = f5(dead) is only a dead end *because* dead
+    # itself is one -- neither is mentioned by the live output expression,
+    # transitively. This is the algebraic counterpart of the real pass's
+    # reverse-iteration cascade: removing dead2 first, then dead, still
+    # leaves the live output expression untouched either way.
+    f1 = z3.Function("f1", z3.RealSort(), z3.RealSort())
+    f2 = z3.Function("f2", z3.RealSort(), z3.RealSort())
+    f3 = z3.Function("f3", z3.RealSort(), z3.RealSort())
+    f4 = z3.Function("f4", z3.RealSort(), z3.RealSort())
+    f5 = z3.Function("f5", z3.RealSort(), z3.RealSort())
+    inp = z3.Real("input")
+
+    v1 = f1(inp)
+    v2 = f2(v1)
+    output = f3(v2)
+    dead = f4(v1)
+    dead2 = f5(dead)
+
+    prove(
+        z3.Implies(
+            z3.And(dead == f4(v1), dead2 == f5(dead)),
+            output == f3(f2(f1(inp))),
+        )
+    )
+
+
+def test_eliminate_deadend_negative_control_needs_no_actual_dependency():
+    # Sanity check that the proof above isn't vacuously true regardless of
+    # what "dead" is: construct a deliberately WRONG model where the output
+    # expression is made to actually reference dead (as if a dead node's
+    # value leaked into a live computation), and confirm Z3 finds this is
+    # NOT the same expression as the honest, dead-free output -- i.e. the
+    # "removing an unused definition changes nothing" argument only works
+    # because the real `output` genuinely never mentions `dead`.
+    f1 = z3.Function("f1", z3.RealSort(), z3.RealSort())
+    f2 = z3.Function("f2", z3.RealSort(), z3.RealSort())
+    f3 = z3.Function("f3", z3.RealSort(), z3.RealSort())
+    f4 = z3.Function("f4", z3.RealSort(), z3.RealSort())
+    inp = z3.Real("input")
+
+    v1 = f1(inp)
+    v2 = f2(v1)
+    output_without_dead = f3(v2)
+    dead = f4(v1)
+    output_actually_depends_on_dead = f3(v2) + dead  # bogus: not a dead end
+
+    solver = z3.Solver()
+    solver.add(z3.Not(output_without_dead == output_actually_depends_on_dead))
+    assert solver.check() == z3.sat
+
+
+def test_eliminate_deadend_pass_matches_single_dead_node():
+    # A live chain (v1 -> v2 -> Y, reaching the graph output) alongside one
+    # directly-dead node (dead, consumed by nothing): the compiled pass,
+    # run alone, should remove exactly `dead` and leave the live chain
+    # untouched.
+    model = _model(
+        """
+        g (float[2,2] X) => (float[2,2] Y)
+        {
+          v1 = Relu(X)
+          v2 = Sigmoid(v1)
+          Y = Tanh(v2)
+          dead = Neg(v1)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_deadend")
+    assert ops == {"Relu": 1, "Sigmoid": 1, "Tanh": 1}
+    assert [n.output[0] for n in sim_model.graph.node] == ["v1", "v2", "Y"]
+
+
+def test_eliminate_deadend_pass_matches_cascade():
+    # The key behavior: a chain of THREE dead-end nodes (dead1 consumed only
+    # by dead2, dead2 only by dead3, dead3 by nothing), alongside a live
+    # v1 -> Y chain. A naive single-pass-single-node removal would only
+    # catch dead3 (the sole directly-0-use node before any removal) on one
+    # invocation; the real pass's reverse node-order iteration instead
+    # removes all three in this ONE simplify_isolated call, confirming the
+    # header's cascade claim empirically -- and, per this pass's
+    # PassEfficiency::Complete (see this file's module docstring), the
+    # fixed-point driver never re-invokes it to catch stragglers, so this
+    # result reflects genuinely a single runPass call.
+    model = _model(
+        """
+        g (float[2,2] X) => (float[2,2] Y)
+        {
+          v1 = Relu(X)
+          Y = Sigmoid(v1)
+          dead1 = Neg(v1)
+          dead2 = Abs(dead1)
+          dead3 = Sqrt(dead2)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_deadend")
+    assert ops == {"Relu": 1, "Sigmoid": 1}
+    assert [n.output[0] for n in sim_model.graph.node] == ["v1", "Y"]
+
+
+def test_eliminate_deadend_declines_when_everything_is_live():
+    # Every node's output reaches a graph output (v1 feeds both Y1 and Y2):
+    # nothing is a dead end, so the pass -- run alone -- makes no changes at
+    # all.
+    model = _model(
+        """
+        g (float[2,2] X) => (float[2,2] Y1, float[2,2] Y2)
+        {
+          v1 = Relu(X)
+          Y1 = Sigmoid(v1)
+          Y2 = Tanh(v1)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_deadend")
+    assert ops == {"Relu": 1, "Sigmoid": 1, "Tanh": 1}
+    assert [n.output[0] for n in sim_model.graph.node] == ["v1", "Y1", "Y2"]
+
+
+def test_eliminate_deadend_keeps_value_captured_by_nested_if_subgraph():
+    # v1's only use is inside the `then_branch`/`else_branch` subgraph
+    # bodies of an If node (a captured outer value) -- it has NO use in the
+    # outer graph's own direct node list, so hasUsesInCurrentGraph() alone
+    # would (wrongly) call it a dead end. GraphMayHaveCapturedValues(graph)
+    # sees the If op and makes the pass fall back to the more expensive,
+    # subgraph-aware hasUses() instead, which correctly finds the captured
+    # use and keeps v1. A separate, genuinely-unused `dead` node (reachable
+    # from nothing, not even a subgraph) is included alongside it and
+    # confirmed removed regardless -- i.e. the capture-awareness doesn't
+    # just make the pass universally conservative once an If is present.
+    #
+    # The If node's attribute-graph syntax needs no trailing `()` after the
+    # closing `>` -- confirmed against
+    # third_party/onnx/tests/cpp/parser_test.cc's IfNodeTest grammar after
+    # an initial guess with a trailing `()` failed to parse.
+    model = _model(
+        """
+        g (float[4] X, bool cond) => (float[4] Y)
+        {
+          v1 = Relu(X)
+          dead = Neg(X)
+          Y = If (cond) <
+              then_branch = g1 () => (float[4] z) { z = Sigmoid(v1) },
+              else_branch = g2 () => (float[4] z) { z = Neg(v1) }
+              >
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_deadend")
+    assert ops == {"Relu": 1, "If": 1}
+    assert [n.output[0] for n in sim_model.graph.node] == ["v1", "Y"]
+
+
+def test_eliminate_deadend_is_a_real_default_pass():
+    # Sanity check underpinning every "left dangling ... eliminate_deadend
+    # would normally clean this up" comment elsewhere in this test suite:
+    # eliminate_deadend is a genuine default onnxsim pass, and isolate()
+    # (used throughout this suite, including above) skips it whenever a
+    # *different* single pass is isolated -- e.g. isolate("eliminate_identity")
+    # lists eliminate_deadend among the passes to skip, exactly as
+    # simplify_isolated's own module docstring describes.
+    assert "eliminate_deadend" in onnxsim.onnxsim_cpp2py_export._list_optimizers()
+    assert "eliminate_deadend" in isolate("eliminate_identity")

--- a/tests/test_formal_verify_eliminate_if_with_const_cond.py
+++ b/tests/test_formal_verify_eliminate_if_with_const_cond.py
@@ -1,0 +1,294 @@
+"""Formal check for EliminateIfWithConstCond
+(eliminate_if_with_const_cond.h): given an ``If`` node whose ``cond`` input is
+a compile-time constant (a ``Constant`` node's output, or a constant
+initializer -- ``patternMatchPredicate``), inline the taken branch's subgraph
+(``then_branch`` if ``cond`` is true, else ``else_branch`` -- the ``If`` op's
+own two ``GraphProto`` attributes) directly into the parent graph and destroy
+the ``If`` node (``runTransform``).
+
+The DEEP correctness content of this pass is *not* algebraic. ONNX's own
+``If`` operator is DEFINED by its spec as "evaluate ``then_branch`` and use
+its outputs if ``cond`` is true, else evaluate ``else_branch`` and use its
+outputs" -- so modeling ``if_result = If(cond, then_val, else_val)`` as Z3's
+native ``z3.If(cond, then_val, else_val)`` (exactly mirroring
+test_formal_verify_rewrite_where.py's use of ``z3.If`` for a similarly
+definitional boolean-selection identity) makes "when ``cond`` is the concrete
+boolean ``True``, ``if_result == then_val``" nothing more than Z3's own
+``If``-simplification at a known condition value -- there is no derivation to
+do. That *is* however the whole point of this pass: because ``cond`` is known
+at COMPILE TIME (not merely constant-but-opaque-to-the-compiler at runtime),
+"run ``If(True, T, E)``" and "run ``T`` directly" are the same computation,
+so replacing the former with the latter -- i.e. beta-reduction / substitution
+transparency for a pure, side-effect-free computation graph -- is sound.
+
+What actually has teeth here is getting the SUBGRAPH-INLINING MECHANICS
+right: copying each taken-branch node's kind/attributes into the parent
+graph, remapping each of its inputs to either an already-copied sibling
+node's output, a value captured from the outer (parent) scope, or a copied
+subgraph-local initializer (the ``value_dict``/``kCaptured``/``kParam``
+handling in ``runTransform``), and rewiring the original ``If`` node's own
+outputs to the corresponding inlined values. None of that is expressible as
+a clean algebraic claim -- it is exactly what the differential tests below
+exist to check, by running the real compiled pass on concrete graphs and
+inspecting the resulting node/edge structure.
+
+``onnx.parser.parse_model()`` turns out to handle ``If`` nodes with
+``then_branch``/``else_branch`` ``GraphProto`` attributes cleanly -- the
+text-format grammar treats a bare (non-numeric, non-typed) attribute value as
+a nested graph literal (``name (ins) => (outs) { nodes }``), so e.g.
+``Z = If <then_branch = g1 () => (float[4] Y) { Y = Relu(X) }, ...> (cond)``
+parses and passes ``onnx.checker`` directly, with no ``onnx.helper`` fallback
+needed anywhere in this file.
+"""
+
+from _formal_verify_common import producer, prove, simplify_isolated, z3
+from onnx import parser
+
+
+def test_eliminate_if_with_const_cond_is_sound():
+    # `captured` stands for one arbitrary element of a value captured from
+    # the outer (parent) scope; `then_val`/`else_val` stand for whatever a
+    # branch's own internal computation produces from it (an arbitrary
+    # uninterpreted function -- the branch's actual node graph is opaque to
+    # this proof, only the definitional If-selects-a-branch fact matters).
+    cond = z3.Bool("cond")
+    captured = z3.Real("captured")
+    then_fn = z3.Function("then_fn", z3.RealSort(), z3.RealSort())
+    else_fn = z3.Function("else_fn", z3.RealSort(), z3.RealSort())
+    then_val = then_fn(captured)
+    else_val = else_fn(captured)
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+
+    # If's own definition: select then_val when cond holds, else_val
+    # otherwise. This is z3.If verbatim -- there is no algebra to derive.
+    if_result = z3.If(cond, then_val, else_val)
+
+    # The pass's soundness claim, split by which constant cond takes:
+    # inlining then_branch (dropping the If and else_branch entirely) is
+    # correct exactly when cond is statically True, and symmetrically for
+    # False/else_branch.
+    prove(z3.Implies(cond, if_result == then_val))
+    prove(z3.Implies(z3.Not(cond), if_result == else_val))
+
+    # Full substitution-safety claim: composed with an arbitrary downstream
+    # consumer of the If's output, inlining the taken branch produces the
+    # exact same value for *any* consumer -- not just the one-hop checks in
+    # test_eliminate_if_with_const_cond_pass_matches_true/false below.
+    prove(z3.Implies(cond, consumer(if_result) == consumer(then_val)))
+    prove(z3.Implies(z3.Not(cond), consumer(if_result) == consumer(else_val)))
+
+
+def test_eliminate_if_with_const_cond_negative_control_wrong_branch_is_unsound():
+    # Sanity check that the proof is genuine, not vacuous: selecting the
+    # WRONG branch when cond is (statically) true -- If(cond, T, E) == E,
+    # rather than == T -- must NOT hold for every cond/T/E. Confirm Z3 finds
+    # a real counterexample rather than reporting the (wrong) claim valid.
+    cond = z3.Bool("cond")
+    then_val = z3.Real("then_val")
+    else_val = z3.Real("else_val")
+    if_result = z3.If(cond, then_val, else_val)
+    wrong_claim = z3.Implies(cond, if_result == else_val)
+    solver = z3.Solver()
+    solver.add(z3.Not(wrong_claim))
+    assert solver.check() == z3.sat
+
+
+def test_eliminate_if_with_const_cond_pass_matches_true():
+    # Differential check: with cond statically True, the real compiled pass,
+    # run alone, inlines then_branch's Relu node directly into the parent
+    # graph, rewires Z (the If's own output) to read from it, and destroys
+    # both the If node and the untaken else_branch's Sigmoid entirely --
+    # confirmed by inspecting the surviving graph's actual node structure,
+    # not merely counting op types.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4] X) => (float[4] Z)
+        {
+            cond = Constant <value = bool[1] {1}> ()
+            Z = If <
+                then_branch = then_g () => (float[4] Y) { Y = Relu(X) },
+                else_branch = else_g () => (float[4] Y) { Y = Sigmoid(X) }
+            > (cond)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_if_with_const_cond")
+    assert ops["If"] == 0
+    assert ops["Sigmoid"] == 0
+    z_node = producer(sim_model, "Z")
+    assert z_node.op_type == "Relu"
+    assert list(z_node.input) == ["X"]
+
+
+def test_eliminate_if_with_const_cond_pass_matches_false():
+    # Symmetric case: cond statically False inlines else_branch's Sigmoid
+    # instead, and then_branch's Relu does not appear anywhere in the result.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4] X) => (float[4] Z)
+        {
+            cond = Constant <value = bool[1] {0}> ()
+            Z = If <
+                then_branch = then_g () => (float[4] Y) { Y = Relu(X) },
+                else_branch = else_g () => (float[4] Y) { Y = Sigmoid(X) }
+            > (cond)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_if_with_const_cond")
+    assert ops["If"] == 0
+    assert ops["Relu"] == 0
+    z_node = producer(sim_model, "Z")
+    assert z_node.op_type == "Sigmoid"
+    assert list(z_node.input) == ["X"]
+
+
+def test_eliminate_if_with_const_cond_captured_value_used_twice():
+    # The taken branch (then_branch here) reads the outer-scope value X both
+    # directly (as one of Add's two inputs) and indirectly (through its own
+    # internal Relu node feeding Add's other input) -- exercising the
+    # unique_name_to_value_in_parent/kCaptured remapping machinery more
+    # thoroughly than a single-input branch does: X must be correctly
+    # resolved to the SAME parent-graph Value both times, not duplicated or
+    # left dangling.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4] X) => (float[4] Z)
+        {
+            cond = Constant <value = bool[1] {1}> ()
+            Z = If <
+                then_branch = then_g () => (float[4] Y) {
+                    internal = Relu(X)
+                    Y = Add(X, internal)
+                },
+                else_branch = else_g () => (float[4] Y) { Y = Sigmoid(X) }
+            > (cond)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_if_with_const_cond")
+    assert ops["If"] == 0
+    assert ops["Sigmoid"] == 0
+    z_node = producer(sim_model, "Z")
+    assert z_node.op_type == "Add"
+    relu_node = producer(sim_model, z_node.input[1])
+    assert relu_node.op_type == "Relu"
+    # Both of Add's paths back to a graph input resolve to the very same
+    # captured X -- not two independently-captured copies of it.
+    assert z_node.input[0] == "X"
+    assert list(relu_node.input) == ["X"]
+
+
+def test_eliminate_if_with_const_cond_constant_initializer_cond():
+    # patternMatchPredicate also matches a cond that is a constant
+    # INITIALIZER rather than a Constant node's output
+    # (is_constant_initializer) -- exercise that half of the predicate too.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4] X) => (float[4] Z)
+        <bool[1] cond = {1}>
+        {
+            Z = If <
+                then_branch = then_g () => (float[4] Y) { Y = Relu(X) },
+                else_branch = else_g () => (float[4] Y) { Y = Sigmoid(X) }
+            > (cond)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_if_with_const_cond")
+    assert ops["If"] == 0
+    assert ops["Sigmoid"] == 0
+    z_node = producer(sim_model, "Z")
+    assert z_node.op_type == "Relu"
+    assert list(z_node.input) == ["X"]
+
+
+def test_eliminate_if_with_const_cond_declines_when_cond_is_not_constant():
+    # cond is a genuine graph input (a runtime-computed boolean, from the
+    # pass's point of view) rather than a Constant node's output or a
+    # constant initializer -- patternMatchPredicate declines outright, so
+    # the real compiled pass, run alone, must leave the If node (and both of
+    # its branches, unexamined) completely untouched.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4] X, bool[1] Cond) => (float[4] Z)
+        {
+            Z = If <
+                then_branch = then_g () => (float[4] Y) { Y = Relu(X) },
+                else_branch = else_g () => (float[4] Y) { Y = Sigmoid(X) }
+            > (Cond)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_if_with_const_cond")
+    assert ops["If"] == 1
+    z_node = producer(sim_model, "Z")
+    assert z_node.op_type == "If"
+    assert list(z_node.input) == ["Cond"]
+
+
+def test_eliminate_if_with_const_cond_forwarded_initializer_output():
+    # A related special case to the one above: else_branch has no nodes at
+    # all -- its sole output C is directly one of the subgraph's own
+    # constant initializers (as if constant folding had already reduced
+    # that branch down to a bare constant before this pass runs). This hits
+    # the `output_in_subgraph->node()->kind() == kParam` branch at the end
+    # of runTransform: C is absent from value_dict (nothing produces it),
+    # so the initializer itself must be copied into the parent graph and
+    # used as If's output directly.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4] X) => (float[4] Z)
+        {
+            cond = Constant <value = bool[1] {0}> ()
+            Z = If <
+                then_branch = then_g () => (float[4] Y) { Y = Relu(X) },
+                else_branch = else_g () => (float[4] C)
+                    <float[4] C = {1.0, 2.0, 3.0, 4.0}> { }
+            > (cond)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_if_with_const_cond")
+    assert ops["If"] == 0
+    assert ops["Relu"] == 0
+    assert "Z" in [i.name for i in sim_model.graph.initializer]
+
+
+# Not covered: a branch that forwards a CAPTURED outer-scope value straight
+# through as ITS OWN OUTPUT with no intervening node at all (the
+# `output_in_subgraph->node()->kind() == kCaptured` special case, as
+# distinct from the kParam one just above). This is not just awkward to
+# write -- it is not constructible as a model onnx.checker accepts at all: a
+# subgraph output name that is neither produced by one of the subgraph's own
+# nodes nor a formal graph input is rejected ("Graph output '...' is not an
+# output of any node in graph"), and If's branch subgraphs never declare
+# their captured names as formal inputs (that is precisely what makes them
+# "captured" rather than ordinary parameters) -- confirmed by hand against
+# both onnx.checker directly and the real compiled pass (which raises the
+# same checker error before the pass itself ever runs, since onnxsim
+# validates its input model up front).

--- a/tests/test_formal_verify_eliminate_unused_initializer.py
+++ b/tests/test_formal_verify_eliminate_unused_initializer.py
@@ -1,0 +1,341 @@
+"""Formal check for EliminateUnusedInitializer (eliminate_unused_initializer.h).
+
+Like ``eliminate_duplicate_initializer`` (its closest sibling: read that file's
+module docstring first, this one follows the same shape), this pass is a
+``FullGraphBasedPass`` (whole-graph analysis via ``runPass(Graph&)``), not a
+``PredicateBasedPass``. It computes, once per graph, the set of every
+initializer name; walks every node's inputs (recursively descending into any
+nested subgraph attribute too, via ``DescendOnGraphAttributesUnconstrained`` --
+relevant for ``If``/``Loop``/``Scan`` bodies) and every graph output, erasing
+from that set any initializer name actually referenced anywhere; and finally
+deletes whatever names remain -- from the initializer list, and (if the same
+name also happens to appear in the graph's input list) from the input list
+too. The header states its two safety conditions plainly: "condition 1: A is
+not used as any node's input; condition 2: A is not an output."
+
+Formal content, and why the proof here is intentionally thin (same honest
+framing as ``eliminate_duplicate_initializer``'s docstring): this is not an
+algebraic identity about some operator's semantics -- there is no operator
+algebra involved at all. An initializer erased by this pass is, by
+construction, referenced by *nothing*: no node input anywhere in the graph
+(including nested subgraphs), no graph output. Zero syntactic dependents means
+removing it from the initializer list cannot change what any node computes or
+what any graph output evaluates to, because nothing in the graph's computation
+ever reads it in the first place. This is modeled below as literally as
+possible: the graph's node structure and output are built as Z3 terms from
+named, uninterpreted tensors and an uninterpreted ``Add``, and the "unused
+initializer" is a value that is accepted as a parameter but never mentioned
+anywhere inside that term -- i.e. syntactic non-dependency, not a derived
+algebraic equivalence. Proving the output is invariant under any change to
+that unmentioned value is close to a tautology, deliberately so: unlike
+``eliminate_duplicate_initializer``'s content-equality/substitution argument,
+there is no substitution reasoning to do here at all. The negative control
+below (a variant output expression that actually *does* reference the
+"unused" value) confirms the claim is not vacuously true regardless of
+reference -- invariance genuinely fails once the value is actually used.
+
+Given how thin the algebra is, the real engineering content of this pass --
+and what the differential tests below actually exercise against the real
+compiled pass -- is entirely in getting the two safety conditions right:
+(a) an initializer consumed by any node anywhere, including inside a nested
+``If``/``Loop``/``Scan`` subgraph, must survive; (b) an initializer that is
+itself a graph output (no producing node -- a ``Value`` initialized straight
+from a constant tensor and output verbatim) must survive; (c) a genuinely
+unreferenced initializer must be dropped, from the initializer list and, if
+present, the input list.
+
+A surprise found empirically while developing this file's differential
+tests, on point (c)'s input-list interaction: this pass has *no* protection
+at all for an initializer whose name also happens to be a graph input -- in
+sharp contrast to ``eliminate_duplicate_initializer``, which explicitly skips
+any initializer named in the input set (never touching it either as a
+duplicate or as a merge target). Here, the header's two conditions
+("not a node input", "not an output") say nothing about graph inputs: if an
+initializer is genuinely unused by that definition, it is erased regardless
+of whether its name is also a graph input, and its ``graph.input`` entry is
+erased right along with it (see ``eliminate_unused_initializer.h``'s own
+``graph.eraseInput`` call). Reaching this cleanly through
+``onnxsim.simplify()`` needs the same workaround as
+``eliminate_duplicate_initializer``'s own input-name test, and for the same
+underlying reason: onnxsim's own Python-level preprocessing
+(``remove_initializer_from_input`` in ``onnx_simplifier.py``) unconditionally
+strips any ``graph.input`` entry duplicating an initializer name *before* the
+model reaches the C++ optimizer, so by default the duplicate input entry is
+already gone before this pass has a chance to touch it either way. Passing
+``mutable_initializer=True`` disables that stripping and is what lets the
+differential test below actually observe the pass erasing the input entry
+itself; since ``mutable_initializer`` is not part of ``simplify_isolated``'s
+signature, that one test calls ``onnxsim.simplify`` directly (reusing
+``isolate()`` for the skip list) instead of going through the shared helper,
+exactly as ``eliminate_duplicate_initializer``'s own input-name test does.
+
+A second, unrelated surprise found while developing these tests: onnxsim's
+constant-folding stage (entirely separate from ``skipped_optimizers`` --
+see ``onnxsim/constant_folding.cpp``) also invokes this exact same compiled
+onnx-optimizer pass directly at the end of every fold call, to sweep up
+initializers that folding itself leaves dangling (issue #174) -- independent
+of whether the pass is in the active optimizer-pass list. This never changes
+what the tests below observe (it is the identical real pass, so results
+agree either way, and every model here is built with a genuinely-unused
+initializer regardless of folding), but it does mean the pass under test
+effectively runs even when ``skipped_optimizers`` tries to exclude it, so
+long as constant folding itself is enabled (the default). Confirmed
+empirically (throwaway script, not committed) by disabling constant folding
+(``skip_constant_folding=True``) and isolating only this pass via
+``skipped_optimizers``: behavior was identical to the default path.
+
+The recursive subgraph-descent case (an initializer referenced only from
+inside a nested ``If`` node's ``then_branch``) *was* reachable and is
+exercised below, via ``onnx.parser``'s inline subgraph-attribute syntax
+(``then_branch = g () => (...) { ... }`` inside the node's ``< ... >``
+attribute list, no positional call parens after it -- confirmed empirically;
+naively adding trailing ``()`` after the attribute list, as an ordinary node
+call, is a parse error).
+"""
+
+import numpy as np
+import onnx
+from _formal_verify_common import isolate, prove, simplify_isolated, z3
+from onnx import helper, numpy_helper, parser
+
+import onnxsim
+
+
+def _tensor(name, array):
+    return numpy_helper.from_array(np.asarray(array, dtype=np.float32), name=name)
+
+
+def test_eliminate_unused_initializer_is_sound():
+    # Uninterpreted stand-ins for the graph's node structure: B and C are
+    # genuinely used (via D = Add(B, C), then G = Add(X, D)); the "unused
+    # initializer" under test never appears in that structure at all.
+    B = z3.Function("B", z3.IntSort(), z3.RealSort())
+    C = z3.Function("C", z3.IntSort(), z3.RealSort())
+    X = z3.Function("X", z3.IntSort(), z3.RealSort())
+    Add = z3.Function("Add", z3.RealSort(), z3.RealSort(), z3.RealSort())
+    i = z3.Int("i")
+
+    def graph_output(unused_val):
+        # `unused_val` stands for "whatever value the unused initializer A
+        # might have held" -- accepted as a parameter here purely so the two
+        # calls below can range over every possible such value, but never
+        # actually used inside this expression. That is exactly condition 1
+        # from the header comment ("A is not used as any node's input"): the
+        # node structure (D, then G) is built entirely from B, C and X.
+        d = Add(B(i), C(i))
+        g = Add(X(i), d)
+        return g
+
+    # Since graph_output's term never mentions unused_val, its value cannot
+    # depend on it: the graph's output is identical for every possible value
+    # the removed initializer A could have held, so deleting A's initializer
+    # entry changes nothing any node computes or any output evaluates to.
+    u1, u2 = z3.Reals("u1 u2")
+    prove(graph_output(u1) == graph_output(u2))
+
+
+def test_eliminate_unused_initializer_negative_control_needs_reference():
+    # If the output expression actually DID reference the "unused" value --
+    # i.e. it were not actually unused -- the invariance claim above must NOT
+    # be valid, or the "proof" would be vacuously true regardless of whether
+    # anything depends on the value at all. Build a variant that plugs the
+    # value into the output (`Add(g, unused_val)`) and confirm Z3 finds a sat
+    # counterexample to invariance, not unsat.
+    B = z3.Function("B", z3.IntSort(), z3.RealSort())
+    C = z3.Function("C", z3.IntSort(), z3.RealSort())
+    X = z3.Function("X", z3.IntSort(), z3.RealSort())
+    Add = z3.Function("Add", z3.RealSort(), z3.RealSort(), z3.RealSort())
+    i = z3.Int("i")
+
+    def graph_output_referencing(referenced_val):
+        d = Add(B(i), C(i))
+        g = Add(X(i), d)
+        return Add(g, referenced_val)  # now genuinely depends on the value
+
+    u1, u2 = z3.Reals("u1 u2")
+    solver = z3.Solver()
+    solver.add(z3.Not(graph_output_referencing(u1) == graph_output_referencing(u2)))
+    assert solver.check() == z3.sat
+
+
+def test_eliminate_unused_initializer_pass_matches():
+    # A is genuinely orphaned: referenced by no node and no graph output. B
+    # and C are consumed together with the runtime input X (not with each
+    # other alone), which keeps onnxsim's own constant-folding stage from
+    # folding D = Add(B, C) away into a fresh initializer before this pass
+    # ever runs (a pure Add(initializer, initializer) would constant-fold
+    # entirely, defeating the point of a test about B/C staying untouched --
+    # confirmed empirically while developing this test, the same class of
+    # pitfall `eliminate_duplicate_initializer`'s own shape/dtype tests
+    # avoid). The compiled pass, run alone, removes A and leaves B/C in
+    # place.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,2] X) => (float[2,2] G)
+        {
+          D = Add(X, B)
+          G = Add(D, C)
+        }
+        """
+    )
+    values = [1.0, 2.0, 3.0, 4.0]
+    model.graph.initializer.extend(
+        [
+            _tensor("A", np.array(values).reshape(2, 2)),
+            _tensor("B", np.array(values).reshape(2, 2)),
+            _tensor("C", np.array(values).reshape(2, 2)),
+        ]
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_unused_initializer")
+    assert [i.name for i in sim_model.graph.initializer] == ["B", "C"]
+    assert ops["Add"] == 2
+
+
+def test_eliminate_unused_initializer_declines_when_all_used():
+    # Every initializer is actually consumed (B and C, both via Add against
+    # the runtime input X): nothing is unused, so the pass makes no changes.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,2] X) => (float[2,2] G)
+        {
+          D = Add(X, B)
+          G = Add(D, C)
+        }
+        """
+    )
+    values = [1.0, 2.0, 3.0, 4.0]
+    model.graph.initializer.extend(
+        [
+            _tensor("B", np.array(values).reshape(2, 2)),
+            _tensor("C", np.array(values).reshape(2, 2)),
+        ]
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_unused_initializer")
+    assert [i.name for i in sim_model.graph.initializer] == ["B", "C"]
+    assert ops["Add"] == 2
+
+
+def test_eliminate_unused_initializer_protects_output_named_initializer():
+    # Y is a graph output produced directly by an initializer (no producing
+    # node) -- condition 2 from the header ("A is not an output") must
+    # protect it. Z is a separate, genuinely-unreferenced initializer
+    # included so the pass still has real work to do alongside Y surviving.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,2] X) => (float[2,2] Y, float[2,2] W)
+        {
+          W = Add(X, B)
+        }
+        """
+    )
+    values = [1.0, 2.0, 3.0, 4.0]
+    model.graph.initializer.extend(
+        [
+            _tensor("Y", np.array(values).reshape(2, 2)),
+            _tensor("B", np.array(values).reshape(2, 2)),
+            _tensor("Z", np.array(values).reshape(2, 2)),  # genuinely unused
+        ]
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_unused_initializer")
+    assert [i.name for i in sim_model.graph.initializer] == ["Y", "B"]
+    assert [o.name for o in sim_model.graph.output] == ["Y", "W"]
+    assert ops["Add"] == 1
+
+
+def test_eliminate_unused_initializer_removes_orphan_named_as_input():
+    # A is genuinely orphaned (no node input, no output) AND its name also
+    # appears in graph.input -- unlike eliminate_duplicate_initializer, this
+    # pass has no exclusion for that case (the header's two conditions say
+    # nothing about graph inputs): A is erased, and per the pass's own
+    # `graph.eraseInput` call, its graph.input entry is erased right along
+    # with it. B and C are consumed via the runtime input X so they survive
+    # untouched, showing the pass still discriminates correctly alongside A's
+    # removal.
+    #
+    # `mutable_initializer=True` is required to observe this cleanly:
+    # onnxsim's default preprocessing strips any graph.input entry that
+    # duplicates an initializer name *before* the C++ optimizer ever runs
+    # (see this file's module docstring) -- with the default
+    # `mutable_initializer=False`, A's duplicate input entry would already be
+    # gone before this pass runs, leaving the "does the pass itself erase the
+    # input entry" question unanswered (confirmed empirically while
+    # developing this test). This also means `simplify_isolated` (which
+    # doesn't expose `mutable_initializer`) can't be used here -- call
+    # `onnxsim.simplify` directly instead, reusing `isolate()` for the skip
+    # list, exactly as `eliminate_duplicate_initializer`'s own input-name
+    # test does.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,2] X) => (float[2,2] G)
+        {
+          D = Add(X, B)
+          G = Add(D, C)
+        }
+        """
+    )
+    values = [1.0, 2.0, 3.0, 4.0]
+    model.graph.initializer.extend(
+        [
+            _tensor("A", np.array(values).reshape(2, 2)),
+            _tensor("B", np.array(values).reshape(2, 2)),
+            _tensor("C", np.array(values).reshape(2, 2)),
+        ]
+    )
+    model.graph.input.append(
+        helper.make_tensor_value_info("A", onnx.TensorProto.FLOAT, [2, 2])
+    )
+
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("eliminate_unused_initializer"),
+        mutable_initializer=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+
+    assert [i.name for i in sim_model.graph.initializer] == ["B", "C"]
+    assert [i.name for i in sim_model.graph.input] == ["X"]  # A's input erased too
+
+
+def test_eliminate_unused_initializer_recursive_subgraph_descent():
+    # InnerA is referenced ONLY from inside a nested If node's then_branch
+    # subgraph -- not by any node in the outer graph's own node list. A naive
+    # implementation that only checked the outer graph's direct node inputs
+    # would incorrectly consider InnerA dead; the real pass's
+    # `DescendOnGraphAttributesUnconstrained` walk correctly recognizes it as
+    # used and leaves it (and the outer graph's initializer list) untouched.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        agraph (float[2,2] X, bool Cond) => (float[2,2] Out)
+        {
+          Out = If (Cond) <
+              then_branch = then_g () => (float[2,2] ThenOut) { ThenOut = Add(X, InnerA) },
+              else_branch = else_g () => (float[2,2] ElseOut) { ElseOut = Identity(X) }
+              >
+        }
+        """
+    )
+    values = [1.0, 2.0, 3.0, 4.0]
+    model.graph.initializer.append(_tensor("InnerA", np.array(values).reshape(2, 2)))
+    sim_model, _ = simplify_isolated(model, "eliminate_unused_initializer")
+    assert [i.name for i in sim_model.graph.initializer] == ["InnerA"]

--- a/tests/test_formal_verify_fuse_consecutive_log_softmax.py
+++ b/tests/test_formal_verify_fuse_consecutive_log_softmax.py
@@ -1,0 +1,221 @@
+"""Formal check for FuseConsecutiveLogSoftmax (fuse_consecutive_log_softmax.h).
+
+``patternMatchPredicate`` matches ``Log(Softmax(X, axis=k))`` -- a ``Log``
+node whose sole input is the output of a ``Softmax`` node -- only when that
+Softmax's output has exactly 1 use (``node->input()->uses().size() == 1``),
+i.e. the Log is its sole consumer.
+
+``runTransform`` creates a brand-new ``LogSoftmax`` node with the SAME
+``axis`` attribute as the original Softmax, reading the SAME input ``X`` the
+Softmax read; the old Log node's consumers are rewired onto the new
+LogSoftmax node's output, and the old Log node is destroyed
+(``NodeDestroyType::DestroyOne``). The old Softmax node itself is left
+dangling (0 uses) -- not destroyed by this pass -- the same
+dangling-producer pattern seen throughout this repo's other fusion-pass
+formal-verify tests (cleanup is ``eliminate_deadend``'s job, a separate
+default pass).
+
+Unlike most passes in this fusion-pass family (mostly structural/index-
+algebra arguments), this one rests on a genuine real-analysis identity:
+``Log(Softmax(x)_i) == LogSoftmax(x)_i`` for every index ``i`` along the
+softmax axis, because
+
+* ``Softmax(x)_i = exp(x_i) / sum_j exp(x_j)``
+* ``LogSoftmax(x)_i`` is DEFINED (per the ONNX LogSoftmax spec, and
+  mathematically) as ``x_i - Log(sum_j exp(x_j))``
+* ``Log(Softmax(x)_i) = Log(exp(x_i) / sum_j exp(x_j))
+                       = Log(exp(x_i)) - Log(sum_j exp(x_j))``   [quotient law,
+                                                                   valid since
+                                                                   exp is always
+                                                                   > 0]
+                       ``= x_i - Log(sum_j exp(x_j))``            [Log(Exp(y)) == y]
+
+  which is exactly ``LogSoftmax(x)_i``.
+
+This is modeled below with an uninterpreted ``logsumexp`` real constant
+standing in for ``Log(sum_j exp(x_j))`` -- the actual sum-over-exp
+computation is never itself modeled, only that BOTH Softmax's own
+denominator and LogSoftmax's own defining equation refer to the exact same
+quantity ``sum_j exp(x_j)`` for the same input ``x`` and axis -- plus two
+axioms capturing the two real-analysis laws actually used
+(``ForAll([a, b], a>0 => b>0 => log(a/b) == log(a) - log(b))`` and
+``ForAll([x], log(exp(x)) == x)``). The proof below derives the elementwise
+identity from those two axioms plus each op's own defining equation, walking
+through the ``log(a/b) = log(a) - log(b)`` step in Z3 exactly as the
+source-level derivation above does, rather than asserting the two
+definitions are equal outright. This is closer in spirit to
+``test_formal_verify_fuse_bn_into_conv.py``'s handling of BatchNorm's
+``sqrt``/variance side condition (a real piece of nontrivial algebra) than
+to most of this repo's other "index remapping" proofs.
+"""
+
+import numpy as np
+import onnxruntime as ort
+from _formal_verify_common import producer, prove, simplify_isolated, z3
+from onnx import parser
+
+
+def test_fuse_consecutive_log_softmax_is_sound():
+    log = z3.Function("log", z3.RealSort(), z3.RealSort())
+    exp = z3.Function("exp", z3.RealSort(), z3.RealSort())
+
+    # X(i) == x_i: an uninterpreted per-index reader of the (arbitrary,
+    # symbolic) input tensor along the softmax axis.
+    X = z3.Function("X", z3.IntSort(), z3.RealSort())
+    i = z3.Int("i")
+
+    # sum_exp == sum_j exp(x_j): the shared axis-reduction quantity both
+    # Softmax's denominator and LogSoftmax's own logsumexp term refer to.
+    # Its actual computation (the sum itself) is never modeled -- only that
+    # both ops' defining equations name the exact same quantity.
+    sum_exp = z3.Real("sum_exp")
+    # logsumexp == Log(sum_j exp(x_j)): the uninterpreted stand-in
+    # LogSoftmax's own defining equation uses, tied to sum_exp by the axiom
+    # below (not asserted equal to the conclusion outright).
+    logsumexp = z3.Real("logsumexp")
+
+    def softmax_i(i):
+        return exp(X(i)) / sum_exp  # Softmax(x)_i, ONNX Softmax's own definition
+
+    def log_softmax_i(i):
+        return X(i) - logsumexp  # LogSoftmax(x)_i, ONNX LogSoftmax's own definition
+
+    # The two real-analysis laws the source-level derivation above actually
+    # uses, instantiated directly at the concrete points this proof needs
+    # (a=exp(X(i)), b=sum_exp; y=X(i)) rather than left as ForAll-quantified
+    # axioms for Z3 to instantiate itself. prove()'s own implicit universal
+    # quantification over every free variable here (i, sum_exp, logsumexp,
+    # and X itself) already makes this argument general for every index and
+    # every input -- a ForAll would only ask Z3 to re-derive, via its own
+    # quantifier-instantiation heuristics, the single ground instantiation
+    # this proof actually needs. Ground instantiation avoids a real
+    # observed fragility: with the ForAll form, this same proof passed in
+    # well under a second in isolation but, when run after many other
+    # Solver() instances earlier in the same test session, occasionally took
+    # far longer -- nonlinear real arithmetic combined with quantified
+    # uninterpreted functions is a case where Z3's E-matching can be
+    # sensitive to accumulated internal solver state. The ground form sidesteps
+    # that instability entirely (mirroring the same fast-instantiation fix
+    # test_formal_verify_eliminate_nop_reshape.py's own proof uses for an
+    # unrelated ForAll-over-div/mod performance concern).
+    log_quotient_here = log(exp(X(i)) / sum_exp) == log(exp(X(i))) - log(sum_exp)
+    log_exp_here = log(exp(X(i))) == X(i)
+
+    side_conditions = z3.And(
+        sum_exp > 0,
+        exp(X(i)) > 0,  # exp is always strictly positive -- the quotient law's a>0 need
+        logsumexp == log(sum_exp),  # ties logsumexp to the SAME sum_exp quantity
+    )
+
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+
+    prove(
+        z3.Implies(
+            z3.And(log_quotient_here, log_exp_here, side_conditions),
+            consumer(log(softmax_i(i))) == consumer(log_softmax_i(i)),
+        )
+    )
+
+
+def _model(body, opset=13):
+    return parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+
+
+def test_fuse_consecutive_log_softmax_pass_matches():
+    model = _model(
+        """
+        g (float[2,3] X) => (float[2,3] Y)
+        {
+          s = Softmax<axis = 1>(X)
+          Y = Log(s)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_log_softmax")
+    assert ops["LogSoftmax"] == 1
+    assert ops["Log"] == 0
+
+    # The live output is produced directly by the new LogSoftmax node, fed
+    # by the ORIGINAL input X (not by the old Softmax's output) and carrying
+    # the SAME axis attribute the Softmax had.
+    fused = producer(sim_model, "Y")
+    assert fused.op_type == "LogSoftmax"
+    assert list(fused.input) == ["X"]
+    axis_attr = next(a.i for a in fused.attribute if a.name == "axis")
+    assert axis_attr == 1
+
+    # The old Softmax node is left dangling (0 uses) -- not itself destroyed
+    # by this pass (eliminate_deadend is skipped by simplify_isolated).
+    dangling = [n for n in sim_model.graph.node if n.output[0] == "s"]
+    assert len(dangling) == 1 and dangling[0].op_type == "Softmax"
+
+    # Numeric check: this is a genuine mathematical identity, so a mismatch
+    # here would indicate a real bug, not just a structural difference.
+    # simplify_isolated's own check_ok already asserted onnxsim's internal
+    # equivalence check passed; run onnxruntime directly too so the exact
+    # claim ("the output values are the same") is visible here.
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((2, 3)).astype(np.float32)
+    orig_sess = ort.InferenceSession(model.SerializeToString())
+    fused_sess = ort.InferenceSession(sim_model.SerializeToString())
+    (orig_out,) = orig_sess.run(None, {"X": x})
+    (fused_out,) = fused_sess.run(None, {"X": x})
+    np.testing.assert_allclose(orig_out, fused_out, rtol=1e-5, atol=1e-6)
+
+
+def test_fuse_consecutive_log_softmax_declines_multi_use_softmax():
+    # The Softmax's output also feeds a second graph output directly -- more
+    # than 1 use, so the predicate declines: both Softmax and Log survive,
+    # still chained.
+    model = _model(
+        """
+        g (float[2,3] X) => (float[2,3] Y, float[2,3] S)
+        {
+          s = Softmax<axis = 1>(X)
+          Y = Log(s)
+          S = Identity(s)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_log_softmax")
+    assert ops["LogSoftmax"] == 0
+    assert ops["Softmax"] == 1
+    assert ops["Log"] == 1
+
+    log_node = producer(sim_model, "Y")
+    assert log_node.op_type == "Log"
+    assert log_node.input[0] == "s"
+    softmax_node = producer(sim_model, log_node.input[0])
+    assert softmax_node.op_type == "Softmax"
+    assert list(softmax_node.input) == ["X"]
+
+
+def test_fuse_consecutive_log_softmax_declines_non_softmax_producer():
+    # Log's input is produced by Sigmoid, not Softmax -- CheckKind's kind
+    # check fails outright, so the predicate declines without even looking
+    # at use counts.
+    model = _model(
+        """
+        g (float[2,3] X) => (float[2,3] Y)
+        {
+          s = Sigmoid(X)
+          Y = Log(s)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_log_softmax")
+    assert ops["LogSoftmax"] == 0
+    assert ops["Sigmoid"] == 1
+    assert ops["Log"] == 1
+
+    log_node = producer(sim_model, "Y")
+    assert log_node.op_type == "Log"
+    assert log_node.input[0] == "s"


### PR DESCRIPTION
## Summary

Continues the translation-validation effort from #1272/#1295 (see `tests/_formal_verify_common.py` for the architecture: a hand-written Z3 soundness proof paired with a differential check against the real compiled pass, run in isolation, for each targeted optimizer rewrite).

This PR adds 8 more proofs, raising coverage from 26/106 to 34/106 (32.1%), tracked by `scripts/formal_verify_coverage.py`:

- `eliminate_consecutive_idempotent_ops`, `eliminate_duplicate_initializer`, `fuse_transpose_into_gemm`, `eliminate_nop_monotone_argmax`
- `eliminate_deadend`, `eliminate_unused_initializer`, `fuse_consecutive_log_softmax`, `eliminate_if_with_const_cond`

Highlights:

- **`eliminate_deadend`** and **`eliminate_unused_initializer`** are thin, honestly-scoped proofs (a node/initializer with zero syntactic dependents contributes nothing to the graph's output) for the two whole-graph "sweep" passes referenced throughout this suite's other proofs as "left dangling, `eliminate_deadend` would normally clean this up." `eliminate_deadend`'s test confirms empirically that a single pass invocation cascades through an entire chain of newly-dead nodes at once (reverse node-order iteration), not just directly-dead ones.
- **`fuse_consecutive_log_softmax`** is a genuine real-analysis identity (`Log(Softmax(x)_i) == LogSoftmax(x)_i`, derived via the `log(a/b)` quotient law) rather than an index-algebra argument. Its Z3 proof was originally written with `ForAll`-quantified axioms; the combined 36-file regression caught a real fragility — that form passed in well under a second standalone but hung indefinitely when run after many other `Solver()` instances earlier in the same test session (Z3's quantifier instantiation for nonlinear real arithmetic + uninterpreted functions proved sensitive to accumulated internal solver state). Fixed by rewriting to ground-instantiate both axioms at the exact point the proof needs, matching a technique already used elsewhere in this suite; confirmed the fix makes the full suite pass reliably in ~30s.
- **`eliminate_if_with_const_cond`** inlines a statically-known `If` branch's subgraph into the parent graph. The deep correctness content is definitional (`If` is literally branch selection, modeled via `z3.If`), so the real content is in the subgraph-inlining mechanics (captured-value remapping, initializer copying), which the differential tests exercise directly — including one genuinely unconstructible case (a branch forwarding a captured value straight through as its own output) documented rather than forced, since `onnx.checker` itself rejects it.
- **`eliminate_consecutive_idempotent_ops`** covers both the "f(f(x))==f(x)" family (Ceil/Floor/Round/Relu/Sign) and the structurally distinct `Reshape(Reshape(X,S1),S2)==Reshape(X,S2)` composability claim, reusing `eliminate_nop_reshape`'s row-major flatten/unflatten technique.
- **`fuse_transpose_into_gemm`** proves folding a `[1,0]`-perm `Transpose` into Gemm's own `transA`/`transB` flag is sound, composed into a genuine concrete Gemm computation across all 4 combinations of both operands' flag states.

Every proof includes at least one differential test exercising a case where the pass's predicate declines, confirmed against the real compiled pass, and every Z3 proof was checked non-vacuous during development via a throwaway negative-control script (deliberately broken claim → genuine `sat` counterexample) — none of these throwaway scripts are part of the committed diff.

## Test plan

- [x] `pytest tests/test_formal_verify_*.py tests/test_fusion_patterns.py -q` — 240 passed in ~30s
- [x] `ruff check onnxsim tests` — clean
- [x] `ruff format --check onnxsim tests` — clean (2 pre-existing, unrelated findings elsewhere)
- [x] `python3 scripts/formal_verify_coverage.py` — 34/106 (32.1%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYPkPSuY9aARnGkHCpVzLV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYPkPSuY9aARnGkHCpVzLV)_