### PR TITLE
axera: emit an .axmodel without the compiler, and an error model that matches the card

### DIFF
--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -54,6 +54,7 @@ on:
       - "tests/test_axera_op_coverage_report.py"
       - "tests/test_axera_legalize.py"
       - "tests/test_axera_precision.py"
+      - "tests/test_axera_replay.py"
 
 concurrency:
   group: axera-integration-${{ github.ref }}
@@ -121,7 +122,7 @@ jobs:
       - name: Run in-tree smoke tests
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py" "$GITHUB_WORKSPACE/tests/test_axera_legalize.py" "$GITHUB_WORKSPACE/tests/test_axera_precision.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py" "$GITHUB_WORKSPACE/tests/test_axera_legalize.py" "$GITHUB_WORKSPACE/tests/test_axera_precision.py" "$GITHUB_WORKSPACE/tests/test_axera_replay.py"
       - name: Run static Pulsar2 compatibility suite
         working-directory: ${{ runner.temp }}
         run: |

--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -55,6 +55,7 @@ on:
       - "tests/test_axera_legalize.py"
       - "tests/test_axera_precision.py"
       - "tests/test_axera_replay.py"
+      - "tests/test_axera_emitter.py"
 
 concurrency:
   group: axera-integration-${{ github.ref }}
@@ -122,7 +123,7 @@ jobs:
       - name: Run in-tree smoke tests
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py" "$GITHUB_WORKSPACE/tests/test_axera_legalize.py" "$GITHUB_WORKSPACE/tests/test_axera_precision.py" "$GITHUB_WORKSPACE/tests/test_axera_replay.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py" "$GITHUB_WORKSPACE/tests/test_axera_legalize.py" "$GITHUB_WORKSPACE/tests/test_axera_precision.py" "$GITHUB_WORKSPACE/tests/test_axera_replay.py" "$GITHUB_WORKSPACE/tests/test_axera_emitter.py"
       - name: Run static Pulsar2 compatibility suite
         working-directory: ${{ runner.temp }}
         run: |

--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -53,6 +53,7 @@ on:
       - "tests/test_axera_mcode_validator.py"
       - "tests/test_axera_op_coverage_report.py"
       - "tests/test_axera_legalize.py"
+      - "tests/test_axera_precision.py"
 
 concurrency:
   group: axera-integration-${{ github.ref }}
@@ -120,7 +121,7 @@ jobs:
       - name: Run in-tree smoke tests
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py" "$GITHUB_WORKSPACE/tests/test_axera_legalize.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py" "$GITHUB_WORKSPACE/tests/test_axera_legalize.py" "$GITHUB_WORKSPACE/tests/test_axera_precision.py"
       - name: Run static Pulsar2 compatibility suite
         working-directory: ${{ runner.temp }}
         run: |

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -6049,6 +6049,41 @@ actually failed, and `emit_mcode` refuses those. 46 of 48 re-emit exactly.
 A refusal is a real limit, not a formality: those two models need Pulsar2, or
 a nudge to the calibration range that moves the scale off the bad value.
 
+### The same method on an `llm_build` layer
+
+The LLM path needs no new machinery, only more samples -- and it supplies them
+itself. Every layer of a build is the same shape with different weights, so one
+`llm_build` of SmolLM2-135M is thirty samples; two more builds on checkpoints
+with randomised 2-D weights make ninety.
+
+More are needed than for a convolution because unambiguity costs about twice
+the log of the code count, and a layer here holds 3,538,944 codes against a
+convolution's 3,072:
+
+| samples | table bits mapped | constant | unexplained | colliding sources |
+| --- | --- | --- | --- | --- |
+| 30 | 28,316,585 | 3,210,223 | 182,408 | 372,373 |
+| **54** | **28,311,552** | 3,209,913 | 187,751 | **0** |
+
+At 54 the mapped count is again *exactly* `3,538,944 * 8`: every weight code
+bit appears in the table once, and nothing is ambiguous. `llm_codes_of` is the
+quantiser it maps through -- `llm_build`'s own, not the convolution
+pipeline's.
+
+Trained on 82 samples and held out on eight whole layers, the emitted tables
+are **byte-exact everywhere except one localised remainder**: 27,000-odd bytes
+of 3,963,652, and **zero** wrong bytes outside it. That is 99.3% of an
+`llm_build` layer's weight table written from the checkpoint with no compiler.
+
+The remainder is 33,965 bytes in 13,824 runs of one to three bytes, laid out
+two bytes in every four from offset 4096 -- the shape of a half-width field in
+a full-width slot. It is not the per-row scale `-peak/128` in matmul order
+(one of 5,184 matches), and read as float32 it contains NaNs, so it is not a
+float array at that offset either. **Undecoded**, and until it is, this path
+emits a table that is 99.3% right rather than a model that runs -- unlike the
+convolution path above, where the last 1,719 bits turned out to be the
+requantisation in closed form and closed it completely.
+
 ### What this does and does not replace
 
 It replaces the compiler's **weight handling**, which is what changes when a

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -5747,15 +5747,25 @@ Precision configurations and calibration sets can be scored against a build's
 own quantisation table with no card and no rebuild.
 
 **Where it is not yet faithful: fusion.** On the full Audio8 decoder the
-replay reads 3.65 dB against the card's 7.37 -- pessimistic, and for a
-findable reason. `quant/quant_axmodel.onnx` is the graph Pulsar2 actually
-lowers, and 385 of the float graph's 1002 tensors are simply *not in it*,
-folded inside a fused `AxQuantizedRMSNorm`, `AxQuantizedRoPE` or
-`AxQuantizedFullyConnected`. Nothing on the card rounds those, so quantising
-them invents error: doing so read 1.12 dB. Filtering to the tensors that
-survive as edges recovers 2.5 dB of the 6.3, and the rest is presumably
-higher-precision arithmetic *inside* the fused ops. So the replay is exact on
-a graph the compiler does not fuse and a lower bound on one it does.
+replay reads 3.65 dB against the card's 7.37. `quant/quant_axmodel.onnx` is
+the graph Pulsar2 actually lowers, and 385 of the float graph's 1002 tensors
+are simply *not in it*, folded inside a fused `AxQuantizedRMSNorm`,
+`AxQuantizedRoPE` or `AxQuantizedFullyConnected`. Nothing on the card rounds
+those, so quantising them invents error: doing so read 1.12 dB. Filtering to
+the tensors that survive as edges recovers 2.5 dB of the 6.3.
+
+The obvious next filter does not settle it either. `AxReshape`, `AxSlice`,
+`AxTranspose`, `AxTile` and `AxPad` move codes without recomputing them, so
+arguably nothing rounds their output; dropping those too reads **23.40 dB**,
+overshooting as far as the first rule undershot. The two rules bracket the
+measurement instead of explaining it, and ten `Reshape` outputs on their own
+are worth 4.6 dB (3.65 -> 8.23), so a movement op's output is evidently
+rounded *sometimes*. Unresolved. `replay.py` defaults to the pessimistic rule
+-- a lower bound is more useful than a flattering guess -- and offers the
+strict one as `quantising_only=True`.
+
+So: exact on a graph the compiler does not fuse, and bracketing on one it
+does.
 
 ### The fused-op namespace, and how to see it before you trip on it
 

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -5715,9 +5715,47 @@ Worth stating on its own, because it is cheaper than any of this: **a
 calibration set that does not cover the input costs more than the quantiser
 does, and no amount of bit depth buys it back.**
 
-The card reaching 33.00 where the model says 53.26 leaves about 20 dB
-unexplained -- a floor that is not the weights (the same simulation with
-*exact* weights reads 71 dB) and not the activation width. That is open.
+#### The 20 dB that looked unexplained was the scales, and there is no floor
+
+The card reaching 33.00 where an idealised simulation says 53.26 looked like a
+hardware floor. It is not. `pulsar2 build` writes every scale it chose into
+`<output>/quant/quant_axmodel.json` -- bit width, policy, and a hash into a
+shared `values` table holding the scale and zero point. Feed *those* numbers
+back into the float graph instead of recomputing MinMax ranges, and the
+prediction lands on the measurement:
+
+| build | replayed offline | on the AX650N |
+| --- | --- | --- |
+| INT8 | 21.64 dB | 21.64 dB |
+| INT8, split weights | 21.15 dB | 21.34 dB |
+| U16 | 25.78 dB | 25.77 dB |
+| U16, split weights | **33.03 dB** | **33.00 dB** |
+
+Four builds, worst case 0.19 dB, two of them exact. **The card computes
+precisely the affine quantisation the compiler wrote down.** There is no
+unexplained numerical floor, and the gap was never the hardware -- it was that
+the compiler's chosen ranges are wider than an ideal MinMax fit, which is the
+calibration point above stated a second way.
+
+`replay.py` is that replay, spelled as ONNX arithmetic (`Div`, `Round`,
+`Clip`, `Mul`) rather than `QuantizeLinear`, because a UINT16 zero point needs
+opset 21 and bumping a real graph that far breaks ops whose signature moved on
+the way -- `ReduceMean`'s `axes` became an input at opset 18.
+
+The practical consequence: **accuracy on this NPU can be searched offline.**
+Precision configurations and calibration sets can be scored against a build's
+own quantisation table with no card and no rebuild.
+
+**Where it is not yet faithful: fusion.** On the full Audio8 decoder the
+replay reads 3.65 dB against the card's 7.37 -- pessimistic, and for a
+findable reason. `quant/quant_axmodel.onnx` is the graph Pulsar2 actually
+lowers, and 385 of the float graph's 1002 tensors are simply *not in it*,
+folded inside a fused `AxQuantizedRMSNorm`, `AxQuantizedRoPE` or
+`AxQuantizedFullyConnected`. Nothing on the card rounds those, so quantising
+them invents error: doing so read 1.12 dB. Filtering to the tensors that
+survive as edges recovers 2.5 dB of the 6.3, and the rest is presumably
+higher-precision arithmetic *inside* the fused ops. So the replay is exact on
+a graph the compiler does not fuse and a lower bound on one it does.
 
 ### The fused-op namespace, and how to see it before you trip on it
 
@@ -6343,6 +6381,7 @@ CNN/LLM focus.
 | `pulsar2_quantizer.py` | `quantize_like_pulsar2()`: a thin wrapper over `onnxsim.quantize_static(method="minmax")`, which already matches Pulsar2's real numeric convention (U8 asymmetric activations, S8 per-channel weights, MinMax calibration). `PULSAR2_QUANTIZER_AVAILABLE` reflects both `onnxruntime`'s availability and `onnxsim` itself actually being importable (a checkout with `onnxsim`'s compiled extension not yet built fails `import onnxsim`, not just the lazy `onnxruntime` import inside it -- both are caught the same way so this degrades gracefully instead of taking `pulsar2_simulator.py`'s `import` down with it). |
 | `precision.py` | `weight_residual_split()`: rewrites `Conv`/`MatMul`/`Gemm`/`ConvTranspose` as `op(x, W_hi) + op(x, W_lo)` so two INT8 weights carry ~16 bits between them, plus `quantise_dequantise()`/`compiler_view()` (Pulsar2's per-output-channel weight quantiser, and the re-rounding the residual has to be taken against), `weight_error_db()` and `split_op_types()` (the op types to promote to `U16`, without which the split does not pay). Measured +7.23 dB on the AX650N at 16-bit activations -- see above. |
 | `pulsar2_simulator.py` | `partition()`/`coverage()` (real `AX650_SUPPORTED_OPS` membership, no dependency beyond `onnx`) and `simulate()` (fp32-vs-INT8 estimate via `pulsar2_quantizer.py` + onnxruntime's CPU EP). Validated against real hardware -- see above. |
+| `replay.py` | `load_scales()`/`insert_qdq()`/`replay()`: re-runs a float graph at the scales `pulsar2 build` recorded in `quant/quant_axmodel.json`, reproducing four real AX650N measurements to within 0.19 dB with no card and no rebuild. `surviving_edges()` drops the tensors the compiler fused away -- quantising those invents error the hardware never makes. Exact on an unfused graph, a lower bound on a fused one. |
 | `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
 | `run_pulsar2_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. No `--require-*` flag or `skipped` status -- unlike the EP harnesses, this needs no vendor package or device, so it always runs. Entry point for `axera-integration.yml`'s `pulsar2-compat` job (stock runner, no Docker/device). |
 | `screen_onnxmodelzoo.py` | fast, static, Docker/device-free screening of `onnxmodelzoo` models via `pulsar2_simulator`/`pulsar2_backend.ax650_build_risks()` -- run this first. |

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -5931,6 +5931,134 @@ bases and the per-tap input splits are allocator output, and the vocoder's own
 splits (`[80]`, then `[48, 32]`, then `[24, 56]` on consecutive taps of one
 layer) are the evidence that no rule is waiting to be found there.
 
+## Replacing the ONNX compiler at a fixed shape
+
+"How much of a CNN's mcode depends on its weights" above answers 96.2%
+weight-independent and stops there, because the remaining bytes were not
+understood and the weight table's layout was a pile of hand-derived rules.
+Both are now closed, and the result is a compiler replacement: **given
+reference builds at a shape, any weights at that shape emit a working
+`.axmodel` with no Pulsar2 in the loop.** Eight held-out weight sets produced
+weight tables byte-identical to Pulsar2's and device output bit-identical to
+Pulsar2's own build.
+
+### Learn the layout instead of deriving it
+
+This file derives seven weight layouts by hand -- gaps of 36, strides of 144,
+per-tap padding, polyphase reversal, a per-output-channel cost charged per
+*bit*. Each was worth deriving. None is a good foundation for an emitter,
+because every new shape or dtype adds another.
+
+They all have one thing in common: **each is a bit permutation.** A byte of
+`npu_params` mixes single bits from several codes, but every bit of the table
+is either constant for the shape, or equal to one specific bit of one specific
+code. So compile the same shape `k` times with different weights and read the
+permutation off: each table bit's column of `k` observed values is a
+signature, and the code bit with the same signature is where it came from.
+
+Naming one code bit out of `32*32*3*8 = 24,576` needs about 15 bits of
+signature. `k` builds give `k`, so the method's own failure mode is visible
+and countable -- it is the number of code bits sharing a signature:
+
+| builds | table bits mapped | constant | unexplained | colliding sources |
+| --- | --- | --- | --- | --- |
+| 8 | 26,006 | 13,225 | 0 | 24,129 |
+| 16 | 25,116 | 12,972 | 1,144 | 4,074 |
+| **48** | **24,576** | 12,937 | 1,719 | **0** |
+
+At 48 builds the mapped count is **exactly** `32*32*3*8`: every weight code
+bit appears in the table exactly once, and nothing is ambiguous. The 8- and
+16-build rows are the same method being honestly wrong, which is the point of
+measuring collisions rather than trusting the fit.
+
+### The 1,719 unexplained bits are the requantisation, in closed form
+
+They are one contiguous run -- bytes 4608 to 4864, which is `32 channels x
+8 bytes` -- and they are not copies of anything, they are computed. Read as
+float32 they are two vectors, and a quantised convolution says what they must
+be. Its output in code units is
+
+```
+y_code = zy + sum_i (x_code_i - zx) * q_i * (x_scale * w_scale / y_scale)
+```
+
+and the AX650N precomputes the constant half per output channel:
+
+| floats | meaning |
+| --- | --- |
+| `[0:C]` | `bias[c] = zy - zx * sum(q_c) * M_c` |
+| `[C:2C]` | `M_c = x_scale * w_scale_c / y_scale` |
+
+Across 48 builds x 32 channels the formula reproduces **every one** of the
+stored values to `6.1e-05` -- float32 rounding, nothing else.
+
+That closes the table: codes through the learned map, this block in closed
+form, everything else copied from the reference. Emitting eight held-out
+weight sets gives **0 differing bytes of 4904**, every time.
+
+### The mcode's weight-dependent bytes, and the seven that do not matter
+
+With 48 builds of one shape, 24 of the mcode's 2824 bytes move. Five of them
+are the output quantisation written down literally:
+
+| offsets | field |
+| --- | --- |
+| 1846, 1853, 1860, 1867 | little-endian float32 `y_scale`, four copies |
+| 1835 | one byte, `round(y_zero)` |
+
+The other seven -- 301, 303, 309, 311, 317, 319, 323, 325 -- hold a
+permutation of `0x10/0x20/0x30/0x40` with `0x13`/`0x23` separators, and 20
+distinct patterns appear across 48 builds. What chooses them is not known.
+**It also does not matter.** Every emitted model here left them at the
+*reference's* values, differing from Pulsar2's own build in 2 to 5 bytes, and
+the card returned bit-identical output all eight times. They are scheduling,
+not semantics.
+
+### On the card
+
+Reference: one build of `Conv(32, 32, 3)`. Target: eight weight sets it never
+saw. Nothing but `emitter.py` between them.
+
+| held-out | table bytes differing | mcode bytes differing | emitted | Pulsar2 | identical |
+| --- | --- | --- | --- | --- | --- |
+| s202 | 0 | 4 | 33.44 dB | 33.44 dB | yes |
+| s303 | 0 | 3 | 35.36 dB | 35.36 dB | yes |
+| s404 | 0 | 2 | 32.52 dB | 32.52 dB | yes |
+| s505 | 0 | 5 | 33.93 dB | 33.93 dB | yes |
+| s606 | 0 | 5 | 33.90 dB | 33.90 dB | yes |
+| s707 | 0 | 5 | 33.96 dB | 33.96 dB | yes |
+| s808 | 0 | 4 | 27.61 dB | 27.61 dB | yes |
+| s1040 | 0 | 3 | 35.45 dB | 35.45 dB | yes |
+
+Bit-identical, not correlated: `np.array_equal` on the returned float32.
+
+### Two builds of 48 that cannot be patched in place
+
+The mcode is a tagged byte stream, and twice in 48 builds a field's value was
+not written inline but escaped, shifting every byte after it:
+
+* one build's output zero point came out exactly **128**,
+* one build's `y_scale` had low byte **0x9e**.
+
+No rule tried here predicts which -- plenty of perfectly patchable builds
+carry bytes in `0x80..0x9f`, including the reference itself, whose zero point
+is `0x83`. So `learn_mcode` does not guess: it finds outliers by *re-emitting
+every training build and checking what survives*, records the values that
+actually failed, and `emit_mcode` refuses those. 46 of 48 re-emit exactly.
+
+A refusal is a real limit, not a formality: those two models need Pulsar2, or
+a nudge to the calibration range that moves the scale off the bad value.
+
+### What this does and does not replace
+
+It replaces the compiler's **weight handling**, which is what changes when a
+model is retrained, fine-tuned, quantisation-aware-trained, or pruned. It does
+not originate a shape: hidden size, channel count, kernel and layout still
+come from a reference build, exactly as `README.md`'s `llm_build` emitter
+above needs one. The reference is needed **once per shape**, and the number of
+builds it takes is measurable rather than guessed -- push `collisions()` to
+zero and the map is exact.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`
@@ -6410,6 +6538,7 @@ CNN/LLM focus.
 | `precision.py` | `weight_residual_split()`: rewrites `Conv`/`MatMul`/`Gemm`/`ConvTranspose` as `op(x, W_hi) + op(x, W_lo)` so two INT8 weights carry ~16 bits between them, plus `quantise_dequantise()`/`compiler_view()` (Pulsar2's per-output-channel weight quantiser, and the re-rounding the residual has to be taken against), `weight_error_db()` and `split_op_types()` (the op types to promote to `U16`, without which the split does not pay). Measured +7.23 dB on the AX650N at 16-bit activations -- see above. |
 | `pulsar2_simulator.py` | `partition()`/`coverage()` (real `AX650_SUPPORTED_OPS` membership, no dependency beyond `onnx`) and `simulate()` (fp32-vs-INT8 estimate via `pulsar2_quantizer.py` + onnxruntime's CPU EP). Validated against real hardware -- see above. |
 | `replay.py` | `load_scales()`/`insert_qdq()`/`replay()`: re-runs a float graph at the scales `pulsar2 build` recorded in `quant/quant_axmodel.json`, reproducing four real AX650N measurements to within 0.19 dB with no card and no rebuild. `surviving_edges()` drops the tensors the compiler fused away -- quantising those invents error the hardware never makes. Exact on an unfused graph, a lower bound on a fused one. |
+| `emitter.py` | `learn()`/`emit_axmodel()`: learns a shape's weight-table encoding as a bit permutation from k reference builds, instead of deriving its layout rules, then writes any new weights at that shape with no compiler in the loop -- byte-identical tables and bit-identical device output on eight held-out weight sets. `requant_block()` is the per-channel bias/multiplier in closed form; `learn_mcode()`/`emit_mcode()` find and rewrite the mcode's output scale and zero point, and report the streams that cannot be patched in place. |
 | `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
 | `run_pulsar2_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. No `--require-*` flag or `skipped` status -- unlike the EP harnesses, this needs no vendor package or device, so it always runs. Entry point for `axera-integration.yml`'s `pulsar2-compat` job (stock runner, no Docker/device). |
 | `screen_onnxmodelzoo.py` | fast, static, Docker/device-free screening of `onnxmodelzoo` models via `pulsar2_simulator`/`pulsar2_backend.ax650_build_risks()` -- run this first. |

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -5597,6 +5597,11 @@ and the only lever that moves it is fewer quantised operations.** Weight
 precision does not (the scale search below finds nothing), activation width
 buys 4 dB and then plateaus, and the nonlinearities are free.
 
+(That last sentence is too strong, and "Correction: weight precision *does*
+move it" below says how: re-spelling one convolution as two whose weights
+carry sixteen bits between them beats the depth law by 7 dB on the card, even
+though it doubles the operation count.)
+
 A smaller observation from the same run: `Relu` is 4 dB *worse* than either
 bare or Snake. It zeroes half its activations, so the calibrated range then
 covers a distribution with a spike at zero and the codes near it are wasted.
@@ -5606,6 +5611,113 @@ Which also corrects something said above: Pulsar2's precision analysis is
 `precision_analysis_mode` is `Reference`, which scores each layer against
 float inputs; `NPUBackend` is the other option. The earlier claim that the
 tool "cannot show this" should have been "does not show this by default".
+
+### Correction: weight precision *does* move it, but only in the right shape
+
+The claim just above -- that fewer quantised operations is the only lever --
+is too strong, and the thing that corrects it comes from
+`docs/ozaki-scheme-axera-handoff.md`. The Ozaki scheme splits a high-precision
+matrix into several low-precision components, runs a low-precision matmul on
+each, and sums them. That handoff note concluded the toolchain could not host
+it, because every documented way to pin a per-matmul scale is broken:
+`quant.highest_mix_precision` fails with `TileFailException` and `QuantONNX`'s
+QDQ path crashes Pulsar2's own PPQ pass on any `DequantizeLinear`-fed
+`MatMul`.
+
+**None of that is needed.** Split the weight and let the compiler's ordinary
+PTQ *derive* the two scales itself:
+
+```
+W_hi = the value Pulsar2's own quantiser lands on
+W_lo = W - W_hi                     # its peak is 255x smaller, per channel
+y    = conv(x, W_hi) + conv(x, W_lo)
+```
+
+Nothing asks for a scale. `W_lo`'s peak is 255x smaller, so per-tensor MinMax
+calibration gives the second convolution a 255x finer scale on its own. On a
+real conv weight the pair carries **79.5 dB** where one INT8 pass carries
+37.7 dB.
+
+`precision.py` is that rewrite, and `tests/test_axera_precision.py` pins it.
+
+#### First, a correction to how the weights are quantised at all
+
+The first error budget written for this was wrong, and wrong against something
+this repository already knew. `pulsar2_quantizer.py`'s docstring says it, read
+straight off a real `AxQuantizedConv`: activations are **per tensor,
+asymmetric U8**; weights are **per output channel, symmetric S8**. A build's
+own `quant/quant_axmodel.json` confirms both to the last digit:
+
+| tensor | policy | scale |
+| --- | --- | --- |
+| activation | `PER_TENSOR`, `ASYMMETRICAL`, `[0, 255]` | `(max - min) / 255`, `zp = round(-min/scale)` |
+| weight | `PER_CHANNEL`, `SYMMETRICAL`, `[-128, 127]` | `max\|w_c\| / 127.5`, `zp = 0` |
+
+That per-channel scale is worth about 8 dB by itself: on the same heavy-tailed
+weight, peak/rms is **14.7** per tensor but **5.6** per channel. A budget that
+assumes per-tensor weights therefore blames the weights for error they are not
+making -- and it produced a number, 3.28 dB against the vocoder's measured
+3.33 dB, close enough to look like confirmation. It was a coincidence.
+
+#### The trap: the quantiser is not idempotent
+
+The obvious residual, `W_lo = W - quantise(W)`, throws away most of the gain,
+and the reason is a half-step. A quantised channel's largest code is 127 where
+the scale assumed 127.5, so handing `W_hi` back to the compiler makes it
+derive a scale 0.4% smaller and re-round -- moving values by up to half a step,
+which is the same size as the error being corrected.
+
+| residual taken against | weight SNR |
+| --- | --- |
+| a per-*tensor* high half | 39.5 dB |
+| `W - quantise(W)` | 48.1 dB |
+| `W - compiler_view(quantise(W))` | **79.5 dB** |
+
+A hardware probe built the first way measured **no gain at all**, which is how
+the trap was found.
+
+#### On the AX650N, at two activation widths
+
+Sixteen convolutions deep, 32 channels, heavy-tailed weights, the same graph
+compiled and run on the card both ways:
+
+| activations | plain | split | change |
+| --- | --- | --- | --- |
+| U8 | 21.64 dB | 21.34 dB | **-0.30** |
+| U16 | 25.77 dB | **33.00 dB** | **+7.23** |
+
+**The split only pays when the join is wide.** It costs one extra
+convolution and one `Add`, so the output is requantised twice instead of once.
+At INT8 activations that second requantisation is worth more than the residual
+returns, and per-channel weight quantisation was already good enough that
+there was little to return. At 16-bit activations the requantisations get out
+of the way and the residual is worth 7 dB. So the `layer_configs` entry is
+part of the technique, not an optional extra -- `precision.split_op_types()`
+returns exactly the op types to promote, `Add` included.
+
+This is the first thing in this file to beat the depth law rather than obey
+it: the split *doubles* the convolution count and the result improves by 7 dB.
+Depth still sets the ceiling, but "fewer operations" is not the only way to
+move it -- fewer operations *carrying INT8-sized error* also works.
+
+#### And a calibration artifact that hid it for two builds
+
+The first two U16 probes measured +0.45 and +1.79 dB, and a simulator using
+the corrected quantisers agreed with the plain build to 0.02 dB while
+insisting the split should be worth far more. The gap was **clipping**: MinMax
+calibration ran on eight samples that did not include the evaluation input, so
+every variant clipped, and clipping error does not shrink with bit depth. It
+pinned all three variants at the same ~26 dB ceiling. With the evaluation
+input in the calibration set, the same simulation goes 25.79 -> 53.26 dB and
+the card goes 25.77 -> 33.00.
+
+Worth stating on its own, because it is cheaper than any of this: **a
+calibration set that does not cover the input costs more than the quantiser
+does, and no amount of bit depth buys it back.**
+
+The card reaching 33.00 where the model says 53.26 leaves about 20 dB
+unexplained -- a floor that is not the weights (the same simulation with
+*exact* weights reads 71 dB) and not the activation width. That is open.
 
 ### The fused-op namespace, and how to see it before you trip on it
 
@@ -6229,6 +6341,7 @@ CNN/LLM focus.
 | `inspect_axmodel.py` | standalone CLI for a **real** `.axmodel` file: loads it with `onnx.load()`, then reports non-standard-domain nodes, op types outside the model's declared opset, and suspiciously large raw attributes -- what originally found the `neu mode` node in the real YOLOv8 file. |
 | `models.py` | the shared `scripts/common/synthetic_models.py` suite plus `axera_npu_compiled_leaf` (real CNN `neu mode` node shape) and `axera_llm_layer_leaf` (real per-layer LLM shape: two `neu mode` nodes sharing one initializer) -- no real device needed to exercise the corruption check in CI. |
 | `pulsar2_quantizer.py` | `quantize_like_pulsar2()`: a thin wrapper over `onnxsim.quantize_static(method="minmax")`, which already matches Pulsar2's real numeric convention (U8 asymmetric activations, S8 per-channel weights, MinMax calibration). `PULSAR2_QUANTIZER_AVAILABLE` reflects both `onnxruntime`'s availability and `onnxsim` itself actually being importable (a checkout with `onnxsim`'s compiled extension not yet built fails `import onnxsim`, not just the lazy `onnxruntime` import inside it -- both are caught the same way so this degrades gracefully instead of taking `pulsar2_simulator.py`'s `import` down with it). |
+| `precision.py` | `weight_residual_split()`: rewrites `Conv`/`MatMul`/`Gemm`/`ConvTranspose` as `op(x, W_hi) + op(x, W_lo)` so two INT8 weights carry ~16 bits between them, plus `quantise_dequantise()`/`compiler_view()` (Pulsar2's per-output-channel weight quantiser, and the re-rounding the residual has to be taken against), `weight_error_db()` and `split_op_types()` (the op types to promote to `U16`, without which the split does not pay). Measured +7.23 dB on the AX650N at 16-bit activations -- see above. |
 | `pulsar2_simulator.py` | `partition()`/`coverage()` (real `AX650_SUPPORTED_OPS` membership, no dependency beyond `onnx`) and `simulate()` (fp32-vs-INT8 estimate via `pulsar2_quantizer.py` + onnxruntime's CPU EP). Validated against real hardware -- see above. |
 | `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
 | `run_pulsar2_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. No `--require-*` flag or `skipped` status -- unlike the EP harnesses, this needs no vendor package or device, so it always runs. Entry point for `axera-integration.yml`'s `pulsar2-compat` job (stock runner, no Docker/device). |

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -5700,6 +5700,24 @@ it: the split *doubles* the convolution count and the result improves by 7 dB.
 Depth still sets the ceiling, but "fewer operations" is not the only way to
 move it -- fewer operations *carrying INT8-sized error* also works.
 
+#### And on the real vocoder it does not help
+
+Splitting all 126 weighted ops of the Audio8 decoder and building it the same
+way measured **6.95 dB against the unsplit build's 7.37** -- a small loss, not
+a gain. Which the budget above predicts, and it is worth being explicit about
+why, because it bounds where this technique is worth reaching for. On that
+graph the weights are not what is binding: per output channel they read
+`e_W = 36.5 dB` against `e_Y = 35.7`, so removing the weight term entirely
+cannot buy much, while the 126 extra `Add`s each pay a requantisation. The
+probe gains 7 dB because its weights are deliberately outlier-heavy and its
+graph is sixteen ops long; the vocoder's are neither.
+
+**So the rule is `e_W` versus `e_Y`, per layer, and it has to be measured.**
+`weight_error_db` gives the first from the weight alone;
+`replay.py` below gives the second from the build. Splitting everything is the
+wrong default -- `weight_residual_split(layers=...)` and `min_peak_to_rms`
+exist for that reason.
+
 #### And a calibration artifact that hid it for two builds
 
 The first two U16 probes measured +0.45 and +1.79 dB, and a simulator using

--- a/scripts/axera/emitter.py
+++ b/scripts/axera/emitter.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Emit an `.axmodel`'s weight table without a compiler, by learning its encoding.
+
+The AX650N stores a convolution's weights as **bit planes**: a byte of
+`npu_params` is a mixture of single bits taken from several different weight
+codes, at offsets that this repository's README recovers rule by rule -- gaps
+of 36, strides of 144, per-tap padding, polyphase reversal for transposes, and
+a per-output-channel cost that is charged per *bit* rather than per row. Those
+rules were worth deriving because they explain the format. They are a poor
+foundation for an emitter, because each new shape or dtype adds another.
+
+This module skips the rules. Every bit of the table is either constant for a
+given shape, or *equal to one specific bit of one specific weight code* -- the
+encoding is a bit permutation, whatever the arithmetic behind it. So compile
+the same shape `k` times with different weights, and read the permutation off
+directly: each table bit's column of `k` observed values is a signature, and
+the code bit carrying the same signature is the one it came from.
+
+`k` random builds give `8k` independent sample bits per code, and naming one
+code bit out of `Cout*Cin*K*8` needs about 15, so four builds already make a
+wrong match a ~1e-5 event and six leave no doubt. That is the entire method,
+and it does not care which of the seven layouts the shape happens to use.
+
+What it buys: one set of reference builds per *shape*, after which any weights
+at that shape can be written without Pulsar2 -- which is what
+`README.md`'s "An emitter for the llm_build path" already showed for the LLM
+path by hand, generalised and made shape-agnostic.
+
+Usage::
+
+    emitter.py learn out_a/ out_b/ ... --weights a.npy b.npy ... -o map.npz
+    emitter.py emit reference.axmodel map.npz new_weights.npy -o new.axmodel
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import onnx
+
+#: A table bit that is the same in every sample carries no information about
+#: the weights; it is part of the shape's own scaffolding.
+CONST = -1
+
+
+def codes_of(w, bits=8, axis=0):
+    """The unsigned codes Pulsar2 stores for weight `w`.
+
+    Per output channel, symmetric, step ``max|w_c| / 127.5``, then offset by
+    ``2**(bits-1)`` -- the quantiser `README.md` recovered byte-exactly from
+    real weight tables. `precision.quantise_dequantise` is the same rule
+    without the storage offset.
+    """
+    w = np.asarray(w, dtype=np.float32)
+    red = tuple(i for i in range(w.ndim) if i != axis)
+    peak = np.abs(w).max(axis=red, keepdims=True)
+    step = np.where(peak == 0, 1.0, peak / (2.0 ** (bits - 1) - 0.5))
+    half = 2 ** (bits - 1)
+    q = np.clip(np.rint(w / step), -half, half - 1) + half
+    return q.astype(np.uint8)
+
+
+def table_of(axmodel_path, name="npu_params"):
+    """The raw weight table out of a compiled `.axmodel`."""
+    model = onnx.load(axmodel_path, load_external_data=False)
+    for init in model.graph.initializer:
+        if init.name == name:
+            return np.frombuffer(bytes(init.raw_data), dtype=np.uint8)
+    raise KeyError(f"{name} not in {axmodel_path}")
+
+
+def _bits(arr):
+    """`(n, 8*len)` bit matrix, LSB first within each byte."""
+    a = np.asarray(arr, dtype=np.uint8).reshape(len(arr), -1)
+    return np.unpackbits(a, axis=1, bitorder="little").astype(np.uint8)
+
+
+def _signatures(bit_matrix):
+    """One integer per column, packing that column's value in every sample."""
+    n = bit_matrix.shape[0]
+    if n > 63:
+        raise ValueError("more than 63 samples would overflow the signature")
+    weights = (1 << np.arange(n, dtype=np.uint64)).reshape(-1, 1)
+    return (bit_matrix.astype(np.uint64) * weights).sum(axis=0)
+
+
+def learn(code_samples, table_samples):
+    """Learn each table bit's origin from `k` builds of one shape.
+
+    `code_samples` and `table_samples` are equal-length sequences of uint8
+    arrays -- the codes (`codes_of`) and the table (`table_of`) of each build.
+
+    Returns `(origin, const, ambiguous)`:
+
+    * `origin[i]` -- the code-bit index table bit `i` copies, or `CONST`,
+    * `const[i]` -- that bit's fixed value where `origin[i]` is `CONST`,
+    * `ambiguous` -- table bit indices whose signature matched no code bit,
+      i.e. everything the shape's scaffolding computes rather than copies
+      (per-channel scales and biases live here).
+    """
+    code_bits = _bits([c.ravel() for c in code_samples])
+    table_bits = _bits(table_samples)
+    n = code_bits.shape[0]
+    if n != table_bits.shape[0]:
+        raise ValueError("need one table per code sample")
+
+    code_sig = _signatures(code_bits)
+    table_sig = _signatures(table_bits)
+    all_zero, all_one = np.uint64(0), np.uint64((1 << n) - 1)
+
+    lookup = {}
+    for idx, sig in enumerate(code_sig):
+        if sig in (all_zero, all_one):
+            continue  # this code bit is itself constant: uninformative
+        lookup.setdefault(sig, idx)
+
+    origin = np.full(table_bits.shape[1], CONST, dtype=np.int64)
+    const = np.zeros(table_bits.shape[1], dtype=np.uint8)
+    ambiguous = []
+    for i, sig in enumerate(table_sig):
+        if sig == all_zero or sig == all_one:
+            const[i] = 1 if sig == all_one else 0
+            continue
+        hit = lookup.get(sig)
+        if hit is None:
+            ambiguous.append(i)
+        else:
+            origin[i] = hit
+    return origin, const, np.asarray(ambiguous, dtype=np.int64)
+
+
+def collisions(code_samples, origin):
+    """How many table bits have more than one consistent source.
+
+    A learned map is only trustworthy when this is zero -- it is the direct
+    measure of whether `k` was large enough.
+    """
+    code_bits = _bits([c.ravel() for c in code_samples])
+    sig = _signatures(code_bits)
+    n = code_bits.shape[0]
+    all_zero, all_one = np.uint64(0), np.uint64((1 << n) - 1)
+    counts = {}
+    for s in sig:
+        if s in (all_zero, all_one):
+            continue
+        counts[s] = counts.get(s, 0) + 1
+    used = origin[origin != CONST]
+    return int(sum(counts[sig[u]] - 1 for u in np.unique(used)))
+
+
+def emit_table(reference_table, origin, codes):
+    """Write `codes` into a copy of `reference_table` through a learned map.
+
+    Bits the map calls `CONST` -- and anything it could not explain -- keep the
+    reference's value, so the result is the reference table with exactly the
+    weight bits replaced.
+    """
+    table_bits = _bits([np.asarray(reference_table, dtype=np.uint8)])[0]
+    code_bits = _bits([np.asarray(codes, dtype=np.uint8).ravel()])[0]
+    mapped = origin != CONST
+    out = table_bits.copy()
+    out[mapped] = code_bits[origin[mapped]]
+    return np.packbits(out, bitorder="little")
+
+
+def requant_block(codes, x_scale, x_zero, y_scale, y_zero, w_scale):
+    """The per-output-channel float32 pair the table carries after the codes.
+
+    A quantised convolution's output in code units is
+
+        y_code = zy + sum_i (x_code_i - zx) * q_i * (x_scale * w_scale / y_scale)
+
+    and the constant half of that is precomputed per channel. The AX650N stores
+    both terms, back to back, as float32:
+
+        [0 : C]      bias[c] = zy - zx * sum(q_c) * M_c
+        [C : 2C]     M_c     = x_scale * w_scale_c / y_scale
+
+    Read off 48 builds of one shape: the formula reproduces every one of
+    48 x 32 stored values to 6.1e-05, which is float32 rounding.
+    """
+    codes = np.asarray(codes, dtype=np.int64)
+    q = codes.reshape(codes.shape[0], -1) - 2 ** (8 - 1)
+    m = (np.asarray(x_scale) * np.asarray(w_scale) / np.asarray(y_scale)).astype(
+        np.float32
+    )
+    bias = (y_zero - x_zero * q.sum(axis=1) * m).astype(np.float32)
+    return np.concatenate([bias, m]).view(np.uint8)
+
+
+def weight_scales(w, bits=8, axis=0):
+    """The per-output-channel step Pulsar2 quantises `w` with."""
+    w = np.asarray(w, dtype=np.float32)
+    red = tuple(i for i in range(w.ndim) if i != axis)
+    peak = np.abs(w).max(axis=red)
+    return np.where(peak == 0, 1.0, peak / (2.0 ** (bits - 1) - 0.5)).astype(np.float32)
+
+
+def emit(reference_table, origin, w, x_scale, x_zero, y_scale, y_zero, block_at=None):
+    """A whole table for new weights: codes through the map, block in closed form.
+
+    `block_at` is the byte offset of the requantisation block, which `learn`
+    reports as the run of unexplained bits. Left `None`, only the codes are
+    written and the reference's block is kept -- correct only if the weights
+    happen to share its scales.
+    """
+    codes = codes_of(w)
+    table = emit_table(reference_table, origin, codes)
+    if block_at is not None:
+        block = requant_block(codes, x_scale, x_zero, y_scale, y_zero, weight_scales(w))
+        table[block_at : block_at + len(block)] = block
+    return table
+
+
+def emit_mcode(reference_mcode, fields, y_scale, y_zero):
+    """A copy of `reference_mcode` carrying a new output quantisation.
+
+    Raises if the new zero point is `RESERVED_OPERAND`, which the stream
+    cannot hold as a literal -- there is no in-place edit for it, and writing
+    it anyway would produce a stream that decodes as something else.
+    """
+    zero = int(round(float(y_zero))) & 0xFF
+    scale_bytes = np.float32(y_scale).tobytes()
+    bad = fields.get("unpatchable", {})
+    if zero in set(bad.get("zero", ())):
+        raise ValueError(
+            f"output zero point {zero} is one this shape's mcode does not "
+            "encode as a plain literal -- it shifts the stream, so no in-place "
+            "patch expresses it. Nudge the calibration range, or build it."
+        )
+    if scale_bytes[0] in set(bad.get("scale_low_byte", ())):
+        raise ValueError(
+            f"output scale {float(y_scale)!r} has low byte "
+            f"0x{scale_bytes[0]:02x}, which this shape's mcode does not encode "
+            "as a plain literal -- it shifts the stream. Nudge the scale, or "
+            "build it."
+        )
+    out = bytearray(np.asarray(reference_mcode, dtype=np.uint8).tobytes())
+    for off in fields.get("scale_offsets", ()):
+        out[off : off + 4] = scale_bytes
+    for off in fields.get("zero_offsets", ()):
+        out[off] = zero
+    return np.frombuffer(bytes(out), dtype=np.uint8)
+
+
+def learn_mcode(mcodes, y_scales, y_zeros, min_agreement=0.9):
+    """Find the mcode fields that follow the output quantisation.
+
+    A convolution's mcode is otherwise a function of shape alone -- across 48
+    builds of one shape only 24 of 2824 bytes move at all, once the one build
+    with a shifted layout is set aside. Of those, this identifies the ones that
+    are the output scale or zero point written down literally:
+
+    * `scale_offsets` -- little-endian float32 equal to `y_scale`; the AX650N
+      writes four copies,
+    * `zero_offsets` -- one byte equal to `round(y_zero)`,
+    * `free_offsets` -- varying, and neither. On the reference shape these are
+      seven bytes near 303-326 holding a permutation of 0x10/0x20/0x30/0x40
+      with 0x13/0x23 separators. **They do not affect the result**: emitting
+      eight held-out models with the reference's values left in place produced
+      device output bit-identical to Pulsar2's own build every time. They are
+      scheduling, not semantics,
+    * `outliers` -- builds whose stream does not agree with the majority
+      layout, which is how the 0x80 case announces itself.
+
+    A field is accepted when at least `min_agreement` of the builds carry it,
+    so one shifted stream does not hide the other 47.
+    """
+    stack = np.stack([np.asarray(m, dtype=np.uint8) for m in mcodes])
+    y_scales = np.asarray(y_scales, dtype=np.float32)
+    y_zeros = np.round(np.asarray(y_zeros)).astype(np.int64)
+    need = int(np.ceil(min_agreement * len(stack)))
+
+    varying = np.flatnonzero((stack != stack[0]).any(axis=0))
+    scale_offsets, zero_offsets, free = [], [], []
+    agree = np.zeros(len(stack), dtype=np.int64)
+    claimed = set()
+    for off in varying:
+        off = int(off)
+        if off in claimed:
+            continue
+        if off + 4 <= stack.shape[1]:
+            word = stack[:, off : off + 4].copy().view(np.float32).ravel()
+            hit = word == y_scales
+            if hit.sum() >= need:
+                scale_offsets.append(off)
+                claimed.update(range(off, off + 4))
+                agree += hit
+                continue
+        hit = stack[:, off].astype(np.int64) == (y_zeros & 0xFF)
+        if hit.sum() >= need:
+            zero_offsets.append(off)
+            agree += hit
+            continue
+        free.append(off)
+    # An outlier is a build the reference cannot be patched into: re-emit each
+    # one and see whether anything outside the free offsets survives. That is
+    # the property an emitter actually needs, and it does not care why a
+    # stream disagrees.
+    fields = {"scale_offsets": scale_offsets, "zero_offsets": zero_offsets}
+    allowed = set(free)
+    outliers = []
+    for i in range(len(stack)):
+        try:
+            got = emit_mcode(stack[0], fields, y_scales[i], y_zeros[i])
+        except ValueError:
+            outliers.append(i)
+            continue
+        if not set(np.flatnonzero(got != stack[i]).tolist()) <= allowed:
+            outliers.append(i)
+    if outliers:
+        # a shifted stream makes every byte after the shift look weight-
+        # dependent, which would bury the handful that really are. Recompute
+        # what varies using only the builds that share the majority layout.
+        keep = np.setdiff1d(np.arange(len(stack)), np.asarray(outliers))
+        sub = stack[keep]
+        claimed = set(o for off in scale_offsets for o in range(off, off + 4))
+        free = [
+            int(o)
+            for o in np.flatnonzero((sub != sub[0]).any(axis=0))
+            if int(o) not in claimed and int(o) not in zero_offsets
+        ]
+    # The stream refuses some literals -- two of 48 builds of the reference
+    # shape shift everything after the field rather than writing the value
+    # inline, one with an output zero point of exactly 128 and one with a
+    # scale whose low byte is 0x9e. No rule tried here predicts which
+    # (plenty of non-outliers also carry bytes in 0x80-0x9f), so record the
+    # values that actually failed and let `emit_mcode` refuse those.
+    ok_zero = {int(y_zeros[i]) & 0xFF for i in range(len(stack)) if i not in outliers}
+    ok_low = {
+        np.float32(y_scales[i]).tobytes()[0]
+        for i in range(len(stack))
+        if i not in outliers
+    }
+    bad_zero = sorted({int(y_zeros[i]) & 0xFF for i in outliers} - ok_zero)
+    # attribute each outlier to one field: a zero point no good build uses
+    # explains it on its own, and only what is left is blamed on the scale.
+    rest = [i for i in outliers if (int(y_zeros[i]) & 0xFF) not in bad_zero]
+    unpatchable = {
+        "zero": bad_zero,
+        "scale_low_byte": sorted(
+            {np.float32(y_scales[i]).tobytes()[0] for i in rest} - ok_low
+        ),
+    }
+    return {
+        "scale_offsets": scale_offsets,
+        "zero_offsets": zero_offsets,
+        "free_offsets": free,
+        "outliers": outliers,
+        "unpatchable": unpatchable,
+    }
+
+
+def mcode_name(axmodel_path):
+    """The name of the initializer holding the command stream.
+
+    Pulsar2 names it after the subgraph (`subgraph_npu_0_b1_neu`); the `neu`
+    suffix is the marker `pulsar2_ops.AXERA_NPU_OP_TYPE` is built around.
+    """
+    model = onnx.load(axmodel_path, load_external_data=False)
+    for init in model.graph.initializer:
+        if init.name.endswith("_neu"):
+            return init.name
+    raise KeyError(f"no *_neu initializer in {axmodel_path}")
+
+
+def emit_axmodel(
+    reference_path,
+    out_path,
+    w,
+    x_scale,
+    x_zero,
+    y_scale,
+    y_zero,
+    origin,
+    block_at,
+    fields,
+    table_name="npu_params",
+):
+    """Write a whole `.axmodel` for new weights, from a reference build.
+
+    Everything the compiler decides from the *shape* is inherited from the
+    reference; everything it decides from the *weights* is recomputed here.
+    On the reference shape this reproduces Pulsar2's own weight table byte for
+    byte and its own device output bit for bit -- see `README.md`.
+    """
+    model = onnx.load(reference_path, load_external_data=False)
+    name = mcode_name(reference_path)
+    table = mc = None
+    for init in model.graph.initializer:
+        if init.name == table_name:
+            table = np.frombuffer(bytes(init.raw_data), dtype=np.uint8)
+        elif init.name == name:
+            mc = np.frombuffer(bytes(init.raw_data), dtype=np.uint8)
+    if table is None or mc is None:
+        raise KeyError(f"{reference_path} is missing {table_name} or {name}")
+
+    new_table = emit(
+        table, origin, w, x_scale, x_zero, y_scale, y_zero, block_at=block_at
+    )
+    new_mcode = emit_mcode(mc, fields, y_scale, y_zero)
+    for init in model.graph.initializer:
+        if init.name == table_name:
+            init.raw_data = new_table.tobytes()
+        elif init.name == name:
+            init.raw_data = new_mcode.tobytes()
+    onnx.save(model, out_path)
+    return new_table, new_mcode
+
+
+def save_map(path, origin, const, ambiguous, shape):
+    np.savez_compressed(
+        path,
+        origin=origin,
+        const=const,
+        ambiguous=ambiguous,
+        shape=np.asarray(shape, dtype=np.int64),
+    )
+
+
+def load_map(path):
+    z = np.load(path)
+    return z["origin"], z["const"], z["ambiguous"], tuple(z["shape"].tolist())
+
+
+def _replace_initializer(model, name, data):
+    for init in model.graph.initializer:
+        if init.name == name:
+            init.raw_data = bytes(data)
+            return True
+    return False
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    lp = sub.add_parser("learn", help="learn the map from k builds of one shape")
+    lp.add_argument("axmodels", nargs="+")
+    lp.add_argument(
+        "--weights",
+        nargs="+",
+        required=True,
+        help=".npy of each build's float weights, same order",
+    )
+    lp.add_argument("-o", "--out", required=True)
+
+    ep = sub.add_parser("emit", help="write new weights through a learned map")
+    ep.add_argument("reference")
+    ep.add_argument("map")
+    ep.add_argument("weights")
+    ep.add_argument("-o", "--out", required=True)
+
+    args = p.parse_args(argv)
+    if args.cmd == "learn":
+        ws = [np.load(w) for w in args.weights]
+        codes = [codes_of(w) for w in ws]
+        tables = [table_of(a) for a in args.axmodels]
+        origin, const, ambiguous = learn(codes, tables)
+        save_map(args.out, origin, const, ambiguous, ws[0].shape)
+        mapped = int((origin != CONST).sum())
+        print(
+            f"{len(tables)} builds, table {len(tables[0])} B "
+            f"({8 * len(tables[0])} bits)"
+        )
+        print(f"  mapped to a weight bit : {mapped}")
+        print(
+            f"  constant across builds : {int((origin == CONST).sum()) - len(ambiguous)}"
+        )
+        print(f"  unexplained            : {len(ambiguous)}")
+        print(f"  colliding sources      : {collisions(codes, origin)}")
+        return 0
+
+    origin, const, ambiguous, shape = load_map(args.map)
+    model = onnx.load(args.reference, load_external_data=False)
+    ref = table_of(args.reference)
+    codes = codes_of(np.load(args.weights))
+    table = emit_table(ref, origin, codes)
+    if not _replace_initializer(model, "npu_params", table.tobytes()):
+        raise SystemExit("no npu_params in the reference")
+    onnx.save(model, args.out)
+    print(f"wrote {args.out}: {int((table != ref).sum())} of {len(ref)} bytes changed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/axera/emitter.py
+++ b/scripts/axera/emitter.py
@@ -61,6 +61,26 @@ def codes_of(w, bits=8, axis=0):
     return q.astype(np.uint8)
 
 
+def llm_codes_of(weights):
+    """The codes `pulsar2 llm_build` stores -- a different quantiser from `codes_of`.
+
+    Three things differ from the convolution pipeline's, and all three matter
+    (`README.md`, "The LLM path quantises differently"). The scale divides by
+    128, not 127.5. It is taken from the *signed* weight at the peak index and
+    then negated, so a row's extreme weight always lands on code 0 and zero
+    lands on 128, whichever sign that extreme has. And ties round toward
+    `+inf`, not to even.
+
+    The arithmetic happens in the checkpoint's own precision: pass a bfloat16
+    file's values already widened to float32, which is what they are.
+    """
+    w = np.asarray(weights, dtype=np.float32)
+    peak = w[np.arange(len(w)), np.abs(w).argmax(1)].astype(np.float32)
+    scale = (-peak / np.float32(128)).astype(np.float32)
+    codes = np.floor(w / scale[:, None] + np.float32(0.5)) + 128
+    return np.clip(codes, 0, 255).astype(np.uint8)
+
+
 def table_of(axmodel_path, name="npu_params"):
     """The raw weight table out of a compiled `.axmodel`."""
     model = onnx.load(axmodel_path, load_external_data=False)
@@ -77,12 +97,19 @@ def _bits(arr):
 
 
 def _signatures(bit_matrix):
-    """One integer per column, packing that column's value in every sample."""
+    """One key per column, packing that column's value in every sample.
+
+    Up to 64 samples this is a `uint64` array, which keeps the lookups
+    vectorised. Beyond that -- and the LLM path needs beyond that, because a
+    layer holds millions of codes and unambiguity costs about twice their log
+    -- the key becomes the packed bytes of the column.
+    """
     n = bit_matrix.shape[0]
-    if n > 63:
-        raise ValueError("more than 63 samples would overflow the signature")
-    weights = (1 << np.arange(n, dtype=np.uint64)).reshape(-1, 1)
-    return (bit_matrix.astype(np.uint64) * weights).sum(axis=0)
+    if n <= 64:
+        shifts = np.arange(n, dtype=np.uint64)
+        return (bit_matrix.astype(np.uint64) << shifts.reshape(-1, 1)).sum(axis=0)
+    packed = np.packbits(bit_matrix, axis=0, bitorder="little")
+    return [row.tobytes() for row in packed.T]
 
 
 def learn(code_samples, table_samples):
@@ -107,7 +134,8 @@ def learn(code_samples, table_samples):
 
     code_sig = _signatures(code_bits)
     table_sig = _signatures(table_bits)
-    all_zero, all_one = np.uint64(0), np.uint64((1 << n) - 1)
+    all_zero = _signatures(np.zeros((n, 1), np.uint8))[0]
+    all_one = _signatures(np.ones((n, 1), np.uint8))[0]
 
     lookup = {}
     for idx, sig in enumerate(code_sig):
@@ -139,7 +167,8 @@ def collisions(code_samples, origin):
     code_bits = _bits([c.ravel() for c in code_samples])
     sig = _signatures(code_bits)
     n = code_bits.shape[0]
-    all_zero, all_one = np.uint64(0), np.uint64((1 << n) - 1)
+    all_zero = _signatures(np.zeros((n, 1), np.uint8))[0]
+    all_one = _signatures(np.ones((n, 1), np.uint8))[0]
     counts = {}
     for s in sig:
         if s in (all_zero, all_one):

--- a/scripts/axera/precision.py
+++ b/scripts/axera/precision.py
@@ -72,7 +72,7 @@ def channel_axis(node, ndim):
     if node.op_type == "Gemm":
         trans_b = any(a.name == "transB" and a.i for a in node.attribute)
         return 0 if trans_b else ndim - 1
-    return ndim - 1                      # MatMul: x @ W, output channel last
+    return ndim - 1  # MatMul: x @ W, output channel last
 
 
 def quantise_dequantise(w, bits=8, axis=0):
@@ -114,10 +114,10 @@ def peak_to_rms(w, axis=None):
     """
     w = np.asarray(w, dtype=np.float64)
     if axis is None:
-        rms = float(np.sqrt((w ** 2).mean()))
+        rms = float(np.sqrt((w**2).mean()))
         return float(np.abs(w).max()) / rms if rms else 0.0
     red = tuple(i for i in range(w.ndim) if i != axis)
-    rms = np.sqrt((w ** 2).mean(axis=red))
+    rms = np.sqrt((w**2).mean(axis=red))
     peak = np.abs(w).max(axis=red)
     ok = rms > 0
     return float(np.median(peak[ok] / rms[ok])) if ok.any() else 0.0
@@ -136,7 +136,7 @@ def weight_error_db(w, bits=8, axis=0):
     if p2r == 0.0:
         return float("inf")
     full = 2.0 ** (bits - 1) - 0.5
-    return float(10 * np.log10(12 * full ** 2) - 20 * np.log10(p2r))
+    return float(10 * np.log10(12 * full**2) - 20 * np.log10(p2r))
 
 
 def _initializers(model):
@@ -174,8 +174,9 @@ def split_weight(w, bits=8, axis=0):
     return hi, lo
 
 
-def weight_residual_split(model, bits=8, ops=SPLITTABLE, layers=None,
-                          min_peak_to_rms=0.0):
+def weight_residual_split(
+    model, bits=8, ops=SPLITTABLE, layers=None, min_peak_to_rms=0.0
+):
     """Rewrite eligible weighted ops as ``op(x, W_hi) + op(x, W_lo)``.
 
     `layers` restricts the rewrite to a set of node names; `min_peak_to_rms`
@@ -187,9 +188,11 @@ def weight_residual_split(model, bits=8, ops=SPLITTABLE, layers=None,
     the result is far closer to the original than either half alone.
     """
     inits = _initializers(model)
-    taken = ({i.name for i in model.graph.initializer}
-             | {n.name for n in model.graph.node if n.name}
-             | {o for n in model.graph.node for o in n.output})
+    taken = (
+        {i.name for i in model.graph.initializer}
+        | {n.name for n in model.graph.node if n.name}
+        | {o for n in model.graph.node for o in n.output}
+    )
     targets = []
     for node in splittable_nodes(model, ops):
         if layers is not None and node.name not in layers:
@@ -208,8 +211,9 @@ def weight_residual_split(model, bits=8, ops=SPLITTABLE, layers=None,
         stem = node.name or node.output[0]
         hi_w = _unique(taken, f"{stem}_hi_w")
         lo_w = _unique(taken, f"{stem}_lo_w")
-        model.graph.initializer.extend([numpy_helper.from_array(hi, hi_w),
-                                        numpy_helper.from_array(lo, lo_w)])
+        model.graph.initializer.extend(
+            [numpy_helper.from_array(hi, hi_w), numpy_helper.from_array(lo, lo_w)]
+        )
         hi_out = _unique(taken, f"{stem}_hi")
         lo_out = _unique(taken, f"{stem}_lo")
 
@@ -230,8 +234,12 @@ def weight_residual_split(model, bits=8, ops=SPLITTABLE, layers=None,
         del lo_node.output[:]
         lo_node.output.append(lo_out)
 
-        add = helper.make_node("Add", [hi_out, lo_out], [node.output[0]],
-                               name=_unique(taken, f"{stem}_join"))
+        add = helper.make_node(
+            "Add",
+            [hi_out, lo_out],
+            [node.output[0]],
+            name=_unique(taken, f"{stem}_join"),
+        )
         replacement[id(node)] = [hi_node, lo_node, add]
 
     rebuilt = []
@@ -256,13 +264,24 @@ def main(argv=None):
     p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     p.add_argument("input")
     p.add_argument("output", nargs="?")
-    p.add_argument("--bits", type=int, default=8,
-                   help="width the compiler will quantise the weight to (8)")
-    p.add_argument("--min-peak-to-rms", type=float, default=0.0,
-                   help="only split weights at least this outlier-heavy")
+    p.add_argument(
+        "--bits",
+        type=int,
+        default=8,
+        help="width the compiler will quantise the weight to (8)",
+    )
+    p.add_argument(
+        "--min-peak-to-rms",
+        type=float,
+        default=0.0,
+        help="only split weights at least this outlier-heavy",
+    )
     p.add_argument("--ops", default=",".join(SPLITTABLE))
-    p.add_argument("--dry-run", action="store_true",
-                   help="report what would be split and why, change nothing")
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be split and why, change nothing",
+    )
     args = p.parse_args(argv)
 
     model = onnx.load(args.input)
@@ -274,16 +293,21 @@ def main(argv=None):
             w = numpy_helper.to_array(inits[node.input[1]])
             ax = channel_axis(node, w.ndim)
             hi, lo = split_weight(w, args.bits, ax)
-            got = compiler_view(hi, args.bits, ax) + quantise_dequantise(lo, args.bits, ax)
+            got = compiler_view(hi, args.bits, ax) + quantise_dequantise(
+                lo, args.bits, ax
+            )
             err = float(((w - got).astype(np.float64) ** 2).sum())
             sig = float((w.astype(np.float64) ** 2).sum())
-            print(f"{(node.name or node.output[0])[:43]:<44}{node.op_type:<15}"
-                  f"{peak_to_rms(w, ax):>9.2f}{weight_error_db(w, args.bits, ax):>9.2f}"
-                  f"{10 * np.log10(sig / max(err, 1e-30)):>10.2f}")
+            print(
+                f"{(node.name or node.output[0])[:43]:<44}{node.op_type:<15}"
+                f"{peak_to_rms(w, ax):>9.2f}{weight_error_db(w, args.bits, ax):>9.2f}"
+                f"{10 * np.log10(sig / max(err, 1e-30)):>10.2f}"
+            )
         return 0
-    n = weight_residual_split(model, bits=args.bits, ops=ops,
-                              min_peak_to_rms=args.min_peak_to_rms)
-    onnx.save(model, args.output, save_as_external_data=model.ByteSize() > 2 ** 30)
+    n = weight_residual_split(
+        model, bits=args.bits, ops=ops, min_peak_to_rms=args.min_peak_to_rms
+    )
+    onnx.save(model, args.output, save_as_external_data=model.ByteSize() > 2**30)
     print(f"split {n} op(s); promote {split_op_types(model, ops)} to U16")
     return 0
 

--- a/scripts/axera/precision.py
+++ b/scripts/axera/precision.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Weight-residual splitting: two INT8 passes that carry ~16 bits of weight.
+
+A Pulsar2-compiled graph loses accuracy in three separable places:
+
+* ``e_W`` -- the weight is quantised to INT8, **per output channel**,
+  symmetric, at ``max|w_c| / 127.5`` (confirmed against a build's own
+  ``quant/quant_axmodel.json``, which agrees to the last digit),
+* ``e_X`` -- the input activation is quantised per tensor, **asymmetric**
+  uint8, at ``(max - min) / 255`` with ``zp = round(-min/scale)``,
+* ``e_Y`` -- the INT32 accumulator is requantised on the way out, same rule.
+
+This module attacks ``e_W`` with the Ozaki scheme's shape
+(`docs/ozaki-scheme-axera-handoff.md`) and none of the machinery that note
+found broken. Rather than pinning scales through QDQ -- which crashes
+Pulsar2's PPQ pass -- split the weight in two::
+
+    W_hi = the value the compiler's own quantiser will land on
+    W_lo = W - W_hi                    # peak(W_lo) <= peak(W)/255, per channel
+
+and emit ``conv(x, W_hi) + conv(x, W_lo)``. Nothing asks the compiler for a
+scale: ``W_lo``'s peak is 255x smaller, so ordinary per-tensor PTQ *derives* a
+255x finer scale for the second convolution on its own. On a real conv weight
+that lifts the weight's own SNR from 37.7 dB to 79.5 dB.
+
+**The residual must be taken against what the compiler will materialise, not
+against what you asked for.** `quantise_dequantise` is not idempotent -- the
+peak of a quantised channel is ``127`` steps, not ``127.5``, so re-quantising
+shifts the scale by 0.4% and moves values by up to half a step. Subtracting
+the once-quantised weight leaves that half-step behind and the split recovers
+48 dB instead of 79 dB; a hardware probe built that way gained nothing at all
+(see `compiler_view`).
+
+What it costs: one extra convolution and one extra ``Add``, so the output is
+requantised twice instead of once -- ``e_Y`` is paid twice, 3 dB worse on that
+term. **The split therefore only pays when ``e_Y`` is not the binding
+constraint**, which in practice means running the split ops' activations at
+16 bits (``layer_configs: [{"op_types": [...], "data_type": "U16"}]``). At
+INT8 activations throughout, per-channel weight quantisation is already good
+enough that the extra requantisation costs more than the residual returns.
+
+Usage::
+
+    precision.py in.onnx out.onnx                  # split every eligible op
+    precision.py --dry-run in.onnx                 # report per-layer e_W
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+#: Ops whose second input is a weight this module knows how to split.
+SPLITTABLE = ("Conv", "ConvTranspose", "MatMul", "Gemm")
+
+
+def channel_axis(node, ndim):
+    """Which axis of `node`'s weight carries the per-channel scale.
+
+    Pulsar2 gives every weight one scale per *output* channel, and where that
+    axis sits depends on the op's own layout: `Conv` is ``(Cout, Cin/g, k...)``
+    but `ConvTranspose` is ``(Cin, Cout/g, k...)``, and `Gemm`'s depends on
+    `transB`.
+    """
+    if node.op_type == "ConvTranspose":
+        return 1
+    if node.op_type == "Conv":
+        return 0
+    if node.op_type == "Gemm":
+        trans_b = any(a.name == "transB" and a.i for a in node.attribute)
+        return 0 if trans_b else ndim - 1
+    return ndim - 1                      # MatMul: x @ W, output channel last
+
+
+def quantise_dequantise(w, bits=8, axis=0):
+    """`w` through Pulsar2's weight quantiser and back.
+
+    Symmetric, one scale per `axis` slice, step ``max|w_c| / (2**(bits-1) -
+    0.5)``, round-half-even -- the quantiser `README.md` recovered byte-exactly
+    from real weight tables, minus the ``+128`` storage offset, which cancels
+    here.
+    """
+    w = np.asarray(w, dtype=np.float32)
+    if w.ndim == 0:
+        axis = None
+    red = None if axis is None else tuple(i for i in range(w.ndim) if i != axis)
+    peak = np.abs(w).max(axis=red, keepdims=red is not None)
+    peak = np.asarray(peak, dtype=np.float32)
+    step = np.where(peak == 0, 1.0, peak / (2.0 ** (bits - 1) - 0.5))
+    lo, hi = -(2 ** (bits - 1)), 2 ** (bits - 1) - 1
+    return (np.clip(np.rint(w / step), lo, hi) * step).astype(np.float32)
+
+
+def compiler_view(w, bits=8, axis=0):
+    """What Pulsar2 will actually materialise for an initializer holding `w`.
+
+    For a weight that is already quantised this is *not* `w`: a quantised
+    channel's peak is 127 steps where the scale assumed 127.5, so the compiler
+    derives a scale 0.4% smaller and re-rounds. The residual has to be taken
+    against this, or half a step of the original error survives the split.
+    """
+    return quantise_dequantise(w, bits, axis)
+
+
+def peak_to_rms(w, axis=None):
+    """How much of the quantiser's range the outliers are wasting.
+
+    With `axis`, the median across per-channel slices -- which is the number
+    that matters, since the scale is per channel. Per-tensor peak/rms
+    overstates the damage badly: 14.7 against 5.6 on the same weights.
+    """
+    w = np.asarray(w, dtype=np.float64)
+    if axis is None:
+        rms = float(np.sqrt((w ** 2).mean()))
+        return float(np.abs(w).max()) / rms if rms else 0.0
+    red = tuple(i for i in range(w.ndim) if i != axis)
+    rms = np.sqrt((w ** 2).mean(axis=red))
+    peak = np.abs(w).max(axis=red)
+    ok = rms > 0
+    return float(np.median(peak[ok] / rms[ok])) if ok.any() else 0.0
+
+
+def weight_error_db(w, bits=8, axis=0):
+    """SNR, in dB, that quantising `w` alone costs the layer's output.
+
+    Rounding error is uniform over one step, so its energy is ``step**2/12``
+    against the weight's own variance; both ride the same activations, so the
+    activations cancel and only `peak_to_rms` survives::
+
+        e_W = 10 log10(12 * (2**(bits-1) - 0.5)**2) - 20 log10(peak/rms)
+    """
+    p2r = peak_to_rms(w, axis)
+    if p2r == 0.0:
+        return float("inf")
+    full = 2.0 ** (bits - 1) - 0.5
+    return float(10 * np.log10(12 * full ** 2) - 20 * np.log10(p2r))
+
+
+def _initializers(model):
+    return {i.name: i for i in model.graph.initializer}
+
+
+def splittable_nodes(model, ops=SPLITTABLE):
+    """Nodes whose weight is a float initializer this module can split."""
+    inits = _initializers(model)
+    out = []
+    for node in model.graph.node:
+        if node.op_type not in ops or len(node.input) < 2:
+            continue
+        w = inits.get(node.input[1])
+        if w is None or w.data_type != TensorProto.FLOAT or not w.dims:
+            continue
+        out.append(node)
+    return out
+
+
+def _unique(taken, stem):
+    name, n = stem, 0
+    while name in taken:
+        n += 1
+        name = f"{stem}_{n}"
+    taken.add(name)
+    return name
+
+
+def split_weight(w, bits=8, axis=0):
+    """`(W_hi, W_lo)` such that the compiler's view of the pair reconstructs `w`."""
+    w = np.asarray(w, dtype=np.float32)
+    hi = quantise_dequantise(w, bits, axis)
+    lo = (w - compiler_view(hi, bits, axis)).astype(np.float32)
+    return hi, lo
+
+
+def weight_residual_split(model, bits=8, ops=SPLITTABLE, layers=None,
+                          min_peak_to_rms=0.0):
+    """Rewrite eligible weighted ops as ``op(x, W_hi) + op(x, W_lo)``.
+
+    `layers` restricts the rewrite to a set of node names; `min_peak_to_rms`
+    is the calibration-free filter, applied to the per-channel peak/rms.
+
+    Returns the number of nodes rewritten. The rewrite is *not* exact in
+    float -- ``W_hi + W_lo`` differs from ``W`` by the compiler's own
+    re-rounding of ``W_hi``, about 0.4% of one INT8 step -- but a float run of
+    the result is far closer to the original than either half alone.
+    """
+    inits = _initializers(model)
+    taken = ({i.name for i in model.graph.initializer}
+             | {n.name for n in model.graph.node if n.name}
+             | {o for n in model.graph.node for o in n.output})
+    targets = []
+    for node in splittable_nodes(model, ops):
+        if layers is not None and node.name not in layers:
+            continue
+        w = numpy_helper.to_array(inits[node.input[1]])
+        if peak_to_rms(w, channel_axis(node, w.ndim)) < min_peak_to_rms:
+            continue
+        targets.append(node)
+    if not targets:
+        return 0
+
+    replacement = {}
+    for node in targets:
+        w = numpy_helper.to_array(inits[node.input[1]]).astype(np.float32)
+        hi, lo = split_weight(w, bits, channel_axis(node, w.ndim))
+        stem = node.name or node.output[0]
+        hi_w = _unique(taken, f"{stem}_hi_w")
+        lo_w = _unique(taken, f"{stem}_lo_w")
+        model.graph.initializer.extend([numpy_helper.from_array(hi, hi_w),
+                                        numpy_helper.from_array(lo, lo_w)])
+        hi_out = _unique(taken, f"{stem}_hi")
+        lo_out = _unique(taken, f"{stem}_lo")
+
+        hi_node = onnx.NodeProto()
+        hi_node.CopyFrom(node)
+        hi_node.name = _unique(taken, f"{stem}_hi_op")
+        hi_node.input[1] = hi_w
+        del hi_node.output[:]
+        hi_node.output.append(hi_out)
+
+        lo_node = onnx.NodeProto()
+        lo_node.CopyFrom(node)
+        lo_node.name = _unique(taken, f"{stem}_lo_op")
+        lo_node.input[1] = lo_w
+        # The bias / Gemm `C` rides on the high half only: it is not what is
+        # being split, and adding it to both would double it.
+        del lo_node.input[2:]
+        del lo_node.output[:]
+        lo_node.output.append(lo_out)
+
+        add = helper.make_node("Add", [hi_out, lo_out], [node.output[0]],
+                               name=_unique(taken, f"{stem}_join"))
+        replacement[id(node)] = [hi_node, lo_node, add]
+
+    rebuilt = []
+    for node in model.graph.node:
+        rebuilt.extend(replacement.get(id(node), [node]))
+    del model.graph.node[:]
+    model.graph.node.extend(rebuilt)
+    return len(targets)
+
+
+def split_op_types(model, ops=SPLITTABLE):
+    """Op types a split graph introduces, for a `layer_configs` entry.
+
+    The whole point of the split is undone if the ``Add`` that joins the two
+    halves requantises to INT8, so the caller almost always wants to promote
+    these to ``U16``.
+    """
+    return sorted({n.op_type for n in splittable_nodes(model, ops)} | {"Add"})
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("input")
+    p.add_argument("output", nargs="?")
+    p.add_argument("--bits", type=int, default=8,
+                   help="width the compiler will quantise the weight to (8)")
+    p.add_argument("--min-peak-to-rms", type=float, default=0.0,
+                   help="only split weights at least this outlier-heavy")
+    p.add_argument("--ops", default=",".join(SPLITTABLE))
+    p.add_argument("--dry-run", action="store_true",
+                   help="report what would be split and why, change nothing")
+    args = p.parse_args(argv)
+
+    model = onnx.load(args.input)
+    ops = tuple(o for o in args.ops.split(",") if o)
+    if args.dry_run or not args.output:
+        inits = _initializers(model)
+        print(f"{'node':<44}{'op':<15}{'peak/rms':>9}{'e_W dB':>9}{'split dB':>10}")
+        for node in splittable_nodes(model, ops):
+            w = numpy_helper.to_array(inits[node.input[1]])
+            ax = channel_axis(node, w.ndim)
+            hi, lo = split_weight(w, args.bits, ax)
+            got = compiler_view(hi, args.bits, ax) + quantise_dequantise(lo, args.bits, ax)
+            err = float(((w - got).astype(np.float64) ** 2).sum())
+            sig = float((w.astype(np.float64) ** 2).sum())
+            print(f"{(node.name or node.output[0])[:43]:<44}{node.op_type:<15}"
+                  f"{peak_to_rms(w, ax):>9.2f}{weight_error_db(w, args.bits, ax):>9.2f}"
+                  f"{10 * np.log10(sig / max(err, 1e-30)):>10.2f}")
+        return 0
+    n = weight_residual_split(model, bits=args.bits, ops=ops,
+                              min_peak_to_rms=args.min_peak_to_rms)
+    onnx.save(model, args.output, save_as_external_data=model.ByteSize() > 2 ** 30)
+    print(f"split {n} op(s); promote {split_op_types(model, ops)} to U16")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/axera/replay.py
+++ b/scripts/axera/replay.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Replay what the AX650N will compute, from the build's own quantisation table.
+
+`pulsar2 build` writes `<output>/quant/quant_axmodel.json`, and it contains
+every number needed to reproduce the card exactly: one entry per tensor giving
+its bit width, quantisation policy, and -- through a hash into a shared
+`values` table -- its scale and zero point.
+
+Feeding those scales back into the float graph as `QuantizeLinear` /
+`DequantizeLinear` pairs and running it under onnxruntime reproduces real
+AX650N output to a fraction of a decibel. On four builds of the same graph
+(INT8 and 16-bit activations, with and without `precision.py`'s weight split)
+the replay landed within **0.19 dB** of the card, two of them exactly:
+
+| build | replayed | device |
+| --- | --- | --- |
+| INT8 | 21.64 dB | 21.64 dB |
+| INT8, split weights | 21.15 dB | 21.34 dB |
+| U16 | 25.77 dB | 25.77 dB |
+| U16, split weights | 33.03 dB | 33.00 dB |
+
+Which settles something this repository had left open: there is no unexplained
+numerical floor in the hardware. The card computes exactly the affine
+quantisation the compiler wrote down, so **accuracy on this NPU is set by the
+scales, and the scales are set by calibration** -- both of which can now be
+searched offline, without a card and without a rebuild.
+
+The scales come from the build, so this needs a `pulsar2 build` output
+directory. It does not need Docker or a device.
+
+Usage::
+
+    replay.py model.onnx output_dir/ --input x=input.npy --ref
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper
+
+#: activation widths the table uses; 32 means the tensor was left in float.
+_ACTIVATION_BITS = (8, 16)
+
+
+def surviving_edges(build_dir):
+    """Tensor names that are still real edges in the compiler's own graph.
+
+    `quant/quant_axmodel.onnx` is what Pulsar2 actually lowers -- its own
+    `AxQuantized*` ops, with fusion already applied. On the Audio8 decoder 385
+    of the float graph's 1002 tensors are gone from it, folded inside a fused
+    op. Those tensors still have entries in `quant_axmodel.json`, but nothing
+    on the card ever rounds them, so quantising them in a replay invents error
+    the hardware does not make: doing so read 1.12 dB where the card measured
+    7.37.
+
+    Returns `None` if the file is absent, meaning "no filter".
+    """
+    path = os.path.join(build_dir, "quant", "quant_axmodel.onnx")
+    if not os.path.exists(path):
+        return None
+    graph = onnx.load(path, load_external_data=False).graph
+    return ({o for node in graph.node for o in node.output}
+            | {i.name for i in graph.input})
+
+
+def load_scales(build_dir, fused_aware=True):
+    """`{tensor: (bit_width, scale, zero_point, per_channel, axis)}` for a build.
+
+    `quant_axmodel.json` stores one config per (op, tensor) pair and hashes
+    into a shared `values` table, so a tensor consumed by several ops appears
+    several times; the entries agree, and the first one carrying a value wins.
+
+    `fused_aware` drops the tensors `surviving_edges` says the compiler fused
+    away. Weights are always kept -- fusion does not stop a weight being
+    quantised.
+    """
+    path = os.path.join(build_dir, "quant", "quant_axmodel.json")
+    with open(path) as fh:
+        doc = json.load(fh)
+    keep = surviving_edges(build_dir) if fused_aware else None
+    values = doc["values"]
+    out = {}
+    for cfg in doc["tensor_configs"].values():
+        for tensor, entry in cfg.items():
+            if tensor in out:
+                continue
+            value = values.get(str(entry.get("hash")))
+            if not value or not value.get("scale"):
+                continue
+            policy = entry["policy"]
+            if (keep is not None and tensor not in keep
+                    and not policy.get("PER_CHANNEL")):
+                continue
+            out[tensor] = (
+                entry["bit_width"],
+                np.asarray(value["scale"], dtype=np.float32),
+                np.asarray(value["zero_point"], dtype=np.float64),
+                bool(policy.get("PER_CHANNEL")),
+                None,
+            )
+    return out
+
+
+def _weight_axis(node, ndim):
+    from precision import channel_axis
+    return channel_axis(node, ndim)
+
+
+def insert_qdq(model, scales):
+    """Return a copy of `model` with the build's quantisation spelled out.
+
+    Every tensor the table knows about gets a `QuantizeLinear` /
+    `DequantizeLinear` pair at its producer: activations per tensor and
+    asymmetric, weights per output channel and symmetric. Tensors the table
+    does not mention (shape operands, anything the compiler kept in float)
+    are left alone.
+
+    Returns `(model, n_activations, n_weights)`.
+    """
+    model = onnx.ModelProto.FromString(model.SerializeToString())
+    graph = model.graph
+    inits = {i.name: i for i in graph.initializer}
+    used = {n.name for n in graph.node if n.name}
+    n_act = n_w = 0
+
+    def const(name, arr):
+        graph.initializer.append(numpy_helper.from_array(np.asarray(arr), name))
+        return name
+
+    def unique(stem):
+        name, k = stem, 0
+        while name in used:
+            k += 1
+            name = f"{stem}_{k}"
+        used.add(name)
+        return name
+
+    # weights first: they are initializers, so quantise the stored values
+    # directly rather than adding nodes the compiler would not have.
+    for node in graph.node:
+        if len(node.input) < 2:
+            continue
+        init = inits.get(node.input[1])
+        entry = scales.get(node.input[1])
+        if init is None or entry is None:
+            continue
+        bits, scale, zero, per_channel, _ = entry
+        w = numpy_helper.to_array(init).astype(np.float32)
+        axis = _weight_axis(node, w.ndim) if per_channel else None
+        s = scale.reshape([-1] + [1] * (w.ndim - 1 - (axis or 0))) if per_channel \
+            else scale.reshape(())
+        if per_channel and axis:
+            s = scale.reshape([1] * axis + [-1] + [1] * (w.ndim - axis - 1))
+        z = zero.reshape(s.shape) if per_channel else zero.reshape(())
+        lo, hi = -(2 ** (bits - 1)), 2 ** (bits - 1) - 1
+        q = np.clip(np.rint(w / s) + z, lo, hi)
+        init.CopyFrom(numpy_helper.from_array(((q - z) * s).astype(np.float32),
+                                              init.name))
+        n_w += 1
+
+    # then activations. Spelled as arithmetic (`Div`, `Round`, `Clip`, `Mul`)
+    # rather than `QuantizeLinear`, because a UINT16 zero point needs opset 21
+    # and bumping a real graph's opset that far breaks ops whose signature
+    # moved on the way (`ReduceMean`'s `axes` became an input at 18). The
+    # arithmetic form runs at whatever opset the model already declares, and
+    # ONNX `Round` is round-half-to-even, the same rule `QuantizeLinear` uses.
+    def fake_quant(raw, out, bits, scale, zero):
+        s_name = const(unique(f"{out}_s"), np.float32(scale))
+        z_name = const(unique(f"{out}_z"), np.float32(zero))
+        lo_name = const(unique(f"{out}_lo"), np.float32(0.0))
+        hi_name = const(unique(f"{out}_hi"), np.float32(2 ** bits - 1))
+        t = [unique(f"{out}_t{i}") for i in range(4)]
+        return [
+            helper.make_node("Div", [raw, s_name], [t[0]], name=unique(f"{out}_Q0")),
+            helper.make_node("Round", [t[0]], [t[1]], name=unique(f"{out}_Q1")),
+            helper.make_node("Add", [t[1], z_name], [t[2]], name=unique(f"{out}_Q2")),
+            helper.make_node("Clip", [t[2], lo_name, hi_name], [t[3]],
+                             name=unique(f"{out}_Q3")),
+            helper.make_node("Sub", [t[3], z_name], [t[0] + "_d"],
+                             name=unique(f"{out}_Q4")),
+            helper.make_node("Mul", [t[0] + "_d", s_name], [out],
+                             name=unique(f"{out}_Q5")),
+        ]
+
+    new_nodes = []
+    for node in graph.node:
+        new_nodes.append(node)
+        for i, out in enumerate(node.output):
+            entry = scales.get(out)
+            if entry is None or out in inits:
+                continue
+            bits, scale, zero, per_channel, _ = entry
+            if per_channel or bits not in _ACTIVATION_BITS:
+                continue
+            raw = unique(f"{out}_pre_q")
+            node.output[i] = raw
+            new_nodes.extend(fake_quant(raw, out, bits,
+                                        float(scale.reshape(())),
+                                        float(zero.reshape(()))))
+            n_act += 1
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+
+    # the graph's own inputs are quantised too, and have no producer to hang a
+    # pair off, so give them one at the front.
+    front = []
+    for inp in graph.input:
+        entry = scales.get(inp.name)
+        if entry is None:
+            continue
+        bits, scale, zero, per_channel, _ = entry
+        if per_channel or bits not in _ACTIVATION_BITS:
+            continue
+        renamed = unique(f"{inp.name}_in")
+        for node in graph.node:
+            for i, name in enumerate(node.input):
+                if name == inp.name:
+                    node.input[i] = renamed
+        front.extend(fake_quant(inp.name, renamed, bits,
+                                float(scale.reshape(())), float(zero.reshape(()))))
+        n_act += 1
+    if front:
+        nodes = list(graph.node)
+        del graph.node[:]
+        graph.node.extend(front + nodes)
+    model.ir_version = max(model.ir_version, 7)
+    return model, n_act, n_w
+
+
+def replay(model, build_dir, feeds, fused_aware=True):
+    """Run `model` as the card will run it. Returns the graph's outputs."""
+    import onnxruntime as ort
+
+    scales = load_scales(build_dir, fused_aware=fused_aware)
+    quantised, _, _ = insert_qdq(model, scales)
+    options = ort.SessionOptions()
+    options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    sess = ort.InferenceSession(quantised.SerializeToString(), options,
+                                providers=["CPUExecutionProvider"])
+    return sess.run(None, feeds)
+
+
+def snr_db(ref, got):
+    ref = np.asarray(ref, np.float64).ravel()
+    got = np.asarray(got, np.float64).ravel()
+    n = min(ref.size, got.size)
+    err = ref[:n] - got[:n]
+    return float(10 * np.log10((ref[:n] ** 2).sum() / max((err ** 2).sum(), 1e-30)))
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("model")
+    p.add_argument("build_dir")
+    p.add_argument("--input", action="append", default=[],
+                   metavar="NAME=FILE.npy", help="repeatable")
+    p.add_argument("--ref", action="store_true",
+                   help="also run the float model and report the SNR")
+    args = p.parse_args(argv)
+
+    model = onnx.load(args.model)
+    feeds = {}
+    for spec in args.input:
+        name, _, path = spec.partition("=")
+        feeds[name] = np.load(path)
+    if not feeds:
+        for inp in model.graph.input:
+            shape = [d.dim_value or 1 for d in inp.type.tensor_type.shape.dim]
+            feeds[inp.name] = np.random.default_rng(0).standard_normal(
+                shape).astype(np.float32)
+
+    got = replay(model, args.build_dir, feeds)
+    if args.ref:
+        import onnxruntime as ort
+        ref = ort.InferenceSession(args.model,
+                                   providers=["CPUExecutionProvider"]).run(None, feeds)
+        for i, (r, g) in enumerate(zip(ref, got)):
+            print(f"output {i}: {snr_db(r, g):.2f} dB")
+    else:
+        for i, g in enumerate(got):
+            print(f"output {i}: shape {np.shape(g)} "
+                  f"rms {float(np.sqrt((np.asarray(g, np.float64) ** 2).mean())):.6g}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/axera/replay.py
+++ b/scripts/axera/replay.py
@@ -47,16 +47,32 @@ from onnx import helper, numpy_helper
 _ACTIVATION_BITS = (8, 16)
 
 
-def surviving_edges(build_dir):
-    """Tensor names that are still real edges in the compiler's own graph.
+#: Ax op prefixes/names whose output the hardware actually rounds. Everything
+#: else in `quant_axmodel.onnx` -- `AxReshape`, `AxSlice`, `AxTranspose`,
+#: `AxTile`, `AxPad` -- moves codes around without re-quantising them.
+_QUANTISING = ("AxQuantized", "AxQuantizeLinear", "AxRequantizeLinear")
 
-    `quant/quant_axmodel.onnx` is what Pulsar2 actually lowers -- its own
-    `AxQuantized*` ops, with fusion already applied. On the Audio8 decoder 385
-    of the float graph's 1002 tensors are gone from it, folded inside a fused
-    op. Those tensors still have entries in `quant_axmodel.json`, but nothing
-    on the card ever rounds them, so quantising them in a replay invents error
-    the hardware does not make: doing so read 1.12 dB where the card measured
-    7.37.
+
+def surviving_edges(build_dir, quantising_only=False):
+    """Tensor names the card actually rounds, from the compiler's own graph.
+
+    `quant/quant_axmodel.onnx` is what Pulsar2 lowers -- its `AxQuantized*`
+    ops, fusion applied. Two kinds of tensor in `quant_axmodel.json` are not
+    rounded on the card and must not be rounded in a replay:
+
+    * **fused away.** 385 of the Audio8 decoder's 1002 tensors are simply not
+      in that graph, folded inside an `AxQuantizedRMSNorm` or
+      `AxQuantizedRoPE`. Rounding them read 1.12 dB against a measured 7.37.
+    * **moved, not computed** (`quantising_only`, off by default). `AxReshape`,
+      `AxSlice`, `AxTranspose`, `AxTile` and `AxPad` carry codes without
+      recomputing them, so arguably nothing rounds their output either. This
+      is *not* the default because on the decoder it overshoots as badly as
+      the first rule undershoots: 23.40 dB against the same measured 7.37,
+      and the two rules bracket it rather than settling it. Ten `Reshape`
+      outputs alone are worth 4.6 dB (3.65 -> 8.23), so a movement op's output
+      is clearly rounded *sometimes*. Which is unresolved; the default stays
+      on the pessimistic side, where the answer is a lower bound rather than a
+      flattering guess.
 
     Returns `None` if the file is absent, meaning "no filter".
     """
@@ -64,11 +80,12 @@ def surviving_edges(build_dir):
     if not os.path.exists(path):
         return None
     graph = onnx.load(path, load_external_data=False).graph
-    return ({o for node in graph.node for o in node.output}
+    return ({o for node in graph.node for o in node.output
+             if not quantising_only or node.op_type.startswith(_QUANTISING)}
             | {i.name for i in graph.input})
 
 
-def load_scales(build_dir, fused_aware=True):
+def load_scales(build_dir, fused_aware=True, quantising_only=False):
     """`{tensor: (bit_width, scale, zero_point, per_channel, axis)}` for a build.
 
     `quant_axmodel.json` stores one config per (op, tensor) pair and hashes
@@ -82,7 +99,7 @@ def load_scales(build_dir, fused_aware=True):
     path = os.path.join(build_dir, "quant", "quant_axmodel.json")
     with open(path) as fh:
         doc = json.load(fh)
-    keep = surviving_edges(build_dir) if fused_aware else None
+    keep = surviving_edges(build_dir, quantising_only) if fused_aware else None
     values = doc["values"]
     out = {}
     for cfg in doc["tensor_configs"].values():
@@ -232,11 +249,12 @@ def insert_qdq(model, scales):
     return model, n_act, n_w
 
 
-def replay(model, build_dir, feeds, fused_aware=True):
+def replay(model, build_dir, feeds, fused_aware=True, quantising_only=False):
     """Run `model` as the card will run it. Returns the graph's outputs."""
     import onnxruntime as ort
 
-    scales = load_scales(build_dir, fused_aware=fused_aware)
+    scales = load_scales(build_dir, fused_aware=fused_aware,
+                         quantising_only=quantising_only)
     quantised, _, _ = insert_qdq(model, scales)
     options = ort.SessionOptions()
     options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL

--- a/scripts/axera/replay.py
+++ b/scripts/axera/replay.py
@@ -80,9 +80,12 @@ def surviving_edges(build_dir, quantising_only=False):
     if not os.path.exists(path):
         return None
     graph = onnx.load(path, load_external_data=False).graph
-    return ({o for node in graph.node for o in node.output
-             if not quantising_only or node.op_type.startswith(_QUANTISING)}
-            | {i.name for i in graph.input})
+    return {
+        o
+        for node in graph.node
+        for o in node.output
+        if not quantising_only or node.op_type.startswith(_QUANTISING)
+    } | {i.name for i in graph.input}
 
 
 def load_scales(build_dir, fused_aware=True, quantising_only=False):
@@ -110,8 +113,11 @@ def load_scales(build_dir, fused_aware=True, quantising_only=False):
             if not value or not value.get("scale"):
                 continue
             policy = entry["policy"]
-            if (keep is not None and tensor not in keep
-                    and not policy.get("PER_CHANNEL")):
+            if (
+                keep is not None
+                and tensor not in keep
+                and not policy.get("PER_CHANNEL")
+            ):
                 continue
             out[tensor] = (
                 entry["bit_width"],
@@ -125,6 +131,7 @@ def load_scales(build_dir, fused_aware=True, quantising_only=False):
 
 def _weight_axis(node, ndim):
     from precision import channel_axis
+
     return channel_axis(node, ndim)
 
 
@@ -169,15 +176,19 @@ def insert_qdq(model, scales):
         bits, scale, zero, per_channel, _ = entry
         w = numpy_helper.to_array(init).astype(np.float32)
         axis = _weight_axis(node, w.ndim) if per_channel else None
-        s = scale.reshape([-1] + [1] * (w.ndim - 1 - (axis or 0))) if per_channel \
+        s = (
+            scale.reshape([-1] + [1] * (w.ndim - 1 - (axis or 0)))
+            if per_channel
             else scale.reshape(())
+        )
         if per_channel and axis:
             s = scale.reshape([1] * axis + [-1] + [1] * (w.ndim - axis - 1))
         z = zero.reshape(s.shape) if per_channel else zero.reshape(())
         lo, hi = -(2 ** (bits - 1)), 2 ** (bits - 1) - 1
         q = np.clip(np.rint(w / s) + z, lo, hi)
-        init.CopyFrom(numpy_helper.from_array(((q - z) * s).astype(np.float32),
-                                              init.name))
+        init.CopyFrom(
+            numpy_helper.from_array(((q - z) * s).astype(np.float32), init.name)
+        )
         n_w += 1
 
     # then activations. Spelled as arithmetic (`Div`, `Round`, `Clip`, `Mul`)
@@ -190,18 +201,21 @@ def insert_qdq(model, scales):
         s_name = const(unique(f"{out}_s"), np.float32(scale))
         z_name = const(unique(f"{out}_z"), np.float32(zero))
         lo_name = const(unique(f"{out}_lo"), np.float32(0.0))
-        hi_name = const(unique(f"{out}_hi"), np.float32(2 ** bits - 1))
+        hi_name = const(unique(f"{out}_hi"), np.float32(2**bits - 1))
         t = [unique(f"{out}_t{i}") for i in range(4)]
         return [
             helper.make_node("Div", [raw, s_name], [t[0]], name=unique(f"{out}_Q0")),
             helper.make_node("Round", [t[0]], [t[1]], name=unique(f"{out}_Q1")),
             helper.make_node("Add", [t[1], z_name], [t[2]], name=unique(f"{out}_Q2")),
-            helper.make_node("Clip", [t[2], lo_name, hi_name], [t[3]],
-                             name=unique(f"{out}_Q3")),
-            helper.make_node("Sub", [t[3], z_name], [t[0] + "_d"],
-                             name=unique(f"{out}_Q4")),
-            helper.make_node("Mul", [t[0] + "_d", s_name], [out],
-                             name=unique(f"{out}_Q5")),
+            helper.make_node(
+                "Clip", [t[2], lo_name, hi_name], [t[3]], name=unique(f"{out}_Q3")
+            ),
+            helper.make_node(
+                "Sub", [t[3], z_name], [t[0] + "_d"], name=unique(f"{out}_Q4")
+            ),
+            helper.make_node(
+                "Mul", [t[0] + "_d", s_name], [out], name=unique(f"{out}_Q5")
+            ),
         ]
 
     new_nodes = []
@@ -216,9 +230,11 @@ def insert_qdq(model, scales):
                 continue
             raw = unique(f"{out}_pre_q")
             node.output[i] = raw
-            new_nodes.extend(fake_quant(raw, out, bits,
-                                        float(scale.reshape(())),
-                                        float(zero.reshape(()))))
+            new_nodes.extend(
+                fake_quant(
+                    raw, out, bits, float(scale.reshape(())), float(zero.reshape(()))
+                )
+            )
             n_act += 1
     del graph.node[:]
     graph.node.extend(new_nodes)
@@ -238,8 +254,15 @@ def insert_qdq(model, scales):
             for i, name in enumerate(node.input):
                 if name == inp.name:
                     node.input[i] = renamed
-        front.extend(fake_quant(inp.name, renamed, bits,
-                                float(scale.reshape(())), float(zero.reshape(()))))
+        front.extend(
+            fake_quant(
+                inp.name,
+                renamed,
+                bits,
+                float(scale.reshape(())),
+                float(zero.reshape(())),
+            )
+        )
         n_act += 1
     if front:
         nodes = list(graph.node)
@@ -253,13 +276,15 @@ def replay(model, build_dir, feeds, fused_aware=True, quantising_only=False):
     """Run `model` as the card will run it. Returns the graph's outputs."""
     import onnxruntime as ort
 
-    scales = load_scales(build_dir, fused_aware=fused_aware,
-                         quantising_only=quantising_only)
+    scales = load_scales(
+        build_dir, fused_aware=fused_aware, quantising_only=quantising_only
+    )
     quantised, _, _ = insert_qdq(model, scales)
     options = ort.SessionOptions()
     options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
-    sess = ort.InferenceSession(quantised.SerializeToString(), options,
-                                providers=["CPUExecutionProvider"])
+    sess = ort.InferenceSession(
+        quantised.SerializeToString(), options, providers=["CPUExecutionProvider"]
+    )
     return sess.run(None, feeds)
 
 
@@ -268,17 +293,23 @@ def snr_db(ref, got):
     got = np.asarray(got, np.float64).ravel()
     n = min(ref.size, got.size)
     err = ref[:n] - got[:n]
-    return float(10 * np.log10((ref[:n] ** 2).sum() / max((err ** 2).sum(), 1e-30)))
+    return float(10 * np.log10((ref[:n] ** 2).sum() / max((err**2).sum(), 1e-30)))
 
 
 def main(argv=None):
     p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     p.add_argument("model")
     p.add_argument("build_dir")
-    p.add_argument("--input", action="append", default=[],
-                   metavar="NAME=FILE.npy", help="repeatable")
-    p.add_argument("--ref", action="store_true",
-                   help="also run the float model and report the SNR")
+    p.add_argument(
+        "--input",
+        action="append",
+        default=[],
+        metavar="NAME=FILE.npy",
+        help="repeatable",
+    )
+    p.add_argument(
+        "--ref", action="store_true", help="also run the float model and report the SNR"
+    )
     args = p.parse_args(argv)
 
     model = onnx.load(args.model)
@@ -289,20 +320,25 @@ def main(argv=None):
     if not feeds:
         for inp in model.graph.input:
             shape = [d.dim_value or 1 for d in inp.type.tensor_type.shape.dim]
-            feeds[inp.name] = np.random.default_rng(0).standard_normal(
-                shape).astype(np.float32)
+            feeds[inp.name] = (
+                np.random.default_rng(0).standard_normal(shape).astype(np.float32)
+            )
 
     got = replay(model, args.build_dir, feeds)
     if args.ref:
         import onnxruntime as ort
-        ref = ort.InferenceSession(args.model,
-                                   providers=["CPUExecutionProvider"]).run(None, feeds)
+
+        ref = ort.InferenceSession(args.model, providers=["CPUExecutionProvider"]).run(
+            None, feeds
+        )
         for i, (r, g) in enumerate(zip(ref, got)):
             print(f"output {i}: {snr_db(r, g):.2f} dB")
     else:
         for i, g in enumerate(got):
-            print(f"output {i}: shape {np.shape(g)} "
-                  f"rms {float(np.sqrt((np.asarray(g, np.float64) ** 2).mean())):.6g}")
+            print(
+                f"output {i}: shape {np.shape(g)} "
+                f"rms {float(np.sqrt((np.asarray(g, np.float64) ** 2).mean())):.6g}"
+            )
     return 0
 
 

--- a/tests/test_axera_emitter.py
+++ b/tests/test_axera_emitter.py
@@ -1,0 +1,277 @@
+"""Learning an AX650N weight table's encoding as a bit map, checked offline.
+
+`scripts/axera/emitter.py` does not implement the seven weight layouts
+`README.md` reverse-engineered. It observes that all of them are bit
+permutations and reads the permutation off a handful of same-shape builds.
+The tests here build synthetic "compilers" -- a known permutation, a known
+bit-plane split, a table with scaffolding mixed in -- so the method can be
+checked without Docker, a card, or a committed multi-megabyte fixture.
+"""
+
+import os
+import sys
+
+import numpy as np
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import emitter  # noqa: E402
+
+
+def _fake_compiler(n_codes, n_table_bytes, seed=0, const_bits=None):
+    """A permutation that scatters every code bit into a fixed table position.
+
+    Returns `encode(codes) -> table`, standing in for `pulsar2 build` at one
+    shape: the placement is fixed, only the codes move.
+    """
+    rng = np.random.default_rng(seed)
+    n_code_bits = n_codes * 8
+    n_table_bits = n_table_bytes * 8
+    slots = rng.permutation(n_table_bits)[:n_code_bits]
+    scaffold = rng.integers(0, 2, n_table_bits).astype(np.uint8)
+    if const_bits is not None:
+        scaffold[:] = const_bits
+
+    def encode(codes):
+        bits = np.unpackbits(np.asarray(codes, np.uint8).ravel(), bitorder="little")
+        out = scaffold.copy()
+        out[slots] = bits
+        return np.packbits(out, bitorder="little")
+
+    return encode, slots
+
+
+def _random_weights(shape, seed):
+    return (np.random.default_rng(seed).standard_normal(shape) * 0.1).astype(np.float32)
+
+
+def test_codes_are_the_quantiser_plus_the_storage_offset():
+    """The table stores unsigned codes: the per-channel symmetric quantiser
+    with 128 added, which is what `README.md` read out of real tables."""
+    import precision
+
+    w = _random_weights((4, 3, 3), 1)
+    codes = emitter.codes_of(w)
+    assert codes.dtype == np.uint8
+    step = np.abs(w).max(axis=(1, 2), keepdims=True) / 127.5
+    assert np.array_equal(
+        codes.astype(np.int16) - 128,
+        np.clip(np.rint(w / step), -128, 127).astype(np.int16),
+    )
+    # and it agrees with the module that does the same job without the offset
+    assert np.allclose(
+        (codes.astype(np.float32) - 128) * step,
+        precision.quantise_dequantise(w, axis=0),
+    )
+
+
+def test_a_permutation_is_learned_exactly_from_enough_builds():
+    """Thirty-two samples name one code bit out of 3456 with room to spare."""
+    shape = (12, 12, 3)
+    n_codes = int(np.prod(shape))
+    encode, slots = _fake_compiler(n_codes, 700, seed=5)
+    ws = [_random_weights(shape, s) for s in range(32)]
+    codes = [emitter.codes_of(w) for w in ws]
+    tables = [encode(c) for c in codes]
+
+    origin, const, ambiguous = emitter.learn(codes, tables)
+    assert len(ambiguous) == 0
+    assert emitter.collisions(codes, origin) == 0
+    mapped = np.flatnonzero(origin != emitter.CONST)
+    # every code bit that actually varied is accounted for, at the right slot
+    for code_bit, table_bit in enumerate(slots):
+        if origin[table_bit] != emitter.CONST:
+            assert origin[table_bit] == code_bit
+    assert len(mapped) >= 0.99 * len(slots)
+
+
+def test_the_learned_map_writes_an_unseen_weight_set_byte_exactly():
+    """The point of the exercise: emit a table the compiler was never asked
+    for, and have it match what the compiler would have produced."""
+    shape = (12, 12, 3)
+    encode, _ = _fake_compiler(int(np.prod(shape)), 700, seed=6)
+    ws = [_random_weights(shape, s) for s in range(32)]
+    codes = [emitter.codes_of(w) for w in ws]
+    origin, _, _ = emitter.learn(codes, [encode(c) for c in codes])
+
+    held_out = emitter.codes_of(_random_weights(shape, 999))
+    got = emitter.emit_table(encode(codes[0]), origin, held_out)
+    assert np.array_equal(got, encode(held_out))
+
+
+def test_bit_planes_are_no_harder_than_a_permutation():
+    """The real format interleaves bits from several codes into one byte. That
+    is still a permutation, so nothing about the method changes."""
+    shape = (8, 8, 3)
+    n_codes = int(np.prod(shape))
+
+    def encode(codes):
+        bits = np.unpackbits(np.asarray(codes, np.uint8).ravel(), bitorder="little")
+        planes = bits.reshape(n_codes, 8).T.ravel()  # plane-major
+        return np.packbits(planes, bitorder="little")
+
+    ws = [_random_weights(shape, s) for s in range(32)]
+    codes = [emitter.codes_of(w) for w in ws]
+    origin, _, ambiguous = emitter.learn(codes, [encode(c) for c in codes])
+    assert len(ambiguous) == 0
+    held_out = emitter.codes_of(_random_weights(shape, 4242))
+    assert np.array_equal(
+        emitter.emit_table(encode(codes[0]), origin, held_out), encode(held_out)
+    )
+
+
+def test_too_few_builds_shows_up_as_collisions():
+    """The method's own failure mode is detectable, which is what makes it
+    safe to use: with four samples the signatures are four bits wide and
+    thousands of code bits share each one."""
+    shape = (12, 12, 3)
+    encode, _ = _fake_compiler(int(np.prod(shape)), 700, seed=7)
+    ws = [_random_weights(shape, s) for s in range(32)]
+    codes = [emitter.codes_of(w) for w in ws]
+    tables = [encode(c) for c in codes]
+    few = emitter.learn(codes[:4], tables[:4])[0]
+    assert emitter.collisions(codes[:4], few) > 100
+    many = emitter.learn(codes, tables)[0]
+    assert emitter.collisions(codes, many) == 0
+
+
+def test_scaffolding_that_is_not_a_weight_bit_is_reported_not_guessed():
+    """A table also holds things computed from the weights rather than copied
+    from them -- per-channel scales, biases. Those must come back as
+    unexplained, so an emitter knows it has to model them."""
+    shape = (8, 8, 3)
+    n_codes = int(np.prod(shape))
+    encode, _ = _fake_compiler(n_codes, 400, seed=8)
+
+    def encode_with_field(codes):
+        table = encode(codes).copy()
+        # a byte that is a function of the weights but not a copy of any bit
+        table[-1] = np.uint8(int(np.asarray(codes, np.int64).sum()) & 0xFF)
+        return table
+
+    ws = [_random_weights(shape, s) for s in range(32)]
+    codes = [emitter.codes_of(w) for w in ws]
+    origin, const, ambiguous = emitter.learn(
+        codes, [encode_with_field(c) for c in codes]
+    )
+    assert len(ambiguous) > 0
+    assert all(bit // 8 == 399 for bit in ambiguous)
+
+
+def test_constant_scaffolding_is_kept_from_the_reference():
+    shape = (8, 8, 3)
+    encode, _ = _fake_compiler(int(np.prod(shape)), 400, seed=9, const_bits=1)
+    ws = [_random_weights(shape, s) for s in range(32)]
+    codes = [emitter.codes_of(w) for w in ws]
+    tables = [encode(c) for c in codes]
+    origin, const, _ = emitter.learn(codes, tables)
+    got = emitter.emit_table(tables[0], origin, codes[5])
+    assert np.array_equal(got, tables[5])
+
+
+def test_the_map_round_trips_through_a_file(tmp_path):
+    shape = (8, 8, 3)
+    encode, _ = _fake_compiler(int(np.prod(shape)), 400, seed=10)
+    ws = [_random_weights(shape, s) for s in range(32)]
+    codes = [emitter.codes_of(w) for w in ws]
+    origin, const, ambiguous = emitter.learn(codes, [encode(c) for c in codes])
+    path = str(tmp_path / "map.npz")
+    emitter.save_map(path, origin, const, ambiguous, shape)
+    o2, c2, a2, s2 = emitter.load_map(path)
+    assert np.array_equal(o2, origin) and np.array_equal(c2, const)
+    assert np.array_equal(a2, ambiguous) and s2 == shape
+
+
+def _mcode_samples(n, scales, zeros, free_values):
+    """Streams shaped like a real one: constant, except an output scale written
+    four times, a one-byte zero point, and a few bytes that move for reasons of
+    their own."""
+    base = np.arange(64, dtype=np.uint8) * 3
+    out = []
+    for i in range(n):
+        m = base.copy()
+        m[10] = np.uint8(zeros[i])
+        for off in (20, 28, 36, 44):
+            m[off : off + 4] = np.frombuffer(np.float32(scales[i]).tobytes(), np.uint8)
+        for j, off in enumerate((5, 7)):
+            m[off] = free_values[i][j]
+        out.append(m)
+    return out
+
+
+def test_the_mcode_fields_that_follow_the_output_quantisation_are_found():
+    rng = np.random.default_rng(3)
+    n = 20
+    scales = (0.02 + rng.random(n) * 0.01).astype(np.float32)
+    zeros = rng.integers(110, 150, n)
+    free = rng.integers(0, 64, (n, 2)).astype(np.uint8)
+    fields = emitter.learn_mcode(_mcode_samples(n, scales, zeros, free), scales, zeros)
+    assert fields["scale_offsets"] == [20, 28, 36, 44]
+    assert fields["zero_offsets"] == [10]
+    assert fields["free_offsets"] == [5, 7]
+    assert fields["outliers"] == []
+
+
+def test_a_stream_that_cannot_hold_a_literal_is_reported_not_silently_wrong():
+    """Two of 48 real builds encode a field with an extra byte instead of
+    inline, shifting everything after it. No rule tried predicted which, so the
+    values that actually failed are recorded and refused."""
+    rng = np.random.default_rng(4)
+    n = 12
+    scales = (0.02 + rng.random(n) * 0.01).astype(np.float32)
+    zeros = rng.integers(110, 150, n)
+    zeros[3] = 128
+    free = np.zeros((n, 2), np.uint8)
+    samples = _mcode_samples(n, scales, zeros, free)
+    samples[3] = np.roll(samples[3], 1)  # the shifted stream
+
+    fields = emitter.learn_mcode(samples, scales, zeros)
+    assert fields["outliers"] == [3]
+    assert fields["unpatchable"]["zero"] == [128]
+    emitter.emit_mcode(samples[0], fields, scales[0], zeros[0])  # fine
+    try:
+        emitter.emit_mcode(samples[0], fields, scales[0], 128)
+    except ValueError as exc:
+        assert "128" in str(exc)
+    else:
+        raise AssertionError("writing the unpatchable zero point should refuse")
+
+
+def test_emit_mcode_changes_only_the_quantisation_fields():
+    rng = np.random.default_rng(5)
+    n = 16
+    scales = (0.02 + rng.random(n) * 0.01).astype(np.float32)
+    zeros = rng.integers(110, 150, n)
+    free = np.zeros((n, 2), np.uint8)
+    samples = _mcode_samples(n, scales, zeros, free)
+    fields = emitter.learn_mcode(samples, scales, zeros)
+    for i in range(n):
+        got = emitter.emit_mcode(samples[0], fields, scales[i], zeros[i])
+        assert np.array_equal(got, samples[i])
+
+
+def test_the_requant_block_is_the_quantised_convolutions_constant_term():
+    """`bias[c] = zy - zx * sum(q_c) * M_c` and `M_c = x_scale*w_scale/y_scale`
+    -- read off 48 real builds, where the formula reproduces all 48x32 stored
+    float32s to 6.1e-05."""
+    w = _random_weights((5, 4, 3), 2)
+    codes = emitter.codes_of(w)
+    x_scale, x_zero, y_scale, y_zero = 0.0279, 113.0, 0.0255, 131.0
+    block = emitter.requant_block(
+        codes, x_scale, x_zero, y_scale, y_zero, emitter.weight_scales(w)
+    )
+    got = block.copy().view(np.float32)
+    assert len(got) == 10
+    m = x_scale * emitter.weight_scales(w) / y_scale
+    q = codes.reshape(5, -1).astype(np.int64) - 128
+    assert np.allclose(got[5:], m, rtol=1e-6)
+    assert np.allclose(got[:5], y_zero - x_zero * q.sum(axis=1) * m, rtol=1e-5)
+
+
+def test_weight_scales_match_the_quantiser():
+    w = _random_weights((6, 4, 3), 3)
+    assert np.allclose(emitter.weight_scales(w), np.abs(w).max(axis=(1, 2)) / 127.5)

--- a/tests/test_axera_emitter.py
+++ b/tests/test_axera_emitter.py
@@ -275,3 +275,27 @@ def test_the_requant_block_is_the_quantised_convolutions_constant_term():
 def test_weight_scales_match_the_quantiser():
     w = _random_weights((6, 4, 3), 3)
     assert np.allclose(emitter.weight_scales(w), np.abs(w).max(axis=(1, 2)) / 127.5)
+
+
+def test_the_llm_quantiser_is_not_the_convolution_one():
+    """`llm_build` divides by 128, takes the scale from the *signed* peak and
+    negates it, and rounds ties toward +inf -- so a row's extreme weight lands
+    on code 0 and zero lands on 128."""
+    w = np.array([[-1.0, 0.5, 0.0, 0.25], [2.0, -1.0, 0.0, 0.5]], dtype=np.float32)
+    codes = emitter.llm_codes_of(w)
+    assert codes.dtype == np.uint8
+    # the extreme of each row is code 0, and an exact zero is 128
+    assert codes[0, 0] == 0 and codes[1, 0] == 0
+    assert codes[0, 2] == 128 and codes[1, 2] == 128
+    # and it differs from the convolution quantiser, which is symmetric
+    conv = emitter.codes_of(w.reshape(2, 4, 1))
+    assert not np.array_equal(conv.reshape(2, 4), codes)
+
+
+def test_the_llm_quantiser_puts_a_negative_peak_at_code_zero_too():
+    """The sign of the extreme is kept, not its magnitude: a row whose largest
+    weight is positive still lands that weight on 0."""
+    codes = emitter.llm_codes_of(np.array([[3.0, -1.0, 0.0]], dtype=np.float32))
+    assert codes[0, 0] == 0
+    assert codes[0, 2] == 128
+    assert codes[0, 1] > 128

--- a/tests/test_axera_precision.py
+++ b/tests/test_axera_precision.py
@@ -16,7 +16,7 @@ import sys
 import numpy as np
 import onnx
 import onnx.parser
-from onnx import TensorProto, helper, numpy_helper
+from onnx import helper, numpy_helper
 
 _AXERA_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
@@ -38,12 +38,12 @@ def _heavy_tailed(shape, seed=3):
 def _snr(ref, got):
     ref = np.asarray(ref, np.float64)
     err = ref - np.asarray(got, np.float64)
-    return 10 * np.log10((ref ** 2).sum() / max((err ** 2).sum(), 1e-30))
+    return 10 * np.log10((ref**2).sum() / max((err**2).sum(), 1e-30))
 
 
 def _model(body, initializer=(), opset=17, ir_version=10):
     model = onnx.parser.parse_model(
-        f"<ir_version: {ir_version}, opset_import: [\"\": {opset}]> {body}"
+        f'<ir_version: {ir_version}, opset_import: ["": {opset}]> {body}'
     )
     model.graph.initializer.extend(initializer)
     return model
@@ -104,7 +104,9 @@ def test_split_carries_far_more_than_one_int8_pass():
     w = _heavy_tailed((32, 32, 3))
     plain = _snr(w, precision.quantise_dequantise(w, axis=0))
     hi, lo = precision.split_weight(w, axis=0)
-    got = precision.compiler_view(hi, axis=0) + precision.quantise_dequantise(lo, axis=0)
+    got = precision.compiler_view(hi, axis=0) + precision.quantise_dequantise(
+        lo, axis=0
+    )
     assert 35 < plain < 42, plain
     assert _snr(w, got) > plain + 35
 
@@ -117,9 +119,12 @@ def test_the_residual_must_be_taken_against_the_compilers_view():
     hi = precision.quantise_dequantise(w, axis=0)
     naive_lo = w - hi
     naive = precision.compiler_view(hi, axis=0) + precision.quantise_dequantise(
-        naive_lo, axis=0)
+        naive_lo, axis=0
+    )
     _, lo = precision.split_weight(w, axis=0)
-    right = precision.compiler_view(hi, axis=0) + precision.quantise_dequantise(lo, axis=0)
+    right = precision.compiler_view(hi, axis=0) + precision.quantise_dequantise(
+        lo, axis=0
+    )
     assert _snr(w, right) > _snr(w, naive) + 25
 
 
@@ -148,8 +153,9 @@ def test_a_conv_becomes_two_convs_joined_by_an_add():
     assert add.input == list(hi.output) + list(lo.output)
     assert add.output[0] == "y"
     inits = {i.name: numpy_helper.to_array(i) for i in model.graph.initializer}
-    got = precision.compiler_view(inits[hi.input[1]], axis=0) + \
-        precision.quantise_dequantise(inits[lo.input[1]], axis=0)
+    got = precision.compiler_view(
+        inits[hi.input[1]], axis=0
+    ) + precision.quantise_dequantise(inits[lo.input[1]], axis=0)
     assert _snr(w, got) > 70
     onnx.checker.check_model(model)
 
@@ -166,8 +172,12 @@ def test_the_split_graph_runs_and_stays_within_half_an_int8_step():
     after = _conv_model(w)
     assert precision.weight_residual_split(after) == 1
     x = np.random.default_rng(11).standard_normal((1, 4, 8)).astype(np.float32)
-    run = lambda m: ort.InferenceSession(
-        m.SerializeToString(), providers=["CPUExecutionProvider"]).run(None, {"x": x})[0]
+
+    def run(m):
+        return ort.InferenceSession(
+            m.SerializeToString(), providers=["CPUExecutionProvider"]
+        ).run(None, {"x": x})[0]
+
     assert run(after).shape == run(before).shape
     # the miss is exactly the compiler's re-rounding of the high half, which is
     # bounded by half an INT8 step -- the same size as the error a plain INT8
@@ -234,6 +244,7 @@ def test_a_matmul_splits_on_its_last_axis():
     assert [n.op_type for n in model.graph.node] == ["MatMul", "MatMul", "Add"]
     inits = {i.name: numpy_helper.to_array(i) for i in model.graph.initializer}
     hi, lo, _ = model.graph.node
-    got = precision.compiler_view(inits[hi.input[1]], axis=1) + \
-        precision.quantise_dequantise(inits[lo.input[1]], axis=1)
+    got = precision.compiler_view(
+        inits[hi.input[1]], axis=1
+    ) + precision.quantise_dequantise(inits[lo.input[1]], axis=1)
     assert _snr(w, got) > 70

--- a/tests/test_axera_precision.py
+++ b/tests/test_axera_precision.py
@@ -1,0 +1,239 @@
+"""Weight-residual splitting for the AX650N, checked offline.
+
+`scripts/axera/precision.py` splits a weight into an INT8 part and an INT8
+residual so that two INT8 convolutions carry about sixteen bits of weight
+between them. The tests here pin the two facts a hardware probe had to teach
+this module the hard way -- the scale is per output *channel*, and the
+residual has to be taken against what the compiler will re-quantise the high
+half to, not against the high half as written.
+
+Neither needs Docker or a card.
+"""
+
+import os
+import sys
+
+import numpy as np
+import onnx
+import onnx.parser
+from onnx import TensorProto, helper, numpy_helper
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import precision  # noqa: E402
+
+
+def _heavy_tailed(shape, seed=3):
+    """A weight with the outlier tail a real conv weight has (peak/rms ~ 11)."""
+    rng = np.random.default_rng(seed)
+    w = rng.standard_normal(shape).astype(np.float32)
+    w *= rng.standard_gamma(0.35, shape).astype(np.float32)
+    return w
+
+
+def _snr(ref, got):
+    ref = np.asarray(ref, np.float64)
+    err = ref - np.asarray(got, np.float64)
+    return 10 * np.log10((ref ** 2).sum() / max((err ** 2).sum(), 1e-30))
+
+
+def _model(body, initializer=(), opset=17, ir_version=10):
+    model = onnx.parser.parse_model(
+        f"<ir_version: {ir_version}, opset_import: [\"\": {opset}]> {body}"
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _conv_model(w, b=None):
+    inits = [numpy_helper.from_array(w, "w")]
+    sig = "float[1, %d, 8] x" % w.shape[1]
+    if b is None:
+        body = f"""
+            g ({sig}) => (float[1, {w.shape[0]}, 8] y) {{
+                y = Conv <kernel_shape = [3], pads = [1, 1]> (x, w)
+            }}
+        """
+    else:
+        inits.append(numpy_helper.from_array(b, "b"))
+        body = f"""
+            g ({sig}) => (float[1, {w.shape[0]}, 8] y) {{
+                y = Conv <kernel_shape = [3], pads = [1, 1]> (x, w, b)
+            }}
+        """
+    return _model(body, inits)
+
+
+def test_the_weight_quantiser_is_per_channel_at_peak_over_127_5():
+    """The scale Pulsar2 writes into `quant_axmodel.json` for a conv weight is
+    `max|w_c| / 127.5`, one per output channel, zero point 0."""
+    w = _heavy_tailed((8, 4, 3))
+    got = precision.quantise_dequantise(w, axis=0)
+    step = np.abs(w).max(axis=(1, 2)) / 127.5
+    for c in range(w.shape[0]):
+        codes = got[c] / step[c]
+        assert np.allclose(codes, np.rint(codes), atol=1e-3)
+        assert codes.min() >= -128 and codes.max() <= 127
+    # per channel, not per tensor: a channel far below the global peak keeps
+    # its own resolution
+    quiet = w.copy()
+    quiet[0] *= 1e-3
+    per_channel = precision.quantise_dequantise(quiet, axis=0)
+    per_tensor = precision.quantise_dequantise(quiet, axis=None)
+    assert _snr(quiet[0], per_channel[0]) > _snr(quiet[0], per_tensor[0]) + 40
+
+
+def test_the_quantiser_is_not_idempotent():
+    """A quantised channel peaks at 127 steps where the scale assumed 127.5, so
+    re-quantising moves values by up to half a step. This is the whole reason
+    `compiler_view` exists."""
+    w = _heavy_tailed((16, 8, 3))
+    once = precision.quantise_dequantise(w, axis=0)
+    twice = precision.compiler_view(once, axis=0)
+    assert not np.array_equal(once, twice)
+    step = np.abs(w).max(axis=(1, 2), keepdims=True) / 127.5
+    assert np.abs(twice - once).max() <= 0.51 * step.max()
+
+
+def test_split_carries_far_more_than_one_int8_pass():
+    """Two INT8 weights reconstruct the float weight to about sixteen bits."""
+    w = _heavy_tailed((32, 32, 3))
+    plain = _snr(w, precision.quantise_dequantise(w, axis=0))
+    hi, lo = precision.split_weight(w, axis=0)
+    got = precision.compiler_view(hi, axis=0) + precision.quantise_dequantise(lo, axis=0)
+    assert 35 < plain < 42, plain
+    assert _snr(w, got) > plain + 35
+
+
+def test_the_residual_must_be_taken_against_the_compilers_view():
+    """`W - quantise(W)` is the intuitive residual and it throws away most of
+    the gain -- the compiler re-rounds the high half, and that half-step is
+    left uncorrected. A hardware probe built this way measured no gain at all."""
+    w = _heavy_tailed((32, 32, 3))
+    hi = precision.quantise_dequantise(w, axis=0)
+    naive_lo = w - hi
+    naive = precision.compiler_view(hi, axis=0) + precision.quantise_dequantise(
+        naive_lo, axis=0)
+    _, lo = precision.split_weight(w, axis=0)
+    right = precision.compiler_view(hi, axis=0) + precision.quantise_dequantise(lo, axis=0)
+    assert _snr(w, right) > _snr(w, naive) + 25
+
+
+def test_channel_axis_follows_each_ops_weight_layout():
+    """`Conv` is (Cout, Cin, k) but `ConvTranspose` is (Cin, Cout, k), and
+    `Gemm`'s output axis moves with `transB`."""
+    conv = helper.make_node("Conv", ["x", "w"], ["y"])
+    deconv = helper.make_node("ConvTranspose", ["x", "w"], ["y"])
+    matmul = helper.make_node("MatMul", ["x", "w"], ["y"])
+    gemm_t = helper.make_node("Gemm", ["x", "w"], ["y"], transB=1)
+    gemm_n = helper.make_node("Gemm", ["x", "w"], ["y"])
+    assert precision.channel_axis(conv, 3) == 0
+    assert precision.channel_axis(deconv, 3) == 1
+    assert precision.channel_axis(matmul, 2) == 1
+    assert precision.channel_axis(gemm_t, 2) == 0
+    assert precision.channel_axis(gemm_n, 2) == 1
+
+
+def test_a_conv_becomes_two_convs_joined_by_an_add():
+    w = _heavy_tailed((6, 4, 3))
+    model = _conv_model(w)
+    assert precision.weight_residual_split(model) == 1
+    kinds = [n.op_type for n in model.graph.node]
+    assert kinds == ["Conv", "Conv", "Add"]
+    hi, lo, add = model.graph.node
+    assert add.input == list(hi.output) + list(lo.output)
+    assert add.output[0] == "y"
+    inits = {i.name: numpy_helper.to_array(i) for i in model.graph.initializer}
+    got = precision.compiler_view(inits[hi.input[1]], axis=0) + \
+        precision.quantise_dequantise(inits[lo.input[1]], axis=0)
+    assert _snr(w, got) > 70
+    onnx.checker.check_model(model)
+
+
+def test_the_split_graph_runs_and_stays_within_half_an_int8_step():
+    """Run in float the split is *not* exact -- the residual is deliberately
+    taken against the compiler's re-rounding of the high half, so the two
+    halves sum to `W` plus that half-step. What matters is that the miss is
+    smaller than the INT8 pass it replaces, and that onnxruntime accepts the
+    graph."""
+    ort = __import__("onnxruntime")
+    w = _heavy_tailed((6, 4, 3))
+    before = _conv_model(w)
+    after = _conv_model(w)
+    assert precision.weight_residual_split(after) == 1
+    x = np.random.default_rng(11).standard_normal((1, 4, 8)).astype(np.float32)
+    run = lambda m: ort.InferenceSession(
+        m.SerializeToString(), providers=["CPUExecutionProvider"]).run(None, {"x": x})[0]
+    assert run(after).shape == run(before).shape
+    # the miss is exactly the compiler's re-rounding of the high half, which is
+    # bounded by half an INT8 step -- the same size as the error a plain INT8
+    # build makes, and it disappears once the pair is quantised
+    inits = {i.name: numpy_helper.to_array(i) for i in after.graph.initializer}
+    hi, lo, _ = after.graph.node
+    step = np.abs(w).max(axis=(1, 2), keepdims=True) / 127.5
+    delta = inits[hi.input[1]] + inits[lo.input[1]] - w
+    assert np.abs(delta).max() <= 0.51 * step.max()
+    assert _snr(run(before), run(after)) > 40
+
+
+def test_the_bias_rides_on_the_high_half_only():
+    """Copying the bias to both halves would double it."""
+    w = _heavy_tailed((6, 4, 3))
+    b = np.arange(6, dtype=np.float32) + 1.0
+    model = _conv_model(w, b)
+    assert precision.weight_residual_split(model) == 1
+    hi, lo, _ = model.graph.node
+    assert len(hi.input) == 3 and hi.input[2] == "b"
+    assert len(lo.input) == 2
+
+
+def test_min_peak_to_rms_leaves_well_behaved_weights_alone():
+    """A weight with no outlier tail has little to gain, and the filter is the
+    calibration-free way to say so."""
+    rng = np.random.default_rng(5)
+    tame = rng.standard_normal((8, 8, 3)).astype(np.float32)
+    assert precision.peak_to_rms(tame, 0) < 5.0
+    model = _conv_model(tame)
+    assert precision.weight_residual_split(model, min_peak_to_rms=6.0) == 0
+    assert [n.op_type for n in model.graph.node] == ["Conv"]
+
+
+def test_weight_error_db_predicts_the_measured_loss():
+    """The closed form is what picks layers without running calibration; it has
+    to track the real number, not just rank layers."""
+    for shape, seed in (((32, 32, 3), 3), ((16, 64, 1), 7), ((64, 8, 3), 11)):
+        w = _heavy_tailed(shape, seed)
+        got = precision.quantise_dequantise(w, axis=0)
+        # the weight's own SNR is the output SNR the quantiser costs, because
+        # both ride the same activations
+        assert abs(precision.weight_error_db(w, axis=0) - _snr(w, got)) < 2.0
+
+
+def test_split_op_types_names_the_add_that_must_stay_wide():
+    """The join is the op that undoes the split if it requantises to INT8, so
+    it belongs in the `layer_configs` entry the caller writes."""
+    model = _conv_model(_heavy_tailed((6, 4, 3)))
+    assert precision.split_op_types(model) == ["Add", "Conv"]
+
+
+def test_a_matmul_splits_on_its_last_axis():
+    w = _heavy_tailed((4, 6))
+    model = _model(
+        """
+            g (float[2, 4] x) => (float[2, 6] y) {
+                y = MatMul (x, w)
+            }
+        """,
+        [numpy_helper.from_array(w, "w")],
+    )
+    assert precision.weight_residual_split(model) == 1
+    assert [n.op_type for n in model.graph.node] == ["MatMul", "MatMul", "Add"]
+    inits = {i.name: numpy_helper.to_array(i) for i in model.graph.initializer}
+    hi, lo, _ = model.graph.node
+    got = precision.compiler_view(inits[hi.input[1]], axis=1) + \
+        precision.quantise_dequantise(inits[lo.input[1]], axis=1)
+    assert _snr(w, got) > 70

--- a/tests/test_axera_replay.py
+++ b/tests/test_axera_replay.py
@@ -1,0 +1,187 @@
+"""Replaying a Pulsar2 build's quantisation offline, checked without a build.
+
+`scripts/axera/replay.py` reads `quant/quant_axmodel.json` -- the table
+`pulsar2 build` writes -- and re-runs the float graph with exactly those
+scales, which reproduced four real AX650N measurements to within 0.19 dB.
+The tests here build the two files a real output directory would contain, so
+they need neither Docker, a card, nor a committed multi-megabyte fixture.
+"""
+
+import json
+import os
+import sys
+
+import numpy as np
+import onnx
+import onnx.parser
+from onnx import helper, numpy_helper
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import replay  # noqa: E402
+
+
+def _policy(per_channel=False):
+    return {
+        "PER_TENSOR": not per_channel, "PER_CHANNEL": per_channel,
+        "LINEAR": True, "EXPONENTIAL": False,
+        "SYMMETRICAL": per_channel, "ASYMMETRICAL": not per_channel,
+        "POWER_OF_2": False, "PER_CHANNEL_RE_GROUP": False, "PER_BLOCK": False,
+    }
+
+
+def _write_build(tmp_path, entries, fused_graph=None):
+    """A minimal `out_*/quant/` directory in the shape Pulsar2 writes one.
+
+    `entries` is `{op: {tensor: (bit_width, scale, zero_point, per_channel)}}`.
+    """
+    quant = tmp_path / "quant"
+    quant.mkdir(parents=True, exist_ok=True)
+    values, configs = {}, {}
+    for op, tensors in entries.items():
+        configs[op] = {}
+        for tensor, (bits, scale, zero, per_channel) in tensors.items():
+            h = str(abs(hash((op, tensor))) % (10 ** 10))
+            values[h] = {"scale": list(np.atleast_1d(scale).astype(float)),
+                         "zero_point": list(np.atleast_1d(zero).astype(float))}
+            configs[op][tensor] = {
+                "bit_width": bits, "policy": _policy(per_channel),
+                "state": "ACTIVATED", "hash": int(h),
+                "quant_min": -(2 ** (bits - 1)) if per_channel else 0,
+                "quant_max": 2 ** (bits - 1) - 1 if per_channel else 2 ** bits - 1,
+            }
+    (quant / "quant_axmodel.json").write_text(json.dumps(
+        {"quant_config": {}, "tensor_configs": configs,
+         "dispatchings": {op: "AX_NPU_AX650_INT8" for op in entries},
+         "values": values}))
+    if fused_graph is not None:
+        onnx.save(fused_graph, str(quant / "quant_axmodel.onnx"))
+    return str(tmp_path)
+
+
+def _conv_model(w):
+    model = onnx.parser.parse_model(
+        '<ir_version: 10, opset_import: ["": 17]>'
+        f' g (float[1, {w.shape[1]}, 8] x) => (float[1, {w.shape[0]}, 8] y) {{'
+        "   y = Conv <kernel_shape = [3], pads = [1, 1]> (x, w)"
+        " }"
+    )
+    model.graph.initializer.append(numpy_helper.from_array(w, "w"))
+    return model
+
+
+def _affine(x, bits, scale, zero):
+    n = 2 ** bits - 1
+    codes = np.clip(np.rint(x / scale) + zero, 0, n)
+    return ((codes - zero) * scale).astype(np.float32)
+
+
+def test_scales_load_from_the_table_the_compiler_writes(tmp_path):
+    build = _write_build(tmp_path, {
+        "conv": {"x": (8, 0.031, 130.0, False),
+                 "w": (8, [0.004, 0.002], 0.0, True),
+                 "y": (16, 9.3e-05, 0.0, False)}})
+    scales = replay.load_scales(build)
+    assert set(scales) == {"x", "w", "y"}
+    assert scales["x"][0] == 8 and scales["y"][0] == 16
+    assert scales["w"][3] is True and scales["x"][3] is False
+    assert list(scales["w"][1]) == [0.004, 0.002]
+
+
+def test_fused_away_tensors_are_dropped(tmp_path):
+    """A tensor the compiler folded inside one of its own ops still has a table
+    entry, but nothing on the card rounds it. Quantising it anyway invented
+    6 dB of error on the Audio8 decoder."""
+    fused = onnx.parser.parse_model(
+        '<ir_version: 10, opset_import: ["": 17]>'
+        " g (float[1, 4, 8] x) => (float[1, 4, 8] y) {"
+        "   y = Relu (x)"
+        " }"
+    )
+    build = _write_build(tmp_path, {
+        "op": {"x": (8, 0.03, 128.0, False),
+               "gone": (8, 0.02, 128.0, False),
+               "y": (8, 0.01, 128.0, False)}}, fused_graph=fused)
+    assert set(replay.load_scales(build)) == {"x", "y"}
+    assert set(replay.load_scales(build, fused_aware=False)) == {"x", "gone", "y"}
+    assert replay.surviving_edges(build) == {"x", "y"}
+
+
+def test_no_fused_graph_means_no_filter(tmp_path):
+    build = _write_build(tmp_path, {"op": {"x": (8, 0.03, 128.0, False)}})
+    assert replay.surviving_edges(build) is None
+    assert set(replay.load_scales(build)) == {"x"}
+
+
+def test_the_replay_reproduces_the_affine_quantisation_exactly(tmp_path):
+    """The inserted arithmetic has to be the quantiser, not something like it:
+    a replay is only worth having if it is exact."""
+    rng = np.random.default_rng(4)
+    w = rng.standard_normal((6, 4, 3)).astype(np.float32) * 0.3
+    model = _conv_model(w)
+    x_scale, x_zp = 0.03115052543580532, 130.0
+    y_scale, y_zp = 9.281877282774076e-05, 32768.0
+    w_scale = np.abs(w).max(axis=(1, 2)) / 127.5
+    build = _write_build(tmp_path, {
+        "y": {"x": (8, x_scale, x_zp, False),
+              "w": (8, w_scale, np.zeros(6), True),
+              "y": (16, y_scale, y_zp, False)}})
+
+    x = rng.standard_normal((1, 4, 8)).astype(np.float32) * 0.5
+    got = replay.replay(model, build, {"x": x})[0]
+
+    xq = _affine(x, 8, x_scale, x_zp)
+    s = w_scale.reshape(-1, 1, 1)
+    wq = (np.clip(np.rint(w / s), -128, 127) * s).astype(np.float32)
+    pad = np.pad(xq, ((0, 0), (0, 0), (1, 1)))
+    acc = sum(np.einsum("oi,bil->bol", wq[:, :, k], pad[:, :, k:k + 8])
+              for k in range(3))
+    want = _affine(acc, 16, y_scale, y_zp)
+    assert np.allclose(got, want, atol=1e-6), np.abs(got - want).max()
+
+
+def test_widening_the_activations_stalls_on_the_int8_weights(tmp_path):
+    """The replay reproduces the plateau the card shows: widen the activations
+    to 16 bits and the result improves, then stops, because the weights are
+    still INT8 -- which is what `precision.weight_residual_split` is for."""
+    rng = np.random.default_rng(9)
+    w = rng.standard_normal((6, 4, 3)).astype(np.float32) * 0.3
+    model = _conv_model(w)
+    x = rng.standard_normal((1, 4, 8)).astype(np.float32) * 0.5
+    ort = __import__("onnxruntime")
+    ref = ort.InferenceSession(model.SerializeToString(),
+                               providers=["CPUExecutionProvider"]).run(None, {"x": x})[0]
+    w_scale = np.abs(w).max(axis=(1, 2)) / 127.5
+    snrs = {}
+    for bits in (8, 16):
+        n = 2 ** bits - 1
+        build = _write_build(tmp_path / f"b{bits}", {
+            "y": {"x": (bits, 2 * float(np.abs(x).max()) / n, n // 2, False),
+                  "w": (8, w_scale, np.zeros(6), True),
+                  "y": (bits, 2 * float(np.abs(ref).max()) / n, n // 2, False)}})
+        got = replay.replay(_conv_model(w), build, {"x": x})[0]
+        snrs[bits] = replay.snr_db(ref, got)
+    import precision
+
+    assert 20 < snrs[8] < 60
+    assert snrs[16] > snrs[8] + 3
+    # and it stops at the weights: the closed form for INT8 per-channel weight
+    # error is what the 16-bit activation run is left sitting on
+    assert abs(snrs[16] - precision.weight_error_db(w, axis=0)) < 6
+
+
+def test_a_tensor_with_no_entry_is_left_in_float(tmp_path):
+    """Pulsar2 leaves shape operands and some ops in float; the replay must not
+    invent a scale for them."""
+    rng = np.random.default_rng(1)
+    w = rng.standard_normal((6, 4, 3)).astype(np.float32) * 0.3
+    build = _write_build(tmp_path, {"y": {"w": (8, np.abs(w).max(axis=(1, 2)) / 127.5,
+                                                np.zeros(6), True)}})
+    model = _conv_model(w)
+    quantised, n_act, n_w = replay.insert_qdq(model, replay.load_scales(build))
+    assert (n_act, n_w) == (0, 1)
+    assert [n.op_type for n in quantised.graph.node] == ["Conv"]

--- a/tests/test_axera_replay.py
+++ b/tests/test_axera_replay.py
@@ -111,6 +111,28 @@ def test_fused_away_tensors_are_dropped(tmp_path):
     assert replay.surviving_edges(build) == {"x", "y"}
 
 
+def test_quantising_only_drops_the_movement_ops(tmp_path):
+    """`AxReshape` and friends carry codes without recomputing them. Whether
+    the card rounds their output is unresolved -- the two rules bracket the one
+    measurement rather than settling it -- so the strict rule is opt-in and the
+    default stays on the pessimistic side."""
+    fused = onnx.parser.parse_model(
+        '<ir_version: 10, opset_import: ["": 17]>'
+        " g (float[1, 4, 8] x) => (float[1, 8, 4] moved) {"
+        "   y = Relu (x)"
+        "   moved = Transpose <perm = [0, 2, 1]> (y)"
+        " }"
+    )
+    for node in fused.graph.node:
+        node.op_type = "AxQuantizedRelu" if node.op_type == "Relu" else "AxTranspose"
+    build = _write_build(tmp_path, {
+        "op": {"x": (8, 0.03, 128.0, False),
+               "y": (8, 0.02, 128.0, False),
+               "moved": (8, 0.01, 128.0, False)}}, fused_graph=fused)
+    assert replay.surviving_edges(build) == {"x", "y", "moved"}
+    assert replay.surviving_edges(build, quantising_only=True) == {"x", "y"}
+
+
 def test_no_fused_graph_means_no_filter(tmp_path):
     build = _write_build(tmp_path, {"op": {"x": (8, 0.03, 128.0, False)}})
     assert replay.surviving_edges(build) is None

--- a/tests/test_axera_replay.py
+++ b/tests/test_axera_replay.py
@@ -14,7 +14,7 @@ import sys
 import numpy as np
 import onnx
 import onnx.parser
-from onnx import helper, numpy_helper
+from onnx import numpy_helper
 
 _AXERA_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
@@ -27,10 +27,15 @@ import replay  # noqa: E402
 
 def _policy(per_channel=False):
     return {
-        "PER_TENSOR": not per_channel, "PER_CHANNEL": per_channel,
-        "LINEAR": True, "EXPONENTIAL": False,
-        "SYMMETRICAL": per_channel, "ASYMMETRICAL": not per_channel,
-        "POWER_OF_2": False, "PER_CHANNEL_RE_GROUP": False, "PER_BLOCK": False,
+        "PER_TENSOR": not per_channel,
+        "PER_CHANNEL": per_channel,
+        "LINEAR": True,
+        "EXPONENTIAL": False,
+        "SYMMETRICAL": per_channel,
+        "ASYMMETRICAL": not per_channel,
+        "POWER_OF_2": False,
+        "PER_CHANNEL_RE_GROUP": False,
+        "PER_BLOCK": False,
     }
 
 
@@ -45,19 +50,29 @@ def _write_build(tmp_path, entries, fused_graph=None):
     for op, tensors in entries.items():
         configs[op] = {}
         for tensor, (bits, scale, zero, per_channel) in tensors.items():
-            h = str(abs(hash((op, tensor))) % (10 ** 10))
-            values[h] = {"scale": list(np.atleast_1d(scale).astype(float)),
-                         "zero_point": list(np.atleast_1d(zero).astype(float))}
-            configs[op][tensor] = {
-                "bit_width": bits, "policy": _policy(per_channel),
-                "state": "ACTIVATED", "hash": int(h),
-                "quant_min": -(2 ** (bits - 1)) if per_channel else 0,
-                "quant_max": 2 ** (bits - 1) - 1 if per_channel else 2 ** bits - 1,
+            h = str(abs(hash((op, tensor))) % (10**10))
+            values[h] = {
+                "scale": list(np.atleast_1d(scale).astype(float)),
+                "zero_point": list(np.atleast_1d(zero).astype(float)),
             }
-    (quant / "quant_axmodel.json").write_text(json.dumps(
-        {"quant_config": {}, "tensor_configs": configs,
-         "dispatchings": {op: "AX_NPU_AX650_INT8" for op in entries},
-         "values": values}))
+            configs[op][tensor] = {
+                "bit_width": bits,
+                "policy": _policy(per_channel),
+                "state": "ACTIVATED",
+                "hash": int(h),
+                "quant_min": -(2 ** (bits - 1)) if per_channel else 0,
+                "quant_max": 2 ** (bits - 1) - 1 if per_channel else 2**bits - 1,
+            }
+    (quant / "quant_axmodel.json").write_text(
+        json.dumps(
+            {
+                "quant_config": {},
+                "tensor_configs": configs,
+                "dispatchings": {op: "AX_NPU_AX650_INT8" for op in entries},
+                "values": values,
+            }
+        )
+    )
     if fused_graph is not None:
         onnx.save(fused_graph, str(quant / "quant_axmodel.onnx"))
     return str(tmp_path)
@@ -66,7 +81,7 @@ def _write_build(tmp_path, entries, fused_graph=None):
 def _conv_model(w):
     model = onnx.parser.parse_model(
         '<ir_version: 10, opset_import: ["": 17]>'
-        f' g (float[1, {w.shape[1]}, 8] x) => (float[1, {w.shape[0]}, 8] y) {{'
+        f" g (float[1, {w.shape[1]}, 8] x) => (float[1, {w.shape[0]}, 8] y) {{"
         "   y = Conv <kernel_shape = [3], pads = [1, 1]> (x, w)"
         " }"
     )
@@ -75,16 +90,22 @@ def _conv_model(w):
 
 
 def _affine(x, bits, scale, zero):
-    n = 2 ** bits - 1
+    n = 2**bits - 1
     codes = np.clip(np.rint(x / scale) + zero, 0, n)
     return ((codes - zero) * scale).astype(np.float32)
 
 
 def test_scales_load_from_the_table_the_compiler_writes(tmp_path):
-    build = _write_build(tmp_path, {
-        "conv": {"x": (8, 0.031, 130.0, False),
-                 "w": (8, [0.004, 0.002], 0.0, True),
-                 "y": (16, 9.3e-05, 0.0, False)}})
+    build = _write_build(
+        tmp_path,
+        {
+            "conv": {
+                "x": (8, 0.031, 130.0, False),
+                "w": (8, [0.004, 0.002], 0.0, True),
+                "y": (16, 9.3e-05, 0.0, False),
+            }
+        },
+    )
     scales = replay.load_scales(build)
     assert set(scales) == {"x", "w", "y"}
     assert scales["x"][0] == 8 and scales["y"][0] == 16
@@ -102,10 +123,17 @@ def test_fused_away_tensors_are_dropped(tmp_path):
         "   y = Relu (x)"
         " }"
     )
-    build = _write_build(tmp_path, {
-        "op": {"x": (8, 0.03, 128.0, False),
-               "gone": (8, 0.02, 128.0, False),
-               "y": (8, 0.01, 128.0, False)}}, fused_graph=fused)
+    build = _write_build(
+        tmp_path,
+        {
+            "op": {
+                "x": (8, 0.03, 128.0, False),
+                "gone": (8, 0.02, 128.0, False),
+                "y": (8, 0.01, 128.0, False),
+            }
+        },
+        fused_graph=fused,
+    )
     assert set(replay.load_scales(build)) == {"x", "y"}
     assert set(replay.load_scales(build, fused_aware=False)) == {"x", "gone", "y"}
     assert replay.surviving_edges(build) == {"x", "y"}
@@ -125,10 +153,17 @@ def test_quantising_only_drops_the_movement_ops(tmp_path):
     )
     for node in fused.graph.node:
         node.op_type = "AxQuantizedRelu" if node.op_type == "Relu" else "AxTranspose"
-    build = _write_build(tmp_path, {
-        "op": {"x": (8, 0.03, 128.0, False),
-               "y": (8, 0.02, 128.0, False),
-               "moved": (8, 0.01, 128.0, False)}}, fused_graph=fused)
+    build = _write_build(
+        tmp_path,
+        {
+            "op": {
+                "x": (8, 0.03, 128.0, False),
+                "y": (8, 0.02, 128.0, False),
+                "moved": (8, 0.01, 128.0, False),
+            }
+        },
+        fused_graph=fused,
+    )
     assert replay.surviving_edges(build) == {"x", "y", "moved"}
     assert replay.surviving_edges(build, quantising_only=True) == {"x", "y"}
 
@@ -148,10 +183,16 @@ def test_the_replay_reproduces_the_affine_quantisation_exactly(tmp_path):
     x_scale, x_zp = 0.03115052543580532, 130.0
     y_scale, y_zp = 9.281877282774076e-05, 32768.0
     w_scale = np.abs(w).max(axis=(1, 2)) / 127.5
-    build = _write_build(tmp_path, {
-        "y": {"x": (8, x_scale, x_zp, False),
-              "w": (8, w_scale, np.zeros(6), True),
-              "y": (16, y_scale, y_zp, False)}})
+    build = _write_build(
+        tmp_path,
+        {
+            "y": {
+                "x": (8, x_scale, x_zp, False),
+                "w": (8, w_scale, np.zeros(6), True),
+                "y": (16, y_scale, y_zp, False),
+            }
+        },
+    )
 
     x = rng.standard_normal((1, 4, 8)).astype(np.float32) * 0.5
     got = replay.replay(model, build, {"x": x})[0]
@@ -160,8 +201,9 @@ def test_the_replay_reproduces_the_affine_quantisation_exactly(tmp_path):
     s = w_scale.reshape(-1, 1, 1)
     wq = (np.clip(np.rint(w / s), -128, 127) * s).astype(np.float32)
     pad = np.pad(xq, ((0, 0), (0, 0), (1, 1)))
-    acc = sum(np.einsum("oi,bil->bol", wq[:, :, k], pad[:, :, k:k + 8])
-              for k in range(3))
+    acc = sum(
+        np.einsum("oi,bil->bol", wq[:, :, k], pad[:, :, k : k + 8]) for k in range(3)
+    )
     want = _affine(acc, 16, y_scale, y_zp)
     assert np.allclose(got, want, atol=1e-6), np.abs(got - want).max()
 
@@ -175,16 +217,23 @@ def test_widening_the_activations_stalls_on_the_int8_weights(tmp_path):
     model = _conv_model(w)
     x = rng.standard_normal((1, 4, 8)).astype(np.float32) * 0.5
     ort = __import__("onnxruntime")
-    ref = ort.InferenceSession(model.SerializeToString(),
-                               providers=["CPUExecutionProvider"]).run(None, {"x": x})[0]
+    ref = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    ).run(None, {"x": x})[0]
     w_scale = np.abs(w).max(axis=(1, 2)) / 127.5
     snrs = {}
     for bits in (8, 16):
-        n = 2 ** bits - 1
-        build = _write_build(tmp_path / f"b{bits}", {
-            "y": {"x": (bits, 2 * float(np.abs(x).max()) / n, n // 2, False),
-                  "w": (8, w_scale, np.zeros(6), True),
-                  "y": (bits, 2 * float(np.abs(ref).max()) / n, n // 2, False)}})
+        n = 2**bits - 1
+        build = _write_build(
+            tmp_path / f"b{bits}",
+            {
+                "y": {
+                    "x": (bits, 2 * float(np.abs(x).max()) / n, n // 2, False),
+                    "w": (8, w_scale, np.zeros(6), True),
+                    "y": (bits, 2 * float(np.abs(ref).max()) / n, n // 2, False),
+                }
+            },
+        )
         got = replay.replay(_conv_model(w), build, {"x": x})[0]
         snrs[bits] = replay.snr_db(ref, got)
     import precision
@@ -201,8 +250,10 @@ def test_a_tensor_with_no_entry_is_left_in_float(tmp_path):
     invent a scale for them."""
     rng = np.random.default_rng(1)
     w = rng.standard_normal((6, 4, 3)).astype(np.float32) * 0.3
-    build = _write_build(tmp_path, {"y": {"w": (8, np.abs(w).max(axis=(1, 2)) / 127.5,
-                                                np.zeros(6), True)}})
+    build = _write_build(
+        tmp_path,
+        {"y": {"w": (8, np.abs(w).max(axis=(1, 2)) / 127.5, np.zeros(6), True)}},
+    )
     model = _conv_model(w)
     quantised, n_act, n_w = replay.insert_qdq(model, replay.load_scales(build))
     assert (n_act, n_w) == (0, 1)


### PR DESCRIPTION
Stacks on #1312 (whose single commit is the first here; once that merges this
PR's diff collapses to the rest).

Started from the handoff note in #1313, which concluded Pulsar2 could not host
an Ozaki-style split matmul because every documented way to pin a per-matmul
scale is broken. It turns out none of that is needed, and following the thread
ended somewhere larger: a working replacement for the compiler's weight
handling.

## Replacing the ONNX compiler at a fixed shape

`scripts/axera/emitter.py`. This repo derives seven weight-table layouts by
hand; all seven are bit permutations, so the layout can be *read off* instead.
Compile one shape k times with different weights, and each table bit's column
of k observed values names the code bit it copies. The method's failure mode is
countable — at 8 builds 24,129 code bits share a signature, at 48 none do, and
the mapped count lands on exactly `32*32*3*8`.

The 1,719 bits left over are one contiguous run, `32 channels × 8 bytes`, and a
quantised convolution says what they are:

```
bias[c] = zy - zx * sum(q_c) * M_c        M_c = x_scale * w_scale_c / y_scale
```

reproducing all 48×32 stored float32s to 6.1e-05.

**On the AX650N**, eight held-out weight sets emitted from one reference build:
weight tables byte-identical to Pulsar2's, device output bit-identical
(`np.array_equal`, not correlation) to Pulsar2's own build, every time. Two of
48 builds refuse an in-place mcode patch; `learn_mcode` finds them by
re-emitting every training build rather than guessing a rule, and refuses them.

The same method on an `llm_build` layer reaches zero collisions at 54 samples
and emits 99.3% of a layer's table byte-exactly; the localised remainder is
recorded as undecoded rather than papered over.

## An error model that matches the card

`scripts/axera/replay.py` re-runs a float graph at the scales
`quant/quant_axmodel.json` records. Four builds reproduce the device to within
0.19 dB, two exactly — so the 20 dB that looked like a hardware floor was the
scales, and precision choices can now be scored offline. On a heavily fused
graph it is not yet faithful; two filters bracket the measurement at 3.65 and
23.40 dB against 7.37, and that is stated rather than tuned to fit.

## Weight-residual splitting

`scripts/axera/precision.py`. `conv(x, W_hi) + conv(x, W_lo)` with no scale
pinning at all — the residual's peak is 255× smaller, so ordinary PTQ derives
the finer scale itself. **+7.23 dB on the card** at 16-bit activations
(25.77 → 33.00), and −0.30 at INT8, because the split pays an extra output
requantisation. On the real vocoder it *loses* 0.4 dB, which the error budget
predicts and which the README states as the technique's boundary.

Three corrections came out of it, two found by being wrong: weights are
quantised **per output channel** (which `pulsar2_quantizer.py` already said,
and my first budget contradicted); the quantiser is not idempotent, so the
residual must be taken against the compiler's re-rounding; and two probes
measured nothing because MinMax calibration did not cover the evaluation input.

## Test plan

34 new offline tests across `tests/test_axera_{precision,replay,emitter}.py`,
wired into the existing no-Docker `pulsar2-compat` job. No Docker or card
needed — the emitter tests build synthetic "compilers" rather than committing
fixtures. Hardware numbers were measured on a real AX650N and are recorded in
`scripts/axera/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS