### PR TITLE
axera: the Audio8 decoder compiles and runs on an AX650N, and the audio is poor

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -5414,11 +5414,66 @@ padding into an explicit `Pad` node is a correct rewrite -- 16 sites, verified
 identical to 5.4e-7 -- and it does not help, because **Pulsar2 re-fuses `Pad`
 into `Conv`**: the next build reports the identical `padding=(54, 0)`. The rule
 is kept because it is right and cheap, and because knowing the frontend undoes
-it is worth more than not knowing. A rewrite that survives fusion would have to
-change the convolution itself, not its padding.
+it is worth more than not knowing.
 
-So the decoder does not compile yet, and what stands between is now three named
-things rather than a percentage.
+**`dilated_conv_to_taps` is what actually clears it.** `y[t] = sum_j w[:,:,j] .
+xp[t + j*d]` is the definition of a dilated convolution, so slicing the padded
+input at each tap offset and convolving with a kernel of one computes the same
+thing -- with the dilation gone, and the padding now feeding a `Slice` rather
+than a convolution, where the `Pad`-into-`Conv` fusion cannot reach it. It is
+also the shape the hardware wants: the weight table already stores a widely
+dilated convolution as one block per tap.
+
+Eight convolutions rewritten, verified against onnxruntime at 6.2e-7. **The
+model compiles.**
+
+### And then it ran
+
+One more thing stood in the way, and it is this harness's own bug rather than
+the compiler's. `axcl_run_model` feeds a model by writing one
+`<tensor name>.bin` per input, and Pulsar2 carries an ONNX name through to the
+`.axmodel` unchanged. This decoder's input is called `/Add_10_output_0`, and a
+leading slash makes `os.path.join` produce an *absolute* path -- the runner
+tries to write `/Add_10_output_0.bin` and dies with `PermissionError`.
+Exporters emit slash-prefixed names constantly. `filename_safe_io_names` is the
+fifth rule.
+
+With that, the Audio8 codec decoder's vocoder body **compiles for the AX650 and
+runs on an AX650N**, 65,536 samples out of a 141 MB `.axmodel`.
+
+### The audio is poor, and the reason is worth more than the result
+
+| measure | value |
+| --- | --- |
+| correlation against the CPU reference | 0.808 |
+| signal-to-noise ratio | **3.33 dB** |
+| above 9 kHz | error *exceeds* signal, -16 to -42 dB |
+
+The error is a flat broadband noise floor while the vocoder's energy sits below
+6 kHz. Three hypotheses, and measuring each was the whole point:
+
+* **Calibration too thin?** No. Eight feature maps from different windows
+  instead of two copies of one made it slightly *worse* (0.763).
+* **The legalizer's own fault, for unfusing Snake into five quantised
+  intermediates?** No. Simulating INT8 on both forms costs **2 dB per
+  activation** (39.7 -> 37.7 dB); compounded over 29 of them that is ~23 dB,
+  nowhere near 3.3.
+* **A few bad layers?** No. Pulsar2's own per-layer analysis puts 661 of 675
+  layers above 0.99 cosine similarity, the worst at 0.9964.
+
+What is left is the sum: **675 quantised operations, each individually
+excellent, accumulating**. A few percent relative error per layer over that
+depth is a random walk of `sqrt(675)`, which lands about where the device
+measurement is.
+
+The sharpest part is that Pulsar2's precision analysis **cannot show this**,
+and says so in its own title -- *PerLayer Reference* scores each layer against
+float inputs, so accumulation is invisible by construction. A table of
+uniformly excellent per-layer numbers sitting above a 3 dB end-to-end result is
+not a contradiction; it is the two things measuring different quantities.
+
+So: the path is open and the model is not usable as built. Getting audio out of
+it needs higher precision through part of the network, not another rewrite.
 
 ## LLMs: a separate pipeline onnxsim has no hook into
 

--- a/scripts/axera/legalize.py
+++ b/scripts/axera/legalize.py
@@ -25,6 +25,7 @@ import collections
 
 import numpy as np
 import onnx
+import onnx.shape_inference
 from onnx import AttributeProto, TensorProto, helper, numpy_helper
 
 
@@ -173,10 +174,176 @@ def explicit_conv_padding(model):
     return changed
 
 
+def _initializer(model, name):
+    for init in model.graph.initializer:
+        if init.name == name:
+            return init
+    return None
+
+
+def dilated_conv_to_taps(model, min_dilation=2):
+    """A dilated 1-D convolution becomes one 1x1 convolution per tap, summed.
+
+    `y[t] = sum_j w[:, :, j] . xp[t + j*d]` is the definition, so slicing the
+    padded input at each tap offset and convolving with a kernel of one is
+    exactly the same function -- with `dilation` gone and the padding consumed
+    by an explicit `Pad` that no longer sits against a convolution, so the
+    frontend's `Pad`-into-`Conv` fusion cannot put it back.
+
+    This is also the shape the hardware wants: the weight table stores a widely
+    dilated convolution as one block per tap already (see "A widely dilated
+    convolution is K convolutions"), so the rewrite moves the graph towards
+    what the compiler does internally rather than away from it.
+    """
+    # Shapes are needed to size each tap's slice, and a graph that was cut out
+    # of a larger one carries no `value_info` at all -- which made an earlier
+    # version of this rule skip every convolution in silence.
+    try:
+        shaped = onnx.shape_inference.infer_shapes(model, strict_mode=False)
+        known = {
+            v.name: [d.dim_value for d in v.type.tensor_type.shape.dim]
+            for v in list(shaped.graph.value_info) + list(shaped.graph.output)
+        }
+    except Exception:  # noqa: BLE001 -- shape inference is best-effort here
+        known = {}
+
+    changed = 0
+    out = []
+    for node in model.graph.node:
+        attrs = {a.name: a for a in node.attribute}
+        dil = list(attrs["dilations"].ints) if "dilations" in attrs else []
+        weight = _initializer(model, node.input[1]) if len(node.input) > 1 else None
+        strides = list(attrs["strides"].ints) if "strides" in attrs else [1]
+        group = attrs["group"].i if "group" in attrs else 1
+        shape = known.get(node.output[0], [])
+        if (
+            node.op_type != "Conv"
+            or weight is None
+            or len(dil) != 1
+            or dil[0] < min_dilation
+            or strides != [1]
+            or group != 1
+            or len(shape) != 3
+            or not shape[2]
+        ):
+            out.append(node)
+            continue
+
+        w = numpy_helper.to_array(weight)
+        taps, d, length = w.shape[2], dil[0], shape[2]
+        pads = list(attrs["pads"].ints) if "pads" in attrs else [0, 0]
+        stem = node.name or node.output[0]
+
+        pad_name = f"{stem}_pads"
+        model.graph.initializer.append(
+            numpy_helper.from_array(
+                np.array([0, 0, pads[0], 0, 0, pads[1]], np.int64), pad_name
+            )
+        )
+        padded = f"{stem}_padded"
+        out.append(
+            helper.make_node(
+                "Pad",
+                [node.input[0], pad_name],
+                [padded],
+                name=f"{stem}_pad",
+                mode="constant",
+            )
+        )
+
+        partials = []
+        for j in range(taps):
+            tap_w = f"{stem}_w{j}"
+            model.graph.initializer.append(
+                numpy_helper.from_array(np.ascontiguousarray(w[:, :, j : j + 1]), tap_w)
+            )
+            starts, ends, axes = (f"{stem}_s{j}", f"{stem}_e{j}", f"{stem}_a{j}")
+            for name, value in ((starts, j * d), (ends, j * d + length), (axes, 2)):
+                model.graph.initializer.append(
+                    numpy_helper.from_array(np.array([value], np.int64), name)
+                )
+            sliced = f"{stem}_x{j}"
+            out.append(
+                helper.make_node(
+                    "Slice",
+                    [padded, starts, ends, axes],
+                    [sliced],
+                    name=f"{stem}_slice{j}",
+                )
+            )
+            inputs = [sliced, tap_w]
+            if j == 0 and len(node.input) > 2:
+                inputs.append(node.input[2])
+            partial = f"{stem}_y{j}"
+            out.append(
+                helper.make_node(
+                    "Conv",
+                    inputs,
+                    [partial],
+                    name=f"{stem}_tap{j}",
+                    kernel_shape=[1],
+                    pads=[0, 0],
+                    dilations=[1],
+                    strides=[1],
+                )
+            )
+            partials.append(partial)
+
+        acc = partials[0]
+        for j, part in enumerate(partials[1:], start=1):
+            nxt = node.output[0] if j == len(partials) - 1 else f"{stem}_acc{j}"
+            out.append(
+                helper.make_node("Add", [acc, part], [nxt], name=f"{stem}_add{j}")
+            )
+            acc = nxt
+        changed += 1
+
+    if changed:
+        del model.graph.node[:]
+        model.graph.node.extend(out)
+    return changed
+
+
+def filename_safe_io_names(model):
+    """Graph inputs and outputs get names that can be a file name.
+
+    `axcl_run_model` feeds a compiled model by writing one `<tensor name>.bin`
+    per input, and Pulsar2 carries an ONNX name through to the `.axmodel`
+    unchanged. Exporters routinely emit names like `/Add_10_output_0`, and a
+    leading slash turns that path into an absolute one -- the runner then tries
+    to write `/Add_10_output_0.bin` and fails with `PermissionError`. Renaming
+    is safe: only the graph's own boundary names change, and nothing outside
+    the model refers to them.
+    """
+    renamed = {}
+    for value in list(model.graph.input) + list(model.graph.output):
+        if "/" in value.name or value.name.startswith("."):
+            clean = value.name.strip("/").replace("/", "_").lstrip(".")
+            renamed[value.name] = clean or "tensor"
+            value.name = renamed[value.name]
+    if not renamed:
+        return 0
+    for node in model.graph.node:
+        for i, name in enumerate(node.input):
+            if name in renamed:
+                node.input[i] = renamed[name]
+        for i, name in enumerate(node.output):
+            if name in renamed:
+                node.output[i] = renamed[name]
+    for value in model.graph.value_info:
+        if value.name in renamed:
+            value.name = renamed[value.name]
+    return len(renamed)
+
+
+#: Order matters. `dilated_conv_to_taps` consumes a convolution's `pads`
+#: attribute, so it has to run before `explicit_conv_padding` zeroes it.
 RULES = {
     "float16_to_float32": float16_to_float32,
     "pow2_to_mul": pow2_to_mul,
+    "dilated_conv_to_taps": dilated_conv_to_taps,
     "explicit_conv_padding": explicit_conv_padding,
+    "filename_safe_io_names": filename_safe_io_names,
 }
 
 

--- a/tests/test_axera_legalize.py
+++ b/tests/test_axera_legalize.py
@@ -118,6 +118,38 @@ def test_float16_graph_is_retyped_everywhere_it_matters():
     )  # loads, which the half-converted graph does not
 
 
+def _dilated_conv_model(pads, dilation, k=3, C=4, L=16):
+    """A dilated 1-D convolution with shapes resolved, the way an export that
+    has been through shape inference looks."""
+    w = numpy_helper.from_array(
+        np.random.RandomState(0).randn(C, C, k).astype(np.float32), "w"
+    )
+    b = numpy_helper.from_array(
+        np.random.RandomState(1).randn(C).astype(np.float32), "b"
+    )
+    out_len = L + pads[0] + pads[1] - ((k - 1) * dilation + 1) + 1
+    graph = helper.make_graph(
+        [
+            helper.make_node(
+                "Conv",
+                ["x", "w", "b"],
+                ["y"],
+                kernel_shape=[k],
+                pads=list(pads),
+                dilations=[dilation],
+                strides=[1],
+            )
+        ],
+        "dilated",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, C, L])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, C, out_len])],
+        initializer=[w, b],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 10
+    return model
+
+
 def _causal_conv_model():
     """A convolution padded only on the left -- the causal form a streaming
     codec uses, and the one Pulsar2's backend refuses."""
@@ -174,6 +206,61 @@ def test_symmetric_padding_is_left_alone():
             attr.ints.extend([2, 2])
     assert legalize.explicit_conv_padding(model) == 0
     assert [n.op_type for n in model.graph.node] == ["Conv"]
+
+
+def test_dilated_conv_becomes_one_convolution_per_tap():
+    """`y[t] = sum_j w[:,:,j] . xp[t + j*d]` -- slicing the padded input at each
+    tap and convolving with a kernel of one is the same function, with the
+    dilation gone."""
+    ort = __import__("onnxruntime")
+    for pads, dilation in (((4, 0), 2), ((2, 2), 2), ((0, 0), 3)):
+        before = _dilated_conv_model(pads, dilation)
+        after = _dilated_conv_model(pads, dilation)
+        assert legalize.dilated_conv_to_taps(after) == 1, (pads, dilation)
+        kinds = [n.op_type for n in after.graph.node]
+        assert kinds.count("Conv") == 3 and "Pad" in kinds and "Slice" in kinds
+        onnx.checker.check_model(after)
+
+        x = np.random.RandomState(3).randn(1, 4, 16).astype(np.float32)
+        runs = [
+            ort.InferenceSession(
+                m.SerializeToString(), providers=["CPUExecutionProvider"]
+            ).run(None, {"x": x})[0]
+            for m in (before, after)
+        ]
+        assert np.allclose(runs[0], runs[1], atol=1e-5), (
+            pads,
+            dilation,
+            np.abs(runs[0] - runs[1]).max(),
+        )
+
+
+def test_dilated_conv_rule_needs_shapes_and_says_so_by_not_firing():
+    """The rule sizes each slice from the convolution's output length. A graph
+    cut out of a larger one carries no `value_info`, and an earlier version
+    skipped every convolution in silence because of it -- so the rule now runs
+    shape inference itself, and this is the case that regressed."""
+    model = _dilated_conv_model((4, 0), 2)
+    del model.graph.value_info[:]
+    assert legalize.dilated_conv_to_taps(model) == 1
+
+
+def test_io_names_are_made_filename_safe():
+    """`axcl_run_model` writes one `<tensor name>.bin` per input, so an
+    exporter's `/Add_10_output_0` becomes an absolute path and the run dies
+    with `PermissionError`."""
+    model = _dilated_conv_model((4, 0), 2)
+    model.graph.input[0].name = "/Add_10_output_0"
+    model.graph.node[0].input[0] = "/Add_10_output_0"
+    assert legalize.filename_safe_io_names(model) == 1
+    assert model.graph.input[0].name == "Add_10_output_0"
+    assert model.graph.node[0].input[0] == "Add_10_output_0"
+    onnx.checker.check_model(model)
+
+
+def test_clean_io_names_are_left_alone():
+    model = _dilated_conv_model((4, 0), 2)
+    assert legalize.filename_safe_io_names(model) == 0
 
 
 def test_legalize_reports_what_each_rule_changed():


### PR DESCRIPTION
Two more legalization rules, and the first end-to-end run of an Audio8 model on real hardware.

## `dilated_conv_to_taps` clears the last compiler blocker

`y[t] = Σⱼ w[:,:,j] · xp[t + j·d]` is the definition of a dilated convolution, so slicing the padded input at each tap offset and convolving with a kernel of one computes the same thing — with the dilation gone, and the padding now feeding a `Slice` rather than a convolution, **where pulsar2's `Pad`-into-`Conv` fusion cannot reach it** (which is why the earlier `explicit_conv_padding` rule was correct and useless). It is also the shape the hardware wants: the weight table already stores a widely dilated convolution as one block per tap.

Eight convolutions rewritten, verified against onnxruntime at 6.2e-7. **The model compiles** — 141 MB `.axmodel`.

## `filename_safe_io_names` is our bug, not the compiler's

`axcl_run_model` feeds a model by writing one `<tensor name>.bin` per input, and pulsar2 carries ONNX names through unchanged. This decoder's input is `/Add_10_output_0` — the leading slash makes `os.path.join` produce an *absolute* path, and the run dies with `PermissionError: '/Add_10_output_0.bin'`. Exporters emit slash-prefixed names constantly.

With both, the vocoder body **runs on an AX650N**: 65,536 samples out.

## The audio is poor, and the reason is worth more than the result

| measure | value |
| --- | --- |
| correlation vs CPU | 0.808 |
| SNR | **3.33 dB** |
| above 9 kHz | error *exceeds* signal, −16 to −42 dB |

Three hypotheses, each measured rather than assumed:

- **Calibration too thin?** No — eight feature maps from different windows instead of two copies of one made it slightly *worse* (0.763).
- **The legalizer's fault, for unfusing Snake into five quantised intermediates?** No — simulating INT8 on both forms costs **2 dB per activation** (39.7 → 37.7 dB); over 29 of them that is ~23 dB, nowhere near 3.3.
- **A few bad layers?** No — pulsar2's own analysis puts **661 of 675 layers above 0.99 cosine**, the worst at 0.9964.

What is left is the sum: **675 quantised operations, each individually excellent, accumulating.** A few percent relative error per layer over that depth is a random walk of `sqrt(675)`, which lands about where the device measurement is.

The sharpest part: pulsar2's precision analysis **cannot show this**, and says so in its own title — *PerLayer **Reference*** scores each layer against float inputs, so accumulation is invisible by construction. Uniformly excellent per-layer numbers above a 3 dB end-to-end result are not a contradiction; they measure different quantities.

**The path is open and the model is not usable as built.** Getting audio out of it needs higher precision through part of the network, not another rewrite.

Eleven offline tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS