### PR TITLE
Support Axelera Voyager SDK integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,13 +1370,17 @@ custom operators in the sense of the [Custom operators](#custom-operators)
 section above: `simplify()` preserves them -- with or without a schema
 registered for them -- and simplifies the rest of the graph around them.
 
-For a rough, no-hardware read on which operators in a model Voyager SDK's
+For a rough, no-install read on which operators in a model Voyager SDK's
 Metis AIPU compiler documents as accelerated versus CPU-fallback (and,
 for most "Constrained" operators, whether a node's actual attributes/shapes
 satisfy Axelera's own published per-operator constraints), see
-[`scripts/axelera/README.md`](scripts/axelera/README.md) -- built entirely
-from Voyager SDK's public docs, with no real compiler or hardware behind it
-(that README explains exactly why, and what that limits).
+[`scripts/axelera/README.md`](scripts/axelera/README.md) -- built from
+Voyager SDK's public docs. That directory also has a real-compiler backend
+(`voyager_backend.py`, an optional heavy install): running it confirmed
+onnxsim's Conv+BatchNorm fusion produces bit-identical quantized output
+through Voyager SDK's actual quantizer, and cross-checked the scraped
+constraint data against the real compiler's own error messages -- see that
+README for the full account, including what still needs real hardware.
 
 ## Quantization-aware fine-tuning
 

--- a/README.md
+++ b/README.md
@@ -1370,6 +1370,14 @@ custom operators in the sense of the [Custom operators](#custom-operators)
 section above: `simplify()` preserves them -- with or without a schema
 registered for them -- and simplifies the rest of the graph around them.
 
+For a rough, no-hardware read on which operators in a model Voyager SDK's
+Metis AIPU compiler documents as accelerated versus CPU-fallback (and,
+for most "Constrained" operators, whether a node's actual attributes/shapes
+satisfy Axelera's own published per-operator constraints), see
+[`scripts/axelera/README.md`](scripts/axelera/README.md) -- built entirely
+from Voyager SDK's public docs, with no real compiler or hardware behind it
+(that README explains exactly why, and what that limits).
+
 ## Quantization-aware fine-tuning
 
 onnxsim's post-training quantization passes stop at *rounding*: AdaRound,

--- a/scripts/axelera/README.md
+++ b/scripts/axelera/README.md
@@ -20,24 +20,47 @@ including formal `rule`/`allow_config` predicates for most "Constrained"
 operators, not just an op-type list. `scrape_onnx_support_docs.py` scrapes
 that into `voyager_op_support_data.py`; `voyager_ops.py` and
 `voyager_simulator.py` turn it into a queryable partition + a best-effort
-per-node constraint evaluator.
+per-node constraint evaluator -- all of that **without** any real compiler.
 
-**Unlike `scripts/axera/`, nothing here was ever checked against a real
-compiler or real hardware.** Axera's Pulsar2 tooling got to download an
-already-compiled `.axmodel` from a public model repo and hand-decode it
-without needing Axera's own toolchain at all. Voyager SDK's compiler has no
-such public artifact to inspect, and running `deploy.py` directly --
-including its no-hardware `--pipe=quantized` calibration/quantization path
--- needs `axelera-types` and `axelera-runtime`, proprietary packages served
-only from Axelera's own private `axelera_runtime` package index (see
-`installer_support.py` in a voyager-sdk checkout). That index is not public
-and this environment has no credentials for it, so there was no way to
-actually run any part of Voyager SDK's compiler here. Everything in this
-directory is "what the docs say", never "what the compiler was observed to
-do" -- see `voyager_simulator.py`'s module docstring for the fuller version
-of this caveat, and for exactly how conservatively `evaluate_constraints()`
-tries to compensate (fail closed to "unknown" on anything it can't
-statically resolve, rather than guess).
+There is also a real backend now: **`voyager_backend.py`** wraps Voyager
+SDK's actual `axelera.compiler.quantize()`. An earlier version of this
+README claimed the real compiler was unreachable here (proprietary,
+credentials-only) -- that was wrong. `axelera-rt`/`axelera-devkit` install
+from a genuinely public Artifactory PyPI mirror with no login, exactly as
+voyager-sdk's own `docs/user-guides/sdk-install.md` documents:
+
+```bash
+pip install --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple axelera-rt axelera-devkit[all]
+```
+
+(This is a large, optional install -- it pulls torch, several CUDA toolkit
+packages, TVM, and more. Nothing in onnxsim's own test suite or CI requires
+it.) Running it for real turned up two concrete things:
+
+- Quantizing a `Conv -> BatchNormalization -> Relu` graph and its
+  onnxsim-simplified `Conv -> Relu` form (BN fused into Conv) through the
+  real quantizer produces **bit-identical** output.
+- A `Conv` with `auto_pad="SAME_UPPER"` (violating the scraped rule
+  `auto_pad == "NOTSET"`) makes `quantize()` fail outright, and the real
+  compiler's own warning quotes that *exact* constraint string --
+  confirming `voyager_op_support_data.py` matches the compiler's actual
+  internal check, and correcting `onnx-support.md`'s own "falls back to
+  host CPU" framing: that's what happens for an *undocumented* op type, not
+  for a documented-but-violated "Constrained" one.
+
+See `voyager_backend.py`'s module docstring for the full account (including
+what still doesn't work here -- `axelera.compiler.compile()`, i.e. real
+deployable `.axmodel` artifacts, needs a "device support directory" this
+environment doesn't have), and `tests/test_axelera_voyager_real_compiler.py`
+for these pinned as regression tests (skipped automatically if
+`axelera.compiler` isn't installed).
+
+`voyager_ops.py`/`voyager_simulator.py` stay docs-only by design even
+though the real compiler turned out to be reachable -- they're useful
+exactly because they don't need the heavy optional install. Read their
+output as an estimate corroborated by, but not equivalent to, what
+`voyager_backend.py` (better) or the real `deploy.py` (authoritative) would
+say.
 
 ## Usage
 
@@ -57,9 +80,23 @@ print(p.npu_node_fraction, p.cpu_fallback_op_types)
 
 for result in sim.evaluate_all_constraints(model):
     if result.verdict == "violated":
-        print(result.op_type, "would fall back to CPU:", result.detail)
+        # observed, for at least one op: quantize() fails outright here,
+        # not a graceful CPU fallback -- see voyager_backend.py's docstring
+        print(result.op_type, "violates a documented constraint:", result.detail)
     elif result.verdict == "unknown":
         print(result.op_type, "constraint not statically checkable here")
+```
+
+With the real compiler installed (see above), cross-check against it directly:
+
+```python
+import voyager_backend as backend
+
+if backend.has_axelera_compiler():
+    result = backend.compare_before_after_simplify(
+        model, simplified_model, calibration_dataset_fn, test_input
+    )
+    print(result["bit_identical"], result["max_abs_diff"])
 ```
 
 ## Regenerating `voyager_op_support_data.py`

--- a/scripts/axelera/README.md
+++ b/scripts/axelera/README.md
@@ -1,0 +1,79 @@
+# Axelera Voyager SDK / Metis AIPU compatibility check
+
+A docs-derived, no-hardware/no-Docker estimate of whether a graph is
+friendly to Axelera AI's [Voyager SDK](https://github.com/axelera-ai-hub/voyager-sdk)
+(`deploy.py`, which compiles ONNX models to `.axmodel` for Metis AIPU
+devices), and of whether `onnxsim.simplify()` stays safe to run ahead of it.
+
+Also see the ["Deploying to Axelera Metis devices" section](../../README.md#deploying-to-axelera-metis-devices-voyager-sdk)
+of the top-level README, and `tests/test_voyager_sdk_patterns.py` (onnxsim's
+own compatibility tests against Voyager SDK's Focus/Reshape+Gemm graph
+rewriter, in the main `tests/` directory) for the structural-simplification
+side of this. This directory is about the AIPU op-support side instead.
+
+## What this actually is, and isn't
+
+Voyager SDK publishes a real per-operator AIPU support reference
+(`docs/reference/compiler/onnx-support.md` and its per-opset detail pages,
+auto-generated from Axelera's own operator acceleration definitions) --
+including formal `rule`/`allow_config` predicates for most "Constrained"
+operators, not just an op-type list. `scrape_onnx_support_docs.py` scrapes
+that into `voyager_op_support_data.py`; `voyager_ops.py` and
+`voyager_simulator.py` turn it into a queryable partition + a best-effort
+per-node constraint evaluator.
+
+**Unlike `scripts/axera/`, nothing here was ever checked against a real
+compiler or real hardware.** Axera's Pulsar2 tooling got to download an
+already-compiled `.axmodel` from a public model repo and hand-decode it
+without needing Axera's own toolchain at all. Voyager SDK's compiler has no
+such public artifact to inspect, and running `deploy.py` directly --
+including its no-hardware `--pipe=quantized` calibration/quantization path
+-- needs `axelera-types` and `axelera-runtime`, proprietary packages served
+only from Axelera's own private `axelera_runtime` package index (see
+`installer_support.py` in a voyager-sdk checkout). That index is not public
+and this environment has no credentials for it, so there was no way to
+actually run any part of Voyager SDK's compiler here. Everything in this
+directory is "what the docs say", never "what the compiler was observed to
+do" -- see `voyager_simulator.py`'s module docstring for the fuller version
+of this caveat, and for exactly how conservatively `evaluate_constraints()`
+tries to compensate (fail closed to "unknown" on anything it can't
+statically resolve, rather than guess).
+
+## Usage
+
+```python
+import sys
+
+sys.path.insert(0, "scripts/axelera")  # or run from this directory
+
+import onnx
+import voyager_simulator as sim
+
+model = onnx.load("model.onnx")
+
+print(sim.coverage(model))  # 'full' | 'partial' | 'none', by op-type membership alone
+p = sim.partition(model)
+print(p.npu_node_fraction, p.cpu_fallback_op_types)
+
+for result in sim.evaluate_all_constraints(model):
+    if result.verdict == "violated":
+        print(result.op_type, "would fall back to CPU:", result.detail)
+    elif result.verdict == "unknown":
+        print(result.op_type, "constraint not statically checkable here")
+```
+
+## Regenerating `voyager_op_support_data.py`
+
+The scraped data snapshot tracks whatever Voyager SDK checkout it was last
+run against, not upstream automatically. To refresh it:
+
+```bash
+git clone https://github.com/axelera-ai-hub/voyager-sdk /tmp/voyager-sdk
+python3 scrape_onnx_support_docs.py /tmp/voyager-sdk > voyager_op_support_data.py
+```
+
+The scraper cross-checks opsets 14-17 against each other and prints a
+warning to stderr if a future Voyager SDK release makes them diverge (as of
+this writing, support levels and constraints are identical across all four,
+so only opset 17 -- the compiler's own recommended default -- is captured
+in detail).

--- a/scripts/axelera/scrape_onnx_support_docs.py
+++ b/scripts/axelera/scrape_onnx_support_docs.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Regenerate `voyager_op_support_data.py` from Axelera's Voyager SDK docs.
+
+Voyager SDK (https://github.com/axelera-ai-hub/voyager-sdk) publishes a
+per-opset, per-operator ONNX support reference for its Metis AIPU compiler at
+`docs/reference/compiler/onnx-support.md` (a hand-written summary table) and
+`docs/reference/compiler/onnx-opset{14,15,16,17}-support.md` (auto-generated,
+one section per operator, each with a `**AIPU Acceleration Constraints**`
+block of `- rule: \`<expr>\`` (all must hold) and/or
+`- allow_config: \`<expr>\`` (at least one must hold) lines, plus free-text
+"Axelera's notes for developers").
+
+This script re-scrapes that reference and regenerates
+`voyager_op_support_data.py`, so the data here tracks a specific Voyager SDK
+checkout rather than being hand-maintained. Verified (as of the checkout this
+was last run against) that support level, rules, and allow_config are
+byte-identical across opsets 14-16 vs. opset 17 for every operator that
+appears in all of them -- so only opset 17 (the compiler's own recommended
+default, see onnx-support.md's "Recommended opset" section) is scraped in
+detail; the summary table is still cross-checked against all four opsets to
+catch any future divergence.
+
+Usage: clone axelera-ai-hub/voyager-sdk next to this checkout (or anywhere),
+then:
+
+    python3 scrape_onnx_support_docs.py /path/to/voyager-sdk > voyager_op_support_data.py
+
+The constraint expression strings are transcribed verbatim -- including any
+oddities in Axelera's own DSL (e.g. `B.shape==(0)`, where `(0)` is the bare
+Python int `0`, not a 1-tuple -- almost certainly meant as a "no such input"
+sentinel, but not "fixed" here since that would mean guessing at Axelera's
+intent instead of reporting what the docs actually say). See
+`voyager_simulator.py` for how (and how conservatively) these get evaluated.
+"""
+
+import re
+import sys
+
+OPSETS = (14, 15, 16, 17)
+DETAIL_OPSET = 17
+
+
+def parse_summary_table(docs_dir: str) -> dict:
+    with open(f"{docs_dir}/onnx-support.md") as f:
+        text = f.read()
+    m = re.search(r"\| Operator \| Opset 14.*?\n((?:\|.*\n)+)", text)
+    levels = {}
+    levels_per_opset = {}
+    for row in m.group(1).strip().splitlines():
+        cells = [c.strip().strip("*") for c in row.strip("|").split("|")]
+        if not cells[0] or set(cells[0]) == {"-"}:
+            continue
+        name = cells[0]
+        per_opset = dict(zip(OPSETS, cells[1:5]))
+        levels[name] = per_opset[DETAIL_OPSET]
+        levels_per_opset[name] = per_opset
+    return levels, levels_per_opset
+
+
+def parse_opset_detail(docs_dir: str, opset: int) -> dict:
+    with open(f"{docs_dir}/onnx-opset{opset}-support.md") as f:
+        text = f.read()
+    sections = re.split(r"\n## (\S+)\n", text)
+    pairs = list(zip(sections[1::2], sections[2::2]))
+    out = {}
+    for name, body in pairs:
+        m = re.search(r"\*\*AIPU Acceleration Constraints\*\*\n((?:- .*\n?)*)", body)
+        block = m.group(1) if m else ""
+        rules = re.findall(r"- rule: `(.*)`", block)
+        allow_config = re.findall(r"- allow_config: `(.*)`", block)
+        notes = None
+        nm = re.search(r"Axelera's notes for developers\*\*\n\n(.*?)\n\n", body, re.S)
+        if nm:
+            notes = " ".join(nm.group(1).split())
+        out[name] = {"rules": rules, "allow_config": allow_config, "notes": notes}
+    return out
+
+
+def main(voyager_sdk_root: str) -> None:
+    docs_dir = f"{voyager_sdk_root}/docs/reference/compiler"
+    levels, levels_per_opset = parse_summary_table(docs_dir)
+    detail = parse_opset_detail(docs_dir, DETAIL_OPSET)
+
+    for opset in OPSETS:
+        if opset == DETAIL_OPSET:
+            continue
+        d = parse_opset_detail(docs_dir, opset)
+        for name, entry in detail.items():
+            if d.get(name) != entry:
+                print(
+                    f"WARNING: opset {opset} constraints for {name!r} differ from "
+                    f"opset {DETAIL_OPSET} -- data below is opset-{DETAIL_OPSET}-only "
+                    "and no longer accurate for other opsets; extend the data model "
+                    "before trusting it across opsets.",
+                    file=sys.stderr,
+                )
+        for name, per_opset in levels_per_opset.items():
+            if len(set(per_opset.values())) != 1:
+                print(
+                    f"WARNING: support level for {name!r} differs across opsets: "
+                    f"{per_opset} -- VOYAGER_OP_SUPPORT below only records the "
+                    f"opset-{DETAIL_OPSET} value.",
+                    file=sys.stderr,
+                )
+
+    print(
+        '"""Scraped from Voyager SDK\'s docs/reference/compiler/onnx-support.md and\n'
+        f"onnx-opset{DETAIL_OPSET}-support.md (opset {DETAIL_OPSET}, the compiler's own\n"
+        "recommended default -- see scrape_onnx_support_docs.py's docstring for why\n"
+        "only one opset is captured). Auto-generated -- do not hand-edit; re-run\n"
+        'scrape_onnx_support_docs.py against a voyager-sdk checkout instead."""'
+    )
+    print()
+    print("VOYAGER_OP_SUPPORT = {")
+    for name in sorted(levels):
+        level = levels[name]
+        d = detail.get(name, {"rules": [], "allow_config": [], "notes": None})
+        print(f"    {name!r}: {{")
+        print(f"        'level': {level!r},")
+        print(f"        'rules': {d['rules']!r},")
+        print(f"        'allow_config': {d['allow_config']!r},")
+        print(f"        'notes': {d['notes']!r},")
+        print("    },")
+    print("}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(
+            f"usage: {sys.argv[0]} /path/to/voyager-sdk > voyager_op_support_data.py"
+        )
+    main(sys.argv[1])

--- a/scripts/axelera/voyager_backend.py
+++ b/scripts/axelera/voyager_backend.py
@@ -1,0 +1,160 @@
+"""A *real* backend for `scripts/axelera/`, wrapping Voyager SDK's actual
+`axelera.compiler.quantize()` -- unlike `voyager_simulator.py` (docs-only,
+no compiler involved at all), this module calls Axelera's real quantizer and
+reports genuinely observed behavior.
+
+**This corrects an earlier, wrong assumption** in this directory (see git
+history / `voyager_simulator.py`'s docstring for the original framing):
+`axelera-rt` and `axelera-devkit` -- the packages providing `axelera.
+compiler` -- install cleanly via `pip install --extra-index-url https://
+software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple axelera-rt
+axelera-devkit[all]` (the exact command voyager-sdk's own `docs/user-guides/
+sdk-install.md` documents) with **no login or token**. That is a genuinely
+public Artifactory PyPI mirror, confirmed by actually installing from it.
+The earlier "proprietary, credentials-only" claim was based on the
+deprecated TOML-based installer's `axelera_runtime` package name/framing
+(`installer_support.py`) and never actually re-tested against the current
+pip-based install path -- a real mistake, not a deliberate simplification.
+
+**What actually works here, confirmed by running it:**
+
+- `axelera.compiler.quantize(model, calibration_dataset, config)` runs real
+  INT8 post-training quantization and returns an `AxeleraQuantizedModel`
+  callable on CPU -- no Metis hardware, no device driver, no extra setup
+  needed beyond the two pip packages above.
+- Observed: quantizing a `Conv -> BatchNormalization -> Relu` graph and its
+  onnxsim-simplified `Conv -> Relu` form (BN fused into Conv) through this
+  real quantizer produces **bit-identical** output on the same test input.
+- Observed: a `Conv` with `auto_pad="SAME_UPPER"` (violating the
+  `voyager_ops.VOYAGER_OP_SUPPORT["Conv"]["rules"]` entry `auto_pad ==
+  "NOTSET"`) makes `quantize()` raise `axelera.compiler.exceptions.
+  QtoolsError`, and the real error message quotes that *exact* constraint
+  string back -- direct confirmation that `voyager_op_support_data.py`'s
+  scraped rules are the literal predicates the real compiler's own
+  compatibility checker evaluates, not just prose.
+- **This refines (and partly corrects) `onnx-support.md`'s own "falls back
+  to host CPU" framing**, at least for this case: CPU fallback is what
+  happens for an *undocumented* op type. A *documented* "Constrained" op
+  used **outside** its supported configuration was observed to be a hard
+  `quantize()`-time failure, not a graceful CPU fallback -- so
+  `voyager_simulator.evaluate_constraints()`'s `"violated"` verdict should
+  be read as "quantization will likely fail outright", not merely "this
+  node will run on the host instead".
+
+**What still doesn't work here** (and why): `axelera.compiler.compile()`
+(the step that lowers a quantized model to real deployable `.axmodel`
+artifacts) failed with `axkernelcc: Cannot determine device support
+directory. Set AXE_CHROOT or AXELERA_DEVICE_DIR...` -- it needs a further
+"device support" package/directory this environment doesn't have (likely
+tied to the driver/device install steps in `sdk-install.md`, which do need
+either real hardware or additional setup this module never attempted). So:
+`quantize()` (int8 correctness) is real and covered here; `compile()`
+(real Metis deployment artifacts, and therefore true on-device behavior)
+is not.
+
+**Still be careful generalizing from the above**: the two observations
+above are single data points (one fusion, one constraint), not a general
+audit. Treat this the way `scripts/axera/pulsar2_simulator.py` treats its
+own single real-hardware data point -- informative, not exhaustive.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterator, Optional
+
+_INSTALL_HINT = (
+    "The real Voyager SDK compiler backend needs 'axelera-rt' and "
+    "'axelera-devkit' (large, optional dependencies -- pulls torch, CUDA "
+    "toolkit packages, TVM, and more). Install with: pip install "
+    "--extra-index-url https://software.axelera.ai/artifactory/api/pypi/"
+    "axelera-pypi/simple axelera-rt axelera-devkit[all]"
+)
+
+
+def has_axelera_compiler() -> bool:
+    """Whether `axelera.compiler` (from the `axelera-devkit` package) is
+    importable in this environment."""
+    try:
+        import axelera.compiler  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _import_compiler():
+    try:
+        from axelera import compiler
+    except ImportError as exc:
+        raise RuntimeError(_INSTALL_HINT) from exc
+    return compiler
+
+
+def quantize(model: Any, calibration_dataset: Iterator, config: Optional[Any] = None):
+    """Thin wrapper around `axelera.compiler.quantize()`.
+
+    :param model: a `torch.nn.Module`, `onnx.ModelProto`, or path to a
+            `.onnx` file -- forwarded as-is.
+    :param calibration_dataset: an iterator yielding calibration samples
+            (see Voyager SDK's `docs/reference/compiler/compiler-api.md`
+            for the expected shapes). Consumed once; build a fresh one for
+            each `quantize()` call, e.g. via a generator *function* (not a
+            generator object) so `compare_before_after_simplify` can call
+            it twice with the same seed for a fair comparison.
+    :param config: an `axelera.compiler.CompilerConfig`, or `None` for the
+            default.
+    :returns: an `axelera.compiler.quantized_model.AxeleraQuantizedModel`,
+            callable on CPU with a `torch.Tensor` input.
+    :raises RuntimeError: if `axelera-devkit` is not installed.
+    :raises axelera.compiler.exceptions.QtoolsError: (among other real
+            compiler exceptions) if the model violates a documented
+            constraint, is otherwise unsupported, or quantization
+            otherwise fails -- these are Voyager SDK's own real errors,
+            not wrapped or reinterpreted here.
+    """
+    compiler = _import_compiler()
+    if config is None:
+        config = compiler.CompilerConfig()
+    return compiler.quantize(
+        model=model, calibration_dataset=calibration_dataset, config=config
+    )
+
+
+def compare_before_after_simplify(
+    model: Any,
+    simplified_model: Any,
+    calibration_dataset_fn: Callable[[], Iterator],
+    test_input,
+    config: Optional[Any] = None,
+):
+    """Quantize both `model` and `simplified_model` through the real
+    Voyager SDK compiler (same calibration data, same test input) and
+    report whether their outputs match.
+
+    :param model: the original ONNX model (or path/`torch.nn.Module`).
+    :param simplified_model: typically `onnxsim.simplify(model)[0]`.
+    :param calibration_dataset_fn: a zero-argument callable returning a
+            fresh calibration iterator -- called once per model, so both
+            quantize with identical calibration data.
+    :param test_input: a `torch.Tensor` (or convertible) fed to both
+            quantized models for the comparison.
+    :param config: forwarded to both `quantize()` calls.
+    :returns: a dict with `output_before`, `output_after`,
+            `max_abs_diff` (float), and `bit_identical` (bool).
+    """
+    import torch
+
+    q_before = quantize(model, calibration_dataset_fn(), config)
+    q_after = quantize(simplified_model, calibration_dataset_fn(), config)
+
+    if not torch.is_tensor(test_input):
+        test_input = torch.as_tensor(test_input)
+
+    out_before = q_before(test_input)
+    out_after = q_after(test_input)
+    diff = (out_before - out_after).abs()
+    return {
+        "output_before": out_before,
+        "output_after": out_after,
+        "max_abs_diff": diff.max().item(),
+        "bit_identical": torch.equal(out_before, out_after),
+    }

--- a/scripts/axelera/voyager_op_support_data.py
+++ b/scripts/axelera/voyager_op_support_data.py
@@ -1,0 +1,253 @@
+"""Scraped from Voyager SDK's docs/reference/compiler/onnx-support.md and
+onnx-opset17-support.md (opset 17, the compiler's own
+recommended default -- see scrape_onnx_support_docs.py's docstring for why
+only one opset is captured). Auto-generated -- do not hand-edit; re-run
+scrape_onnx_support_docs.py against a voyager-sdk checkout instead."""
+
+VOYAGER_OP_SUPPORT = {
+    "Add": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": [
+            "A.shape == B.shape and not A.is_constant and not B.is_constant",
+            "len(A.shape)==4 and A.shape[1]==1 and B.shape==(0)",
+            "len(B.shape)==4 and B.shape[1]==1 and A.shape==(0)",
+            "len(A.shape)==4 and A.shape[1]!=1 and (B.shape==(1, A.shape[1], 1, 1) or B.shape==())",
+            "len(B.shape)==4 and B.shape[1]!=1 and (A.shape==(1, B.shape[1], 1, 1) or A.shape==())",
+        ],
+        "notes": "Given an operand with shape [N, C, H, W], Addition is supported with other operands with shape [N, C, H, W], [1, C, 1, 1], and scalars. If operands have the same shapes, they must be non-constant.",
+    },
+    "AveragePool": {
+        "level": "Constrained",
+        "rules": [
+            'auto_pad=="NOTSET"',
+            "pads is None or len(pads)==4",
+            "pads is None or (pads[0]==pads[2] and pads[1]==pads[3] and pads[0]<=0.5*kernel_shape[0] and pads[1]<=0.5*kernel_shape[1]) or (pads[0]!=pads[2]) or (pads[1]!=pads[3])",
+            "pads is None or (pads!=[0, 0, 0, 0] and count_include_pad==1) or (pads==[0, 0, 0, 0])",
+        ],
+        "allow_config": [],
+        "notes": 'Only AveragePool operators with explicit padding (i.e., auto_pad = "NOTSET") are currently supported. Moreover, due to torch runtime constraints, symmetric padding along each dimension must be at most half of the kernel size along the same dimension. Lastly, note that count_include_pad is only supported equal to 1. If padding is specified for this operator, count_include_pad !=1 may lead to wrong results.',
+    },
+    "BatchNormalization": {
+        "level": "Supported",
+        "rules": [],
+        "allow_config": [],
+        "notes": "Operator is supported in any configurations.",
+    },
+    "Clip": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": ["min==0 and max==6", "min==-1 and max==1"],
+        "notes": "Only Clip operators implementing ReLU6 (min=0, max=6) and HardTanh (min=-1, max=1) are currently supported.",
+    },
+    "Concat": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": [
+            "all([len(x.shape) == 4 for x in inputs]) and axis in [-3, -2, -1, 1, 2, 3]"
+        ],
+        "notes": "Concatenation is supported along the C, H, or W dimension for 4D feature maps.",
+    },
+    "Conv": {
+        "level": "Constrained",
+        "rules": [
+            'auto_pad == "NOTSET"',
+            "group == 1 or (W.shape[2] == W.shape[3] and (dilations is None or dilations[0] == dilations[1]) and (strides is None or strides[0] == strides[1]))",
+            "group == 1 or (dilations is not None and ((W.shape[2] - 1) * dilations[0] + 1) * ((W.shape[3] - 1) * dilations[1] + 1) < 128) or (dilations is None and W.shape[2] * W.shape[3] < 128)",
+        ],
+        "allow_config": [],
+        "notes": 'Only Conv operators with explicit padding (i.e., auto_pad = "NOTSET") are currently supported. Only symmetric kernels/strides/dilations with kernel_h * kernel_w < 128 are supported for grouped and depthwise convolutions. The kernel dimensions are read from the weight tensor W (shape [M, C/group, kH, kW]) rather than the optional "kernel_shape" attribute, which ONNX exporters frequently omit (leaving it None and inferring it from W).',
+    },
+    "ConvTranspose": {
+        "level": "Constrained",
+        "rules": [
+            'auto_pad == "NOTSET"',
+            "group == 1",
+            "pads is None or pads[:len(pads)//2] == pads[len(pads)//2:]",
+            "output_shape is None",
+        ],
+        "allow_config": [],
+        "notes": 'Only ConvTranspose operators with explicit padding (i.e., auto_pad = "NOTSET") are currently supported. Grouped convolutions and "output_shape" attribute are not supported.',
+    },
+    "Flatten": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": [],
+        "notes": "The Flatten operations is only supported in specific scenario, such as before a Gemm layer, or at the end of a model. Note that, even in the cases where it is supported, Flatten should have axes specified as >= 0.",
+    },
+    "Gemm": {
+        "level": "Constrained",
+        "rules": ["transA == 0"],
+        "allow_config": [],
+        "notes": "Gemm with automatic transposition of the first operand (i.e., transA == 1) is not supported.",
+    },
+    "GlobalAveragePool": {
+        "level": "Supported",
+        "rules": [],
+        "allow_config": [],
+        "notes": "Operator is supported in any configurations.",
+    },
+    "GlobalMaxPool": {
+        "level": "Supported",
+        "rules": [],
+        "allow_config": [],
+        "notes": "Operator is supported in any configurations.",
+    },
+    "HardSigmoid": {
+        "level": "Constrained",
+        "rules": ["abs(alpha - 0.166667) < 5e-6", "abs(beta - 0.5) < 5e-6"],
+        "allow_config": [],
+        "notes": "Only HardSigmoid operators with pytorch-like parameters (alpha=1/6, beta=0.5) are supported.",
+    },
+    "HardSwish": {
+        "level": "Supported",
+        "rules": [],
+        "allow_config": [],
+        "notes": "Operator is supported in any configurations.",
+    },
+    "LeakyRelu": {
+        "level": "Supported",
+        "rules": [],
+        "allow_config": [],
+        "notes": "Operator is supported in any configurations.",
+    },
+    "MatMul": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": [],
+        "notes": "Matmul is supported only when it is part of the attention block used by the YOLO11 family of networks.",
+    },
+    "MaxPool": {
+        "level": "Constrained",
+        "rules": ['auto_pad=="NOTSET"', "storage_order==0"],
+        "allow_config": [],
+        "notes": 'Only MaxPool operators with explicit padding (i.e., auto_pad = "NOTSET") and row major order (i.e. storage_order=0) are currently supported.',
+    },
+    "Mul": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": [
+            "A.shape == B.shape and not A.is_constant and not B.is_constant",
+            "(A.shape==() and len(B.shape)==4) or (B.shape==() and len(A.shape)==4)",
+            "len(A.shape)==4 and A.shape[1]==1 and B.shape==(0)",
+            "len(B.shape)==4 and B.shape[1]==1 and A.shape==(0)",
+            "len(A.shape)==4 and A.shape[1]!=1 and B.shape==(1, A.shape[1], 1, 1)",
+            "len(B.shape)==4 and B.shape[1]!=1 and A.shape==(1, B.shape[1], 1, 1)",
+        ],
+        "notes": "Given an operand with shape [N, C, H, W], Multiplication is supported with other operands with shape [N, C, H, W], [1, C, 1, 1], and scalars. Multiplication cannot be performed when the left and right operands are the same node.",
+    },
+    "PRelu": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": [
+            "slope.size == 1",
+            "np.array_equal([x for x in slope.shape if x != 1], [X.shape[1]])",
+        ],
+        "notes": "Due to torch runtime constraints, Prelu is supported with either scalar or per-channel slope parameters.",
+    },
+    "Pad": {
+        "level": "Constrained",
+        "rules": [
+            "constant_value is None or constant_value == 0.0",
+            'mode not in ["reflect", "edge"]',
+            "len(pads) == 2 * len(data.shape) and pads[0] == pads[len(data.shape)] == 0",
+            "len(pads) == 2 * len(data.shape) and pads[1] % 64 == pads[1 + len(data.shape)] % 64 == 0",
+        ],
+        "allow_config": [],
+        "notes": 'Pad is currently supported only for the "constant" mode. Moreover, padding along the batch dimension is not supported, and should be specified as 0 in the pads parameter. Padding along the channel dimension should be a multiple of 64.',
+    },
+    "Relu": {
+        "level": "Supported",
+        "rules": [],
+        "allow_config": [],
+        "notes": "Operator is supported in any configurations.",
+    },
+    "Reshape": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": [
+            "allowzero == 0 and np.array_equal(shape, data.shape)",
+            "allowzero == 0 and len(data.shape) >= 2 and len(shape) == 2 and shape[0] == data.shape[0] and (shape[1] == data.shape[1] or shape[1] == -1)",
+        ],
+        "notes": "Reshape is supported in two cases: When used within attention blocks in Yolo11 networks and for trivial operations where the shape parameter equals the input shape (no-op) or acts like a squeeze operation (e.g., [1, N, 1, 1] → [1, N]).",
+    },
+    "Resize": {
+        "level": "Constrained",
+        "rules": [
+            "roi is None",
+            'mode in ["nearest", "linear"]',
+            'coordinate_transformation_mode in ["half_pixel", "pytorch_half_pixel", "asymmetric"]',
+            'nearest_mode in ["round_prefer_floor", "round_prefer_ceil", "floor"]',
+            '(mode == "linear" and coordinate_transformation_mode in ["half_pixel", "pytorch_half_pixel"]) or (mode == "nearest" and coordinate_transformation_mode in ["half_pixel", "pytorch_half_pixel"] and nearest_mode in ["round_prefer_floor", "round_prefer_ceil"]) or (mode == "nearest" and coordinate_transformation_mode in ["asymmetric"] and nearest_mode in ["floor"])',
+            '(mode == "linear" and Y.shape[-2] // X.shape[-2] == Y.shape[-1] // X.shape[-1]) or mode == "nearest"',
+            '(mode == "linear" and Y.shape[-2] % X.shape[-2] == 0) or (mode == "nearest" and (Y.shape[-2] % X.shape[-2] <= 1 or Y.shape[-2] % X.shape[-2] == X.shape[-2] - 1))',
+            '(mode == "linear" and Y.shape[-1] % X.shape[-1] == 0) or (mode == "nearest" and (Y.shape[-1] % X.shape[-1] <= 1 or Y.shape[-1] % X.shape[-1] == X.shape[-1] - 1))',
+        ],
+        "allow_config": [],
+        "notes": 'Three coordinate transformation modes are supported: "half_pixel", "pytorch_half_pixel", and "asymmetric". For nearest mode, available options are "round_prefer_floor", "round_prefer_ceil", or "floor". Linear resizing is limited to symmetric, integer scaling factors, while nearest resizing supports any integer scaling factors. Note that the "floor" nearest mode can only be used with asymmetric coordinate transformation.',
+    },
+    "Selu": {
+        "level": "Constrained",
+        "rules": ["abs(alpha - 1.67326) < 5e-6", "abs(gamma - 1.0507) < 5e-6"],
+        "allow_config": [],
+        "notes": "Selu operators are supported if the alpha and gamma parameters are set to the defaults of 1.67326 and 1.0507, respectively.",
+    },
+    "Sigmoid": {
+        "level": "Supported",
+        "rules": [],
+        "allow_config": [],
+        "notes": "Operator is supported in any configurations.",
+    },
+    "Slice": {
+        "level": "Constrained",
+        "rules": [
+            "axes is not None and len(axes) == 1",
+            "steps is None or (len(steps) == 1 and (steps == 1 or axes == 1))",
+            "(axes[0] != 1 and data.shape[1] % 64 == 0) or axes[0] == 1",
+        ],
+        "allow_config": [],
+        "notes": "Slice is supported along one axis only, which must be specified as input to the operator. Stepped slice is currently supported only on the channel dimension. Slicing along any axis other than the channel axis requires the number of channels to be a multiple of 64",
+    },
+    "Softmax": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": [],
+        "notes": "Softmax is supported only when it is part of the attention block used by the YOLO11 family of networks.",
+    },
+    "Split": {
+        "level": "Constrained",
+        "rules": ["axis > 0"],
+        "allow_config": [],
+        "notes": "Split is not supported as the first operator in a model. Split is supported for axis different than 0. Negative axis values are not supported.",
+    },
+    "Squeeze": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": [],
+        "notes": "The Squeeze operations is only supported in specific scenario, such as before a Gemm layer, or at the end of a model.",
+    },
+    "Sub": {
+        "level": "Constrained",
+        "rules": [],
+        "allow_config": [
+            "(A.shape==() and len(B.shape)==4) or (B.shape==() and len(A.shape)==4)",
+            "len(A.shape)==4 and A.shape[1]==1 and B.shape==(0)",
+            "len(B.shape)==4 and B.shape[1]==1 and A.shape==(0)",
+            "len(A.shape)==4 and A.shape[1]!=1 and B.shape==(1, A.shape[1], 1, 1)",
+            "len(B.shape)==4 and B.shape[1]!=1 and A.shape==(1, B.shape[1], 1, 1)",
+        ],
+        "notes": "Given an operand with shape [N, C, H, W], Subtraction is supported with other operands with shape [1, C, 1, 1] or scalars.",
+    },
+    "Tanh": {
+        "level": "Supported",
+        "rules": [],
+        "allow_config": [],
+        "notes": "Operator is supported in any configurations.",
+    },
+    "Transpose": {
+        "level": "Constrained",
+        "rules": ["perm == [0, 1, 2, 3]"],
+        "allow_config": [],
+        "notes": "Transpose operations that are not the no-op, trivial case (i.e. perm=[0, 1, 2, 3]), are not supported. Transpose with perm=[0, 1, 3, 2] is supported only when it is part of the attention block used by the YOLO11 family of networks.",
+    },
+}

--- a/scripts/axelera/voyager_ops.py
+++ b/scripts/axelera/voyager_ops.py
@@ -11,19 +11,22 @@ including formal `rule`/`allow_config` predicates for most "Constrained"
 operators -- not just an op-type support list. `voyager_op_support_data.py`
 (auto-generated, do not hand-edit) is a faithful transcription of that.
 
-**What this is not**: none of this was checked against Voyager SDK's actual
-compiler or real Metis hardware. Unlike `scripts/axera/pulsar2_ops.py`
-(which got to download a real, already-compiled `.axmodel` from a public
-model repo and hand-decode it), Voyager SDK's own compiler needs
-`axelera-types`/`axelera-runtime` -- proprietary packages served only from
-Axelera's own private `axelera_runtime` package index (see
-`installer_support.py` in a voyager-sdk checkout), not published to PyPI or
-included in the public git repo. There is no way to actually run
-`deploy.py`, even in its no-hardware `--pipe=quantized` mode, without
-credentials for that private index, which this environment does not have.
-So everything here is "what the docs say", not "what was observed the
-compiler actually do" -- see `voyager_simulator.py`'s docstring for how that
-shapes what it does and doesn't claim.
+**This data itself is untouched by any compiler run** -- it's a literal
+transcription of the docs, nothing more. But unlike an earlier version of
+this docstring claimed, the real compiler *is* reachable here: `axelera-rt`/
+`axelera-devkit` (providing `axelera.compiler`) install from a genuinely
+public Artifactory PyPI mirror with no login (`docs/user-guides/sdk-
+install.md`'s own documented command) -- the "proprietary, credentials-only"
+claim was based on the deprecated installer's `axelera_runtime` package name
+(`installer_support.py`) and was never re-tested against the current pip
+path. See `voyager_backend.py` for the real quantizer wrapper, and its
+docstring for a concrete finding that matters here: the real compiler's
+error message for a rule this data records (`Conv`'s `auto_pad ==
+"NOTSET"`) quotes that exact string back -- real, if narrow, confirmation
+that this transcription matches the compiler's actual internal check, not
+just its prose documentation. `voyager_simulator.py`'s docstring explains
+what that does and doesn't license this module's own (still real-compiler-
+free) `evaluate_constraints()` to claim.
 """
 
 from voyager_op_support_data import VOYAGER_OP_SUPPORT

--- a/scripts/axelera/voyager_ops.py
+++ b/scripts/axelera/voyager_ops.py
@@ -1,0 +1,65 @@
+"""Metis AIPU operator-support data for Axelera's Voyager SDK
+(https://github.com/axelera-ai-hub/voyager-sdk), scraped from its own public
+docs -- see `scrape_onnx_support_docs.py` for how, and this module's
+docstring for a crucial caveat about the actual `.axmodel` compiler this data
+describes.
+
+Unlike Axera's Pulsar2 (`scripts/axera/pulsar2_ops.py`), Voyager SDK does
+publish a proper machine-readable-ish per-operator support reference
+(`docs/reference/compiler/onnx-support.md` and its per-opset detail pages),
+including formal `rule`/`allow_config` predicates for most "Constrained"
+operators -- not just an op-type support list. `voyager_op_support_data.py`
+(auto-generated, do not hand-edit) is a faithful transcription of that.
+
+**What this is not**: none of this was checked against Voyager SDK's actual
+compiler or real Metis hardware. Unlike `scripts/axera/pulsar2_ops.py`
+(which got to download a real, already-compiled `.axmodel` from a public
+model repo and hand-decode it), Voyager SDK's own compiler needs
+`axelera-types`/`axelera-runtime` -- proprietary packages served only from
+Axelera's own private `axelera_runtime` package index (see
+`installer_support.py` in a voyager-sdk checkout), not published to PyPI or
+included in the public git repo. There is no way to actually run
+`deploy.py`, even in its no-hardware `--pipe=quantized` mode, without
+credentials for that private index, which this environment does not have.
+So everything here is "what the docs say", not "what was observed the
+compiler actually do" -- see `voyager_simulator.py`'s docstring for how that
+shapes what it does and doesn't claim.
+"""
+
+from voyager_op_support_data import VOYAGER_OP_SUPPORT
+
+#: {op_type: 'Supported' | 'Constrained'} -- every operator Voyager SDK's
+#: docs list at opset 17 (its own recommended default opset; see
+#: `scrape_onnx_support_docs.py` for why only one opset is captured). An
+#: op_type *not* in this dict is not documented as AIPU-accelerated at all
+#: and, per onnx-support.md, "falls back to host CPU via ONNX Runtime
+#: preamble/postamble" -- compilation still succeeds, just with that node
+#: running on the host.
+VOYAGER_OP_LEVEL = {name: entry["level"] for name, entry in VOYAGER_OP_SUPPORT.items()}
+
+#: op_types documented as "Supported": accelerated with no attribute/shape
+#: restrictions Voyager SDK's docs call out.
+VOYAGER_UNCONSTRAINED_OPS = frozenset(
+    name for name, level in VOYAGER_OP_LEVEL.items() if level == "Supported"
+)
+
+#: op_types documented as "Constrained": accelerated, but only for specific
+#: attribute/shape configurations -- see VOYAGER_OP_SUPPORT[name]['rules'] /
+#: ['allow_config'] / ['notes'].
+VOYAGER_CONSTRAINED_OPS = frozenset(
+    name for name, level in VOYAGER_OP_LEVEL.items() if level == "Constrained"
+)
+
+#: Constrained ops whose docs give no formal `rule`/`allow_config` predicate
+#: at all -- only free-text "Axelera's notes for developers" (e.g. MatMul:
+#: "supported only when it is part of the attention block used by the YOLO11
+#: family of networks"). Nothing here is statically checkable from a node's
+#: shape/constness alone; `voyager_simulator.py` always reports these as
+#: unverified, never as violated.
+VOYAGER_PROSE_ONLY_CONSTRAINTS = frozenset(
+    name
+    for name, entry in VOYAGER_OP_SUPPORT.items()
+    if entry["level"] == "Constrained"
+    and not entry["rules"]
+    and not entry["allow_config"]
+)

--- a/scripts/axelera/voyager_simulator.py
+++ b/scripts/axelera/voyager_simulator.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""A partition *estimate* for Axelera's Voyager SDK Metis AIPU compiler, from
+its own published per-operator support docs (`voyager_ops.py`) -- no
+Docker/device/compiler involved. Shaped like `scripts/axera/pulsar2_
+simulator.py`'s `partition()`/`coverage()`, but this one can go one level
+deeper than op-type membership for many operators: Voyager SDK's docs give
+formal `rule`/`allow_config` predicates for most "Constrained" ops (unlike
+Axera's Pulsar2, which only publishes an op-type list -- see
+`pulsar2_ops.py`'s docstring), so `evaluate_constraints()` attempts to check
+those predicates against a node's actual (statically-known) shapes and
+constant inputs.
+
+**This is an estimate, from docs alone, with no execution behind it at
+all** -- read this before trusting any of its output:
+
+- **No compiler, no hardware, no numeric check.** Unlike `scripts/axera/
+  pulsar2_simulator.py`, there is no `simulate()`/numeric-comparison
+  function here at all, and this was never run against Voyager SDK's real
+  compiler. `deploy.py` needs `axelera-types`/`axelera-runtime`, proprietary
+  packages served only from Axelera's own private `axelera_runtime` package
+  index (see `installer_support.py` in a voyager-sdk checkout) -- not on
+  PyPI, not in the public git repo, and this environment has no credentials
+  for it. So there is no way to actually run Voyager SDK's compiler here,
+  not even its no-hardware `--pipe=quantized` calibration/quantization path.
+  Nothing below was checked against real compiler output.
+- **`evaluate_constraints()` is best-effort and fails closed.** It resolves
+  a rule/allow_config expression's referenced names (a node's input shapes,
+  constness, and constant values; its attributes; opset-17 ONNX-spec
+  attribute defaults for the handful where one is unambiguous, e.g. Conv's
+  `auto_pad` defaulting to `"NOTSET"`) against a small per-op parameter
+  table below, then evaluates the expression with Python's `eval` in a
+  restricted namespace. Anything it can't confidently resolve -- a dynamic
+  shape, a non-constant tensor referenced by value, an op not in the table,
+  any exception during evaluation -- comes back as `"unknown"`, never a
+  guessed True/False. It also does not "fix" apparent oddities in Axelera's
+  own constraint DSL (see `voyager_ops.py`'s docstring re: `B.shape==(0)`);
+  it evaluates exactly the text the docs publish.
+- **Only opset 17 is covered** (Voyager SDK's own recommended default for
+  ONNX export -- see `scrape_onnx_support_docs.py`'s docstring for the
+  cross-opset check backing this).
+- **Attribute-less op-type partitioning (`partition()`) is the part you can
+  trust most**: it's a direct, literal reading of the "Supported operators"
+  table in `docs/reference/compiler/onnx-support.md`.
+
+Use this to get a rough first read (does this graph look AIPU-friendly? did
+onnxsim's simplification plausibly help or hurt that?) before ever trusting
+Voyager SDK's own `deploy.py` output, which is authoritative and this is
+not.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import onnx
+from onnx import numpy_helper, shape_inference
+from voyager_ops import (
+    VOYAGER_OP_LEVEL,
+    VOYAGER_OP_SUPPORT,
+    VOYAGER_PROSE_ONLY_CONSTRAINTS,
+)
+
+#: ONNX-spec attribute defaults that are unambiguous constants (not
+#: shape/rank-dependent, unlike e.g. `dilations`/`strides`, which the docs'
+#: own rules already handle via explicit `is None` checks -- see this
+#: module's docstring). Per (op_type, attr_name).
+_ONNX_ATTR_DEFAULTS: Dict[Tuple[str, str], Any] = {
+    ("Conv", "auto_pad"): "NOTSET",
+    ("Conv", "group"): 1,
+    ("ConvTranspose", "auto_pad"): "NOTSET",
+    ("ConvTranspose", "group"): 1,
+    ("AveragePool", "auto_pad"): "NOTSET",
+    ("AveragePool", "count_include_pad"): 0,
+    ("MaxPool", "auto_pad"): "NOTSET",
+    ("MaxPool", "storage_order"): 0,
+    ("Gemm", "transA"): 0,
+    ("Split", "axis"): 0,
+    ("Reshape", "allowzero"): 0,
+}
+
+# Per op_type: ordered tensor-input names as ONNX declares them, and each
+# formal parameter's binding kind -- 'shape' (bind a _ShapeProps proxy),
+# 'value' (bind the tensor's resolved constant value), or 'attr' (bind the
+# node attribute's value). 'Y' is a synthetic name bound to the node's own
+# (single) output. Built from Voyager SDK's own opset-17 doc pages for each
+# op's **Parameters** list and **AIPU Acceleration Constraints** block --
+# see this module's docstring for the accuracy caveats.
+_OP_PARAM_SPEC: Dict[str, Dict[str, tuple]] = {
+    "Add": {"A": ("input", "shape"), "B": ("input", "shape")},
+    "Mul": {"A": ("input", "shape"), "B": ("input", "shape")},
+    "Sub": {"A": ("input", "shape"), "B": ("input", "shape")},
+    "Clip": {"min": ("input", "value"), "max": ("input", "value")},
+    "Concat": {"axis": ("attr", None)},  # 'inputs' handled specially
+    "Conv": {
+        "W": ("input", "shape"),
+        "auto_pad": ("attr", None),
+        "group": ("attr", None),
+        "dilations": ("attr", None),
+        "strides": ("attr", None),
+    },
+    "AveragePool": {
+        "auto_pad": ("attr", None),
+        "pads": ("attr", None),
+        "kernel_shape": ("attr", None),
+        "count_include_pad": ("attr", None),
+    },
+    "MaxPool": {"auto_pad": ("attr", None), "storage_order": ("attr", None)},
+    "Gemm": {"transA": ("attr", None)},
+    "HardSigmoid": {"alpha": ("attr", None), "beta": ("attr", None)},
+    "Selu": {"alpha": ("attr", None), "gamma": ("attr", None)},
+    "Pad": {
+        "data": ("input", "shape"),
+        "pads": ("input", "value"),
+        "constant_value": ("input", "value"),
+        "mode": ("attr", None),
+    },
+    "Resize": {
+        "X": ("input", "shape"),
+        "Y": ("output", "shape"),
+        "roi": ("input", "value"),
+        "mode": ("attr", None),
+        "coordinate_transformation_mode": ("attr", None),
+        "nearest_mode": ("attr", None),
+    },
+    "Slice": {
+        "data": ("input", "shape"),
+        "starts": ("input", "value"),
+        "ends": ("input", "value"),
+        "axes": ("input", "value"),
+        "steps": ("input", "value"),
+    },
+    "Split": {"axis": ("attr", None)},
+    "Transpose": {"perm": ("attr", None)},
+    "ConvTranspose": {
+        "auto_pad": ("attr", None),
+        "group": ("attr", None),
+        "pads": ("attr", None),
+        "output_shape": ("attr", None),
+    },
+    "Reshape": {
+        "data": ("input", "shape"),
+        "shape": ("input", "value"),
+        "allowzero": ("attr", None),
+    },
+    "PRelu": {"X": ("input", "shape"), "slope": ("input", "shape")},
+}
+
+# ONNX input name -> positional index, for ops whose rules/allow_config
+# reference an input by name (needed to look up node.input[i]). Only ops
+# with a 'value' or 'shape' input binding above need an entry here.
+_OP_INPUT_INDEX: Dict[str, Dict[str, int]] = {
+    "Add": {"A": 0, "B": 1},
+    "Mul": {"A": 0, "B": 1},
+    "Sub": {"A": 0, "B": 1},
+    "Clip": {"input": 0, "min": 1, "max": 2},
+    "Conv": {"X": 0, "W": 1, "B": 2},
+    "Pad": {"data": 0, "pads": 1, "constant_value": 2},
+    "Resize": {"X": 0, "roi": 1, "scales": 2, "sizes": 3},
+    "Slice": {"data": 0, "starts": 1, "ends": 2, "axes": 3, "steps": 4},
+    "Reshape": {"data": 0, "shape": 1},
+    "PRelu": {"X": 0, "slope": 1},
+}
+
+
+@dataclass
+class _ShapeProps:
+    shape: Optional[Tuple[int, ...]]
+    is_constant: bool
+    size: Optional[int]
+
+
+class _Unresolvable(Exception):
+    """A name the expression needs could not be statically resolved."""
+
+
+def _onnx_attr_native(node: onnx.NodeProto, name: str, default: Any) -> Any:
+    for attr in node.attribute:
+        if attr.name != name:
+            continue
+        if attr.type == onnx.AttributeProto.INT:
+            return attr.i
+        if attr.type == onnx.AttributeProto.INTS:
+            return list(attr.ints)
+        if attr.type == onnx.AttributeProto.FLOAT:
+            return attr.f
+        if attr.type == onnx.AttributeProto.FLOATS:
+            return list(attr.floats)
+        if attr.type == onnx.AttributeProto.STRING:
+            return attr.s.decode("utf-8")
+        if attr.type == onnx.AttributeProto.STRINGS:
+            return [s.decode("utf-8") for s in attr.strings]
+        raise _Unresolvable(f"unsupported attribute type for {name!r}")
+    return default
+
+
+def _native_constant(value) -> Any:
+    """A numpy array/scalar as a plain Python value (list/int/float/str),
+    so it behaves under ==, %, indexing, len() the way the DSL expects."""
+    arr = value
+    if hasattr(arr, "tolist"):
+        arr = arr.tolist()
+    return arr
+
+
+class _ShapeCache:
+    """Statically-known 4D+ shapes and constant-ness, via one `onnx.shape_
+    inference` pass over the whole model, cached for the model's lifetime.
+    """
+
+    def __init__(self, model: onnx.ModelProto):
+        self._graph = model.graph
+        self._initializers = {i.name: i for i in model.graph.initializer}
+        self._producers = {
+            out: node for node in model.graph.node for out in node.output
+        }
+        inferred = shape_inference.infer_shapes(model)
+        self._value_info = {vi.name: vi for vi in inferred.graph.value_info}
+        self._value_info.update({vi.name: vi for vi in inferred.graph.input})
+        self._value_info.update({vi.name: vi for vi in inferred.graph.output})
+
+    def shape(self, tensor_name: str) -> Optional[Tuple[int, ...]]:
+        if tensor_name in self._initializers:
+            return tuple(numpy_helper.to_array(self._initializers[tensor_name]).shape)
+        vi = self._value_info.get(tensor_name)
+        if vi is None or not vi.type.HasField("tensor_type"):
+            return None
+        dims = vi.type.tensor_type.shape.dim
+        if not all(d.HasField("dim_value") for d in dims):
+            return None
+        return tuple(d.dim_value for d in dims)
+
+    def is_constant(self, tensor_name: str) -> bool:
+        if tensor_name in self._initializers:
+            return True
+        producer = self._producers.get(tensor_name)
+        return producer is not None and producer.op_type == "Constant"
+
+    def constant_value(self, tensor_name: str):
+        if tensor_name in self._initializers:
+            return numpy_helper.to_array(self._initializers[tensor_name])
+        producer = self._producers.get(tensor_name)
+        if producer is not None and producer.op_type == "Constant":
+            for attr in producer.attribute:
+                if attr.name == "value":
+                    return numpy_helper.to_array(attr.t)
+        raise _Unresolvable(f"{tensor_name!r} is not a statically-known constant")
+
+    def shape_props(self, tensor_name: str) -> _ShapeProps:
+        shape = self.shape(tensor_name)
+        size = None
+        if shape is not None:
+            size = 1
+            for d in shape:
+                size *= d
+        return _ShapeProps(
+            shape=shape, is_constant=self.is_constant(tensor_name), size=size
+        )
+
+
+_ALLOWED_AST_NODES = (
+    ast.Expression,
+    ast.BoolOp,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Compare,
+    ast.Call,
+    ast.Name,
+    ast.Load,
+    ast.Store,  # only reachable as a comprehension target in `eval` mode
+    ast.Attribute,
+    ast.Subscript,
+    ast.Index,
+    ast.Slice,
+    ast.List,
+    ast.Tuple,
+    ast.Constant,
+    ast.And,
+    ast.Or,
+    ast.Not,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+    ast.In,
+    ast.NotIn,
+    ast.Is,
+    ast.IsNot,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.USub,
+    ast.comprehension,
+    ast.ListComp,
+    ast.GeneratorExp,
+)
+
+_SAFE_BUILTINS = {
+    "len": len,
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "min": min,
+    "max": max,
+    "round": round,
+}
+
+
+class _NpStub:
+    """Just enough of `numpy` for the DSL's `np.array_equal(...)` calls."""
+
+    @staticmethod
+    def array_equal(a, b) -> bool:
+        return list(a) == list(b)
+
+
+def _check_ast_safety(tree: ast.AST) -> None:
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_AST_NODES):
+            raise _Unresolvable(
+                f"expression uses disallowed syntax: {type(node).__name__}"
+            )
+
+
+def _build_namespace(
+    op_type: str, node: onnx.NodeProto, cache: _ShapeCache
+) -> Dict[str, Any]:
+    """Every name this op's spec knows how to bind, best-effort: a name
+    whose *own* resolution fails (e.g. a non-constant tensor referenced by
+    value) is simply omitted rather than aborting the whole namespace --
+    `eval` raising `NameError` for a *used* missing name still gets caught
+    by `evaluate_expr`, but an *unused* one no longer needs to resolve at
+    all. Free variables Python itself scopes (a comprehension's `for x in
+    ...` target, `np`, and everything in `_SAFE_BUILTINS`) are handled by
+    `eval`'s own namespace chain, not listed here.
+    """
+    spec = _OP_PARAM_SPEC.get(op_type, {})
+    input_index = _OP_INPUT_INDEX.get(op_type, {})
+    ns: Dict[str, Any] = {}
+
+    if op_type == "Concat":
+        ns["inputs"] = [cache.shape_props(t) for t in node.input]
+
+    for name, (kind, sub) in spec.items():
+        try:
+            if kind == "attr":
+                default = _ONNX_ATTR_DEFAULTS.get((op_type, name))
+                ns[name] = _onnx_attr_native(node, name, default)
+            elif kind == "output":
+                if len(node.output) != 1:
+                    continue
+                ns[name] = cache.shape_props(node.output[0])
+            elif kind == "input":
+                if name not in input_index:
+                    continue
+                idx = input_index[name]
+                if idx >= len(node.input) or not node.input[idx]:
+                    ns[name] = None  # optional input, absent
+                    continue
+                tensor_name = node.input[idx]
+                if sub == "shape":
+                    ns[name] = cache.shape_props(tensor_name)
+                elif sub == "value":
+                    ns[name] = _native_constant(cache.constant_value(tensor_name))
+        except _Unresolvable:
+            continue
+    return ns
+
+
+def evaluate_expr(
+    op_type: str, node: onnx.NodeProto, cache: _ShapeCache, expr: str
+) -> Optional[bool]:
+    """Evaluate one `rule`/`allow_config` expression against `node`.
+
+    Returns True/False if it could be statically resolved, or None
+    ("unknown") if any referenced name/operation could not be. Never
+    raises -- every failure mode collapses to None. See this module's
+    docstring for why that's the only safe default.
+    """
+    try:
+        tree = ast.parse(expr, mode="eval")
+        _check_ast_safety(tree)
+        ns = _build_namespace(op_type, node, cache)
+        ns["np"] = _NpStub()
+        code = compile(tree, "<voyager-constraint>", "eval")
+        return bool(eval(code, {"__builtins__": _SAFE_BUILTINS}, ns))
+    except _Unresolvable:
+        return None
+    except Exception:
+        # Any other failure (TypeError from a None operand, IndexError from
+        # a shorter-than-expected shape, ...) also means "can't tell" --
+        # never surfaces as a guessed True/False.
+        return None
+
+
+@dataclass
+class ConstraintResult:
+    op_type: str
+    level: str  # 'Supported' | 'Constrained' | 'CPU fallback'
+    verdict: str  # 'ok' | 'violated' | 'unknown' | 'prose_only' | 'not_applicable'
+    detail: List[str] = field(default_factory=list)
+
+
+def evaluate_constraints(node: onnx.NodeProto, cache: _ShapeCache) -> ConstraintResult:
+    """Best-effort per-node compatibility check against Voyager SDK's
+    published opset-17 AIPU constraints. See this module's docstring for
+    what "best-effort" means here -- this is not a substitute for running
+    the real compiler.
+    """
+    entry = VOYAGER_OP_SUPPORT.get(node.op_type)
+    if entry is None:
+        return ConstraintResult(node.op_type, "CPU fallback", "not_applicable")
+    if entry["level"] == "Supported":
+        return ConstraintResult(node.op_type, "Supported", "ok")
+    if node.op_type in VOYAGER_PROSE_ONLY_CONSTRAINTS:
+        return ConstraintResult(
+            node.op_type, "Constrained", "prose_only", detail=[entry["notes"] or ""]
+        )
+
+    if entry["rules"]:
+        # AND semantics: every rule must hold.
+        results = [evaluate_expr(node.op_type, node, cache, r) for r in entry["rules"]]
+        if any(r is False for r in results):
+            bad = [r for r, ok in zip(entry["rules"], results) if ok is False]
+            return ConstraintResult(node.op_type, "Constrained", "violated", detail=bad)
+        if any(r is None for r in results):
+            return ConstraintResult(node.op_type, "Constrained", "unknown")
+        return ConstraintResult(node.op_type, "Constrained", "ok")
+    else:
+        # OR semantics: at least one allow_config must hold.
+        results = [
+            evaluate_expr(node.op_type, node, cache, r) for r in entry["allow_config"]
+        ]
+        if any(r is True for r in results):
+            return ConstraintResult(node.op_type, "Constrained", "ok")
+        if any(r is None for r in results):
+            return ConstraintResult(node.op_type, "Constrained", "unknown")
+        return ConstraintResult(
+            node.op_type, "Constrained", "violated", detail=list(entry["allow_config"])
+        )
+
+
+@dataclass
+class Partition:
+    npu_nodes: List[str]
+    cpu_fallback_nodes: List[str]
+    cpu_fallback_op_types: Dict[str, int] = field(default_factory=dict)
+
+    @property
+    def npu_node_fraction(self) -> float:
+        total = len(self.npu_nodes) + len(self.cpu_fallback_nodes)
+        return len(self.npu_nodes) / total if total else 1.0
+
+
+def partition(model: onnx.ModelProto) -> Partition:
+    """Op-type-only classification against `voyager_ops.VOYAGER_OP_LEVEL`:
+    any op_type Voyager SDK's docs list at all (Supported or Constrained)
+    counts as NPU-eligible here, matching the docs' own framing that a
+    "Constrained" op "is still hardware-accelerated -- it just has
+    attribute limits". Use `evaluate_constraints()` for the (best-effort,
+    per-node) attribute-level check.
+    """
+    npu: List[str] = []
+    cpu: List[str] = []
+    cpu_types: Dict[str, int] = {}
+    for node in model.graph.node:
+        label = node.name or f"<{node.op_type}>"
+        if node.op_type in VOYAGER_OP_LEVEL:
+            npu.append(label)
+        else:
+            cpu.append(label)
+            cpu_types[node.op_type] = cpu_types.get(node.op_type, 0) + 1
+    return Partition(npu, cpu, cpu_types)
+
+
+def coverage(model: onnx.ModelProto) -> str:
+    """'full' (every node's op_type is documented AIPU-eligible), 'none', or
+    'partial'."""
+    p = partition(model)
+    if not p.cpu_fallback_nodes:
+        return "full"
+    if not p.npu_nodes:
+        return "none"
+    return "partial"
+
+
+def evaluate_all_constraints(model: onnx.ModelProto) -> List[ConstraintResult]:
+    """`evaluate_constraints()` for every node in `model`, in graph order."""
+    cache = _ShapeCache(model)
+    return [evaluate_constraints(node, cache) for node in model.graph.node]

--- a/scripts/axelera/voyager_simulator.py
+++ b/scripts/axelera/voyager_simulator.py
@@ -10,19 +10,35 @@ Axera's Pulsar2, which only publishes an op-type list -- see
 those predicates against a node's actual (statically-known) shapes and
 constant inputs.
 
-**This is an estimate, from docs alone, with no execution behind it at
-all** -- read this before trusting any of its output:
+**This module itself is an estimate, from docs alone, with no execution
+behind it** -- read this before trusting any of its output:
 
-- **No compiler, no hardware, no numeric check.** Unlike `scripts/axera/
-  pulsar2_simulator.py`, there is no `simulate()`/numeric-comparison
-  function here at all, and this was never run against Voyager SDK's real
-  compiler. `deploy.py` needs `axelera-types`/`axelera-runtime`, proprietary
-  packages served only from Axelera's own private `axelera_runtime` package
-  index (see `installer_support.py` in a voyager-sdk checkout) -- not on
-  PyPI, not in the public git repo, and this environment has no credentials
-  for it. So there is no way to actually run Voyager SDK's compiler here,
-  not even its no-hardware `--pipe=quantized` calibration/quantization path.
-  Nothing below was checked against real compiler output.
+- **No compiler, no hardware, no numeric check -- in this module.** Unlike
+  `scripts/axera/pulsar2_simulator.py`, there is no `simulate()`/numeric-
+  comparison function here, and nothing in this file was checked against
+  real compiler output. That real check does exist, though, in the sibling
+  `voyager_backend.py` -- an earlier version of this docstring wrongly
+  claimed there was no way to run Voyager SDK's compiler at all, based on
+  the deprecated installer's `axelera_runtime`/private-index framing
+  (`installer_support.py`) and never re-tested against the current pip
+  path. That was a mistake: `axelera-rt`/`axelera-devkit` (providing
+  `axelera.compiler`) install from a genuinely public Artifactory PyPI
+  mirror with no login, exactly as `docs/user-guides/sdk-install.md`
+  documents -- confirmed by actually doing it. See `voyager_backend.py`'s
+  docstring for what running the real quantizer actually showed (including
+  a real cross-check of this module's own scraped constraint data -- the
+  real compiler's error message for a violated rule quotes the exact
+  constraint string `voyager_ops.py` carries). This module stays docs-only
+  by design -- it needs neither `axelera-rt` nor `axelera-devkit`, both
+  large optional installs -- and its own output should still be read as an
+  estimate, not a substitute for `voyager_backend.py` (better) or the real
+  `deploy.py` (authoritative) when either is available.
+- **A "Constrained" op used outside its rules was observed to hard-fail
+  quantization, not fall back to CPU** -- see `voyager_backend.py`'s
+  docstring. `onnx-support.md`'s own "falls back to host CPU" framing
+  describes *undocumented* op types; treat this module's `"violated"`
+  verdict accordingly (likely a `quantize()`-time error), not as "this
+  node just runs on the host instead".
 - **`evaluate_constraints()` is best-effort and fails closed.** It resolves
   a rule/allow_config expression's referenced names (a node's input shapes,
   constness, and constant values; its attributes; opset-17 ONNX-spec

--- a/tests/test_axelera_voyager_op_support.py
+++ b/tests/test_axelera_voyager_op_support.py
@@ -1,0 +1,398 @@
+"""Tests for `scripts/axelera/voyager_ops.py` / `voyager_simulator.py` -- a
+docs-derived, no-hardware/no-compiler estimate of Voyager SDK's Metis AIPU
+operator support (see that module's docstring for the full scope and, more
+importantly, what it explicitly does NOT claim: no real compiler or
+hardware was ever involved, since Voyager SDK's `axelera-types`/
+`axelera-runtime` packages are served only from Axelera's own private
+package index -- see `installer_support.py` in a voyager-sdk checkout).
+
+Every model below is built with `onnx.parser` and checked against known,
+hand-verified outcomes from Voyager SDK's own opset-17 docs (`docs/
+reference/compiler/onnx-opset17-support.md`) at the time this was written --
+e.g. Conv requires `auto_pad == "NOTSET"`, Gemm requires `transA == 0`,
+Transpose requires `perm == [0, 1, 2, 3]`. These are regression tests for
+the evaluator's own logic (namespace binding, AST safety, tri-state
+fail-closed behavior), not a claim that Voyager SDK's docs (or this
+transcription of them) are permanently correct.
+"""
+
+import os
+import sys
+
+import numpy as np
+import onnx
+from onnx import numpy_helper, parser
+
+_AXELERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axelera"
+)
+if _AXELERA_DIR not in sys.path:
+    sys.path.insert(0, _AXELERA_DIR)
+
+import voyager_ops as ops  # noqa: E402
+import voyager_simulator as sim  # noqa: E402
+
+
+def _model(body, initializer=(), opset=17, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    onnx.checker.check_model(model)
+    return model
+
+
+def _verdicts(model):
+    cache = sim._ShapeCache(model)
+    return [sim.evaluate_constraints(n, cache).verdict for n in model.graph.node]
+
+
+# --- voyager_ops.py: the scraped data itself ---
+
+
+def test_op_support_data_matches_known_levels():
+    # Spot-check against docs/reference/compiler/onnx-support.md's summary
+    # table, read directly at the time this test was written.
+    assert ops.VOYAGER_OP_LEVEL["Relu"] == "Supported"
+    assert ops.VOYAGER_OP_LEVEL["Sigmoid"] == "Supported"
+    assert ops.VOYAGER_OP_LEVEL["Conv"] == "Constrained"
+    assert ops.VOYAGER_OP_LEVEL["Gemm"] == "Constrained"
+    assert "Erf" not in ops.VOYAGER_OP_LEVEL  # undocumented -> CPU fallback
+
+
+def test_unconstrained_and_constrained_partition_is_disjoint_and_covers_all():
+    assert ops.VOYAGER_UNCONSTRAINED_OPS & ops.VOYAGER_CONSTRAINED_OPS == set()
+    assert ops.VOYAGER_UNCONSTRAINED_OPS | ops.VOYAGER_CONSTRAINED_OPS == set(
+        ops.VOYAGER_OP_LEVEL
+    )
+
+
+def test_prose_only_ops_have_no_formal_predicate():
+    for name in ops.VOYAGER_PROSE_ONLY_CONSTRAINTS:
+        entry = ops.VOYAGER_OP_SUPPORT[name]
+        assert entry["level"] == "Constrained"
+        assert not entry["rules"]
+        assert not entry["allow_config"]
+        assert entry["notes"]
+
+
+# --- voyager_simulator.py: partition() (op-type only) ---
+
+
+def test_partition_classifies_by_documented_op_type_membership():
+    model = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        {
+          r = Relu(x)
+          y = Erf(r)
+        }
+        """
+    )
+    p = sim.partition(model)
+    assert len(p.npu_nodes) == 1
+    assert len(p.cpu_fallback_nodes) == 1
+    assert p.cpu_fallback_op_types == {"Erf": 1}
+    assert sim.coverage(model) == "partial"
+
+
+def test_coverage_full_and_none():
+    full = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        { y = Relu(x) }
+        """
+    )
+    assert sim.coverage(full) == "full"
+
+    none = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        { y = Erf(x) }
+        """
+    )
+    assert sim.coverage(none) == "none"
+
+
+# --- voyager_simulator.py: evaluate_constraints() (per-node, best-effort) ---
+
+
+def test_supported_op_is_always_ok():
+    model = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        { y = Relu(x) }
+        """
+    )
+    assert _verdicts(model) == ["ok"]
+
+
+def test_undocumented_op_is_cpu_fallback_not_applicable():
+    model = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        { y = Erf(x) }
+        """
+    )
+    cache = sim._ShapeCache(model)
+    result = sim.evaluate_constraints(model.graph.node[0], cache)
+    assert result.level == "CPU fallback"
+    assert result.verdict == "not_applicable"
+
+
+def test_prose_only_op_is_never_verified_ok_or_violated():
+    model = _model(
+        """
+        g (float[4,8] a, float[8,10] b) => (float[4,10] y)
+        { y = MatMul(a, b) }
+        """
+    )
+    assert _verdicts(model) == ["prose_only"]
+
+
+def test_conv_auto_pad_notset_default_is_ok():
+    model = _model(
+        """
+        g (float[1,8,10,10] x) => (float[1,8,8,8] y)
+        { y = Conv<kernel_shape = [3, 3]>(x, w) }
+        """,
+        initializer=[
+            numpy_helper.from_array(np.zeros((8, 8, 3, 3), np.float32), name="w")
+        ],
+    )
+    assert _verdicts(model) == ["ok"]
+
+
+def test_conv_same_upper_padding_is_violated():
+    model = _model(
+        """
+        g (float[1,8,10,10] x) => (float[1,8,10,10] y)
+        { y = Conv<kernel_shape = [3, 3], auto_pad = "SAME_UPPER">(x, w) }
+        """,
+        initializer=[
+            numpy_helper.from_array(np.zeros((8, 8, 3, 3), np.float32), name="w")
+        ],
+    )
+    assert _verdicts(model) == ["violated"]
+
+
+def test_conv_depthwise_symmetric_kernel_is_ok():
+    model = _model(
+        """
+        g (float[1,8,10,10] x) => (float[1,8,8,8] y)
+        { y = Conv<kernel_shape = [3, 3], group = 8>(x, w) }
+        """,
+        initializer=[
+            numpy_helper.from_array(np.zeros((8, 1, 3, 3), np.float32), name="w")
+        ],
+    )
+    assert _verdicts(model) == ["ok"]
+
+
+def test_conv_depthwise_asymmetric_kernel_is_violated():
+    model = _model(
+        """
+        g (float[1,8,10,10] x) => (float[1,8,8,8] y)
+        { y = Conv<kernel_shape = [3, 5], group = 8>(x, w) }
+        """,
+        initializer=[
+            numpy_helper.from_array(np.zeros((8, 1, 3, 5), np.float32), name="w")
+        ],
+    )
+    assert _verdicts(model) == ["violated"]
+
+
+def test_gemm_transA_default_is_ok():
+    model = _model(
+        """
+        g (float[4,8] a) => (float[4,10] y)
+        { y = Gemm(a, b, c) }
+        """,
+        initializer=[
+            numpy_helper.from_array(np.zeros((8, 10), np.float32), name="b"),
+            numpy_helper.from_array(np.zeros((10,), np.float32), name="c"),
+        ],
+    )
+    assert _verdicts(model) == ["ok"]
+
+
+def test_gemm_transA_set_is_violated():
+    model = _model(
+        """
+        g (float[4,8] a) => (float[8,10] y)
+        { y = Gemm<transA = 1>(a, b, c) }
+        """,
+        initializer=[
+            numpy_helper.from_array(np.zeros((4, 8), np.float32), name="b"),
+            numpy_helper.from_array(np.zeros((10,), np.float32), name="c"),
+        ],
+    )
+    assert _verdicts(model) == ["violated"]
+
+
+def test_clip_relu6_and_hardtanh_are_ok_others_violated():
+    for lo, hi, expected in [
+        (0.0, 6.0, "ok"),
+        (-1.0, 1.0, "ok"),
+        (2.0, 6.0, "violated"),
+    ]:
+        model = _model(
+            f"""
+            g (float[1,4] x) => (float[1,4] y)
+            <float mn = {{{lo}}}, float mx = {{{hi}}}>
+            {{ y = Clip(x, mn, mx) }}
+            """
+        )
+        assert _verdicts(model) == [expected], (lo, hi)
+
+
+def test_transpose_identity_perm_is_ok_others_violated():
+    for perm, expected in [([0, 1, 2, 3], "ok"), ([0, 2, 3, 1], "violated")]:
+        model = _model(
+            f"""
+            g (float[1,2,3,4] x) => (float[1,2,3,4] y)
+            {{ y = Transpose<perm = {perm}>(x) }}
+            """
+        )
+        assert _verdicts(model) == [expected], perm
+
+
+def test_prelu_matching_and_mismatched_channel_broadcast():
+    match = _model(
+        """
+        g (float[1,8,4,4] x) => (float[1,8,4,4] y)
+        { y = PRelu(x, s) }
+        """,
+        initializer=[
+            numpy_helper.from_array(np.zeros((1, 8, 1, 1), np.float32), name="s")
+        ],
+    )
+    assert _verdicts(match) == ["ok"]
+
+    mismatch = _model(
+        """
+        g (float[1,8,4,4] x) => (float[1,8,4,4] y)
+        { y = PRelu(x, s) }
+        """,
+        initializer=[
+            numpy_helper.from_array(np.zeros((1, 4, 1, 1), np.float32), name="s")
+        ],
+    )
+    assert _verdicts(mismatch) == ["violated"]
+
+
+def test_concat_axis_channel_is_ok_batch_axis_is_violated():
+    channel = _model(
+        """
+        g (float[1,4,4,4] a, float[1,4,4,4] b) => (float[1,8,4,4] y)
+        { y = Concat<axis = 1>(a, b) }
+        """
+    )
+    assert _verdicts(channel) == ["ok"]
+
+    batch = _model(
+        """
+        g (float[1,4,4,4] a, float[1,4,4,4] b) => (float[2,4,4,4] y)
+        { y = Concat<axis = 0>(a, b) }
+        """
+    )
+    assert _verdicts(batch) == ["violated"]
+
+
+def test_slice_channel_axis_needs_64_divisible_size():
+    ok = _model(
+        """
+        g (float[1,8,4,4] x) => (float[1,4,4,4] y)
+        <int64[1] starts = {0}, int64[1] ends = {4}, int64[1] axes = {1}>
+        { y = Slice(x, starts, ends, axes) }
+        """
+    )
+    assert _verdicts(ok) == ["ok"]
+
+    violated = _model(
+        """
+        g (float[1,8,10,10] x) => (float[1,8,4,10] y)
+        <int64[1] starts = {0}, int64[1] ends = {4}, int64[1] axes = {2}>
+        { y = Slice(x, starts, ends, axes) }
+        """
+    )
+    assert _verdicts(violated) == ["violated"]
+
+
+def test_reshape_identity_shape_is_ok():
+    model = _model(
+        """
+        g (float[1,8] x) => (float[1,8] y)
+        <int64[2] s = {1, 8}>
+        { y = Reshape(x, s) }
+        """
+    )
+    assert _verdicts(model) == ["ok"]
+
+
+# --- Evaluator safety: never guesses on what it can't resolve ---
+
+
+def test_non_constant_slice_axes_is_unknown_not_a_guess():
+    # `axes` (referenced by all three of Slice's rules) fed by a
+    # non-constant (graph-input) tensor rather than a constant: none of the
+    # rules can be statically resolved without its value. `starts` is left
+    # unbound too (Slice's rules never reference it at all) to double as a
+    # check that an unrelated missing/dynamic input doesn't itself cause a
+    # false "unknown" -- covered instead by the ok/violated cases above,
+    # which all omit `starts`/`ends` from the graph text entirely.
+    model = _model(
+        """
+        g (float[1,8,4,4] x, int64[1] axes) => (float[1,4,4,4] y)
+        <int64[1] starts = {0}, int64[1] ends = {4}>
+        { y = Slice(x, starts, ends, axes) }
+        """
+    )
+    assert _verdicts(model) == ["unknown"]
+
+
+def test_unresolvable_op_without_a_param_spec_is_unknown():
+    # HardSwish is "Supported" (no constraints) but Softmax is "Constrained"
+    # and prose-only, already covered above; pick a Constrained op with a
+    # formal predicate this module's _OP_PARAM_SPEC simply doesn't cover to
+    # confirm the "no known binding" path also fails closed rather than
+    # crashing. Squeeze is prose-only (covered); use a fabricated op_type
+    # absent from VOYAGER_OP_SUPPORT entirely to hit the CPU-fallback path
+    # instead, which is already covered by test_undocumented_op_is_cpu_
+    # fallback_not_applicable -- this test instead exercises evaluate_expr
+    # directly against an op the spec table has no entry for at all.
+    model = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        { y = Relu(x) }
+        """
+    )
+    cache = sim._ShapeCache(model)
+    node = model.graph.node[0]
+    result = sim.evaluate_expr("NotARealOp", node, cache, "some_unbound_name == 1")
+    assert result is None
+
+
+def test_ast_safety_rejects_unexpected_syntax():
+    model = _model(
+        """
+        g (float[1,4] x) => (float[1,4] y)
+        { y = Relu(x) }
+        """
+    )
+    cache = sim._ShapeCache(model)
+    node = model.graph.node[0]
+    # A lambda/exec-style construct should never be reachable from the
+    # docs-sourced expressions, but confirm this fails closed (via the
+    # restricted eval() namespace/builtins, whichever layer catches it
+    # first) rather than silently eval'ing arbitrary code if it ever were.
+    assert (
+        sim.evaluate_expr("Relu", node, cache, "__import__('os').system('echo hi')")
+        is None
+    )

--- a/tests/test_axelera_voyager_real_compiler.py
+++ b/tests/test_axelera_voyager_real_compiler.py
@@ -1,0 +1,155 @@
+"""Tests against Voyager SDK's *real* compiler (`axelera.compiler`, from the
+optional `axelera-devkit` package) -- unlike `test_axelera_voyager_op_
+support.py` (which never imports voyager-sdk or axelera.compiler at all),
+these tests actually run onnxsim-simplified models through Axelera's own
+quantizer for genuine numeric validation. See `scripts/axelera/
+voyager_backend.py`'s module docstring for what this backend can and can't
+do, and for the two concrete real-compiler observations it's built from.
+
+Skipped entirely unless `axelera.compiler` is importable -- these packages
+are large (torch, CUDA toolkit packages, TVM, and more) and genuinely
+optional; nothing in onnxsim's own test suite or CI is expected to install
+them. Install with:
+
+    pip install --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple axelera-rt axelera-devkit[all]
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from onnx import numpy_helper, parser
+
+import onnxsim
+
+_AXELERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axelera"
+)
+if _AXELERA_DIR not in sys.path:
+    sys.path.insert(0, _AXELERA_DIR)
+
+import voyager_backend as backend  # noqa: E402
+
+if not backend.has_axelera_compiler():
+    pytest.skip(
+        "axelera.compiler (from axelera-devkit) is not installed -- see this "
+        "module's docstring for the (large, optional) install command",
+        allow_module_level=True,
+    )
+
+compiler = pytest.importorskip("axelera.compiler")
+torch = pytest.importorskip("torch")
+
+
+def _conv_bn_relu_model():
+    model = parser.parse_model(
+        """
+        <ir_version: 10, opset_import: ["": 17]>
+        agraph (float[1,3,16,16] x) => (float[1,8,16,16] y)
+        {
+          c = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]>(x, w)
+          bn = BatchNormalization(c, scale, bias, mean, var)
+          y = Relu(bn)
+        }
+        """
+    )
+    rng = np.random.default_rng(0)
+    w = rng.standard_normal((8, 3, 3, 3)).astype(np.float32)
+    scale = np.abs(rng.standard_normal((8,)).astype(np.float32)) + 0.1
+    bias = rng.standard_normal((8,)).astype(np.float32)
+    mean = rng.standard_normal((8,)).astype(np.float32) * 0.1
+    var = np.abs(rng.standard_normal((8,)).astype(np.float32)) + 0.5
+    model.graph.initializer.extend(
+        [
+            numpy_helper.from_array(w, name="w"),
+            numpy_helper.from_array(scale, name="scale"),
+            numpy_helper.from_array(bias, name="bias"),
+            numpy_helper.from_array(mean, name="mean"),
+            numpy_helper.from_array(var, name="var"),
+        ]
+    )
+    return model
+
+
+def _conv_model(auto_pad):
+    extra = f', auto_pad = "{auto_pad}"' if auto_pad != "NOTSET" else ""
+    model = parser.parse_model(
+        f"""
+        <ir_version: 10, opset_import: ["": 17]>
+        agraph (float[1,3,16,16] x) => (float[1,8,16,16] y)
+        {{
+          c = Conv<kernel_shape = [3, 3], pads = [1, 1, 1, 1]{extra}>(x, w)
+          y = Relu(c)
+        }}
+        """
+    )
+    w = np.random.default_rng(0).standard_normal((8, 3, 3, 3)).astype(np.float32)
+    model.graph.initializer.append(numpy_helper.from_array(w, name="w"))
+    return model
+
+
+def _calib_fn(shape=(1, 3, 16, 16), n=16, seed=1):
+    def gen():
+        rng = np.random.default_rng(seed)
+        for _ in range(n):
+            yield rng.standard_normal(shape).astype(np.float32)
+
+    return gen
+
+
+def test_bn_fusion_is_bit_identical_through_real_quantizer():
+    """The concrete result documented in voyager_backend.py's docstring,
+    pinned as a regression test: onnxsim's Conv+BatchNorm fusion must not
+    change what the real Voyager SDK compiler's quantizer produces.
+    """
+    raw = _conv_bn_relu_model()
+    simplified, check_ok = onnxsim.simplify(raw, check_n=3)
+    assert check_ok
+    assert [n.op_type for n in raw.graph.node] == ["Conv", "BatchNormalization", "Relu"]
+    assert [n.op_type for n in simplified.graph.node] == ["Conv", "Relu"]
+
+    test_input = (
+        np.random.default_rng(99).standard_normal((1, 3, 16, 16)).astype(np.float32)
+    )
+    result = backend.compare_before_after_simplify(
+        raw, simplified, _calib_fn(), test_input
+    )
+    assert result["bit_identical"]
+    assert result["max_abs_diff"] == 0.0
+
+
+def test_conv_notset_auto_pad_quantizes_cleanly():
+    model = _conv_model("NOTSET")
+    q = backend.quantize(model, _calib_fn()())
+    out = q(
+        torch.from_numpy(
+            np.random.default_rng(2).standard_normal((1, 3, 16, 16)).astype(np.float32)
+        )
+    )
+    assert out.shape == (1, 8, 16, 16)
+
+
+def test_conv_same_upper_auto_pad_fails_quantization_matching_voyager_ops_rule(caplog):
+    """Cross-checks `voyager_ops.VOYAGER_OP_SUPPORT["Conv"]["rules"]` against
+    the real compiler: violating `auto_pad == "NOTSET"` was observed to (a)
+    log a WARNING quoting that exact constraint string, via the compiler's
+    own `onnx_validator`, and (b) raise `QtoolsError` (with a shorter,
+    differently-worded message -- the constraint text lives in the logged
+    warning, not the exception itself) -- not a silent CPU fallback. See
+    voyager_backend.py's docstring for why that refines onnx-support.md's
+    own "falls back to CPU" prose.
+    """
+    import logging
+
+    import voyager_ops as ops
+
+    rule = ops.VOYAGER_OP_SUPPORT["Conv"]["rules"][0]
+    assert rule == 'auto_pad == "NOTSET"'  # the exact string the real warning quotes
+
+    model = _conv_model("SAME_UPPER")
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(compiler.exceptions.QtoolsError, match="SAME_UPPER"):
+            backend.quantize(model, _calib_fn()())
+
+    assert f"Unsatisfied constraint: {rule}" in caplog.text


### PR DESCRIPTION
## Summary

- Documents how to use `onnxsim.simplify()` ahead of Axelera Voyager SDK's `deploy.py`, and verifies (with regression tests) that onnxsim's fusions don't break Voyager SDK's own structural graph-rewrite patterns (a YOLOX-style Focus/space-to-depth block, a flattened-FC `Reshape`+`Gemm` head) or a custom-domain post-processing op.
- Adds `scripts/axelera/`, a docs-derived (no-hardware) compatibility checker for Voyager SDK's Metis AIPU compiler: an op-support partition (`voyager_ops.py`/`voyager_simulator.py`, scraped from Voyager SDK's own published per-operator constraint docs) plus a best-effort, fail-closed per-node constraint evaluator.
- Adds `scripts/axelera/voyager_backend.py`, a **real** backend wrapping Voyager SDK's actual `axelera.compiler.quantize()` (the `axelera-rt`/`axelera-devkit` packages install from a genuinely public Artifactory PyPI mirror, no credentials needed — confirmed by installing them). Running it for real found two things pinned as regression tests:
  - Quantizing a `Conv → BatchNormalization → Relu` graph and its onnxsim-simplified `Conv → Relu` form (BN fused into Conv) produces **bit-identical** output.
  - A `Conv` with `auto_pad="SAME_UPPER"` (violating the scraped rule `auto_pad == "NOTSET"`) makes the real compiler's `quantize()` fail, quoting that exact constraint string — confirming the scraped data matches the compiler's actual internal check, and correcting the docs' own "falls back to CPU" framing (that's for *undocumented* op types; a documented-but-violated constraint hard-fails instead).

## Test plan

- [x] `tests/test_voyager_sdk_patterns.py` — 4 tests (Focus+Conv, Reshape+Gemm, custom-domain op with/without a registered schema), all passing.
- [x] `tests/test_axelera_voyager_op_support.py` — 23 tests against the docs-derived simulator (Conv padding/grouping, Gemm `transA`, Clip ReLU6/HardTanh, Transpose, PRelu, Concat, Slice, Reshape, plus fail-closed/AST-sandboxing behavior), all passing.
- [x] `tests/test_axelera_voyager_real_compiler.py` — 3 tests against the real compiler backend, all passing; skipped automatically (module-level) when `axelera.compiler` isn't installed, so this never becomes a hard dependency for onnxsim's own CI.
- [x] Full existing test suite re-run with no new failures (3 pre-existing, unrelated `test_fusion_patterns.py` failures confirmed present on `master` before this branch).
- [x] `ruff format`/`ruff check` clean on all new/changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmwoZwebGakYHP2qwVbzYw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmwoZwebGakYHP2qwVbzYw)_