### PR TITLE
Add optional implicit-broadcast-free rewriter pass

### DIFF
--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -74,6 +74,7 @@
 #include "passes/rewrite_gatherelements_to_gather.h"
 #include "passes/rewrite_gathernd_to_gather.h"
 #include "passes/rewrite_gridsample_to_gather.h"
+#include "passes/rewrite_implicit_broadcast.h"
 #include "passes/rewrite_msdeformattn_to_gridsample.h"
 #include "passes/rewrite_trt_batched_nms.h"
 #include "passes/rewrite_trt_batched_rotated_nms.h"
@@ -187,6 +188,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::RewriteGatherNDToGather>(registry);
     RegisterOrReplace<p::RewriteGatherOverConcat>(registry);
     RegisterOrReplace<p::RewriteGridSampleToGather>(registry);
+    RegisterOrReplace<p::RewriteImplicitBroadcast>(registry);
     RegisterOrReplace<p::RewriteMSDeformAttnToGridSample>(registry);
     RegisterOrReplace<p::RewriteTRTBatchedNMS>(registry);
     RegisterOrReplace<p::RewriteTRTBatchedRotatedNMS>(registry);

--- a/onnxsim/passes/rewrite_implicit_broadcast.h
+++ b/onnxsim/passes/rewrite_implicit_broadcast.h
@@ -92,13 +92,13 @@ struct RewriteImplicitBroadcast final : public PredicateBasedPass {
 
   static bool IsMultidirectionalBroadcastOp(Symbol kind) {
     static const std::vector<Symbol> kOps = {
-        Symbol("Add"),          Symbol("Sub"),         Symbol("Mul"),
-        Symbol("Div"),          Symbol("Pow"),         Symbol("Mod"),
-        Symbol("Max"),          Symbol("Min"),         Symbol("Mean"),
-        Symbol("Sum"),          Symbol("Greater"),     Symbol("GreaterOrEqual"),
-        Symbol("Less"),         Symbol("LessOrEqual"), Symbol("Equal"),
-        Symbol("And"),          Symbol("Or"),          Symbol("Xor"),
-        Symbol("BitwiseAnd"),   Symbol("BitwiseOr"),   Symbol("BitwiseXor"),
+        Symbol("Add"),        Symbol("Sub"),         Symbol("Mul"),
+        Symbol("Div"),        Symbol("Pow"),         Symbol("Mod"),
+        Symbol("Max"),        Symbol("Min"),         Symbol("Mean"),
+        Symbol("Sum"),        Symbol("Greater"),     Symbol("GreaterOrEqual"),
+        Symbol("Less"),       Symbol("LessOrEqual"), Symbol("Equal"),
+        Symbol("And"),        Symbol("Or"),          Symbol("Xor"),
+        Symbol("BitwiseAnd"), Symbol("BitwiseOr"),   Symbol("BitwiseXor"),
         Symbol("Where"),
     };
     for (const Symbol& s : kOps) {

--- a/onnxsim/passes/rewrite_implicit_broadcast.h
+++ b/onnxsim/passes/rewrite_implicit_broadcast.h
@@ -1,0 +1,222 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// Rewrites a multidirectional ("NumPy-style" implicit) broadcasting
+// elementwise op -- one or more of whose operands has a shape that differs
+// from the node's own (statically-known) output shape -- into the same op
+// applied to operands that have all already been made exactly the output's
+// shape via an explicit `Expand`:
+//
+//   Y = Add(A, B)              // A: [3,1], B: [4], Y: [3,4] -- implicit
+//   ->
+//   A' = Expand(A, [3,4])
+//   B' = Expand(B, [3,4])
+//   Y  = Add(A', B')           // A', B', Y: all [3,4] -- no broadcasting
+//                              // is needed to evaluate this Add at all
+//
+// Some inference backends and accelerators -- particularly small NPUs, or
+// runtimes whose elementwise kernels are written to require identically-
+// shaped operands -- either don't support NumPy-style broadcasting at all,
+// or only support a narrower form of it (e.g. unidirectional/per-channel).
+// For those targets, a graph that still contains an implicitly-broadcasting
+// Add/Mul/Where/... simply fails to lower or run. Making every broadcast
+// explicit via `Expand` sidesteps that gap entirely: after this rewrite, an
+// elementwise op's operands are always identically shaped, so a backend
+// never needs to implement (or even recognize) broadcasting to run it --
+// only elementwise ops between same-shaped tensors and plain `Expand`
+// (a broadcast-to-shape copy), which is broadly supported on its own.
+//
+// This is emphatically *not* a size/op-count optimization -- it grows the
+// graph (one `Expand` per operand that isn't already the output's shape) and
+// can increase the amount of data actually materialized at runtime (a
+// broadcast operand is realized at its full expanded size rather than
+// reused in place), which is why it is `PassType::Other` and never runs by
+// default. Opt in with `extra_optimizers=["rewrite_implicit_broadcast"]`
+// (Python) or `--enable-optimization rewrite_implicit_broadcast` (CLI) when
+// targeting a backend that needs it.
+//
+// Scope (the predicate declines outside this):
+//  - One of the ops the ONNX spec itself documents as multidirectional-
+//    broadcasting: the binary/variadic arithmetic, comparison, and logical
+//    family (`Add`, `Sub`, `Mul`, `Div`, `Pow`, `Mod`, `Max`, `Min`, `Mean`,
+//    `Sum`, `Greater`, `GreaterOrEqual`, `Less`, `LessOrEqual`, `Equal`,
+//    `And`, `Or`, `Xor`, `BitwiseAnd`, `BitwiseOr`, `BitwiseXor`) plus
+//    `Where` (whose `condition` operand also participates in the same
+//    broadcast as its two data operands). In the default (empty) domain
+//    only -- a same-named op in a vendor/plugin domain is left alone.
+//  - The node's output has exactly one value, with a fully static
+//    (rank *and* every dimension concrete) shape -- needed to spell out the
+//    exact target shape `Expand`'s second input requires. A dynamic output
+//    shape is not handled; nothing here computes a broadcast shape at
+//    runtime.
+//  - At least one operand's own shape does not already exactly equal the
+//    output's shape -- otherwise there is nothing to make explicit and the
+//    predicate declines (this is also what keeps the pass `Complete`: once
+//    every operand of a node matches, re-running never fires on it again).
+//    An operand with an unknown or dynamic shape is conservatively always
+//    wrapped in `Expand` (it cannot be proven to already match), which is
+//    always safe -- `Expand`ing an operand that already has the target
+//    shape is a value-preserving identity, just extra work a later CSE/nop
+//    pass, or the backend itself, can still fold away.
+//  - `Expand`'s tensor-shape-input form is available from opset 8 onward
+//    (its only form in this fork's supported opset range) -- a defensive
+//    floor, since every op in the scope list above already implies that
+//    opset or later.
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct RewriteImplicitBroadcast final : public PredicateBasedPass {
+  explicit RewriteImplicitBroadcast()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "rewrite_implicit_broadcast";
+  }
+
+  static bool IsMultidirectionalBroadcastOp(Symbol kind) {
+    static const std::vector<Symbol> kOps = {
+        Symbol("Add"),          Symbol("Sub"),         Symbol("Mul"),
+        Symbol("Div"),          Symbol("Pow"),         Symbol("Mod"),
+        Symbol("Max"),          Symbol("Min"),         Symbol("Mean"),
+        Symbol("Sum"),          Symbol("Greater"),     Symbol("GreaterOrEqual"),
+        Symbol("Less"),         Symbol("LessOrEqual"), Symbol("Equal"),
+        Symbol("And"),          Symbol("Or"),          Symbol("Xor"),
+        Symbol("BitwiseAnd"),   Symbol("BitwiseOr"),   Symbol("BitwiseXor"),
+        Symbol("Where"),
+    };
+    for (const Symbol& s : kOps) {
+      if (kind == s) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // True only when `v`'s shape is fully known and identical (same rank,
+  // same concrete dims) to `target` -- the condition under which wrapping
+  // `v` in `Expand` would be a no-op, so this pass leaves it alone.
+  static bool AlreadyMatchesTargetShape(const Value* v,
+                                        const std::vector<Dimension>& target) {
+    if (!v->has_sizes()) {
+      return false;
+    }
+    const std::vector<Dimension>& s = v->sizes();
+    if (s.size() != target.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < s.size(); ++i) {
+      if (!s[i].is_int || s[i].dim != target[i].dim) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (!IsMultidirectionalBroadcastOp(node->kind())) {
+      return false;
+    }
+    // Leave a same-named op in a non-ai.onnx domain (e.g. a vendor/plugin
+    // "Add") alone.
+    if (node->has_domain() && !node->domain().empty()) {
+      return false;
+    }
+    if (node->inputs().empty() || node->outputs().size() != 1) {
+      return false;
+    }
+    const Value* out = node->output();
+    if (!out->has_sizes()) {
+      return false;
+    }
+    for (const Dimension& d : out->sizes()) {
+      if (!d.is_int) {
+        return false;
+      }
+    }
+
+    bool any_needs_expand = false;
+    for (Value* in : node->inputs()) {
+      if (!AlreadyMatchesTargetShape(in, out->sizes())) {
+        any_needs_expand = true;
+        break;
+      }
+    }
+    if (!any_needs_expand) {
+      return false;
+    }
+
+    // Defensive: every op in scope already implies opset >= 8 by its own
+    // introduction, so this can only ever be a no-op check.
+    const int opset = getOpsetVersion(*node->owningGraph());
+    return opset == 0 || opset >= 8;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+
+    Value* out = node->output();
+    const std::vector<Dimension> out_sizes = out->sizes();
+    std::vector<int64_t> target_shape;
+    target_shape.reserve(out_sizes.size());
+    for (const Dimension& d : out_sizes) {
+      target_shape.push_back(d.dim);
+    }
+
+    // Built lazily and shared across every operand of this node that needs
+    // one -- Where's condition/x/y operands, say, all Expand to the exact
+    // same target shape.
+    Value* shape_const = nullptr;
+    auto ShapeConst = [&]() -> Value* {
+      if (shape_const == nullptr) {
+        Tensor t;
+        t.elem_type() = TensorProto_DataType_INT64;
+        t.sizes().push_back(static_cast<int64_t>(target_shape.size()));
+        for (int64_t d : target_shape) {
+          t.int64s().push_back(d);
+        }
+        shape_const = graph.addInitializerAndCreateValue(std::move(t));
+      }
+      return shape_const;
+    };
+
+    bool changed = false;
+    const size_t num_inputs = node->inputs().size();
+    for (size_t i = 0; i < num_inputs; ++i) {
+      Value* in = node->input(i);
+      if (AlreadyMatchesTargetShape(in, out_sizes)) {
+        continue;
+      }
+      Node* expand = graph.create(Symbol("Expand"), 1);
+      expand->addInput(in);
+      expand->addInput(ShapeConst());
+      expand->insertBefore(node);
+      expand->output()->setElemType(in->elemType());
+      expand->output()->setSizes(out_sizes);
+      node->replaceInput(i, expand->output());
+      changed = true;
+    }
+    return changed;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/tests/test_rewrite_implicit_broadcast.py
+++ b/tests/test_rewrite_implicit_broadcast.py
@@ -41,14 +41,12 @@ def _simplify_with_pass(model, **kwargs):
     )
 
 
-def _elementwise_ops(model):
-    return [n for n in model.graph.node if n.op_type != "Expand"]
-
-
 def _operand_shapes(model, node):
     value_shapes = {}
-    for vi in list(model.graph.input) + list(model.graph.value_info) + list(
-        model.graph.output
+    for vi in (
+        list(model.graph.input)
+        + list(model.graph.value_info)
+        + list(model.graph.output)
     ):
         value_shapes[vi.name] = tuple(
             d.dim_value for d in vi.type.tensor_type.shape.dim

--- a/tests/test_rewrite_implicit_broadcast.py
+++ b/tests/test_rewrite_implicit_broadcast.py
@@ -1,0 +1,157 @@
+"""Tests for the ``rewrite_implicit_broadcast`` C++ pass
+(onnxsim/passes/rewrite_implicit_broadcast.h).
+
+Some inference backends (small NPUs in particular, or runtimes whose
+elementwise kernels require identically-shaped operands) don't support
+NumPy-style ("implicit"/multidirectional) broadcasting. This pass rewrites a
+broadcasting elementwise op -- e.g. ``Add``/``Mul``/``Where`` -- into the
+same op applied to operands that have each been made exactly the node's
+(statically-known) output shape via an explicit ``Expand``, so the op itself
+never needs to broadcast anything at runtime.
+
+It is registered as ``PassType::Other`` and therefore never runs by default
+-- opt in via ``extra_optimizers=["rewrite_implicit_broadcast"]``.
+"""
+
+import numpy as np
+import onnx
+from onnx import parser
+
+import onnxsim
+
+
+def _model(body, initializer=(), opset=13, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _simplify_with_pass(model, **kwargs):
+    return onnxsim.simplify(
+        model, extra_optimizers=["rewrite_implicit_broadcast"], **kwargs
+    )
+
+
+def _elementwise_ops(model):
+    return [n for n in model.graph.node if n.op_type != "Expand"]
+
+
+def _operand_shapes(model, node):
+    value_shapes = {}
+    for vi in list(model.graph.input) + list(model.graph.value_info) + list(
+        model.graph.output
+    ):
+        value_shapes[vi.name] = tuple(
+            d.dim_value for d in vi.type.tensor_type.shape.dim
+        )
+    return [value_shapes[name] for name in node.input]
+
+
+def test_add_broadcast_made_explicit():
+    model = _model(
+        """
+        g (float[3,1] a, float[4] b) => (float[3,4] y)
+        {
+          y = Add(a, b)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = _simplify_with_pass(model, check_n=0)
+    onnx.checker.check_model(sim_model)
+
+    # Exactly one Add remains, and both its operands (now Expand outputs)
+    # have the Add's own output shape -- no implicit broadcasting left.
+    adds = [n for n in sim_model.graph.node if n.op_type == "Add"]
+    assert len(adds) == 1
+    shapes = _operand_shapes(sim_model, adds[0])
+    assert shapes == [(3, 4), (3, 4)]
+    assert any(n.op_type == "Expand" for n in sim_model.graph.node)
+
+    assert check_ok
+    a = np.random.rand(3, 1).astype(np.float32)
+    b = np.random.rand(4).astype(np.float32)
+    ref = onnx.reference.ReferenceEvaluator(model)
+    (expected,) = ref.run(None, {"a": a, "b": b})
+    sim_ref = onnx.reference.ReferenceEvaluator(sim_model)
+    (actual,) = sim_ref.run(None, {"a": a, "b": b})
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_where_all_three_operands_made_explicit():
+    # cond/x/y all have different (numpy-broadcastable) shapes; all three
+    # participate in Where's own broadcast and should all be expanded.
+    model = _model(
+        """
+        g (bool[1,4] cond, float[4] x, float[3,1] y) => (float[3,4] z)
+        {
+          z = Where(cond, x, y)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = _simplify_with_pass(model, check_n=0)
+    onnx.checker.check_model(sim_model)
+
+    wheres = [n for n in sim_model.graph.node if n.op_type == "Where"]
+    assert len(wheres) == 1
+    shapes = _operand_shapes(sim_model, wheres[0])
+    assert shapes == [(3, 4), (3, 4), (3, 4)]
+
+    assert check_ok
+    cond = np.array([[True, False, True, False]])
+    x = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    y = np.array([[10.0], [20.0], [30.0]], dtype=np.float32)
+    ref = onnx.reference.ReferenceEvaluator(model)
+    (expected,) = ref.run(None, {"cond": cond, "x": x, "y": y})
+    sim_ref = onnx.reference.ReferenceEvaluator(sim_model)
+    (actual,) = sim_ref.run(None, {"cond": cond, "x": x, "y": y})
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_already_same_shape_operands_left_untouched():
+    # Both operands already have the output's exact shape: nothing to make
+    # explicit, so no Expand should be inserted at all.
+    model = _model(
+        """
+        g (float[3,4] a, float[3,4] b) => (float[3,4] y)
+        {
+          y = Add(a, b)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = _simplify_with_pass(model, check_n=0)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    assert not any(n.op_type == "Expand" for n in sim_model.graph.node)
+
+
+def test_pass_is_opt_in_only():
+    # Without extra_optimizers, the pass must not run even though the graph
+    # has an implicit-broadcast Add.
+    model = _model(
+        """
+        g (float[3,1] a, float[4] b) => (float[3,4] y)
+        {
+          y = Add(a, b)
+        }
+        """
+    )
+    onnx.checker.check_model(model)
+
+    sim_model, check_ok = onnxsim.simplify(model, check_n=0)
+    assert check_ok
+    onnx.checker.check_model(sim_model)
+    assert not any(n.op_type == "Expand" for n in sim_model.graph.node)

--- a/tests/test_rewrite_implicit_broadcast.py
+++ b/tests/test_rewrite_implicit_broadcast.py
@@ -15,6 +15,7 @@ It is registered as ``PassType::Other`` and therefore never runs by default
 
 import numpy as np
 import onnx
+import onnx.reference
 from onnx import parser
 
 import onnxsim


### PR DESCRIPTION
## Summary

- Adds `rewrite_implicit_broadcast`, a new `PassType::Other` (opt-in) rewriter pass that rewrites multidirectional ("NumPy-style" implicit) broadcasting elementwise ops (`Add`, `Sub`, `Mul`, `Div`, `Pow`, `Mod`, `Max`, `Min`, `Mean`, `Sum`, the comparison/logical/bitwise family, and `Where`) so every operand is first made exactly the node's (statically-known) output shape via an explicit `Expand`. This lets backends that don't support implicit broadcasting at all (e.g. small NPUs, or runtimes whose elementwise kernels require identically-shaped operands) run the resulting graph without needing to implement broadcasting.
- Since this grows the graph rather than reducing it, it never runs by default — opt in with `extra_optimizers=["rewrite_implicit_broadcast"]` (Python) or `--enable-optimization rewrite_implicit_broadcast` (CLI), matching how other opt-in graph-shape rewrites in this codebase (e.g. `rewrite_gathernd_to_gather`) are exposed.
- Registered in `onnxsim/custom_optimizer_passes.cpp` alongside the other custom passes.

## Test plan

- [x] Added `tests/test_rewrite_implicit_broadcast.py` (built via `onnx.parser`, per this repo's testing convention), covering: `Add` broadcast made explicit, `Where`'s 3-way broadcast (condition + both data operands) made explicit, a no-op case when operand shapes already match the output, and confirming the pass is opt-in only (doesn't fire without `extra_optimizers`).
- [x] Built the C++ extension from source and ran the new test suite locally — all 4 tests pass, verifying both the resulting graph structure (exact operand shapes, `Expand` insertion) and numeric equivalence against `onnx.reference.ReferenceEvaluator`.
- [x] Ran `tests/test_gathernd_to_gather.py` (an existing pass sharing the same registration path) to confirm no regression from the `custom_optimizer_passes.cpp` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvkDKYZon9d2mkYKm3Xav

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmvkDKYZon9d2mkYKm3Xav)_