### PR TITLE
Add Log op to QAT differentiable ops and sync fixture

### DIFF
--- a/.github/workflows/convertmodel-inference.yml
+++ b/.github/workflows/convertmodel-inference.yml
@@ -5,10 +5,17 @@ on:
     branches: ["master"]
     paths:
       - "scripts/convertmodel/**"
+      # test:qat-blocks (qat_blocks.test.mjs) reads this fixture straight out
+      # of onnxsim/, outside scripts/convertmodel/ -- so a rule-table change
+      # there (graph_grad.py/.cpp/.h regenerating it) needs to trigger this
+      # workflow too, or the JS test's own copy of the rule list can drift
+      # unnoticed until it fails on master.
+      - "onnxsim/qat_parity_fixtures.txt"
       - ".github/workflows/convertmodel-inference.yml"
   pull_request:
     paths:
       - "scripts/convertmodel/**"
+      - "onnxsim/qat_parity_fixtures.txt"
       - ".github/workflows/convertmodel-inference.yml"
   workflow_dispatch:
 

--- a/scripts/convertmodel/qat_blocks.mjs
+++ b/scripts/convertmodel/qat_blocks.mjs
@@ -68,6 +68,7 @@ export const DIFFERENTIABLE_OPS = new Set([
   "Identity",
   "InstanceNormalization",
   "LayerNormalization",
+  "Log",
   "MatMul",
   "MaxPool",
   "Mul",


### PR DESCRIPTION
## Summary
Adds support for the `Log` operation in QAT (Quantization-Aware Training) by including it in the set of differentiable operations, and ensures the CI workflow properly detects changes to the QAT parity fixtures.

## Changes
- **scripts/convertmodel/qat_blocks.mjs**: Added `"Log"` to the `DIFFERENTIABLE_OPS` set to enable gradient computation through logarithm operations during QAT
- **.github/workflows/convertmodel-inference.yml**: Updated workflow triggers to include `onnxsim/qat_parity_fixtures.txt` in both push and pull_request paths
  - This ensures the workflow runs when the QAT parity fixture file changes, preventing drift between the fixture and the JS test's copy of the rule list
  - Added explanatory comment documenting why this fixture file is monitored outside the `scripts/convertmodel/` directory

## Implementation Details
The workflow change addresses a dependency where `test:qat-blocks` (qat_blocks.test.mjs) reads the fixture directly from `onnxsim/` rather than from `scripts/convertmodel/`. Changes to the rule table (regenerated by graph_grad.py/.cpp/.h) now properly trigger the inference workflow, preventing unnoticed divergence until failures occur on master.

https://claude.ai/code/session_01PPYrr6Ekyz7hEd3KebQbRN