### PR TITLE
Add Z3 formal-verification proofs for the last 12 default optimizer passes -- 40/40 default coverage

### DIFF
--- a/tests/test_formal_verify_eliminate_common_subexpression.py
+++ b/tests/test_formal_verify_eliminate_common_subexpression.py
@@ -1,0 +1,244 @@
+"""Formal check for EliminateCommonSubexpression (eliminate_common_subexpression.h).
+
+Like ``eliminate_duplicate_initializer``, this pass is a ``FullGraphBasedPass``
+(whole-graph analysis via ``runPass(Graph&)``), not a ``PredicateBasedPass``.
+It walks the graph's nodes in order; for each node it considers (skipping any
+node with no uses at all, and any node ``IsSupportedByCSE`` excludes -- see
+below), it hashes the node (``CSENodeHash``) and looks it up in a hash map
+keyed by structural equality (``CSEEqual``, both in ``cse_util.h``). The first
+time a given structural shape is seen, the node becomes that shape's
+canonical representative in the map. Every later node found structurally
+equal to an already-seen one has every one of its outputs rewired
+(``tryReplacingAllUsesWith``) onto the corresponding output of that earlier,
+canonical node, and is left dead for a later dead-code pass to remove.
+
+``IsSupportedByCSE`` -- read directly from ``cse_util.h`` rather than assumed
+-- is *not* an op-kind allowlist/denylist at all. It excludes a node purely
+by the *kind of its attributes*: any node carrying a graph-valued attribute
+(``AttributeKind::g``/``gs``, e.g. ``If``'s ``then_branch``/``else_branch`` or
+``Loop``'s ``body``) or a sparse-tensor-valued one (``tp``/``ts``... here
+``tp``/``tps``) is excluded, and every other node -- regardless of op type --
+is eligible. So there is no fixed list of "CSE-supported ops" to look up;
+ordinary compute ops like ``Relu``, ``Add``, and ``Cast`` are all eligible
+simply because none of them ever carries a graph- or sparse-tensor-valued
+attribute.
+
+``CSEEqual``'s structural-identity notion -- the real engineering content of
+this pass, and what the differential tests below focus on -- is, precisely:
+same op kind, same number of inputs *and outputs*, the same set of attribute
+names, matching attribute values for each (tensor-valued attributes compared
+by ``CSETensorCompare``, i.e. shape+dtype+bytes, same as
+``eliminate_duplicate_initializer``), and, crucially, same inputs *by
+identity*: ``inputs_l[i]->uniqueName() != inputs_r[i]->uniqueName()`` compares
+the ordered list of input **graph values (edges)** by name, not by any
+looser notion of "equal shape" or "equal type" or "equal content". Two
+``Add`` nodes reading ``(X, Y)`` and ``(X, Z)`` are therefore never merged no
+matter how alike ``Y`` and ``Z`` might otherwise be -- they are literally
+different edges in the graph -- which is the main negative control below.
+
+Formal content, and why the proof is thin (matching
+``eliminate_duplicate_initializer``'s own precedent for this style of pass):
+this is not a nontrivial rewrite of some operator's algebra -- it is a
+determinism/purity argument. If two node instances are structurally
+identical -- same op kind, same attributes, and the exact same input
+*values* (not merely equal-valued-but-distinct tensors, since ``CSEEqual``
+compares graph edges directly) -- then, because an ONNX operator is a
+(deterministic, side-effect-free) *function* of its attributes and inputs,
+applying that same function to the same arguments must produce the same
+result. This is modeled below as a single uninterpreted function
+``op(attr, x, y)``: the hypothesis "two node instances share the exact same
+``attr``, ``x``, ``y`` arguments" makes ``op(attr, x, y) == op(attr, x, y)``
+hold by reflexivity -- essentially the definition of a function, not a
+derivation -- and is stated as such rather than dressed up as deeper. The
+negative control confirms this is not vacuous: two *independent*,
+unconstrained applications of ``op`` are not provably equal.
+
+One more empirically-confirmed subtlety, in the same spirit as
+``eliminate_duplicate_initializer``'s ``producer()`` helper note in
+``_formal_verify_common.py``: this pass only rewires the duplicate node's
+*uses* onto the canonical node -- it does not itself delete the now-unused
+duplicate. Deleting dead nodes is ``eliminate_deadend``'s job, a separate
+default pass that ``isolate()`` disables here along with every other pass.
+So a merge test run through ``simplify_isolated`` still shows *two* nodes of
+the merged op type in the result (one live, one now-dead-but-still-present)
+-- the positive tests below locate the live one by walking back from a real
+graph output (``producer``) rather than by counting op types.
+"""
+
+from _formal_verify_common import isolate, producer, prove, simplify_isolated, z3
+from onnx import parser
+
+
+def test_eliminate_common_subexpression_is_sound():
+    # op(attr, x, y) models an arbitrary ONNX operator as an uninterpreted,
+    # deterministic function of its attribute(s) and (here, two) inputs.
+    # Two node instances that share the exact same attr/x/y arguments -- the
+    # formal counterpart of CSEEqual's "same kind, same attributes, same
+    # input values" -- trivially compute the same output.
+    op = z3.Function("op", z3.RealSort(), z3.RealSort(), z3.RealSort(), z3.RealSort())
+    attr, x, y = z3.Reals("attr x y")
+    prove(op(attr, x, y) == op(attr, x, y))
+
+
+def test_eliminate_common_subexpression_negative_control_needs_hypothesis():
+    # Without the "same arguments" hypothesis, two structurally-unrelated
+    # applications of op (independent attr/x/y on each side) are NOT
+    # provably equal -- confirming the claim above isn't vacuously true
+    # regardless of which arguments are fed in. Z3 must find a sat
+    # counterexample negating equality, not unsat.
+    op = z3.Function("op", z3.RealSort(), z3.RealSort(), z3.RealSort(), z3.RealSort())
+    attr1, x1, y1, attr2, x2, y2 = z3.Reals("attr1 x1 y1 attr2 x2 y2")
+
+    solver = z3.Solver()
+    solver.add(z3.Not(op(attr1, x1, y1) == op(attr2, x2, y2)))
+    assert solver.check() == z3.sat
+
+
+def test_eliminate_common_subexpression_pass_matches():
+    # R1 and R2 are structurally identical Relu(X) nodes, each feeding a
+    # separate downstream Add -- the compiled pass merges them: both
+    # downstream Adds get redirected to read from a single Relu's output.
+    #
+    # This pass only rewires uses; it doesn't itself delete the
+    # now-unused duplicate node (that is eliminate_deadend's job, a
+    # separate default pass skipped here like every other one by
+    # isolate() -- see simplify_isolated/producer's own docstring in
+    # _formal_verify_common.py) -- so both `Relu` nodes are still present
+    # in sim_model.graph.node, and only the *live* one (found by walking
+    # back from a real graph output via `producer`) is meaningful to
+    # check.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,2] X) => (float[2,2] G)
+        {
+          R1 = Relu(X)
+          R2 = Relu(X)
+          A1 = Add(R1, X)
+          A2 = Add(R2, X)
+          G = Add(A1, A2)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_common_subexpression")
+    assert ops["Add"] == 3
+    a1_node = producer(sim_model, "A1")
+    a2_node = producer(sim_model, "A2")
+    # Both surviving consumers read the same Relu output -- whichever of
+    # R1/R2 the pass kept as canonical.
+    assert a1_node.input[0] == a2_node.input[0]
+    assert producer(sim_model, a1_node.input[0]).op_type == "Relu"
+
+
+def test_eliminate_common_subexpression_declines_different_input_value():
+    # Same op kind (Add), same first operand (X), but a DIFFERENT second
+    # operand (Y vs Z) -- CSEEqual compares inputs by graph VALUE (edge
+    # name), not by op-kind-and-shape, so these are not structurally equal
+    # even though both are "an Add of X with some float[2,2]". Both nodes
+    # must survive untouched.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,2] X, float[2,2] Y, float[2,2] Z) => (float[2,2] A1, float[2,2] A2)
+        {
+          A1 = Add(X, Y)
+          A2 = Add(X, Z)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_common_subexpression")
+    assert ops["Add"] == 2
+    (a1_node,) = [n for n in sim_model.graph.node if list(n.output) == ["A1"]]
+    (a2_node,) = [n for n in sim_model.graph.node if list(n.output) == ["A2"]]
+    assert list(a1_node.input) == ["X", "Y"]
+    assert list(a2_node.input) == ["X", "Z"]
+
+
+def test_eliminate_common_subexpression_declines_different_kind():
+    # Relu(X) and Sigmoid(X): same (single) input value, but a different op
+    # kind -- a basic sanity check that CSEEqual's kind check is load-bearing.
+    # Both must survive untouched.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,2] X) => (float[2,2] R1, float[2,2] R2)
+        {
+          R1 = Relu(X)
+          R2 = Sigmoid(X)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_common_subexpression")
+    assert ops["Relu"] == 1
+    assert ops["Sigmoid"] == 1
+
+
+def test_eliminate_common_subexpression_declines_different_attribute():
+    # Two Cast nodes on the same input X, but with different `to` dtypes
+    # (FLOAT vs DOUBLE): CSEEqual compares attribute values too, so these are
+    # not structurally equal despite sharing op kind and input. Both must
+    # survive untouched. (Outputs are typed per-`to`, and left un-combined by
+    # any arithmetic op, so onnxruntime's own type checking during
+    # onnxsim's --check step doesn't itself get in the way of this test.)
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,2] X) => (float[2,2] C1, double[2,2] C2)
+        {
+          C1 = Cast <to = 1> (X)
+          C2 = Cast <to = 11> (X)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_common_subexpression")
+    assert ops["Cast"] == 2
+
+
+def test_eliminate_common_subexpression_merges_same_attribute():
+    # Companion positive case to the test above: two Cast nodes on the same
+    # input with the SAME `to` dtype are structurally identical and must
+    # merge -- confirming the attribute check is comparing values (and
+    # merges when they match), not just detecting mismatches. As in
+    # test_eliminate_common_subexpression_pass_matches above, the
+    # now-unused duplicate Cast node is left behind (eliminate_deadend is
+    # skipped too), so the live one is found via `producer`.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,2] X) => (float[2,2] G)
+        {
+          C1 = Cast <to = 1> (X)
+          C2 = Cast <to = 1> (X)
+          G = Add(C1, C2)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "eliminate_common_subexpression")
+    assert ops["Add"] == 1
+    g_node = producer(sim_model, "G")
+    assert g_node.input[0] == g_node.input[1]
+    assert producer(sim_model, g_node.input[0]).op_type == "Cast"
+
+
+def test_isolate_accepts_eliminate_common_subexpression():
+    # Sanity check that the pass name is a recognized default optimizer, so
+    # isolate()/simplify_isolated actually exercise it above rather than
+    # silently running the full default pipeline.
+    assert "eliminate_common_subexpression" not in isolate(
+        "eliminate_common_subexpression"
+    )

--- a/tests/test_formal_verify_eliminate_shape_gather.py
+++ b/tests/test_formal_verify_eliminate_shape_gather.py
@@ -1,0 +1,254 @@
+"""Formal check for EliminateShapeGather (eliminate_shape_gather.h).
+
+``patternMatchPredicate`` matches ``Gather(Shape(X), indices)`` -- a
+``Gather`` node whose data input (input 0) is the output of a ``Shape`` node
+-- ONLY when ``indices`` is a compile-time constant (``IsConstantTensor``)
+AND ``X`` (the ``Shape`` node's own input) has a statically known rank
+(``HasDimsOfInputOfNode``; individual dims of ``X`` may still be symbolic
+``dim_param``s, only the *rank* need be known -- same predicate shape as
+``eliminate_slice_after_shape``).
+
+``runTransform`` fetches ``indices``' single scalar value
+(``FetchSoleIntValueOfTensor`` -- so, like ``eliminate_slice_after_shape``,
+this pass only ever handles a single-element ``indices``, not a general
+multi-index ``Gather``), then reproduces ONNX ``Gather``'s own negative-index
+wraparound BY HAND: ``AddYIfNegative(indices_val, end - start)`` normalizes a
+negative index relative to the LENGTH OF THE SUB-RANGE ``Shape``'s own
+(rarely used) ``start``/``end`` attributes select -- NOT ``X``'s full rank --
+then adds ``start`` to land on ``X``'s actual axis. It asserts the result is
+in bounds (``ONNX_ASSERT``, not a graceful decline -- only reachable with a
+genuinely out-of-range ``indices`` on a real graph, which no valid ONNX
+model would have, so out-of-range inputs are out of this file's scope, same
+stance ``eliminate_slice_after_shape``'s file takes for its own asserted
+invariants) and declines (leaving both ``Shape`` and ``Gather`` in place) if
+the selected dim isn't statically known as a concrete int (``!dims[
+indices_val].is_int || dims[indices_val].dim == -1``). Otherwise it builds a
+fresh INT64 constant holding just that ONE dim's value -- shaped ``[1]`` if
+``indices`` itself was rank-1, or a bare scalar if ``indices`` was rank-0 --
+and rewires ``Gather``'s consumers onto it directly.
+
+Formal content: as the task framing for this file spells out, this is the
+same "trust static shape metadata equals the actual runtime shape" premise
+every shape-family pass in this suite relies on and cannot itself establish
+(a graph-level property no single-pass proof can prove -- taken as given,
+the same honesty ``eliminate_slice_after_shape``'s file applies), COMBINED
+with ``Gather``'s own single-index-extraction semantics: for a scalar/
+rank-1 index, ``Gather(seq, indices)[0]`` selects exactly ``seq`` at the
+negative-aware normalized index -- a standard, simple indexing fact, not
+something specific to shapes. Modeled below as: an uninterpreted per-axis
+"declared shape" function (``declared_dim``, standing for ``X``'s static
+shape-inference metadata -- what ``dims[...]`` in ``runTransform`` reads) and
+"runtime shape" function (``runtime_dim``, standing for what a real
+``Shape(X)`` op would produce at runtime), related by the premise that they
+agree pointwise; the index arithmetic itself
+(``AddYIfNegative(indices_val, end - start) + start``, a direct
+transliteration of ``runTransform``'s own two-line computation) is encoded
+directly as it is definitional ONNX ``Shape``/``Gather`` spec bookkeeping,
+not a hypothesis needing its own premise -- mirroring how
+``eliminate_slice_after_shape``'s ``_walk_slice`` transliterates its walk
+rather than hypothesizing it; and an arbitrary uninterpreted ``consumer`` for
+substitution safety.
+
+A structural finding shared verbatim with
+``test_formal_verify_extract_constant_to_initializer.py`` (read that file's
+own docstring for the fuller story -- this paragraph only summarizes it):
+unlike every OTHER pass targeted by this suite, ``eliminate_shape_gather`` is
+UNREACHABLE through onnxsim's own Python API, by deliberate design.
+``onnxsim.cpp``'s ``SimplifyImpl`` builds ``config.optimizer_passes`` from
+``onnx::optimization::GetFuseAndEliminationPass()`` filtered through a fixed
+``always_disabled_passes = {"eliminate_shape_gather",
+"extract_constant_to_initializer"}`` list -- applied not only to the default
+pass set but also to ``extra_optimizers`` (the general opt-in mechanism
+every other non-default pass in this suite is exercised through), so there
+is no combination of ``skipped_optimizers``/``isolate()`` and/or
+``extra_optimizers`` that makes it run. This was confirmed empirically while
+writing this file (not just read off the source): reading
+``always_disabled_passes``' definition directly in ``onnxsim/onnxsim.cpp``,
+and separately building a ``Gather(Shape(X), indices)`` model that satisfies
+``eliminate_shape_gather``'s own predicate (constant scalar ``indices``, ``X``
+with fully known static shape) and running it through
+``onnxsim.simplify(model, skipped_optimizers=isolate("eliminate_shape_gather"),
+skip_constant_folding=True)`` -- the ``Gather``/``Shape`` chain survives
+completely untouched, confirming the pass never fires. The comment above
+``always_disabled_passes`` in ``onnxsim.cpp`` explains why: onnxsim's own
+constant folder (see that comment, and ``extract_constant_to_initializer``'s
+docstring) already performs the equivalent shape/gather-constant-folding
+work itself via a dedicated partial-shape-evaluation step ("Shape/Gather-on-
+shape into constants", per the ``FoldConstant`` comment in ``onnxsim.cpp``)
+BEFORE the optimizer passes run, and folds the result into onnxsim's own
+constant-node-preserving representation rather than
+``eliminate_shape_gather``'s bare initializer -- so this onnx-optimizer pass
+is permanently redundant with, and would fight, onnxsim's own folding
+strategy, and is dropped unconditionally.
+
+Consequently, exactly as for ``extract_constant_to_initializer``, there is no
+way to run "the real compiled pass, in isolation" against a concrete model
+*through onnxsim's own public Python surface* -- the surface this suite
+otherwise insists on testing against (see CLAUDE.md and every other
+``test_formal_verify_*.py`` file). An earlier version of the sibling
+``extract_constant_to_initializer`` file drove onnxoptimizer's C++ pass class
+directly via a small C++ harness compiled at test time against this
+checkout's ``.setuptools-cmake-build`` artifacts; that approach was dropped
+because it only works when a source build's ``compile_commands.json`` and
+static libraries happen to be present in the CWD -- true in a local dev
+checkout, but never true in CI's actual test job (``CIBW_TEST_COMMAND`` in
+``.github/workflows/build-and-test.yml`` installs a prebuilt wheel and runs
+``pytest`` against it, with no leftover CMake build tree or C++ toolchain
+available), so those tests would silently skip on every real CI run and
+provide no ongoing verification value there, while adding real fragility
+(compiler flags, link order, static-lib layout) for a local-only benefit.
+The same reasoning applies here unchanged, so this file follows suit and
+does not attempt one either.
+
+Instead, ``test_eliminate_shape_gather_unreachable_via_onnxsim_simplify``
+below tests the property that actually matters for onnxsim's own users and
+behavior -- that this pass never fires through the public API -- directly
+and unconditionally (no special build machinery, so it always runs in CI):
+if onnxsim's own ``always_disabled_passes`` filter (``onnxsim.cpp``) ever
+stopped excluding this pass, this is the test that would catch it, by
+observing the ``Gather``/``Shape`` chain unexpectedly collapsing into a fresh
+initializer.
+"""
+
+from _formal_verify_common import isolate, prove, z3
+from onnx import parser
+
+import onnxsim
+
+
+def _normalize_gather_index(indices_val, start, end):
+    """Transliterates runTransform's own index arithmetic (eliminate_shape_gather.h,
+    lines 45-46): ``AddYIfNegative(indices_val, end - start)`` wraps a negative
+    index relative to the length of the sub-range Shape's own start/end
+    attributes select, then ``+= start`` lands on X's actual axis.
+    """
+    sub_len = end - start
+    idx = indices_val + sub_len if indices_val < 0 else indices_val
+    return start + idx
+
+
+def test_eliminate_shape_gather_index_normalization_matches_python_indexing():
+    # Exhaustively confirms the transliterated index arithmetic always lands
+    # on the same element of X's full declared-shape list that plain
+    # two-step Python indexing -- first Shape's own start:end sub-range
+    # (list slicing), then Gather's negative-aware element index into that
+    # sub-range (list indexing) -- would select, for every valid
+    # (start, end, indices_val) triple. This is pure index bookkeeping (no
+    # value algebra), so a concrete exhaustive sweep is the right tool, the
+    # same choice eliminate_slice_after_shape's file makes for its own
+    # (more elaborate) index walk.
+    dims = [10, 11, 12, 13, 14, 15]
+    n = len(dims)
+    for start in range(0, n + 1):
+        for end in range(start, n + 1):
+            sub = dims[start:end]
+            for indices_val in range(-len(sub), len(sub)):
+                axis = _normalize_gather_index(indices_val, start, end)
+                assert dims[axis] == sub[indices_val]
+
+
+def test_eliminate_shape_gather_is_sound():
+    declared_dim = z3.Function("declared_dim", z3.IntSort(), z3.RealSort())
+    runtime_dim = z3.Function("runtime_dim", z3.IntSort(), z3.RealSort())
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+    a, idx, start, end = z3.Ints("a idx start end")
+
+    # "X's declared (static shape-inference) per-axis dims equal its actual
+    # runtime per-axis dims" -- the premise this suite's shape-family passes
+    # all rely on and cannot themselves establish; taken as given here, same
+    # as eliminate_slice_after_shape's file does for its own comparable
+    # claim.
+    shape_matches_runtime = z3.ForAll([a], declared_dim(a) == runtime_dim(a))
+
+    # runTransform's own index normalization (eliminate_shape_gather.h:45-46),
+    # encoded directly -- definitional ONNX Shape/Gather bookkeeping, not a
+    # hypothesis (see _normalize_gather_index above and the module
+    # docstring).
+    sub_len = end - start
+    normalized = z3.If(idx < 0, idx + sub_len, idx)
+    axis = start + normalized
+
+    # Only in-bounds indices are in scope: the pass ONNX_ASSERTs this rather
+    # than declining gracefully, so any real graph reaching runTransform
+    # already satisfies it (see module docstring).
+    valid_range = z3.And(0 <= start, start <= end, -sub_len <= idx, idx < sub_len)
+
+    # Substitution safety: whatever the fresh constant this pass bakes in
+    # (declared_dim(axis), since axis is exactly where runTransform reads
+    # dims[indices_val].dim) is consumed by, it is indistinguishable from
+    # what the ORIGINAL Gather(Shape(X), indices) would have produced at
+    # runtime (runtime_dim(axis) -- Shape(X)'s runtime output at that axis,
+    # by Shape's own spec, then Gather's own single-index selection, by
+    # Gather's own spec), given the shape-trust premise.
+    prove(
+        z3.Implies(
+            z3.And(shape_matches_runtime, valid_range),
+            consumer(declared_dim(axis)) == consumer(runtime_dim(axis)),
+        )
+    )
+
+
+def test_eliminate_shape_gather_negative_control_needs_shape_trust_premise():
+    # Without shape_matches_runtime, declared_dim and runtime_dim are two
+    # independent, fully unconstrained uninterpreted functions: the claim
+    # must NOT be valid then (even restricted to the same in-bounds
+    # indices), or the proof above would be vacuously true regardless of
+    # what the premise says.
+    declared_dim = z3.Function("declared_dim", z3.IntSort(), z3.RealSort())
+    runtime_dim = z3.Function("runtime_dim", z3.IntSort(), z3.RealSort())
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+    idx, start, end = z3.Ints("idx start end")
+
+    sub_len = end - start
+    normalized = z3.If(idx < 0, idx + sub_len, idx)
+    axis = start + normalized
+    valid_range = z3.And(0 <= start, start <= end, -sub_len <= idx, idx < sub_len)
+
+    solver = z3.Solver()
+    solver.add(valid_range)
+    solver.add(z3.Not(consumer(declared_dim(axis)) == consumer(runtime_dim(axis))))
+    assert solver.check() == z3.sat
+
+
+def test_eliminate_shape_gather_unreachable_via_onnxsim_simplify():
+    # Regression guard for the module docstring's central claim: unlike
+    # every other pass in this suite, no combination of onnxsim.simplify's
+    # own knobs runs this pass. This model satisfies eliminate_shape_gather's
+    # own predicate exactly (a Gather node whose input 0 is Shape(X), a
+    # constant scalar-shaped indices, and X with a fully known static rank
+    # AND fully known static dims) -- it WOULD trigger the pass if it were
+    # reachable. isolate("eliminate_shape_gather") skips every OTHER default
+    # pass, nominally leaving only this one active, and
+    # skip_constant_folding=True keeps onnxsim's separate (and, per the
+    # module docstring, functionally equivalent) shape/gather constant
+    # folder from folding this away on its own first, which would otherwise
+    # obscure whether eliminate_shape_gather itself ever touched anything.
+    # If onnxsim's own always_disabled_passes filter (onnxsim.cpp) ever
+    # stopped excluding this pass, this test would start failing here (the
+    # Gather/Shape chain would collapse into a fresh initializer) rather
+    # than silently changing onnxsim's constant-node-preservation guarantee.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,3,4] X) => (int64[1] Y)
+        <int64[1] indices = {1}>
+        {
+            s = Shape(X)
+            Y = Gather(s, indices)
+        }
+        """
+    )
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("eliminate_shape_gather"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = {n.op_type for n in sim_model.graph.node}
+    assert ops == {"Shape", "Gather"}
+    initializer_names = {init.name for init in sim_model.graph.initializer}
+    assert initializer_names == {"indices"}

--- a/tests/test_formal_verify_eliminate_shape_op.py
+++ b/tests/test_formal_verify_eliminate_shape_op.py
@@ -1,0 +1,309 @@
+"""Formal check for EliminateShapeOp (eliminate_shape_op.h).
+
+``patternMatchPredicate`` matches a ``Shape`` node ONLY when its input ``X``
+has a fully statically known RANK (``HasDimsOfInputOfNode``) AND every dim in
+the sub-range ``[start, end)`` that ``Shape``'s own (rarely-set) ``start``/
+``end`` attributes select (``FetchStartAndEndAttrOfShape`` -- defaults to the
+WHOLE rank when absent) is BOTH statically known as a concrete int and
+non-negative (``dim.is_int && dim.dim >= 0``).
+
+``runTransform`` builds a fresh INT64 constant tensor holding exactly ``X``'s
+declared dims in ``[start, end)``, adds it as a graph initializer, and
+rewires the ``Shape`` node's consumers onto it directly, destroying the
+``Shape`` node outright (unlike ``eliminate_slice_after_shape``, this pass
+deletes the ``Shape`` node itself rather than leaving it dangling).
+
+Formal content, and why the proof here is intentionally thin: this is the
+simplest and most foundational member of this suite's "trust static shape
+metadata equals actual runtime shape" family (see also
+``eliminate_slice_after_shape``, which shares the same premise but layers
+genuinely nontrivial Slice index arithmetic -- forward/reverse walks,
+negative-index normalization, asymmetric clamping -- on top of it). ONNX's
+``Shape`` operator is, by definition, "return the runtime shape of the input
+tensor" -- and ``X``'s own DECLARED static shape metadata (whatever shape
+inference / the model's ``value_info`` claims ``X``'s shape statically is)
+is, by the very meaning of "statically known", a claim that the runtime shape
+WILL equal those declared values whenever the graph actually runs. That
+premise is a graph-level property no single pass's proof can establish in
+isolation -- it is simply taken as given here, the same honesty this suite's
+other shape-family files apply (see ``eliminate_slice_after_shape``'s module
+docstring for the same framing). Given that premise, replacing
+``Shape(X)[start:end]``'s runtime computation with a literal constant holding
+the SAME declared values is trivially sound: there is no interesting index
+arithmetic at all here (no reversal, no clamping, no negative-index
+normalization -- ``start``/``end`` are already resolved to a plain forward
+``[start, end)`` window over ``X``'s own dims by the time this pass runs) --
+this is the base case ``eliminate_slice_after_shape`` and (elsewhere in this
+suite) ``eliminate_shape_gather`` build on. Modeled below the same way
+``eliminate_duplicate_initializer``'s own thin proof is: an uninterpreted
+per-axis "declared shape" function and an uninterpreted "runtime shape"
+function, constrained equal by the premise, composed with an arbitrary
+uninterpreted ``consumer`` reading a value at an axis selected by an
+arbitrary ``[start, end)`` window -- the claim reduces to the premise doing
+essentially all the work, stated plainly rather than dressed up as deeper
+than it is. The negative-control test below confirms this isn't vacuous:
+without the premise, the claim does not hold.
+
+A finding worth flagging honestly: unlike several sibling shape-family tests
+in this suite (e.g. ``eliminate_slice_after_shape``), the differential tests
+below do NOT strictly need ``skip_constant_folding=True`` to see *a* Shape
+node disappear -- confirmed empirically that onnxsim's own separate
+constant-folding step, entirely on its own (with ``eliminate_shape_op``
+itself also skipped via ``skipped_optimizers``), already collapses a
+``Shape(X)`` with fully static ``X`` into an equivalent constant, both with
+and without ``start``/``end`` attributes. So without
+``skip_constant_folding=True``, a passing differential test here would not
+actually prove anything about THIS pass -- it would just be re-observing
+constant folding under a different pass's name. ``skip_constant_folding=True``
+is used throughout below anyway, precisely to rule that out and attribute the
+rewrite to the real compiled ``eliminate_shape_op`` pass alone.
+"""
+
+import collections
+
+from _formal_verify_common import isolate, prove, z3
+from onnx import helper, numpy_helper, parser
+
+import onnxsim
+
+# X's shape for every differential test below: 5 distinct dims, so which ones
+# got selected (and in what order) is unambiguous from the values alone.
+_X_SHAPE = [2, 3, 4, 5, 6]
+
+
+def _model(body, opset=13, ir_version=10):
+    return parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+
+
+def test_eliminate_shape_op_is_sound():
+    # Uninterpreted per-axis "declared shape" and "runtime shape" functions,
+    # to prove substitution safety: given the graph-level premise that X's
+    # declared static dims equal its actual runtime shape (axis by axis),
+    # any downstream consumer sees the exact same value at any axis selected
+    # by Shape's [start, end) window whether it reads the ACTUAL runtime
+    # Shape(X)[start:end] computation, or the FRESH CONSTANT this pass
+    # builds from X's declared dims [start:end) instead. No index arithmetic
+    # is modeled here (unlike eliminate_slice_after_shape's reversed-slice
+    # walk) because this pass does none: the window is a plain forward
+    # sub-range copy.
+    declared = z3.Function("declared", z3.IntSort(), z3.RealSort())
+    runtime = z3.Function("runtime", z3.IntSort(), z3.RealSort())
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+    a, i, start, end = z3.Ints("a i start end")
+
+    declared_matches_runtime = z3.ForAll([a], declared(a) == runtime(a))
+
+    prove(
+        z3.Implies(
+            declared_matches_runtime,
+            z3.Implies(
+                z3.And(start <= i, i < end),
+                consumer(runtime(i)) == consumer(declared(i)),
+            ),
+        ),
+        msg="rewrite is not a sound equivalence",
+    )
+
+
+def test_eliminate_shape_op_negative_control_needs_hypothesis():
+    # Without the declared-equals-runtime-shape premise, "declared" and
+    # "runtime" are two independent, fully unconstrained uninterpreted
+    # functions: the claim must NOT be valid then, or the proof above would
+    # be vacuously true regardless of what the premise says. Z3 should find
+    # a sat counterexample negating the claim, not unsat.
+    declared = z3.Function("declared", z3.IntSort(), z3.RealSort())
+    runtime = z3.Function("runtime", z3.IntSort(), z3.RealSort())
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+    i = z3.Int("i")
+
+    solver = z3.Solver()
+    solver.add(z3.Not(consumer(runtime(i)) == consumer(declared(i))))
+    assert solver.check() == z3.sat
+
+
+def test_eliminate_shape_op_pass_matches_full_shape():
+    # The common case: no start/end attributes, so the whole rank is
+    # selected. skip_constant_folding=True is required -- see the module
+    # docstring -- since onnxsim's own constant-folding step, run alone,
+    # collapses a fully-static Shape(X) into the same constant by itself,
+    # which would make this test pass without ever exercising the real
+    # compiled eliminate_shape_op pass.
+    model = _model(
+        f"""
+        g (float[{",".join(map(str, _X_SHAPE))}] X) => (int64[5] Z)
+        {{
+          Z = Shape(X)
+        }}
+        """
+    )
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("eliminate_shape_op"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    # Unlike eliminate_slice_after_shape, this pass destroys the Shape node
+    # outright -- nothing but the fresh constant should remain.
+    assert ops == {}
+    out_name = sim_model.graph.output[0].name
+    z_init = next(i for i in sim_model.graph.initializer if i.name == out_name)
+    assert list(numpy_helper.to_array(z_init)) == _X_SHAPE
+
+
+def test_eliminate_shape_op_pass_matches_start_end_subrange():
+    # start=1, end=3 selects a genuine sub-range, not the whole shape --
+    # confirms the resulting constant holds exactly that sub-range's dims
+    # ([3, 4], X's axes 1 and 2), not the full [2, 3, 4, 5, 6]. Shape's
+    # start/end attributes were added in opset 15.
+    model = _model(
+        f"""
+        g (float[{",".join(map(str, _X_SHAPE))}] X) => (int64[2] Z)
+        {{
+          Z = Shape<start=1, end=3>(X)
+        }}
+        """,
+        opset=15,
+    )
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("eliminate_shape_op"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert ops == {}
+    out_name = sim_model.graph.output[0].name
+    z_init = next(i for i in sim_model.graph.initializer if i.name == out_name)
+    assert list(numpy_helper.to_array(z_init)) == _X_SHAPE[1:3] == [3, 4]
+
+
+def test_eliminate_shape_op_declines_when_x_rank_is_unresolvable():
+    # X is itself Squeeze(Y, axes) where axes comes from an Add of two
+    # initializers rather than being a constant (or Constant node) itself --
+    # deterministic at runtime ([0, 3] either way), but FetchConstantTensor
+    # can't see through the Add, so X's rank is genuinely unresolvable by
+    # onnxsim's shape inference, and HasDimsOfInputOfNode(shape_node, 0) is
+    # false: the predicate declines outright, before ever looking at
+    # start/end. Same construction eliminate_slice_after_shape's own
+    # formal-verify test uses for the same purpose.
+    # skip_constant_folding=True: constant folding would otherwise fold the
+    # Add/Squeeze away first and restore a statically-known rank before this
+    # pass ever saw the graph.
+    model = _model(
+        """
+        g (float[1,1,2,3,1,5,1] Y) => (int64[?] Z)
+        <int64[2] axes_a = {0, 3}, int64[2] axes_b = {0, 1}>
+        {
+          axes = Add(axes_a, axes_b)
+          X = Squeeze(Y, axes)
+          Z = Shape(X)
+        }
+        """
+    )
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("eliminate_shape_op"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert ops == {"Add": 1, "Squeeze": 1, "Shape": 1}
+    (shape_node,) = [n for n in sim_model.graph.node if n.op_type == "Shape"]
+    assert shape_node.input[0] == "X"
+
+
+def test_eliminate_shape_op_declines_when_selected_dim_is_symbolic():
+    # X's rank is statically known (3), so the predicate's own
+    # HasDimsOfInputOfNode check passes -- but X's axis 0 is a dim_param
+    # ("N"), and with no start/end attributes the whole rank (including axis
+    # 0) is selected. runTransform's own `dim.is_int` check fails for that
+    # axis, so the predicate declines and Shape is left untouched.
+    model = _model(
+        """
+        g (float[N,3,4] X) => (int64[3] Z)
+        {
+          Z = Shape(X)
+        }
+        """
+    )
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("eliminate_shape_op"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert ops == {"Shape": 1}
+
+
+def test_eliminate_shape_op_fires_when_symbolic_dim_is_outside_selected_range():
+    # Same symbolic-axis-0 X as above, but start=1, end=3 excludes axis 0
+    # from the selected window entirely -- every dim actually selected (axes
+    # 1, 2: concrete ints 3 and 4) is known and non-negative, so the
+    # predicate fires despite X's rank containing an unresolved dim_param
+    # elsewhere. Confirms the dim check is scoped to [start, end), not the
+    # whole rank.
+    model = _model(
+        """
+        g (float[N,3,4] X) => (int64[2] Z)
+        {
+          Z = Shape<start=1, end=3>(X)
+        }
+        """,
+        opset=15,
+    )
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("eliminate_shape_op"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert ops == {}
+    out_name = sim_model.graph.output[0].name
+    z_init = next(i for i in sim_model.graph.initializer if i.name == out_name)
+    assert list(numpy_helper.to_array(z_init)) == [3, 4]
+
+
+def test_eliminate_shape_op_declines_when_declared_dim_is_negative():
+    # A genuinely negative declared dim (dim.dim >= 0 fails). Not
+    # constructible through the onnx.parser text format or onnx.helper's
+    # usual shape-inference path (a negative *static* dim_value isn't
+    # something a real exporter or ONNX's own shape inference would ever
+    # produce), so this is built by hand: a value_info whose TensorShapeProto
+    # carries an explicit negative dim_value, which onnx.checker.check_model
+    # accepts (nothing in the ONNX spec's checker actually forbids it, even
+    # though it's semantically nonsensical as a real shape). check_n=0
+    # because onnxsim's own random-input equivalence check can't construct a
+    # tensor with a negative shape dimension to run the model against.
+    X_vi = helper.make_tensor_value_info("X", 1, [2, 3, 4])  # 1 == FLOAT
+    X_vi.type.tensor_type.shape.dim[1].dim_value = -5
+    shape_node = helper.make_node("Shape", ["X"], ["Z"])
+    Z_vi = helper.make_tensor_value_info("Z", 7, [3])  # 7 == INT64
+    graph = helper.make_graph([shape_node], "g", [X_vi], [Z_vi])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 10
+
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=0,
+        skipped_optimizers=isolate("eliminate_shape_op"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert ops == {"Shape": 1}

--- a/tests/test_formal_verify_eliminate_slice_after_shape.py
+++ b/tests/test_formal_verify_eliminate_slice_after_shape.py
@@ -1,0 +1,336 @@
+"""Formal check for EliminateSliceAfterShape (eliminate_slice_after_shape.h).
+
+``patternMatchPredicate`` matches ``Slice(Shape(X)[...])`` -- a ``Slice`` node
+whose sole data input (input 0) is the output of a ``Shape`` node -- ONLY when
+``X`` (the ``Shape`` node's own input) has a statically known rank
+(``HasDimsOfInputOfNode``, i.e. ``X``'s ``Value::has_sizes()``; individual
+dims of ``X`` may still be symbolic ``dim_param``s at this point, only the
+*rank* need be known).
+
+``runTransform`` first resolves ``result_of_shape_op``: the sub-list of
+``X``'s per-axis ``Dimension``s that ``Shape``'s own (rarely used) ``start``/
+``end`` attributes select (``FetchStartAndEndAttrOfShape`` -- always the
+whole list here, since none of the models below set those attributes; that
+part of the pass is out of this file's scope). It then fetches the Slice
+node's own ``starts``/``ends``/``step`` -- a SINGLE scalar each
+(``FetchSoleIntValueOfAttr``/``FetchSoleIntValueOfTensor``), so this pass
+only ever handles a Slice with exactly one axis being sliced -- and applies
+ONNX's own Slice index semantics by hand: negative-index normalization
+(``AddYIfNegative``, applied ONCE), then clamping to ``[0, len]`` for a
+forward step or the DIFFERENT range ``[-1, len-1]`` for a backward
+(negative-step, i.e. reversed) walk, then striding through the selected
+sub-range of ``result_of_shape_op`` with the given (possibly negative) step,
+declining (leaving both ``Shape`` and ``Slice`` in place) if any dim it
+selects along the way isn't statically known as a concrete int
+(``!d.is_int``). The final selected dims become a fresh INT64 constant
+initializer that ``Slice``'s consumers are rewired to directly; the old
+``Shape`` node is left dangling (same pattern as elsewhere in this suite,
+e.g. ``fuse_consecutive_slices``), since ``eliminate_deadend`` -- a separate
+default pass -- isn't what removes it.
+
+This is the same "trust static shape metadata equals the actual runtime
+shape" premise as this suite's other shape-family passes: nothing here
+proves the general claim that ``X``'s declared static dims match its runtime
+shape (that's a graph-level property no single-pass proof can establish, and
+is simply taken as given -- the same honesty this suite's other shape passes
+apply). What IS specific and worth proving carefully here is Slice's own
+general indexing arithmetic -- forward vs. reverse traversal over a
+sub-range, with ONNX's negative-index normalization and *asymmetric* forward/
+backward clamping reproduced exactly. ``_walk_slice`` below is a direct,
+line-for-line transliteration of ``runTransform``'s own walk (operating on a
+plain Python list standing in for ``result_of_shape_op``), so it can be
+compared against Python's/ONNX's own ``list[start:end:step]`` semantics --
+which is genuinely what any ONNX backend computes for ``Slice`` at runtime,
+confirmed directly below: ``onnx.reference``'s own ``Slice`` kernel is
+literally ``data[slice(start, end, step)]``, i.e. plain Python/numpy slicing.
+
+A discovered subtlety, worth flagging honestly rather than hiding: the
+transliterated walk is NOT byte-for-byte equivalent to
+``list[start:end:step]`` for every possible integer ``start``/``end`` --
+only whenever NOT (``step < 0`` and ``start < -len(dims)`` and
+``end < -len(dims)``), i.e. unless the step is negative AND *both* bounds are
+so far out of range that even one ``AddYIfNegative`` pass leaves them
+negative. In that narrow corner, Python's own slice-index-adjustment clamps
+an all-the-way-out-of-range ``start`` to ``-1`` (matching the ``-1`` it also
+uses for ``end``, yielding an empty result), while this pass instead clamps
+``start`` to ``0`` (its clamp range is ``[0, len-1]``, not ``[-1, len-1]``),
+which can select one extra element that plain re-derived Python slicing
+would not. Empirically (see the differential test below), onnxruntime's own
+compiled ``Slice`` kernel agrees with THIS pass's answer in that corner, not
+with ``onnx.reference``'s pure-Python one -- real backends can disagree with
+each other on this kind of pathological double-out-of-range input, and this
+pass happens to match onnxruntime's behavior. This corner is never reachable
+by any ``Slice(Shape(X))`` a real graph author or exporter would produce
+(``start``/``end`` would have to be more negative than ``X``'s own rank), so
+it's excluded from -- and explicitly characterized by -- the proof below
+rather than either silently ignored or wrongly claimed away.
+"""
+
+import collections
+
+from _formal_verify_common import isolate, prove, z3
+from onnx import numpy_helper, parser
+
+import onnxsim
+
+# X's shape for every differential test below: 5 distinct dims, so which
+# ones got selected (and in what order) is unambiguous from the values alone.
+_X_SHAPE = [2, 3, 4, 5, 6]
+
+
+def _walk_slice(dims, start, end, step):
+    """Transliterates runTransform's own index walk (see eliminate_slice_after_shape.h),
+    operating on a plain Python list ``dims`` standing in for
+    ``result_of_shape_op``. Faithful down to the asymmetric clamp ranges for
+    forward vs. backward (negative) ``step`` -- see the module docstring for
+    the one documented corner where this deliberately does NOT match
+    ``dims[start:end:step]``.
+    """
+    n = len(dims)
+    if start < 0:
+        start += n
+    if end < 0:
+        end += n
+
+    out = []
+    if step > 0:
+        start = max(0, min(start, n))
+        end = max(0, min(end, n))
+        i = start
+        while i < end:
+            out.append(dims[i])
+            i += step
+    else:
+        start = max(0, min(start, n - 1))
+        end = max(-1, min(end, n))
+        i = start
+        while i > end:
+            out.append(dims[i])
+            i += step
+    return out
+
+
+# Representative (start, end, step) configs used by both formal-proof tests
+# below -- deliberately outside the one documented divergence corner (no
+# config here has step < 0 with *both* start and end more negative than
+# -len(dims)), i.e. exactly the domain any real Slice(Shape(X)) would ever
+# use. Each is named by what it exercises.
+_REPRESENTATIVE_CONFIGS = [
+    ("forward_basic", 1, 3, 1),
+    ("forward_clamped_end", 2, 10, 1),  # end=10 clamps down to len(dims)=5
+    ("forward_extreme_negative_start", -100, 3, 1),  # start clamps up to 0
+    ("reverse_simple", 3, 0, -1),
+    ("reverse_full_walk", 4, -6, -1),  # end alone is far out of range; start isn't
+    ("reverse_step_2", 4, 0, -2),
+    ("negative_start_forward", -2, 5, 1),
+]
+
+
+def test_eliminate_slice_after_shape_index_walk_is_sound():
+    # Uninterpreted per-element consumer of a selected dim, to prove
+    # substitution safety: no matter what downstream computation reads the
+    # constant this pass produces, it sees the exact same sequence of values
+    # (in the same order) that evaluating the original Slice(Shape(X)) at
+    # runtime would have produced -- given (the pass's own premise) that
+    # X's *declared* static dims equal its *actual* runtime shape, modeled
+    # here by using the very same symbolic reals for both.
+    d = z3.Reals("d0 d1 d2 d3 d4")
+    dims = list(d)
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+
+    for name, start, end, step in _REPRESENTATIVE_CONFIGS:
+        walk = _walk_slice(dims, start, end, step)
+        native = dims[start:end:step]
+        assert len(walk) == len(native), (
+            f"{name}: _walk_slice produced {len(walk)} elements, "
+            f"native slicing produced {len(native)}"
+        )
+        claim = z3.And(*(consumer(w) == consumer(v) for w, v in zip(walk, native)))
+        prove(
+            claim,
+            msg=f"{name}: index walk disagrees with Slice's own runtime semantics",
+        )
+
+
+def test_eliminate_slice_after_shape_index_walk_matches_python_slicing_exhaustively():
+    # Same identity as the Z3 proof above, but swept concretely (plain
+    # equality, no solver needed -- the walk is pure index bookkeeping, not
+    # value algebra) over a broad grid of start/end/step, to pin down
+    # *exactly* where the transliterated walk agrees with true Slice
+    # semantics and where it doesn't (see the module docstring). This both
+    # backs the representative configs above with much wider coverage and
+    # documents the one known divergence precisely rather than leaving it
+    # implicit.
+    dims = [11, 22, 33, 44, 55]
+    n = len(dims)
+    span = range(-2 * n - 3, 2 * n + 4)
+    steps = (-3, -2, -1, 1, 2, 3)
+
+    mismatches = set()
+    for start in span:
+        for end in span:
+            for step in steps:
+                got = tuple(_walk_slice(dims, start, end, step))
+                want = tuple(dims[start:end:step])
+                if got != want:
+                    mismatches.add((start, end, step))
+
+    is_the_documented_corner = {
+        (start, end, step)
+        for start in span
+        for end in span
+        for step in steps
+        if step < 0 and start < -n and end < -n
+    }
+    assert mismatches == is_the_documented_corner, (
+        "the walk's divergence from Python/ONNX slicing semantics no longer "
+        "matches the documented (step<0, start<-n, end<-n) corner -- update "
+        "the module docstring and this characterization together"
+    )
+    assert mismatches, "sanity: the documented corner should be non-empty for this grid"
+
+
+def _slice_after_shape_model(starts, ends, steps):
+    return parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[{",".join(map(str, _X_SHAPE))}] X) => (int64[?] Z)
+        <int64[1] starts = {{{starts}}}, int64[1] ends = {{{ends}}}, int64[1] steps = {{{steps}}}>
+        {{
+          s = Shape(X)
+          Z = Slice(s, starts, ends, , steps)
+        }}
+        """
+    )
+
+
+def _check_fires(model, starts, ends, steps):
+    # skip_constant_folding=True is needed here (unlike some sibling
+    # shape-family tests): without it, onnxsim's separate constant-folding
+    # step -- which always runs before the optimizer passes regardless of
+    # skipped_optimizers -- folds Shape(X) then Slice(...) away by itself
+    # first, on models where X's shape is fully static, leaving nothing for
+    # this pass to actually do (confirmed empirically: with constant folding
+    # left on, the *dangling Shape node* this pass's own header comment
+    # promises never shows up in the result). With it off, the real
+    # compiled eliminate_slice_after_shape pass is what performs the
+    # rewrite, and the dangling Shape node is exactly what's left behind.
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("eliminate_slice_after_shape"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert ops == {"Shape": 1}, "expected only the dangling Shape node to survive"
+
+    expected = _walk_slice(_X_SHAPE, starts, ends, steps)
+    out_name = sim_model.graph.output[0].name
+    z_init = next(i for i in sim_model.graph.initializer if i.name == out_name)
+    assert list(numpy_helper.to_array(z_init)) == expected
+    assert expected == _X_SHAPE[starts:ends:steps]  # cross-check vs. Python itself
+    return sim_model
+
+
+def test_eliminate_slice_after_shape_pass_matches_forward_slice():
+    model = _slice_after_shape_model(1, 3, 1)
+    _check_fires(model, 1, 3, 1)
+
+
+def test_eliminate_slice_after_shape_pass_matches_reversed_slice():
+    # Negative step: the case most likely to have an off-by-one or clamping
+    # bug, so this is checked carefully against Python's own reversed-slice
+    # semantics -- python [2,3,4,5,6][3:0:-1] == [5,4,3] (dims at indices
+    # 3,2,1, in that descending order).
+    model = _slice_after_shape_model(3, 0, -1)
+    sim_model = _check_fires(model, 3, 0, -1)
+    out_name = sim_model.graph.output[0].name
+    z_init = next(i for i in sim_model.graph.initializer if i.name == out_name)
+    assert list(numpy_helper.to_array(z_init)) == [5, 4, 3]
+
+
+def test_eliminate_slice_after_shape_pass_matches_negative_start():
+    # Negative start: python [2,3,4,5,6][-2:5] == [5,6] (indices 3,4).
+    model = _slice_after_shape_model(-2, 5, 1)
+    sim_model = _check_fires(model, -2, 5, 1)
+    out_name = sim_model.graph.output[0].name
+    z_init = next(i for i in sim_model.graph.initializer if i.name == out_name)
+    assert list(numpy_helper.to_array(z_init)) == [5, 6]
+
+
+def test_eliminate_slice_after_shape_declines_when_selected_dim_is_symbolic():
+    # X's rank is statically known (3), so the predicate's own
+    # HasDimsOfInputOfNode check passes -- but X's axis 0 is a dim_param
+    # ("N"), and the Slice selects indices [0, 2) which includes it.
+    # runTransform's own `!d.is_int` check declines mid-walk (on the very
+    # first selected dim), leaving both Shape and Slice untouched.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[N,3,4] X) => (int64[?] Z)
+        <int64[1] starts = {0}, int64[1] ends = {2}, int64[1] steps = {1}>
+        {
+          s = Shape(X)
+          Z = Slice(s, starts, ends, , steps)
+        }
+        """
+    )
+    sim_model, check_ok = onnxsim.simplify(
+        model, check_n=3, skipped_optimizers=isolate("eliminate_slice_after_shape")
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert ops == {"Shape": 1, "Slice": 1}
+    (slice_node,) = [n for n in sim_model.graph.node if n.op_type == "Slice"]
+    assert slice_node.input[0] == "s"  # still chained onto Shape's output
+
+
+def test_eliminate_slice_after_shape_declines_when_x_rank_is_unresolvable():
+    # X is itself Squeeze(Y, axes) where axes comes from an Add of two
+    # initializers rather than being a constant (or Constant node) itself
+    # -- deterministic at runtime ([0, 3] either way), but FetchConstantTensor
+    # can't see through the Add, so X's rank is genuinely unresolvable by
+    # onnxsim's shape inference, and HasDimsOfInputOfNode(shape_node, 0) is
+    # false: the predicate declines outright, before ever looking at the
+    # Slice. Same construction this suite's fuse_consecutive_squeezes and
+    # fuse_consecutive_unsqueezes formal-verify tests use to defeat
+    # FetchConstantTensor for an analogous purpose. This bypasses
+    # simplify_isolated (which only controls the *optimizer pass* list) and
+    # calls onnxsim.simplify directly with skip_constant_folding=True, since
+    # constant folding would otherwise fold the Add/Squeeze away first and
+    # restore a statically-known rank before this pass ever saw the graph.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[1,1,2,3,1,5,1] Y) => (int64[?] Z)
+        <int64[2] axes_a = {0, 3}, int64[2] axes_b = {0, 1},
+         int64[1] starts = {0}, int64[1] ends = {2}, int64[1] steps = {1}>
+        {
+          axes = Add(axes_a, axes_b)
+          X = Squeeze(Y, axes)
+          s = Shape(X)
+          Z = Slice(s, starts, ends, , steps)
+        }
+        """
+    )
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("eliminate_slice_after_shape"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert ops == {"Add": 1, "Squeeze": 1, "Shape": 1, "Slice": 1}
+    (slice_node,) = [n for n in sim_model.graph.node if n.op_type == "Slice"]
+    assert slice_node.input[0] == "s"

--- a/tests/test_formal_verify_extract_constant_to_initializer.py
+++ b/tests/test_formal_verify_extract_constant_to_initializer.py
@@ -1,0 +1,168 @@
+"""Formal check for ExtractConstantToInitializer (extract_constant_to_initializer.h).
+
+``patternMatchPredicate`` matches a ``Constant`` node that carries a ``value``
+(Tensor) attribute. ``runTransform`` takes that embedded tensor and moves it
+into the GRAPH's initializer list as a new named value, rewires every
+consumer of the Constant node's output onto that initializer, and destroys
+the Constant node. (The ``reserved_names_``/``nextReservedName``/
+``initializePass`` machinery in the header is purely a batched-name-
+reservation performance optimization with no semantic effect -- not modeled
+or tested here.)
+
+Formal content, and why the proof here is intentionally thin (the same
+framing ``test_formal_verify_eliminate_duplicate_initializer.py`` uses for
+its own comparable claim): this is a definitional-equality proof, not an
+algebraic derivation. ONNX's own semantics define a ``Constant`` node's
+output as being exactly the tensor embedded in its ``value`` attribute, and
+separately define a graph INITIALIZER's associated value as being exactly
+the tensor it holds -- both are simply "this name denotes this fixed
+tensor," with no operational difference between the two as far as any
+CONSUMER of the name is concerned. The pass just changes which graph-level
+mechanism supplies a given fixed value, not the value itself. Modeled below
+as: an uninterpreted tensor function ``T : Int -> Real`` standing for the
+embedded constant's content, two ways of naming/supplying that same content
+(``constant_node_output`` and ``initializer_value``, both constrained to
+equal ``T`` pointwise -- mirroring how ``eliminate_duplicate_initializer``'s
+proof modeled "two initializer entries with the same content"), and an
+arbitrary uninterpreted ``consumer``. The content-equality hypothesis does
+essentially all the work here -- there is no nontrivial algebra to prove.
+The negative control below (independent, unconstrained
+``constant_node_output``/``initializer_value``, no hypothesis) confirms the
+claim is not vacuously true regardless of that hypothesis.
+
+A structural surprise, found while writing this file's differential tests,
+that has no counterpart in any other file in this suite: unlike every other
+targeted pass, ``extract_constant_to_initializer`` is UNREACHABLE through
+onnxsim's own Python API, by deliberate design. ``onnxsim.cpp``'s
+``SimplifyImpl`` builds ``config.optimizer_passes`` from
+``onnx::optimization::GetFuseAndEliminationPass()`` filtered through a fixed
+``always_disabled_passes = {"eliminate_shape_gather",
+"extract_constant_to_initializer"}`` list -- and that filter is applied not
+only to the default pass set but also to ``extra_optimizers`` (the general
+opt-in mechanism every other non-default pass in this suite is exercised
+through), so there is no combination of ``skipped_optimizers``/``isolate()``
+and/or ``extra_optimizers`` that makes it run. The comment right above that
+list explains why: onnxsim's own constant folder deliberately leaves a
+``Constant`` node in producer form (rather than baking it into an
+initializer) so a fold's origin stays visible in the output model, and
+running this pass would erase that distinction right back -- including for
+``Constant`` nodes onnxsim's own folder just produced -- so it is always
+dropped, unconditionally.
+
+Consequently, unlike every sibling file in this suite, there is no way to
+run "the real compiled pass, in isolation" against a concrete model *through
+onnxsim's own public Python surface* -- the surface this suite otherwise
+insists on testing against (see CLAUDE.md and every other
+``test_formal_verify_*.py`` file). An earlier version of this file drove
+onnxoptimizer's ``ExtractConstantToInitializer`` class directly via a small
+C++ harness compiled at test time against this checkout's
+``.setuptools-cmake-build`` artifacts; that approach was dropped because it
+only works when a source build's ``compile_commands.json`` and static
+libraries happen to be present in the CWD -- true in a local dev checkout,
+but never true in CI's actual test job (``CIBW_TEST_COMMAND`` in
+``.github/workflows/build-and-test.yml`` installs a prebuilt wheel and runs
+``pytest`` against it, with no leftover CMake build tree or C++ toolchain
+available), so those tests would silently skip on every real CI run and
+provide no ongoing verification value there, while adding real fragility
+(compiler flags, link order, static-lib layout) for a local-only benefit.
+
+Instead, ``test_extract_constant_to_initializer_unreachable_via_onnxsim_
+simplify`` below tests the property that actually matters for onnxsim's own
+users and behavior -- that this pass never fires through the public API --
+directly and unconditionally (no special build machinery, so it always runs
+in CI): if onnxsim's own ``always_disabled_passes`` filter (``onnxsim.cpp``)
+ever stopped excluding this pass, this is the test that would catch it, by
+observing a ``Constant`` node unexpectedly disappearing in favor of a fresh
+initializer.
+"""
+
+from _formal_verify_common import isolate, prove, z3
+from onnx import parser
+
+import onnxsim
+
+
+def test_extract_constant_to_initializer_is_sound():
+    T = z3.Function("T", z3.IntSort(), z3.RealSort())
+    constant_node_output = z3.Function(
+        "constant_node_output", z3.IntSort(), z3.RealSort()
+    )
+    initializer_value = z3.Function("initializer_value", z3.IntSort(), z3.RealSort())
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+    i, j = z3.Ints("i j")
+
+    # "constant_node_output and initializer_value denote the same tensor
+    # content": both equal the shared, uninterpreted content function T at
+    # every index -- the ONNX-spec-level fact that a Constant node's value
+    # attribute and an initializer entry are both just "this name denotes
+    # this fixed tensor".
+    same_content = z3.ForAll(
+        [j],
+        z3.And(
+            constant_node_output(j) == T(j),
+            initializer_value(j) == T(j),
+        ),
+    )
+    prove(
+        z3.Implies(
+            same_content,
+            consumer(constant_node_output(i)) == consumer(initializer_value(i)),
+        )
+    )
+
+
+def test_extract_constant_to_initializer_negative_control_needs_hypothesis():
+    # Without the content-equality hypothesis, constant_node_output and
+    # initializer_value are two independent, fully unconstrained
+    # uninterpreted functions: the claim must NOT be valid then, or the
+    # "proof" above would be vacuously true regardless of what same_content
+    # says. Z3 should find a sat counterexample negating the claim.
+    constant_node_output = z3.Function(
+        "constant_node_output", z3.IntSort(), z3.RealSort()
+    )
+    initializer_value = z3.Function("initializer_value", z3.IntSort(), z3.RealSort())
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+    i = z3.Int("i")
+
+    solver = z3.Solver()
+    solver.add(
+        z3.Not(consumer(constant_node_output(i)) == consumer(initializer_value(i)))
+    )
+    assert solver.check() == z3.sat
+
+
+def test_extract_constant_to_initializer_unreachable_via_onnxsim_simplify():
+    # Regression guard for the module docstring's central claim: unlike
+    # every other pass in this suite, no combination of onnxsim.simplify's
+    # own knobs runs this pass. isolate("extract_constant_to_initializer")
+    # skips every OTHER default pass, nominally leaving only this one
+    # active -- and skip_constant_folding=True keeps onnxsim's separate
+    # constant folder from folding Relu(Constant) away on its own, which
+    # would otherwise obscure whether this pass itself ever touched
+    # anything. If onnxsim's own always_disabled_passes filter (onnxsim.cpp)
+    # ever stopped excluding this pass, this test would start failing here
+    # (Constant would disappear and an initializer would appear) rather than
+    # silently changing onnxsim's constant-node-preservation guarantee.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4] X) => (float[4] Y)
+        {
+            A = Constant <value = float[4] {1.0, 2.0, 3.0, 4.0}> ()
+            Y = Relu(A)
+        }
+        """
+    )
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("extract_constant_to_initializer"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    assert list(sim_model.graph.initializer) == []
+    ops = {n.op_type for n in sim_model.graph.node}
+    assert ops == {"Constant", "Relu"}

--- a/tests/test_formal_verify_fuse_concat_into_reshape.py
+++ b/tests/test_formal_verify_fuse_concat_into_reshape.py
@@ -1,0 +1,382 @@
+"""Formal check for FuseConcatIntoReshape (fuse_concat_into_reshape.h).
+
+``patternMatchPredicate`` matches ``Reshape(X, Concat(seg_0, ..., seg_n))``
+(``matchConcatReshape``, the Concat's own ``axis`` attribute must be 0) or
+``Reshape(X, Cast(Concat(seg_0, ..., seg_n), to=INT64))``
+(``matchConcatCastReshape`` -- same Concat shape, with an intervening Cast to
+INT64 in between).
+
+``runTransform`` walks the Concat's own input segments ``v`` one at a time,
+building a flat ``std::vector<int64_t> shapes``:
+
+* if ``FetchConstantTensor(v)`` succeeds (``v`` is a ``Constant`` node or a
+  constant-treated initializer), its raw values are read out and converted
+  to ``int64_t`` (via the ``DO_CASE`` switch, which accepts FLOAT/INT32/
+  INT64/DOUBLE/UINT8/INT8/UINT16/INT16/UINT32/UINT64) and appended to
+  ``shapes``. Without an intervening Cast the tensor must *already* be
+  INT64-typed or the pass declines outright -- moot in valid ONNX, though,
+  since ``Concat`` requires every input to share one element type, and
+  Reshape's own shape input must be INT64, so a non-cast Concat feeding
+  Reshape directly can only ever be all-INT64 to begin with.
+* otherwise (``v`` is not a compile-time constant): if ``v`` has statically
+  known shape ``[1]`` (exactly one element), a literal ``-1`` is appended to
+  ``shapes`` *in place of* ``v``'s real, unknown-at-compile-time value --
+  ONNX Reshape's own "infer this axis" sentinel. If ``v`` is non-constant
+  and does NOT have exactly one element, ``runTransform`` gives up
+  (``return false``) outright; the header's own TODO notes a smarter
+  partial-segment case (``[?, 2, 3]`` concatenated with ``[4]`` producing
+  ``[-1, 2, 3, 4]``) is not implemented, only whole-segment substitution.
+
+After the walk, if more than one ``-1`` ended up in ``shapes``, the pass
+declines (``unknown_dim_count > 1``) -- the same restriction
+``eliminate_nop_reshape``'s own ``-1``-inference reason (c) imposes, since
+Reshape's ``-1`` is only well-defined with exactly one unknown axis.
+Otherwise it builds a brand-new INT64 initializer holding exactly ``shapes``
+and rewires the ``Reshape``'s second input to it directly
+(``node->replaceInput(1, value)``), with ``destroy_current =
+NodeDestroyType::DestroyZero`` -- the old ``Concat``/``Cast`` chain is left
+dangling in the graph, not itself destroyed, the same dangling-producer
+pattern already seen in e.g. ``fuse_consecutive_slices`` and
+``fuse_pad_into_conv``.
+
+Formal content, in two parts:
+
+  (a) **plain constant folding** (trivial/definitional): for every segment
+      the pass reads via ``FetchConstantTensor``, that call's own guarantee
+      *is* that the fetched compile-time value equals the value the segment
+      evaluates to at runtime -- a compile-time constant is, by
+      construction, the same value every time the graph runs. Substituting
+      the folded literal for the live ``Concat`` segment therefore changes
+      nothing observable. There is no interesting algebra here beyond this
+      definitional fact (and, for the Cast variant, that the numeric
+      cast/parse round-trips exactly for the small integer-valued literals
+      any real target shape uses -- exercised empirically below via a
+      FLOAT-typed Concat segment converted through the Cast path).
+
+  (b) **the nontrivial -1-inference argument** (the interesting content,
+      shared in spirit with ``eliminate_nop_reshape``'s own reason (c)):
+      for the *at most one* non-constant, single-element segment that gets
+      replaced by a literal ``-1``, soundness rests on exactly the same
+      auxiliary lemma ``test_formal_verify_eliminate_nop_reshape.py`` proves
+      for its own ``-1``-inference case -- ``new_dim == -1 ∧
+      other_axes_pinned ∧ total_size_preserved ⇒ inferred_dim ==
+      true_dim_at_that_axis`` -- adapted here to a setup where the "true
+      dim" being inferred is not ``old_shape[i]`` (Reshape's own input
+      shape, as in the sibling file) but the *Concat segment*'s true,
+      unknown-at-compile-time-but-deterministic-at-runtime value. The
+      argument is otherwise identical: every *other* axis of the target
+      shape is now a literal, folded-constant value (part (a) above), so
+      Reshape's own size-preservation law (the fused shape's element count
+      must equal ``X``'s total element count -- exactly what made the
+      *original*, pre-fusion ``Reshape(X, Concat(...))`` a valid reshape in
+      the first place, since the original target shape's product must
+      *also* equal that same total) pins the resolved ``-1`` axis to
+      exactly the unknown segment's true value. Once that is established,
+      the fused shape list and the original (pre-fusion) shape list are
+      *literally the same list of numbers*, so the two Reshapes trivially
+      compute the same output -- unlike the sibling file, no row-major
+      flatten/unflatten argument is needed here to bridge two
+      differently-shaped-looking descriptions of the same shape, because
+      here both sides land on the exact same shape after the lemma is
+      applied. This is modeled below with a 3-axis target shape ``[c0, u1,
+      c2]`` -- two known/constant-folded axes ``c0``, ``c2`` flanking one
+      unknown, single-element axis ``u1`` -- concrete enough to exercise
+      part (a) (``c0``, ``c2``) combining with part (b) (``u1`` /
+      ``resolved1``) in one shape, the same way the sibling file's rank-2
+      example was "enough to exercise all three reasons" for its own
+      proof. Reshape's flat-buffer semantics itself (input and output share
+      one row-major buffer of ``D`` elements whenever the target shape's
+      product is ``D``) is modeled directly as a 1-D uninterpreted function
+      ``x: Int -> Real`` indexed by the flattened offset, rather than via
+      the sibling's 2-D div/mod unflattening -- the two shapes being
+      compared here (fused vs. original) are reshapes of the *same* ``X``
+      into shapes that the lemma proves are numerically identical, so a
+      single flat-buffer view suffices; there is no second, differently
+      laid out original shape to bridge against as in the sibling proof.
+
+A key empirical surprise (see the differential tests below): a *fully*
+constant ``Concat`` feeding ``Reshape`` -- and a ``Concat`` segment derived
+from ``Shape(X)`` (used here to construct a genuinely non-constant,
+single-element segment) -- are BOTH resolved away by onnxsim's own separate
+constant-folding step (``_EvalPartialShape`` + the ordinary constant folder,
+see ``onnxsim.cpp``'s ``FoldConstant``) before ``fuse_concat_into_reshape``
+ever gets a chance to run, when that step is left enabled (as
+``simplify_isolated`` always leaves it -- it has no ``skip_constant_folding``
+knob, see ``tests/_formal_verify_common.py``). ``_EvalPartialShape``
+specifically turns ``Shape``/``Gather``-on-shape into constants even for a
+plain (non-initializer, non-``Constant``) graph input, since it works from
+static shape *metadata*, not from the value having to already be a
+compile-time constant per ``IsConstantTensor``. So every differential test
+below bypasses ``simplify_isolated`` and calls ``onnxsim.simplify`` directly
+with ``skip_constant_folding=True`` -- the same workaround
+``test_formal_verify_fuse_consecutive_slices.py`` already uses to inspect a
+fusion pass's own raw output structure rather than a structure any separate
+folding step could have produced instead. With constant folding off, a
+``Shape<start=0,end=1>(X)`` segment survives as a real, un-resolved node
+feeding ``Concat`` -- non-constant per ``FetchConstantTensor`` (it is
+neither a ``Constant`` node nor a constant-treated initializer), with a
+statically-known-shape-``[1]`` output -- exactly the shape this pass's own
+``-1``-substitution branch is written to handle, confirmed below to fire.
+"""
+
+import collections
+
+from _formal_verify_common import isolate, producer, prove, z3
+from onnx import numpy_helper, parser
+
+import onnxsim
+
+
+def test_fuse_concat_into_reshape_is_sound():
+    # x: the flat, row-major data buffer any target shape with the right
+    # total element count reinterprets -- ONNX Reshape's own semantics is
+    # exactly "same flat buffer, different shape labeling."
+    x = z3.Function("x", z3.IntSort(), z3.RealSort())
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+    c0, c2 = z3.Ints("c0 c2")  # the two constant-folded (part (a)) axes
+    u1 = z3.Int("u1")  # the unknown segment's true runtime value
+    resolved1 = z3.Int("resolved1")  # the fused Reshape's own -1 inference
+    D = z3.Int("D")  # X's total element count
+    i, j, k = z3.Ints("i j k")
+
+    def reshape_val(s0, s1, s2, ii, jj, kk):
+        flat = (ii * s1 + jj) * s2 + kk
+        return x(flat)
+
+    domain = z3.And(
+        c0 > 0, c2 > 0, u1 > 0, 0 <= i, i < c0, 0 <= j, j < u1, 0 <= k, k < c2
+    )
+
+    # The pre-fusion graph is valid ONNX: Reshape(X, Concat(c0, u1, c2))
+    # already has target-shape product == X's total size D. This is what
+    # made the *original* Concat->Reshape a legal reshape in the first
+    # place -- not something the pass invents.
+    original_reshape_is_valid = c0 * u1 * c2 == D
+
+    # Reshape's own size-preservation law applied to the FUSED shape
+    # [c0, -1, c2]: whatever resolved1 the runtime infers for the sole -1
+    # axis must make the fused target shape's product equal D too.
+    size_preservation_law = c0 * resolved1 * c2 == D
+
+    prove(
+        z3.Implies(
+            z3.And(domain, original_reshape_is_valid, size_preservation_law),
+            consumer(reshape_val(c0, resolved1, c2, i, j, k))
+            == consumer(reshape_val(c0, u1, c2, i, j, k)),
+        )
+    )
+
+
+def _simplify_isolated_no_cf(model, check_n=3):
+    # Like _formal_verify_common.simplify_isolated, but with constant
+    # folding (and the partial-shape-eval step nested inside it) turned off
+    # -- see this file's docstring for why that is required to observe
+    # fuse_concat_into_reshape's own runTransform output rather than a
+    # structure onnxsim's separate folding step already produced.
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=check_n,
+        skipped_optimizers=isolate("fuse_concat_into_reshape"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    return sim_model, collections.Counter(n.op_type for n in sim_model.graph.node)
+
+
+def _shape_tensor(sim_model, reshape_node):
+    # The fused Reshape's second input, resolved to a numpy array via the
+    # fresh initializer runTransform creates for it.
+    initializers = {i.name: i for i in sim_model.graph.initializer}
+    shape_input = reshape_node.input[1]
+    assert shape_input in initializers, (
+        f"expected {shape_input!r} to be a fresh constant initializer"
+    )
+    return numpy_helper.to_array(initializers[shape_input])
+
+
+def test_fuse_concat_into_reshape_pass_matches_fully_constant():
+    # Concat(a, b) is entirely compile-time constant (both INT64
+    # initializers) -- runTransform should fold it directly into a fresh
+    # [2, 3, 4] initializer and rewire Reshape's second input to it,
+    # leaving the old Concat dangling (DestroyZero; eliminate_deadend is
+    # skipped by isolate()).
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 15]
+        >
+        g (float[2,3,4] X) => (float[?,?,?] Y)
+        <int64[2] a = {2, 3}, int64[1] b = {4}>
+        {
+          shp = Concat<axis=0>(a, b)
+          Y = Reshape(X, shp)
+        }
+        """
+    )
+    sim_model, ops = _simplify_isolated_no_cf(model)
+    assert ops["Reshape"] == 1
+    assert ops["Concat"] == 1  # the old Concat is left dangling, not destroyed
+
+    reshape_node = producer(sim_model, "Y")
+    assert reshape_node.op_type == "Reshape"
+    assert reshape_node.input[1] != "shp"  # rewired away from the old Concat
+    assert list(_shape_tensor(sim_model, reshape_node)) == [2, 3, 4]
+
+    dangling = [n for n in sim_model.graph.node if n.output[0] == "shp"]
+    assert len(dangling) == 1 and dangling[0].op_type == "Concat"
+
+
+def test_fuse_concat_into_reshape_pass_matches_mixed_constant_and_unknown():
+    # dim0 = Shape<start=0,end=1>(X): a genuinely non-constant (per
+    # FetchConstantTensor), statically-shaped-[1] segment -- with constant
+    # folding off (see this file's docstring), it survives as a real Shape
+    # node rather than being resolved by _EvalPartialShape. Concatenated
+    # with two INT64 constants b=3, c=4. runTransform should still fire,
+    # substituting -1 for dim0's own unknown-at-compile-time value.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 15]
+        >
+        g (float[2,3,4] X) => (float[?,?,?] Y)
+        <int64[1] b = {3}, int64[1] c = {4}>
+        {
+          dim0 = Shape<start=0,end=1>(X)
+          shp = Concat<axis=0>(dim0, b, c)
+          Y = Reshape(X, shp)
+        }
+        """
+    )
+    sim_model, ops = _simplify_isolated_no_cf(model)
+    assert ops["Reshape"] == 1
+    assert ops["Shape"] == 1  # dangling
+    assert ops["Concat"] == 1  # dangling
+
+    reshape_node = producer(sim_model, "Y")
+    assert reshape_node.input[1] != "shp"
+    # -1 stands in for dim0's own (unknown-to-the-pass, but actually 2)
+    # value; b, c pass through as plain folded constants.
+    assert list(_shape_tensor(sim_model, reshape_node)) == [-1, 3, 4]
+
+
+def test_fuse_concat_into_reshape_pass_matches_cast_variant():
+    # Same fully-constant Concat as the basic case, but with an
+    # intervening Cast<to=INT64> -- exercises matchConcatCastReshape
+    # instead of matchConcatReshape. Must fire and land on the exact same
+    # [2, 3, 4] result.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 15]
+        >
+        g (float[2,3,4] X) => (float[?,?,?] Y)
+        <int64[2] a = {2, 3}, int64[1] b = {4}>
+        {
+          shp = Concat<axis=0>(a, b)
+          shp64 = Cast<to=7>(shp)
+          Y = Reshape(X, shp64)
+        }
+        """
+    )
+    sim_model, ops = _simplify_isolated_no_cf(model)
+    assert ops["Reshape"] == 1
+    assert ops["Concat"] == 1  # dangling
+    assert ops["Cast"] == 1  # dangling
+
+    reshape_node = producer(sim_model, "Y")
+    assert reshape_node.input[1] != "shp64"
+    assert list(_shape_tensor(sim_model, reshape_node)) == [2, 3, 4]
+
+
+def test_fuse_concat_into_reshape_pass_matches_cast_variant_float_segments():
+    # Same as the Cast variant above, but the Concat's own segments are
+    # FLOAT-typed -- only legal ONNX because of the intervening Cast (a
+    # non-cast Concat->Reshape requires INT64 throughout, per Concat's own
+    # single-element-type rule and Reshape's INT64-only shape input).
+    # Exercises runTransform's DO_CASE FLOAT->int64_t conversion path,
+    # confirming the numeric round-trip is exact for these constants.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 15]
+        >
+        g (float[2,3,4] X) => (float[?,?,?] Y)
+        <float[2] a = {2.0, 3.0}, float[1] b = {4.0}>
+        {
+          shp = Concat<axis=0>(a, b)
+          shp64 = Cast<to=7>(shp)
+          Y = Reshape(X, shp64)
+        }
+        """
+    )
+    sim_model, ops = _simplify_isolated_no_cf(model)
+    assert ops["Reshape"] == 1
+
+    reshape_node = producer(sim_model, "Y")
+    assert reshape_node.input[1] != "shp64"
+    assert list(_shape_tensor(sim_model, reshape_node)) == [2, 3, 4]
+
+
+def test_fuse_concat_into_reshape_declines_two_unknown_segments():
+    # Two independent Shape-derived single-element segments (dim0, dim1)
+    # plus one constant: unknown_dim_count would reach 2, so runTransform
+    # declines outright (more than one -1 is not well-defined for
+    # Reshape) -- Reshape's second input is left pointing at the original
+    # (un-fused) Concat output.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 15]
+        >
+        g (float[2,3,4] X) => (float[?,?,?] Y)
+        <int64[1] b = {4}>
+        {
+          dim0 = Shape<start=0,end=1>(X)
+          dim1 = Shape<start=1,end=2>(X)
+          shp = Concat<axis=0>(dim0, dim1, b)
+          Y = Reshape(X, shp)
+        }
+        """
+    )
+    sim_model, ops = _simplify_isolated_no_cf(model)
+    assert ops["Reshape"] == 1
+    assert ops["Concat"] == 1
+    assert ops["Shape"] == 2
+
+    reshape_node = producer(sim_model, "Y")
+    assert reshape_node.input[1] == "shp"  # unchanged: the pass declined
+
+
+def test_fuse_concat_into_reshape_declines_multi_element_unknown_segment():
+    # dims01 = Shape<start=0,end=2>(X) is non-constant AND has 2 elements
+    # (not the eligible-for-substitution shape [1]) -- runTransform's own
+    # `v->sizes().size() != 1` check trips and it declines outright,
+    # regardless of unknown_dim_count. Reshape's second input is left
+    # pointing at the original Concat output.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 15]
+        >
+        g (float[2,3,4] X) => (float[?,?,?] Y)
+        <int64[1] b = {4}>
+        {
+          dims01 = Shape<start=0,end=2>(X)
+          shp = Concat<axis=0>(dims01, b)
+          Y = Reshape(X, shp)
+        }
+        """
+    )
+    sim_model, ops = _simplify_isolated_no_cf(model)
+    assert ops["Reshape"] == 1
+    assert ops["Concat"] == 1
+    assert ops["Shape"] == 1
+
+    reshape_node = producer(sim_model, "Y")
+    assert reshape_node.input[1] == "shp"  # unchanged: the pass declined

--- a/tests/test_formal_verify_fuse_consecutive_reduce_unsqueeze.py
+++ b/tests/test_formal_verify_fuse_consecutive_reduce_unsqueeze.py
@@ -1,0 +1,346 @@
+"""Formal check for FuseConsecutiveReduceUnsqueeze
+(fuse_consecutive_reduce_unsqueeze.h).
+
+``reduction_operators`` is a fixed set of ONNX's axis-reduction family
+(``ReduceL1``, ``ReduceL2``, ``ReduceLogSum``, ``ReduceLogSumExp``,
+``ReduceMax``, ``ReduceMean``, ``ReduceMin``, ``ReduceProd``, ``ReduceSum``,
+``ReduceSumSquare``) that all share the exact same ``axes``/``keepdims``
+attribute shape and the exact same "does a reduced axis disappear or become
+size-1" behavior controlled by ``keepdims`` -- they differ only in what value
+each kept position computes, which is irrelevant to this pass.
+``patternMatchPredicate`` matches ``Unsqueeze(ReduceX(...))`` where
+``ReduceX`` is one of those kinds, has a ``keepdims`` attribute explicitly
+present, and that attribute is currently ``0`` (the reduction currently DROPS
+the reduced axes entirely rather than keeping them as size-1).
+
+``runTransform`` requires the reduction op's output to have exactly one use
+(only this Unsqueeze consumes it -- the same single-consumer precondition
+seen throughout this fusion-pass family, since the transform mutates the
+reduction op in place and would otherwise change what every other consumer
+sees). It fetches both the Unsqueeze's own ``axes`` and the reduction op's
+own ``axes`` (``GetValueFromAttrOrInput``, so each must be a compile-time
+constant) and declines unless they are EXACTLY EQUAL AS FETCHED (``axes !=
+prev_axes`` bails). This is a stricter, non-normalizing comparison than some
+sibling passes: ``GetValueFromAttrOrInput`` -> ``GetValueFromAttr`` /
+``GetValueFromInput`` (``pass_util.h``) do no negative-axis normalization at
+all before this comparison -- confirmed empirically (see below) with a case
+where the two axes lists are semantically the same axis (``-1`` vs. the
+literal positive equivalent for a rank-3 tensor) but spelled differently: the
+pass declines, exactly as reading the C++ predicts. So "the axes match"
+really means "the two lists are byte-for-byte identical *as written* in the
+graph", not "the two lists denote the same axes once normalized".
+
+When the axes match, ``runTransform`` rewires the Unsqueeze's OWN consumers
+directly to the reduction op's OWN output (skipping the Unsqueeze), then
+MUTATES the reduction op itself: sets its ``keepdims`` attribute to ``1``,
+and manually copies the Unsqueeze's own output ``sizes``/``elemType`` onto
+the reduction op's output (the reduction op's own shape-inference metadata,
+computed back when ``keepdims=0``, is stale for the new ``keepdims=1``
+shape). It destroys only the Unsqueeze node (``NodeDestroyType::DestroyOne``)
+-- the reduction op survives, mutated in place. This is DIFFERENT from most
+passes in this suite (which either rewire-and-leave-both-nodes-alive, or
+destroy the outer node while leaving an inner one dangling for
+``eliminate_deadend`` to sweep up): here there is no dangling node at all,
+confirmed empirically below -- after a successful fuse, exactly one node
+(the same reduction node, by construction, now with ``keepdims=1``) survives
+with the graph's original output name, and the Unsqueeze is gone outright
+(not merely 0-use).
+
+Formal content: ``ReduceX(input, axes, keepdims=0)`` followed by
+``Unsqueeze(_, axes)`` with the IDENTICAL axes list is equivalent to
+``ReduceX(input, axes, keepdims=1)`` directly, because of how ONNX itself
+defines ``keepdims``: ``keepdims=0`` computes the reduction and then DROPS
+the reduced axes from the output shape entirely (rank decreases by
+``len(axes)``); ``keepdims=1`` computes the EXACT SAME per-element reduction
+values but KEEPS those axes in the output shape as size-1 dims AT THEIR
+ORIGINAL POSITIONS, rather than dropping them. So Unsqueeze-ing the
+``keepdims=0`` result back in at exactly the axes that were dropped is
+definitionally the same operation as never having dropped them in the first
+place (``keepdims=1``).
+
+The model below is the same "insert/remove a size-1 axis" technique as
+``fuse_consecutive_squeezes``/``fuse_consecutive_unsqueezes``
+(``_remove_inserted`` here, reused from
+``test_formal_verify_fuse_consecutive_unsqueezes.py``'s helper of the same
+name/shape -- it drops an index's components at each inserted/dim-1 position,
+the inverse of squeeze's own ``_insert_removed``), but the soundness argument
+is structured as an explicit two-step chain rather than a single self-evident
+substitution, since (unlike squeezes-composing-with-squeezes) there is a real
+semantic fact of ONNX's ``Reduce*`` operator family being invoked, not just
+index bookkeeping:
+
+1. (ONNX's own definition of ``keepdims``, modeled as an axiom below, since
+   the actual per-element reduction computation is irrelevant here and would
+   otherwise need one uninterpreted function per op kind for no benefit): for
+   every full-rank index, the ``keepdims=1`` result at that index equals the
+   ``keepdims=0`` result at the index obtained by dropping the components at
+   the reduced-axis positions -- i.e. the exact same computed values, merely
+   kept at their original positions instead of squeezed out.
+2. (Unsqueeze's own semantics): reading ``Unsqueeze(keepdims=0 result,
+   axes)`` at a full-rank index reads the (smaller) ``keepdims=0`` result at
+   that same dropped-components index.
+
+Chaining (1) and (2) through the identical index-projection (using the SAME
+``axes`` on both sides -- modeling the pass's own literal-equality
+requirement) gives ``unsqueeze_of_keepdims0(idx) == direct_keepdims1(idx)``
+for every full-rank ``idx``, composed with an arbitrary uninterpreted
+``consumer`` for substitution safety, matching this suite's established
+style (see e.g. ``test_formal_verify_eliminate_consecutive_idempotent_ops.py``).
+A throwaway negative-control script (since deleted) confirmed Z3 actually
+exercises this index arithmetic rather than trivially discharging the claim:
+corrupting either the reinsertion axes or the axiom's own axes to a different
+list makes the claim `sat` with a genuine counterexample.
+
+Everything above the "Formal content" heading that describes the real
+compiled pass's behavior (single node surviving with the graph's original
+output name, no dangling node, the non-normalizing literal axes comparison)
+was confirmed against the actual compiled pass via a throwaway debug script
+(since deleted), not just assumed from reading the header comment.
+"""
+
+from _formal_verify_common import producer, prove, simplify_isolated, z3
+from onnx import parser
+
+_RANK0 = 4  # X's rank, before the reduction
+_AXES = [1, 3]  # reduced (and re-Unsqueeze'd) axes, relative to X
+
+
+def _remove_inserted(idx, sorted_inserted_axes, rank):
+    # Unsqueeze(T, axes=sorted_inserted_axes)[idx] reads T at the index built
+    # by dropping idx's components at each inserted position (an inserted,
+    # dim-1 axis only ever has index 0 there) and taking the rest, in order.
+    # Reused from test_formal_verify_fuse_consecutive_unsqueezes.py's helper
+    # of the same name/shape; this pass's own reduced-axis positions play the
+    # same "dim-1 axis whose only valid coordinate is dropped" role that an
+    # Unsqueeze's own inserted axes do there -- ReduceX(keepdims=0) is
+    # exactly "Unsqueeze but in reverse: the dim-1 axes never got inserted at
+    # all", and the Unsqueeze this pass fuses away re-inserts them at those
+    # same positions.
+    return [idx[p] for p in range(rank) if p not in sorted_inserted_axes]
+
+
+def _ints_literal(xs):
+    # ONNX text-format tensor literal, e.g. [1, 3] -> "{1, 3}" (as opposed to
+    # the "[1, 3]" square-bracket syntax used for int-list *attributes*).
+    return "{" + ", ".join(map(str, xs)) + "}"
+
+
+def test_fuse_consecutive_reduce_unsqueeze_is_sound():
+    rank_reduced = _RANK0 - len(_AXES)  # keepdims=0 result's rank
+
+    # keepdims=0 result: an uninterpreted function of the reduced-rank index
+    # -- SOME reduction value at each kept position; which reduction
+    # (sum/mean/max/...) is irrelevant, since every reduction_operators kind
+    # shares this exact axes/keepdims shape-handling logic.
+    reduce_keepdims0 = z3.Function(
+        "reduce_keepdims0", *([z3.IntSort()] * rank_reduced), z3.RealSort()
+    )
+    # keepdims=1 result: a SEPARATE uninterpreted function of the full-rank
+    # index, related to reduce_keepdims0 only via the axiom below -- modeling
+    # "the compiled reduction op, reconfigured to keepdims=1" as its own
+    # opaque computation, not something trivially equal to the first function
+    # by construction.
+    reduce_keepdims1 = z3.Function(
+        "reduce_keepdims1", *([z3.IntSort()] * _RANK0), z3.RealSort()
+    )
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+
+    sorted_axes = sorted(_AXES)
+    a = [z3.Int(f"a{i}") for i in range(_RANK0)]  # bound inside the axiom
+    idx = [z3.Int(f"idx{i}") for i in range(_RANK0)]  # free, universally proven over
+
+    # Step 1: ONNX's own definition of keepdims -- keepdims=1 computes the
+    # exact same per-element values as keepdims=0, just kept at their
+    # original positions instead of squeezed out.
+    keepdims_semantics = z3.ForAll(
+        a,
+        reduce_keepdims1(*a)
+        == reduce_keepdims0(*_remove_inserted(a, sorted_axes, _RANK0)),
+    )
+
+    # Step 2: Unsqueeze(keepdims=0 result, axes) read at a full-rank index.
+    unsqueeze_of_keepdims0 = reduce_keepdims0(
+        *_remove_inserted(idx, sorted_axes, _RANK0)
+    )
+    # The direct keepdims=1 read at that same index.
+    direct_keepdims1 = reduce_keepdims1(*idx)
+
+    prove(
+        z3.Implies(
+            keepdims_semantics,
+            consumer(unsqueeze_of_keepdims0) == consumer(direct_keepdims1),
+        )
+    )
+
+
+def test_fuse_consecutive_reduce_unsqueeze_pass_matches_reducesum():
+    # ReduceSum(X, axes, keepdims=0) -> Unsqueeze(_, axes), identical axes:
+    # fuses. Only the ReduceSum node survives (same node, mutated), reading
+    # straight from X, with keepdims flipped to 1 and the graph's original
+    # output name ("Z", formerly the Unsqueeze's) now on the reduction node.
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 18]
+        >
+        g (float[2,3,4,5] X) => (float[2,1,4,1] Z)
+        <int64[{len(_AXES)}] axes = {_ints_literal(_AXES)}>
+        {{
+          r = ReduceSum <keepdims=0> (X, axes)
+          Z = Unsqueeze(r, axes)
+        }}
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_reduce_unsqueeze")
+    assert ops["Unsqueeze"] == 0
+    assert ops["ReduceSum"] == 1
+    (node,) = sim_model.graph.node
+    assert node.op_type == "ReduceSum"
+    assert list(node.input) == ["X", "axes"]
+    assert list(node.output) == ["Z"]
+    keepdims_attr = next(a for a in node.attribute if a.name == "keepdims")
+    assert keepdims_attr.i == 1
+    (out,) = sim_model.graph.output
+    assert [d.dim_value for d in out.type.tensor_type.shape.dim] == [2, 1, 4, 1]
+
+
+def test_fuse_consecutive_reduce_unsqueeze_pass_matches_reducemax():
+    # Same shape of fusion, different reduction_operators member -- confirms
+    # the predicate/transform genuinely isn't kind-specific.
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 18]
+        >
+        g (float[2,3,4,5] X) => (float[2,1,4,1] Z)
+        <int64[{len(_AXES)}] axes = {_ints_literal(_AXES)}>
+        {{
+          r = ReduceMax <keepdims=0> (X, axes)
+          Z = Unsqueeze(r, axes)
+        }}
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_reduce_unsqueeze")
+    assert ops["Unsqueeze"] == 0
+    assert ops["ReduceMax"] == 1
+    (node,) = sim_model.graph.node
+    keepdims_attr = next(a for a in node.attribute if a.name == "keepdims")
+    assert keepdims_attr.i == 1
+
+
+def test_fuse_consecutive_reduce_unsqueeze_declines_on_multi_use_reduction():
+    # Declining case: the reduction op's output is ALSO returned as a second
+    # graph output, so it has more than one use. The pass would otherwise
+    # have to change what that other consumer sees (keepdims=0 -> 1 changes
+    # the output's rank), so runTransform's own single-use check bails --
+    # both nodes survive, keepdims still 0.
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 18]
+        >
+        g (float[2,3,4,5] X) => (float[2,4] R, float[2,1,4,1] Z)
+        <int64[{len(_AXES)}] axes = {_ints_literal(_AXES)}>
+        {{
+          R = ReduceSum <keepdims=0> (X, axes)
+          Z = Unsqueeze(R, axes)
+        }}
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_reduce_unsqueeze")
+    assert ops["ReduceSum"] == 1
+    assert ops["Unsqueeze"] == 1
+    reduce_node = producer(sim_model, "R")
+    keepdims_attr = next(a for a in reduce_node.attribute if a.name == "keepdims")
+    assert keepdims_attr.i == 0
+    unsqueeze_node = producer(sim_model, "Z")
+    assert list(unsqueeze_node.input) == ["R", "axes"]
+
+
+def test_fuse_consecutive_reduce_unsqueeze_declines_on_axes_mismatch():
+    # Declining case: the Unsqueeze's own axes ([2], a single axis) do not
+    # exactly equal the reduction's own axes ([1, 3]) -- both nodes survive
+    # unchanged.
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 18]
+        >
+        g (float[2,3,4,5] X) => (float[2,1,4,1,1] Z)
+        <int64[{len(_AXES)}] axes_r = {_ints_literal(_AXES)}, int64[1] axes_u = {{2}}>
+        {{
+          r = ReduceSum <keepdims=0> (X, axes_r)
+          Z = Unsqueeze(r, axes_u)
+        }}
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_reduce_unsqueeze")
+    assert ops["ReduceSum"] == 1
+    assert ops["Unsqueeze"] == 1
+    reduce_node = producer(sim_model, "r")
+    keepdims_attr = next(a for a in reduce_node.attribute if a.name == "keepdims")
+    assert keepdims_attr.i == 0
+    unsqueeze_node = producer(sim_model, "Z")
+    assert list(unsqueeze_node.input) == ["r", "axes_u"]
+
+
+def test_fuse_consecutive_reduce_unsqueeze_declines_on_negative_vs_positive_axes():
+    # Declining case, more subtle than a genuine axes mismatch: the two axes
+    # lists denote the SAME axis semantically (X has rank 3, so axis -1 and
+    # axis 2 are the same axis), but are spelled differently. GetValueFromAttrOrInput
+    # does no negative-axis normalization before the pass's `axes != prev_axes`
+    # comparison, so this declines exactly like a genuine mismatch would --
+    # confirmed against the real compiled pass, not assumed from reading the
+    # header (see module docstring).
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 18]
+        >
+        g (float[2,3,4] X) => (float[2,3,1] Z)
+        <int64[1] axes_r = {-1}, int64[1] axes_u = {2}>
+        {
+          r = ReduceSum <keepdims=0> (X, axes_r)
+          Z = Unsqueeze(r, axes_u)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_reduce_unsqueeze")
+    assert ops["ReduceSum"] == 1
+    assert ops["Unsqueeze"] == 1
+    reduce_node = producer(sim_model, "r")
+    keepdims_attr = next(a for a in reduce_node.attribute if a.name == "keepdims")
+    assert keepdims_attr.i == 0
+
+
+def test_fuse_consecutive_reduce_unsqueeze_predicate_declines_on_existing_keepdims():
+    # Declining case: the reduction op already has keepdims=1. patternMatchPredicate's
+    # own `prev_node->i(kkeepdims) == 0` check should decline outright -- a
+    # sanity check that the predicate correctly restricts to the keepdims=0
+    # starting state (an Unsqueeze after an already-keepdims=1 reduction is
+    # not this pass's business, whatever else might be true of that graph).
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 18]
+        >
+        g (float[2,3,4,5] X) => (float[2,1,4,1,1] Z)
+        <int64[{len(_AXES)}] axes = {_ints_literal(_AXES)}>
+        {{
+          r = ReduceSum <keepdims=1> (X, axes)
+          Z = Unsqueeze(r, axes)
+        }}
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_reduce_unsqueeze")
+    assert ops["ReduceSum"] == 1
+    assert ops["Unsqueeze"] == 1
+    reduce_node = producer(sim_model, "r")
+    keepdims_attr = next(a for a in reduce_node.attribute if a.name == "keepdims")
+    assert keepdims_attr.i == 1

--- a/tests/test_formal_verify_fuse_consecutive_squeeze_unsqueeze.py
+++ b/tests/test_formal_verify_fuse_consecutive_squeeze_unsqueeze.py
@@ -1,0 +1,357 @@
+"""Formal check for FuseConsecutiveSqueezeUnsqueeze
+(fuse_consecutive_squeeze_unsqueeze.h).
+
+Unlike ``fuse_consecutive_squeezes``/``fuse_consecutive_unsqueezes`` (two
+nodes of the *same* kind, generally *different* axes lists, fused into one
+node with a *composed* axes list), this pass matches a Squeeze immediately
+followed by an Unsqueeze, or an Unsqueeze immediately followed by a Squeeze
+(``patternMatchPredicate``), fetches both nodes' ``axes`` (``kaxes`` -- an
+attribute pre-opset-13, the second input from opset 13 on --
+``GetValueFromAttrOrInput``, so each must be a compile-time constant),
+normalizes negative entries against a shared "reference rank" (the
+Squeeze's own input rank, which by construction equals the Unsqueeze's own
+output rank -- ``ReferenceRank``, recovered from whichever value carries
+static shape info; declines when it is unknown *and* a negative axis is
+present, same pattern as ``fuse_consecutive_unsqueezes``), sorts both lists,
+and -- crucially -- declines *unless they are exactly equal*
+(``axes != prev_axes`` bails: this pass does no index remapping at all).
+When they match, the whole pair collapses to nothing: every consumer of the
+*outer* node's output is rewired straight to the *inner* node's own input
+(``tryReplacingAllUsesWith(node->output(), prev->input(0))``), and only the
+outer node is destroyed (``NodeDestroyType::DestroyOne``) -- confirmed
+empirically below, the inner node is left dangling, unlike
+``fuse_consecutive_squeezes`` (which explicitly destroys the now-unused
+inner node too) and *like* ``fuse_consecutive_unsqueezes`` (which also
+leaves its dead inner node in place).
+
+Formal content: Squeeze removes a set of size-1 axes, by their *index
+position* on the tensor it reads; Unsqueeze inserts size-1 axes back, also
+by index position. ``_insert_removed`` below (Squeeze's own index
+reconstruction, reproduced from ``test_formal_verify_fuse_consecutive_squeezes.py``)
+and ``_remove_inserted`` (Unsqueeze's, reproduced from
+``test_formal_verify_fuse_consecutive_unsqueezes.py``) are exact inverses of
+each other *on the smaller ("squeezed"/pre-unsqueeze) index space* when
+given the *same* axes list -- ``_remove_inserted(_insert_removed(idx, axes,
+rank), axes, rank) == idx`` unconditionally, no shift/remap arithmetic and
+no side condition needed, because insert always places a 0 at exactly the
+positions remove then discards. This is the whole soundness argument: it is
+what makes the pass's decision to require the *same* axes list (rather than
+doing the composition arithmetic the sibling passes do) sufficient. Note this
+is *not* the same as saying "reading Z at an arbitrary full-rank index equals
+reading X there" for literally every index -- it only needs to hold at the
+indices a real (size-1-there) tensor can ever have, and those are exactly
+the ones ``_insert_removed`` produces, which is exactly the index set both
+soundness tests below quantify over.
+
+Both node orders are covered, since the predicate matches them as genuinely
+separate cases (``CheckKind(node, kUnsqueeze, 0, kSqueeze)`` and
+``CheckKind(node, kSqueeze, 0, kUnsqueeze)``) even though the underlying
+index argument is symmetric:
+
+* Squeeze then Unsqueeze: X (rank ``_RANK0``) -> Squeeze(axes) -> y (rank
+  ``rank1``) -> Unsqueeze(axes) -> Z (rank ``_RANK0`` again). For a symbolic
+  index ``idx`` into y (length ``rank1``), ``w = _insert_removed(idx, axes,
+  _RANK0)`` is the corresponding index into X *and* Z (both full rank); the
+  claim is ``Z[w] == X[w]``, which unwinds via the two nodes' own read
+  semantics (``y[i] = X[_insert_removed(i, axes, _RANK0)]``,
+  ``Z[j] = y[_remove_inserted(j, axes, _RANK0)]``) straight into the round
+  trip lemma.
+* Unsqueeze then Squeeze: X (rank ``rank1``) -> Unsqueeze(axes) -> y (rank
+  ``_RANK0``) -> Squeeze(axes) -> Z (rank ``rank1`` again, X's own rank
+  here). For a symbolic index ``idx`` into X directly (length ``rank1``),
+  the claim is ``Z[idx] == X[idx]``, which unwinds the same way
+  (``y[j] = X[_remove_inserted(j, axes, _RANK0)]``,
+  ``Z[i] = y[_insert_removed(i, axes, _RANK0)]``) into the exact same round
+  trip lemma, applied in the same insert-then-remove order.
+
+Each soundness test models the relevant tensor as an uninterpreted function
+from a symbolic integer index tuple to a real value and proves the composed
+(two-node) read equals the direct read at every index, composed with an
+arbitrary uninterpreted ``consumer`` (matching
+``test_formal_verify_eliminate_identity.py``'s style: this is what makes it
+a real "any downstream computation sees the same thing" argument, not just
+restating ``x == x``) -- a genuine universal proof (free variables in a Z3
+validity check are implicitly universally quantified), not a finite sample.
+As with the sibling files, the axes list is concrete (matching the pass's
+own header-comment worked example, ``axes=[1, 3]`` on a rank-4 tensor)
+rather than fully symbolic, so the index arithmetic stays tractable for Z3.
+
+One thing confirmed empirically against the actual compiled pass (rather
+than assumed from reading the header) before writing the differential tests
+below: a model that plugs the Squeeze/Unsqueeze pair directly between a
+graph input and a graph output has both endpoints of the rewire count as
+graph boundary values, and ``tryReplacingAllUsesWith``
+(``onnxoptimizer/pass.h``) unconditionally declines whenever *both* the
+value being replaced and its replacement are graph inputs/outputs
+(``areTwoValuesBothInputOrOutput``) -- an IR representational limit
+unrelated to this pass's own axes-matching algebra, but enough to make the
+pass silently no-op on the naive "X straight into Y straight out" model this
+file's differential tests would otherwise reach for. Every differential test
+below that expects a fuse therefore wraps X and Z in a plain ``Identity`` on
+each side, exactly like other formal-verify files in this suite route
+"the value under test" through a non-boundary node when the rewrite being
+checked would otherwise touch the graph's own input/output values directly.
+"""
+
+import collections
+
+from _formal_verify_common import isolate, producer, prove, simplify_isolated, z3
+from onnx import parser
+
+import onnxsim
+
+_RANK0 = 4  # X's rank before Squeeze / after Unsqueeze -- matches the header
+# comment's own worked example: X shape [2,1,3,1], axes=[1,3].
+_AXES = [1, 3]
+
+
+def _insert_removed(idx, sorted_removed_axes, rank):
+    # Squeeze(T, axes=sorted_removed_axes)[idx] reads T at the index built by
+    # inserting a 0 (the only valid coordinate on a removed, dim-1 axis) at
+    # each removed position, and taking idx's components, in order, at every
+    # other (kept) position. Reproduced from
+    # test_formal_verify_fuse_consecutive_squeezes.py.
+    it = iter(idx)
+    return [0 if p in sorted_removed_axes else next(it) for p in range(rank)]
+
+
+def _remove_inserted(idx, sorted_inserted_axes, rank):
+    # Unsqueeze(T, axes=sorted_inserted_axes)[idx] reads T at the index built
+    # by dropping idx's components at each inserted position (an inserted,
+    # dim-1 axis only ever has index 0 there) and taking the rest, in order.
+    # Reproduced from test_formal_verify_fuse_consecutive_unsqueezes.py.
+    return [idx[p] for p in range(rank) if p not in sorted_inserted_axes]
+
+
+def _ints_literal(xs):
+    # ONNX text-format tensor literal, e.g. [1, 3] -> "{1, 3}" (as opposed to
+    # the "[1, 3]" square-bracket syntax used for int-list *attributes*).
+    return "{" + ", ".join(map(str, xs)) + "}"
+
+
+def test_fuse_consecutive_squeeze_unsqueeze_round_trip_lemma():
+    # The algebraic core both node orders rely on (see module docstring):
+    # applying _insert_removed and then _remove_inserted *with the same axes
+    # list* is an exact, unconditional round trip on the smaller
+    # ("squeezed"/pre-unsqueeze) index space -- unlike the sibling files' own
+    # two-DIFFERENT-axes-lists compositions, no shifting/remapping arithmetic
+    # is needed at all, because insert always places a 0 at exactly the
+    # positions remove then discards right back out.
+    rank1 = _RANK0 - len(_AXES)
+    idx = [z3.Int(f"i{i}") for i in range(rank1)]
+    round_tripped = _remove_inserted(
+        _insert_removed(idx, sorted(_AXES), _RANK0), sorted(_AXES), _RANK0
+    )
+    prove(z3.And(*(a == b for a, b in zip(round_tripped, idx))))
+
+
+def test_fuse_consecutive_squeeze_unsqueeze_is_sound_squeeze_then_unsqueeze():
+    # X (rank _RANK0) --Squeeze(axes)--> y (rank rank1) --Unsqueeze(axes)--> Z
+    # (rank _RANK0 again). For idx into y, w = _insert_removed(idx, axes,
+    # _RANK0) is the corresponding index into X *and* Z; unwinding each
+    # node's own read semantics reduces Z[w] == X[w] to the round trip lemma.
+    rank1 = _RANK0 - len(_AXES)
+    tensor = z3.Function("tensor", *([z3.IntSort()] * _RANK0), z3.RealSort())
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+    idx = [z3.Int(f"i{i}") for i in range(rank1)]
+
+    w = _insert_removed(idx, sorted(_AXES), _RANK0)  # X's (and Z's) own index
+    # y[idx] = X[w] (Squeeze's read); Z[w] = y[_remove_inserted(w, axes, _RANK0)].
+    composed = tensor(
+        *_insert_removed(
+            _remove_inserted(w, sorted(_AXES), _RANK0), sorted(_AXES), _RANK0
+        )
+    )
+    direct = tensor(*w)
+    prove(consumer(composed) == consumer(direct))
+
+
+def test_fuse_consecutive_squeeze_unsqueeze_is_sound_unsqueeze_then_squeeze():
+    # X (rank rank1) --Unsqueeze(axes)--> y (rank _RANK0) --Squeeze(axes)-->
+    # Z (rank rank1 again, X's own rank here). For idx into X directly,
+    # unwinding each node's own read semantics reduces Z[idx] == X[idx] to
+    # the exact same round trip lemma, applied in the same insert-then-remove
+    # order as the other node order above.
+    rank1 = _RANK0 - len(_AXES)
+    tensor = z3.Function("tensor", *([z3.IntSort()] * rank1), z3.RealSort())
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+    idx = [z3.Int(f"i{i}") for i in range(rank1)]  # index into X directly
+
+    # y[w] = X[_remove_inserted(w, axes, _RANK0)] (Unsqueeze's read);
+    # Z[idx] = y[_insert_removed(idx, axes, _RANK0)] (Squeeze's read).
+    composed = tensor(
+        *_remove_inserted(
+            _insert_removed(idx, sorted(_AXES), _RANK0), sorted(_AXES), _RANK0
+        )
+    )
+    direct = tensor(*idx)
+    prove(consumer(composed) == consumer(direct))
+
+
+def test_fuse_consecutive_squeeze_unsqueeze_pass_matches_squeeze_then_unsqueeze():
+    # The header comment's own worked example: X shape [2,1,3,1] --Squeeze
+    # (axes=[1,3])-> [2,3] --Unsqueeze(axes=[1,3])-> [2,1,3,1] == X. X and Z
+    # are each routed through a plain Identity (see module docstring: without
+    # it, both ends of the rewire are graph boundary values and
+    # tryReplacingAllUsesWith declines for an unrelated IR reason). Confirmed
+    # empirically: the pass destroys the *outer* node (Unsqueeze) and leaves
+    # the *inner* one (Squeeze) dangling, rewiring Z0's producer straight to X.
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,1,3,1] X0) => (float[2,1,3,1] Z0)
+        <int64[{len(_AXES)}] axes = {_ints_literal(_AXES)}>
+        {{
+          X = Identity(X0)
+          y = Squeeze(X, axes)
+          Z = Unsqueeze(y, axes)
+          Z0 = Identity(Z)
+        }}
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_squeeze_unsqueeze")
+    # The outer node (Unsqueeze) is destroyed; the inner one (Squeeze) is left
+    # dangling (its output "y" has no more uses) rather than also destroyed.
+    assert ops["Unsqueeze"] == 0
+    assert ops["Squeeze"] == 1
+    fused_node = producer(sim_model, "Z0")
+    assert fused_node.op_type == "Identity"
+    assert fused_node.input[0] == "X", "should read straight from X, not through y/Z"
+
+
+def test_fuse_consecutive_squeeze_unsqueeze_pass_matches_unsqueeze_then_squeeze():
+    # The other order, also from the header comment: X shape [2,3]
+    # --Unsqueeze(axes=[1,3])-> [2,1,3,1] --Squeeze(axes=[1,3])-> [2,3] == X.
+    # Confirmed empirically: here the outer node (Squeeze) is destroyed and
+    # the inner one (Unsqueeze) is left dangling -- the destroyed/dangling
+    # roles swap with the node order, since "outer" always means the node
+    # that matched the predicate (the consumer of the other).
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,3] X0) => (float[2,3] Z0)
+        <int64[{len(_AXES)}] axes = {_ints_literal(_AXES)}>
+        {{
+          X = Identity(X0)
+          y = Unsqueeze(X, axes)
+          Z = Squeeze(y, axes)
+          Z0 = Identity(Z)
+        }}
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_squeeze_unsqueeze")
+    assert ops["Squeeze"] == 0
+    assert ops["Unsqueeze"] == 1
+    fused_node = producer(sim_model, "Z0")
+    assert fused_node.op_type == "Identity"
+    assert fused_node.input[0] == "X", "should read straight from X, not through y/Z"
+
+
+def test_fuse_consecutive_squeeze_unsqueeze_declines_axes_mismatch():
+    # Squeeze removes axes [1, 3] but Unsqueeze re-inserts at [1, 2] instead:
+    # axes != prev_axes, so runTransform bails before ever calling
+    # tryReplacingAllUsesWith and both nodes survive, still chained.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,1,3,1] X) => (float[2,1,1,3] Z)
+        <int64[2] axes_sq = {1, 3},
+         int64[2] axes_un = {1, 2}>
+        {
+          y = Squeeze(X, axes_sq)
+          Z = Unsqueeze(y, axes_un)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_squeeze_unsqueeze")
+    assert ops["Squeeze"] == 1
+    assert ops["Unsqueeze"] == 1
+    fused_node = producer(sim_model, "Z")
+    assert fused_node.op_type == "Unsqueeze"
+    assert fused_node.input[0] == "y", "should decline and leave the two nodes chained"
+
+
+def test_fuse_consecutive_squeeze_unsqueeze_declines_negative_axis_unknown_shape():
+    # X's rank is genuinely unresolvable by shape inference: Base (known
+    # shape [1,2,3,1]) is squeezed by sq_axes = Add(sq_a, sq_b), which is
+    # deterministic ([0] at runtime) but not a compile-time constant --
+    # FetchConstantTensor only recognizes a Constant node or an initializer
+    # directly -- the same trick fuse_consecutive_unsqueezes' own
+    # dynamic-shape test uses. ReferenceRank can recover neither the
+    # Squeeze's input rank nor the Unsqueeze's output rank (both are X's
+    # unresolvable rank), and axes=[-1] contains a negative entry, so
+    # NormalizeAxes declines and both nodes stay chained (y -> Z). Bypasses
+    # simplify_isolated (which only controls the *optimizer pass* list) and
+    # calls onnxsim.simplify directly with skip_constant_folding=True, since
+    # constant folding runs before the optimizer passes regardless of
+    # skipped_optimizers and would otherwise fold the Add/Squeeze away first.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[1,2,3,1] Base) => (float[2,3,1] Z0)
+        <int64[1] sq_a = {0}, int64[1] sq_b = {0},
+         int64[1] axes = {-1}>
+        {
+          sq_axes = Add(sq_a, sq_b)
+          X = Squeeze(Base, sq_axes)
+          y = Squeeze(X, axes)
+          Z = Unsqueeze(y, axes)
+          Z0 = Identity(Z)
+        }
+        """
+    )
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("fuse_consecutive_squeeze_unsqueeze"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+    ops = collections.Counter(n.op_type for n in sim_model.graph.node)
+    assert ops["Squeeze"] == 2
+    assert ops["Unsqueeze"] == 1
+    fused_node = producer(sim_model, "Z0")
+    assert fused_node.op_type == "Identity"
+    assert fused_node.input[0] == "Z", "should decline and leave the two nodes chained"
+
+
+def test_fuse_consecutive_squeeze_unsqueeze_negative_axis_still_fuses_with_known_shape():
+    # Control for the decline test above: the exact same negative axis (-1,
+    # relative to rank 3) declines only because the rank is unresolvable --
+    # with a statically known shape (X a plain graph input routed through
+    # Identity, no Squeeze-by-non-constant-axes involved), it normalizes fine
+    # and the pass still fuses.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,3,1] X0) => (float[2,3,1] Z0)
+        <int64[1] axes = {-1}>
+        {
+          X = Identity(X0)
+          y = Squeeze(X, axes)
+          Z = Unsqueeze(y, axes)
+          Z0 = Identity(Z)
+        }
+        """
+    )
+    sim_model, ops = simplify_isolated(model, "fuse_consecutive_squeeze_unsqueeze")
+    assert ops["Unsqueeze"] == 0
+    assert ops["Squeeze"] == 1
+    fused_node = producer(sim_model, "Z0")
+    assert fused_node.op_type == "Identity"
+    assert fused_node.input[0] == "X", "should fuse despite the negative axis"

--- a/tests/test_formal_verify_fuse_qkv.py
+++ b/tests/test_formal_verify_fuse_qkv.py
@@ -1,0 +1,400 @@
+"""Formal check for FuseQKV (fuse_qkv.h).
+
+onnxsim registers its own copy of this pass (``onnxsim/passes/fuse_qkv.h``)
+via ``RegisterOrReplace``, overwriting the upstream onnx-optimizer entry of
+the same name
+(``third_party/onnx-optimizer/onnxoptimizer/passes/fuse_qkv.h``) in the pass
+registry that ``getPassName()`` keys into -- so onnxsim's version is the one
+that actually runs, the same override pattern
+``test_formal_verify_fuse_add_bias_into_conv.py`` documents for that pass.
+The two are byte-for-byte identical apart from one added guard in
+``runTransform`` (see below); onnxsim's version fixes a real crash in the
+upstream original.
+
+``patternMatchPredicate`` matches any ``MatMul`` node whose **first** input
+(``input(0)``) has *exactly 3 uses* -- i.e. some shared value ``X`` feeds
+exactly 3 different consumers (candidate Q/K/V projections). Note this
+matches on the *shared input*, not on any property distinguishing the
+matched node itself: all 3 of those consumers (if all are themselves
+qualifying MatMuls) satisfy the predicate identically, so which one
+``patternMatchPredicate`` happens to visit first only affects which node
+becomes ``n`` -- confirmed empirically below (see
+``test_fuse_qkv_pass_matches_basic_case``), it's the first one in the
+node list, since that's the first one the pass's node walk reaches.
+
+``runTransform`` (onnxsim's version):
+
+1. **The onnxsim-only fix**: first checks ``n->input(0)->node()->kind() ==
+   kParam`` -- i.e. whether ``X``'s own producer is the graph's placeholder
+   "node" for a plain graph input, meaning there is no real node to anchor
+   the new fused ``Concat`` after. If so, it declines (``return false``)
+   immediately. Upstream's original has no such check: it unconditionally
+   does ``cat->insertAfter(PrevNode(n, 0))``, which for a graph-input ``X``
+   resolves to the ``kParam`` placeholder -- a node that is never part of
+   the real node list ``insertAfter`` requires, tripping an
+   ``ONNX_ASSERT`` and aborting *onnxsim's entire simplify() pipeline*
+   outright, not just this one pass's match. This is exactly the common
+   self-attention shape: ``Q = MatMul(X, Wq)`` etc. reading the graph input
+   ``X`` directly with no intervening node. Confirmed empirically below
+   (``test_fuse_qkv_declines_when_shared_input_is_a_graph_input``) that
+   onnxsim's version declines gracefully here instead of crashing.
+2. For each of the 3 uses of ``X``: bails unless it is operand **0** of
+   another ``MatMul`` (``use.offset != 0`` bails), that MatMul's own output
+   has *exactly 1 use*, and that MatMul's operand 1 (the weight) is a
+   compile-time constant (``IsConstantTensor``).
+3. Fetches the 3 weight tensors (``q_t``/``k_t``/``v_t``, called Q/K/V only
+   by the *order* ``uses()`` happens to return -- the header comment notes
+   "q k v not a one-to-one correspondence actually") and requires them to
+   have the **identical shape**; declines otherwise.
+4. Builds a new ``Concat`` (inputs ``[Wq, Wk, Wv]`` in that order, axis =
+   ``q_t.sizes().size() - 1``, i.e. the weights' own last/output axis), a
+   new ``MatMul(X, Concat(...))``, and a new 3-output ``Split`` (axis
+   ``-1``) of that MatMul's output into chunks sized
+   ``[Wq.sizes().back(), Wk.sizes().back(), Wv.sizes().back()]`` (an
+   initializer input for opset 13+, a ``split`` attribute pre-13 -- both
+   confirmed empirically below).
+5. Rewires the **original** 3 separate MatMul nodes' consumers onto the
+   Split's 3 respective outputs (Q's consumers -> output 0, K's -> output
+   1, V's -> output 2), then destroys **only** the matched node ``n``
+   (``NodeDestroyType::DestroyOne``) -- the *other two* original MatMul
+   nodes are left in the graph, now producing values nothing reads
+   (dangling), not destroyed. Confirmed empirically below: with Q/K/V
+   matched in source order, the pass visits the Q-producing MatMul first
+   (so it becomes ``n`` and is destroyed), while the original K- and
+   V-producing MatMul nodes survive as dead code.
+
+Formal content: this is a genuine BLOCK MATRIX MULTIPLICATION identity --
+matrix multiplication distributes over column-concatenation of the
+right-hand operand: ``X @ [Wq | Wk | Wv] == [X@Wq | X@Wk | X@Wv]`` (weights
+concatenated along their *output*/last axis, multiplied once, then split
+back apart along that same axis). Each output column of the fused product is
+``X`` dotted with one column of the concatenated weight matrix, which is
+exactly a column of whichever of ``Wq``/``Wk``/``Wv`` that column came from
+-- matching, index for index, the corresponding column of the
+corresponding separate ``X@W`` product. Modeled below with ``X`` and each of
+``Wq``/``Wk``/``Wv`` as uninterpreted ``Int, Int -> Real`` functions sharing
+one contraction dimension ``K`` (all three MatMuls share the same ``X``) and
+one output width ``N`` (the predicate's own identical-shape requirement),
+concrete-sized (``K=2``, ``N=2``, fused width ``3*N=6``) to keep the
+contraction sums finite for Z3, mirroring
+``test_formal_verify_fuse_transpose_into_gemm.py``'s and
+``test_formal_verify_fuse_matmul_into_conv.py``'s own concrete ``_M``/``_K``/
+``_N`` matrix proofs rather than a fully symbolic-dimensioned one. Composing
+with an arbitrary uninterpreted ``consumer`` then proves substitution safety
+for any downstream reader of the split outputs, matching this suite's
+established style (see e.g. ``test_formal_verify_eliminate_nop_split.py``).
+"""
+
+import numpy as np
+import onnx
+from _formal_verify_common import isolate, prove, simplify_isolated, z3
+from onnx import parser
+
+import onnxsim
+
+_K = 2  # shared contraction dim -- all 3 MatMuls read the same X, so share K
+_N = 2  # per-head (Q/K/V) output width -- the predicate requires all 3 equal
+
+
+def _concat_cols(weights, k, q):
+    """``Concat(Wq, Wk, Wv, axis=-1)`` read at (row=k, col=q): whichever of
+    the 3 weight matrices column ``q`` falls into (a third of the ``3*_N``
+    fused width each), re-indexed to that matrix's own local column."""
+    third, offset = divmod(q, _N)
+    return weights[third](k, offset)
+
+
+def _matmul(A, B, K):
+    """``MatMul(A, B)`` read at (row, col), contracting over ``range(K)``."""
+
+    def out(row, col):
+        return sum(A(row, k) * B(k, col) for k in range(K))
+
+    return out
+
+
+def test_block_matmul_distributes_over_weight_concat_is_sound():
+    """``X @ Concat(Wq, Wk, Wv, axis=-1)``, read back at fused column
+    ``third * N + offset`` (exactly what the new ``Split`` node does -- it
+    only re-indexes, it does not recompute), equals the corresponding
+    separate ``X @ W_third`` read at its own local column ``offset`` -- for
+    every row, every third (Q/K/V), and every local column. This is exactly
+    the algebra ``runTransform`` relies on: fuse via Concat+MatMul, then
+    split the result back into 3 pieces that must reproduce the 3 original
+    separate MatMuls' outputs untouched.
+    """
+    X = z3.Function("X", z3.IntSort(), z3.IntSort(), z3.RealSort())
+    Wq = z3.Function("Wq", z3.IntSort(), z3.IntSort(), z3.RealSort())
+    Wk = z3.Function("Wk", z3.IntSort(), z3.IntSort(), z3.RealSort())
+    Wv = z3.Function("Wv", z3.IntSort(), z3.IntSort(), z3.RealSort())
+    weights = (Wq, Wk, Wv)
+
+    def concat(k, q):
+        return _concat_cols(weights, k, q)
+
+    fused = _matmul(X, concat, _K)  # X @ Concat(Wq, Wk, Wv, axis=-1)
+
+    claims = []
+    for third, w in enumerate(weights):
+        original = _matmul(X, w, _K)  # the original separate X @ W_third
+        for row in range(_K):
+            for offset in range(_N):
+                split_read = fused(row, third * _N + offset)
+                claims.append(split_read == original(row, offset))
+    prove(z3.And(*claims))
+
+
+def test_block_matmul_composition_with_consumer_is_sound():
+    """The identity above survives substitution into an arbitrary
+    downstream consumer -- proving it's safe for *any* reader of the split
+    outputs (exactly what ``tryReplacingAllUsesWith`` rewires onto), not
+    only a concrete one.
+    """
+    X = z3.Function("X", z3.IntSort(), z3.IntSort(), z3.RealSort())
+    Wq = z3.Function("Wq", z3.IntSort(), z3.IntSort(), z3.RealSort())
+    Wk = z3.Function("Wk", z3.IntSort(), z3.IntSort(), z3.RealSort())
+    Wv = z3.Function("Wv", z3.IntSort(), z3.IntSort(), z3.RealSort())
+    weights = (Wq, Wk, Wv)
+    consumer = z3.Function("consumer", z3.RealSort(), z3.RealSort())
+
+    def concat(k, q):
+        return _concat_cols(weights, k, q)
+
+    fused = _matmul(X, concat, _K)
+
+    claims = []
+    for third, w in enumerate(weights):
+        original = _matmul(X, w, _K)
+        for row in range(_K):
+            for offset in range(_N):
+                split_read = fused(row, third * _N + offset)
+                claims.append(consumer(split_read) == consumer(original(row, offset)))
+    prove(z3.And(*claims))
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _qkv_model(k=_K, n=_N, opset=13, ir_version=10):
+    rng = np.random.default_rng(0)
+    Wq = rng.standard_normal((k, n))
+    Wk = rng.standard_normal((k, n))
+    Wv = rng.standard_normal((k, n))
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        g (float[4,{k}] RawX) => (float[4,{n}] Q, float[4,{n}] Kk, float[4,{n}] V)
+        {{
+          X = Relu(RawX)
+          Q = MatMul(X, Wq)
+          Kk = MatMul(X, Wk)
+          V = MatMul(X, Wv)
+        }}
+        """
+    )
+    model.graph.initializer.extend([_f32(Wq, "Wq"), _f32(Wk, "Wk"), _f32(Wv, "Wv")])
+    return model
+
+
+def test_fuse_qkv_pass_matches_basic_case():
+    # X is NOT a graph input directly -- it's Relu(RawX) -- so the
+    # graph-input decline guard doesn't trip and the fuse actually happens.
+    # skip_constant_folding=True bypasses simplify_isolated (which only
+    # controls the *optimizer pass* list): onnxsim's constant folding is a
+    # separate step that always runs regardless of skipped_optimizers, and
+    # since Wq/Wk/Wv are all constants it would otherwise fold the new
+    # Concat node away into a single initializer before this test could
+    # inspect it directly (confirmed empirically).
+    model = _qkv_model()
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("fuse_qkv"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+
+    nodes = list(sim_model.graph.node)
+    by_op = {}
+    for n in nodes:
+        by_op.setdefault(n.op_type, []).append(n)
+    assert len(by_op["Concat"]) == 1
+    assert len(by_op["Split"]) == 1
+    assert len(by_op["MatMul"]) == 3  # 1 fused + 2 dangling originals (Kk, V)
+
+    cat = by_op["Concat"][0]
+    assert list(cat.input) == ["Wq", "Wk", "Wv"]
+    assert [a.i for a in cat.attribute if a.name == "axis"] == [1]  # sizes()-1
+
+    fused_matmul = next(n for n in by_op["MatMul"] if cat.output[0] in n.input)
+    assert list(fused_matmul.input) == ["X", cat.output[0]]
+
+    split = by_op["Split"][0]
+    assert list(split.input[:1]) == [fused_matmul.output[0]]
+    assert [a.i for a in split.attribute if a.name == "axis"] == [-1]
+    split_sizes_init = next(
+        onnx.numpy_helper.to_array(i)
+        for i in sim_model.graph.initializer
+        if i.name == split.input[1]
+    )
+    np.testing.assert_array_equal(split_sizes_init, [_N, _N, _N])
+
+    # Q/K/V's original consumers now read Split's 3 outputs, in that order.
+    assert list(split.output) == ["Q", "Kk", "V"]
+
+    # The two ORIGINAL MatMul nodes that are not the matched node `n`
+    # survive, dangling: still reading X and their own constant weight, but
+    # producing a value nothing (no node, no graph output) consumes.
+    dangling = [n for n in by_op["MatMul"] if n is not fused_matmul]
+    assert len(dangling) == 2
+    dangling_weights = {n.input[1] for n in dangling}
+    assert dangling_weights == {"Wk", "Wv"}
+    all_outputs_used = {inp for n in nodes for inp in n.input} | set(
+        sim_model.graph.output[i].name for i in range(len(sim_model.graph.output))
+    )
+    for n in dangling:
+        assert n.output[0] not in all_outputs_used, "dangling MatMul should be dead"
+
+    # The matched-and-destroyed node was the Q-producing original MatMul:
+    # patternMatchPredicate visits nodes in graph order (Q, Kk, V), and Q's
+    # original MatMul is the one no longer present at all (not even
+    # dangling) -- confirmed by it being neither the fused MatMul nor one
+    # of the 2 survivors above.
+    assert fused_matmul.input[1] == cat.output[0]
+
+
+def test_fuse_qkv_declines_when_shared_input_is_a_graph_input():
+    # The single most important differential test in this file: X IS the
+    # graph's own input directly (no intervening node) feeding 3 MatMuls
+    # with constant weights -- exactly the shape that crashes upstream's
+    # unfixed original (n->input(0)->node() resolves to the kParam
+    # placeholder, which trips insertAfter's ONNX_ASSERT and aborts the
+    # entire simplify() pipeline). onnxsim's added guard declines this match
+    # gracefully instead: no crash, no fuse, all three MatMuls survive
+    # untouched.
+    rng = np.random.default_rng(0)
+    Wq = rng.standard_normal((_K, _N))
+    Wk = rng.standard_normal((_K, _N))
+    Wv = rng.standard_normal((_K, _N))
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4,{_K}] X) => (float[4,{_N}] Q, float[4,{_N}] Kk, float[4,{_N}] V)
+        {{
+          Q = MatMul(X, Wq)
+          Kk = MatMul(X, Wk)
+          V = MatMul(X, Wv)
+        }}
+        """
+    )
+    model.graph.initializer.extend([_f32(Wq, "Wq"), _f32(Wk, "Wk"), _f32(Wv, "Wv")])
+    # No crash -- this call completing at all is the point of this test.
+    sim_model, ops = simplify_isolated(model, "fuse_qkv")
+    assert ops["MatMul"] == 3
+    assert ops["Concat"] == 0
+    assert ops["Split"] == 0
+    assert [n.input[1] for n in sim_model.graph.node if n.op_type == "MatMul"] == [
+        "Wq",
+        "Wk",
+        "Wv",
+    ]
+
+
+def test_fuse_qkv_declines_on_mismatched_weight_shapes():
+    # Wk is [K, N+1] -- not the same shape as Wq/Wk's [K, N] -- so
+    # `q_t->sizes() != k_t->sizes()` trips and the pass declines outright.
+    rng = np.random.default_rng(0)
+    Wq = rng.standard_normal((_K, _N))
+    Wk = rng.standard_normal((_K, _N + 1))
+    Wv = rng.standard_normal((_K, _N))
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4,{_K}] RawX) => (float[4,{_N}] Q, float[4,{_N + 1}] Kk, float[4,{_N}] V)
+        {{
+          X = Relu(RawX)
+          Q = MatMul(X, Wq)
+          Kk = MatMul(X, Wk)
+          V = MatMul(X, Wv)
+        }}
+        """
+    )
+    model.graph.initializer.extend([_f32(Wq, "Wq"), _f32(Wk, "Wk"), _f32(Wv, "Wv")])
+    _, ops = simplify_isolated(model, "fuse_qkv")
+    assert ops["MatMul"] == 3
+    assert ops["Concat"] == 0
+    assert ops["Split"] == 0
+
+
+def test_fuse_qkv_declines_when_a_weight_is_not_constant():
+    # Kk's "weight" is a runtime graph input, not a constant -- fails
+    # IsConstantTensor(use.user, 1), so the pass declines.
+    rng = np.random.default_rng(0)
+    Wq = rng.standard_normal((_K, _N))
+    Wv = rng.standard_normal((_K, _N))
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[4,{_K}] RawX, float[{_K},{_N}] WkRuntime)
+            => (float[4,{_N}] Q, float[4,{_N}] Kk, float[4,{_N}] V)
+        {{
+          X = Relu(RawX)
+          Q = MatMul(X, Wq)
+          Kk = MatMul(X, WkRuntime)
+          V = MatMul(X, Wv)
+        }}
+        """
+    )
+    model.graph.initializer.extend([_f32(Wq, "Wq"), _f32(Wv, "Wv")])
+    _, ops = simplify_isolated(model, "fuse_qkv")
+    assert ops["MatMul"] == 3
+    assert ops["Concat"] == 0
+    assert ops["Split"] == 0
+
+
+def test_fuse_qkv_declines_when_a_use_output_has_more_than_one_consumer():
+    # Kk also feeds a second graph output (via Identity) -- Kk's own output
+    # has 2 uses, tripping `use.user->output()->uses().size() != 1`, so the
+    # pass declines.
+    model = _qkv_model()
+    y_out = onnx.helper.make_tensor_value_info("Kk2", onnx.TensorProto.FLOAT, [4, _N])
+    model.graph.output.append(y_out)
+    model.graph.node.append(onnx.helper.make_node("Identity", ["Kk"], ["Kk2"]))
+    _, ops = simplify_isolated(model, "fuse_qkv")
+    assert ops["MatMul"] == 3
+    assert ops["Concat"] == 0
+    assert ops["Split"] == 0
+
+
+def test_fuse_qkv_pass_matches_pre_opset13_split_attribute_form():
+    # Same basic-case fuse, but on an opset < 13 model: the new Split's
+    # sizes are carried as a `split` INTS attribute instead of a second
+    # (initializer) input -- the other half of runTransform's
+    # `opset_version >= 13` branch.
+    model = _qkv_model(opset=11, ir_version=8)
+    sim_model, check_ok = onnxsim.simplify(
+        model,
+        check_n=3,
+        skipped_optimizers=isolate("fuse_qkv"),
+        skip_constant_folding=True,
+    )
+    assert check_ok, "simplified model failed onnxsim's own equivalence check"
+
+    split = next(n for n in sim_model.graph.node if n.op_type == "Split")
+    assert len(split.input) == 1  # no sizes-initializer input on this opset
+    split_attrs = {a.name: list(a.ints) for a in split.attribute if a.name == "split"}
+    assert split_attrs["split"] == [_N, _N, _N]
+    assert list(split.output) == ["Q", "Kk", "V"]

--- a/tests/test_formal_verify_nop.py
+++ b/tests/test_formal_verify_nop.py
@@ -1,0 +1,107 @@
+"""Formal check for NopEmptyPass (nop.h).
+
+This is the simplest pass in the whole suite. Straight from the header:
+``NopEmptyPass::runPass(Graph&)`` takes the graph by reference and does
+absolutely nothing to it -- no node is added, removed, or modified -- and
+just returns an empty ``PostPassAnalysis``. There is no comment in the
+header explaining its purpose beyond the code itself, but its shape (a
+registered pass named ``"nop"`` that provably changes nothing) is the
+standard meaning of such a name in an optimizer pass registry: a documented
+"do nothing" option/placeholder pass name, useful e.g. for testing the pass
+harness itself or as an explicit no-op entry in a pass list.
+
+Formal content, and why the proof here is not dressed up as more than it
+is: there is no rewrite here to prove sound -- no algebra, no operator
+semantics, not even the thin "substitution under equality"/"unreachable
+code" arguments the other structurally-simple passes in this suite
+(``eliminate_duplicate_initializer``, ``eliminate_deadend``) still needed.
+A pass that is the identity function on graphs is trivially
+semantics-preserving, for the same reason any identity function trivially
+preserves whatever its argument denotes. This is modeled below as one
+uninterpreted ``graph_semantics`` function -- standing for "whatever a
+graph abstractly computes", with no attempt to model operators, tensors, or
+graph structure at all -- applied to a single arbitrary/uninterpreted graph
+constant ``G``, and the "proof" is exactly reflexivity of equality:
+``graph_semantics(G) == graph_semantics(G)``. That is the entire content;
+it is not narrowed down to this by argument, it simply *is* reflexivity,
+stated honestly rather than padded out with machinery this pass has no use
+for.
+
+Given that the algebra is empty, all of the real verification value here is
+in the differential tests below: confirming, against the actually compiled
+pass, that running ``nop`` in isolation via ``simplify_isolated`` leaves a
+concrete model's node list (kinds, order, inputs, outputs, attributes) and
+initializers genuinely unchanged -- not merely "still computes the same
+thing" (which the trivial proof above already covers by construction) but
+structurally byte-for-byte identical.
+"""
+
+import numpy as np
+from _formal_verify_common import isolate, prove, simplify_isolated, z3
+from onnx import numpy_helper, parser
+
+import onnxsim
+
+
+def test_nop_is_sound():
+    # No graph/operator structure is modeled at all -- graph_semantics is a
+    # totally uninterpreted stand-in for "whatever a graph computes", and G
+    # is a single arbitrary graph. The claim is exactly reflexivity: nop
+    # changes nothing, so a graph's semantics before and after are the same
+    # expression, syntactically.
+    graph_semantics = z3.Function("graph_semantics", z3.IntSort(), z3.RealSort())
+    G = z3.Int("G")
+    prove(graph_semantics(G) == graph_semantics(G))
+
+
+def test_nop_pass_matches_identity_on_multi_node_model():
+    # A small chain of a few different op kinds, plus an initializer, run
+    # through nop in isolation: the resulting graph's nodes (kind, inputs,
+    # outputs, attributes, order) and initializers must be identical to the
+    # input's -- not just equivalent, but the very same structure untouched.
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 13]
+        >
+        g (float[2,2] X) => (float[2,2] Y)
+        {
+          v1 = Relu(X)
+          v2 = Sigmoid(v1)
+          v3 = Add(v2, W)
+          Y = Transpose<perm = [1, 0]>(v3)
+        }
+        """
+    )
+    model.graph.initializer.append(
+        numpy_helper.from_array(
+            np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32).reshape(2, 2), name="W"
+        )
+    )
+
+    sim_model, ops = simplify_isolated(model, "nop")
+
+    assert ops == {"Relu": 1, "Sigmoid": 1, "Add": 1, "Transpose": 1}
+    assert [
+        (n.op_type, list(n.input), list(n.output), list(n.attribute))
+        for n in sim_model.graph.node
+    ] == [
+        (n.op_type, list(n.input), list(n.output), list(n.attribute))
+        for n in model.graph.node
+    ]
+    assert [i.name for i in sim_model.graph.initializer] == ["W"]
+    assert list(numpy_helper.to_array(sim_model.graph.initializer[0]).flatten()) == [
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+    ]
+
+
+def test_nop_is_a_real_default_pass():
+    # Sanity check mirroring eliminate_deadend's own equivalent test: nop is
+    # a genuine default onnxsim pass, and isolate() skips it whenever a
+    # *different* single pass is isolated.
+    assert "nop" in onnxsim.onnxsim_cpp2py_export._list_optimizers()
+    assert "nop" in isolate("eliminate_identity")


### PR DESCRIPTION
## Summary

Continues the translation-validation effort from #1272/#1295/#1298 (see `tests/_formal_verify_common.py` for the architecture: a hand-written Z3 soundness proof paired with a differential check against the real compiled pass, run in isolation, for each targeted optimizer rewrite).

This PR adds 12 more proofs, raising coverage from 34/106 to 44/106 (41.5%) and **completing formal-verification coverage of every on-by-default onnxsim optimizer pass (40/40)**, tracked by `scripts/formal_verify_coverage.py`:

- `nop`, `eliminate_common_subexpression`, `fuse_concat_into_reshape`, `extract_constant_to_initializer`
- `eliminate_slice_after_shape`, `fuse_consecutive_squeeze_unsqueeze`, `fuse_consecutive_reduce_unsqueeze`, `fuse_qkv`
- `eliminate_shape_op`, `eliminate_shape_gather`

Highlights:

- **`fuse_qkv`** is a genuine block-matrix-multiplication identity — `X @ [Wq|Wk|Wv]` read back through `Split` reproduces `[X@Wq|X@Wk|X@Wv]` exactly, embedded as a concrete small matrix computation. onnxsim registers its own override fixing a real crash: upstream unconditionally anchors the new `Concat` node after whatever produces the shared Q/K/V input, which aborts onnxsim's entire pipeline when that input is the graph's own input directly (the common self-attention shape); onnxsim's version declines gracefully instead.
- **`eliminate_slice_after_shape`** found and precisely characterized one narrow divergence corner (negative step with both bounds more negative than `-len`) where this pass's clamping matches onnxruntime's real compiled `Slice` kernel rather than ONNX's own pure-Python reference evaluator — confirmed empirically both ways, and the corner is unreachable by any real `Slice(Shape(X))`.
- **`extract_constant_to_initializer`** and **`eliminate_shape_gather`** were found to be **unconditionally unreachable through onnxsim's own Python API** by deliberate design — `onnxsim.cpp`'s `SimplifyImpl` filters them out of both the default pass set and `extra_optimizers` via a fixed `always_disabled_passes` list, since onnxsim's own constant folder already performs equivalent work in its own constant-node-preserving representation. Both are proven via a Z3 proof plus a CI-safe regression-guard test confirming non-reachability through the public API, rather than a C++ harness that would only ever run in a local dev checkout (an earlier draft of `extract_constant_to_initializer` tried exactly that harness approach and it was reverted after review — see that file's docstring for the full reasoning).
- **`fuse_consecutive_squeeze_unsqueeze`** and **`fuse_consecutive_reduce_unsqueeze`** both reuse the insert/remove index technique already established for `fuse_consecutive_squeezes`/`fuse_consecutive_unsqueezes`, applied respectively to a same-axes-list round-trip cancellation and to ONNX `Reduce*`'s own `keepdims` semantics.
- **`eliminate_common_subexpression`** found that `IsSupportedByCSE` is not an op-kind allowlist at all — it only excludes nodes carrying graph- or sparse-tensor-valued attributes — and confirmed `CSEEqual` compares inputs by graph edge identity, not shape or type.

Every proof includes at least one differential test exercising a case where the pass's predicate declines, confirmed against the real compiled pass (except the two unreachable-pass files, which instead confirm non-reachability), and every Z3 proof was checked non-vacuous during development via a throwaway negative-control script — none of these throwaway scripts are part of the committed diff.

## Test plan

- [x] `pytest tests/test_formal_verify_*.py tests/test_fusion_patterns.py -q` — 303 passed in ~31s
- [x] `ruff check onnxsim tests` — clean
- [x] `ruff format --check onnxsim tests` — clean (2 pre-existing, unrelated findings elsewhere)
- [x] `python3 scripts/formal_verify_coverage.py` — 44/106 (41.5%), 40/40 default passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYPkPSuY9aARnGkHCpVzLV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYPkPSuY9aARnGkHCpVzLV)_