### PR TITLE
Extend torch.autograd grad-coverage cross-checks beyond BatchNormalization

### DIFF
--- a/scripts/dump_aot_autograd_grad_graphs.py
+++ b/scripts/dump_aot_autograd_grad_graphs.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Print, side by side, the backward graph :mod:`onnxsim.graph_grad` emits
+for a handful of ops next to the backward graph torch's own AOTAutograd
+produces for the identical math.
+
+This is a reading aid, not a test. tests/test_graph_grad_torch_autograd.py
+already checks the *numbers* onnxsim's rules produce against
+``torch.autograd.grad`` -- and since AOTAutograd's backward is still
+PyTorch's own autograd underneath (just traced through functionalization
+and partitioned into forward/backward halves), tracing it again here would
+not add a second independent numeric oracle. What AOTAutograd's trace does
+give, that plain ``torch.autograd.grad`` does not, is *visibility*: with
+``torch._decomp.core_aten_decompositions()`` applied, an op whose eager
+backward is a single opaque fused kernel call gets expanded into the
+primitive aten ops that kernel is defined in terms of (see the Relu case
+below: its backward decomposes into an explicit ``le``/``where`` mask, the
+same shape of thing :func:`onnxsim.graph_grad._grad_relu` builds by hand).
+Reading the two lists next to each other is a quick sanity check when
+touching a rule -- structurally implausible output is usually visible at a
+glance -- but it is not asserted anywhere, on purpose:
+
+* ``torch._functorch.aot_autograd.aot_export_module``,
+  ``torch._functorch.partitioners.default_partition`` and
+  ``torch._decomp.core_aten_decompositions`` are all private torch APIs with
+  no stability guarantee across releases (their exact call signature
+  already changed once during this file's own development). A test pinned
+  to their current shape would break on an unrelated torch bump, not on an
+  onnxsim regression.
+* AOTAutograd's decomposition is not the same VJP construction onnxsim's
+  own rules use even where both land on plain arithmetic (different
+  op vocabulary, different intermediate naming, sometimes a different but
+  equivalent factoring), and for Conv/MaxPool/AveragePool it does not
+  decompose at all -- ``aten.convolution_backward``/
+  ``aten.max_pool2d_with_indices_backward`` are themselves part of core
+  aten, so those cases print one opaque call each, in deliberate contrast
+  to onnxsim's own explicit im2col-based graph for the same op (see
+  ``_grad_conv``'s docstring for why onnxsim decomposes there instead of
+  reusing a fused kernel: no such fused kernel exists in
+  :data:`onnxsim.graph_grad.BACKWARD_OPS`). There is no useful op-for-op
+  equality to assert in either direction, so this script only prints.
+
+Every AOTAutograd call is wrapped so a version mismatch prints a "skipped"
+line for that case and moves on rather than aborting the whole run --
+consistent with the above, this stays a best-effort look, never a gate.
+
+Usage: ``python scripts/dump_aot_autograd_grad_graphs.py`` (needs the built
+``onnxsim_cpp2py_export`` extension importable, same as running the tests,
+and ``torch`` installed for the AOTAutograd half -- without it, this still
+prints the onnxsim side of each case).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import onnx  # noqa: E402
+import onnx.parser  # noqa: E402
+import onnx.shape_inference  # noqa: E402
+
+from onnxsim import graph_grad, qat_graph  # noqa: E402
+
+try:
+    import torch
+    import torch.nn.functional as F
+except ImportError:
+    torch = None
+    F = None
+
+_HEADER = '<ir_version: 8, opset_import: ["": 17]>'
+
+
+def _model(body: str) -> onnx.ModelProto:
+    return onnx.parser.parse_model(f"{_HEADER}\n{body}")
+
+
+def _static_shapes(model: onnx.ModelProto) -> dict:
+    inferred = onnx.shape_inference.infer_shapes(model, strict_mode=True)
+    shapes = {}
+    for value in (
+        list(inferred.graph.input)
+        + list(inferred.graph.output)
+        + list(inferred.graph.value_info)
+    ):
+        shapes[value.name] = [d.dim_value for d in value.type.tensor_type.shape.dim]
+    for initializer in inferred.graph.initializer:
+        shapes[initializer.name] = list(initializer.dims)
+    return shapes
+
+
+def _onnxsim_backward_ops(body: str, targets: list) -> list:
+    """The op_type of every node :func:`onnxsim.graph_grad.build_backward`
+    emits for ``body``, in emission order."""
+    model = _model(body)
+    shapes = _static_shapes(model)
+    output = model.graph.output[0].name
+    b = qat_graph.GraphBuilder("bw_")
+    graph_grad.build_backward(
+        b, list(model.graph.node), shapes, {output: "dY"}, targets
+    )
+    return [n.op_type for n in b.nodes]
+
+
+def _aot_backward_ops(fn, n_inputs: int, shapes: list):
+    """AOTAutograd's own decomposed backward graph for ``sum(fn(*xs) *
+    seed)``, seeded the same way ``_onnxsim_backward_ops`` is -- a single
+    upstream gradient over the whole output, not a scalar loss with an
+    implicit gradient of 1. ``shapes`` is ``[*input shapes, seed/output
+    shape]``. Returns ``None`` (after printing why) instead of raising if
+    torch, or the private APIs this leans on, are not available in the
+    shape this script expects -- see the module docstring.
+    """
+    try:
+        import torch.nn as nn
+        from torch._decomp import core_aten_decompositions
+        from torch._functorch.aot_autograd import (
+            aot_export_module,
+            default_partition,
+        )
+    except Exception as e:  # noqa: BLE001
+        print(f"  (skipped -- torch/aot_autograd unavailable: {e})")
+        return None
+
+    class _Loss(nn.Module):
+        def forward(self, *args):
+            xs, seed = args[:n_inputs], args[n_inputs]
+            y = fn(*xs)
+            return ((y * seed).sum(),)
+
+    try:
+        torch.manual_seed(0)
+        args = tuple(
+            torch.randn(*shape, requires_grad=True) for shape in shapes[:n_inputs]
+        )
+        seed = torch.randn(*shapes[n_inputs])
+        gm, _sig = aot_export_module(
+            _Loss(),
+            (*args, seed),
+            trace_joint=True,
+            output_loss_index=0,
+            decompositions=core_aten_decompositions(),
+        )
+        _fw, bw = default_partition(gm, (*args, seed), num_fwd_outputs=1)
+        return [
+            str(node.target) for node in bw.graph.nodes if node.op == "call_function"
+        ]
+    except Exception as e:  # noqa: BLE001
+        print(f"  (skipped -- aot_autograd internals raised: {e})")
+        return None
+
+
+def _layer_norm_fn(axis, eps):
+    def fn(x, scale, bias):
+        dims = tuple(range(axis, x.dim()))
+        xc = x - x.mean(dim=dims, keepdim=True)
+        var = (xc * xc).mean(dim=dims, keepdim=True)
+        return (xc / torch.sqrt(var + eps)) * scale + bias
+
+    return fn
+
+
+def _instance_norm_fn(eps):
+    def fn(x, scale, bias):
+        spatial = tuple(range(2, x.dim()))
+        xc = x - x.mean(dim=spatial, keepdim=True)
+        var = (xc * xc).mean(dim=spatial, keepdim=True)
+        xhat = xc / torch.sqrt(var + eps)
+        bshape = [1, -1] + [1] * (x.dim() - 2)
+        return xhat * scale.reshape(bshape) + bias.reshape(bshape)
+
+    return fn
+
+
+def _batch_norm_fn(eps):
+    # mean/var are the node's own *inputs* here, not reductions of x -- the
+    # same distinction _grad_batch_normalization's own docstring draws
+    # against _grad_layer_normalization.
+    def fn(x, scale, bias, mean, var):
+        bshape = [1, -1] + [1] * (x.dim() - 2)
+        xhat = (x - mean.reshape(bshape)) / torch.sqrt(var.reshape(bshape) + eps)
+        return xhat * scale.reshape(bshape) + bias.reshape(bshape)
+
+    return fn
+
+
+# Each case: an onnxsim ONNX-text forward + the targets to differentiate,
+# and a positional-argument torch function computing the identical forward
+# (last shape in "shapes" is always the seed/output shape). A curated
+# handful -- the ops with the most structurally interesting backward
+# (Norm family's mean/var coupling, Conv/Pool's fused-vs-decomposed
+# contrast) plus a couple of plain ones (Relu, MatMul) for a baseline.
+CASES = [
+    dict(
+        name="relu",
+        onnx_body="""
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Relu(A)
+        }
+        """,
+        onnx_targets=["A"],
+        n_inputs=1,
+        torch_fn=lambda x: torch.relu(x),
+        shapes=[(3, 4), (3, 4)],
+    ),
+    dict(
+        name="softmax",
+        onnx_body="""
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Softmax (A)
+        }
+        """,
+        onnx_targets=["A"],
+        n_inputs=1,
+        torch_fn=lambda x: torch.softmax(x, dim=-1),
+        shapes=[(3, 4), (3, 4)],
+    ),
+    dict(
+        name="matmul",
+        onnx_body="""
+        g (float[3,4] A, float[4,5] B) => (float[3,5] Y) {
+          Y = MatMul(A, B)
+        }
+        """,
+        onnx_targets=["A", "B"],
+        n_inputs=2,
+        torch_fn=lambda a, b: a @ b,
+        shapes=[(3, 4), (4, 5), (3, 5)],
+    ),
+    dict(
+        name="gemm",
+        onnx_body="""
+        g (float[3,4] A, float[4,5] B, float[5] C) => (float[3,5] Y) {
+          Y = Gemm(A, B, C)
+        }
+        """,
+        onnx_targets=["A", "B", "C"],
+        n_inputs=3,
+        torch_fn=lambda a, b, c: a @ b + c,
+        shapes=[(3, 4), (4, 5), (5,), (3, 5)],
+    ),
+    dict(
+        name="layer_norm",
+        onnx_body="""
+        g (float[2,3,4] A, float[4] S, float[4] B) => (float[2,3,4] Y) {
+          Y = LayerNormalization (A, S, B)
+        }
+        """,
+        onnx_targets=["A", "S", "B"],
+        n_inputs=3,
+        torch_fn=_layer_norm_fn(axis=2, eps=1e-5),
+        shapes=[(2, 3, 4), (4,), (4,), (2, 3, 4)],
+    ),
+    dict(
+        name="instance_norm",
+        onnx_body="""
+        g (float[2,3,4,4] X, float[3] S, float[3] Bs) => (float[2,3,4,4] Y) {
+          Y = InstanceNormalization(X, S, Bs)
+        }
+        """,
+        onnx_targets=["X", "S", "Bs"],
+        n_inputs=3,
+        torch_fn=_instance_norm_fn(eps=1e-5),
+        shapes=[(2, 3, 4, 4), (3,), (3,), (2, 3, 4, 4)],
+    ),
+    dict(
+        name="batch_norm",
+        onnx_body="""
+        g (float[2,3,4,4] X, float[3] S, float[3] Bs, float[3] M, float[3] V)
+            => (float[2,3,4,4] Y) {
+          Y = BatchNormalization(X, S, Bs, M, V)
+        }
+        """,
+        onnx_targets=["X", "S", "Bs", "M", "V"],
+        n_inputs=5,
+        torch_fn=_batch_norm_fn(eps=1e-5),
+        shapes=[(2, 3, 4, 4), (3,), (3,), (3,), (3,), (2, 3, 4, 4)],
+    ),
+    dict(
+        name="conv",
+        onnx_body="""
+        g (float[1,2,4,4] A, float[3,2,3,3] B) => (float[1,3,2,2] Y) {
+          Y = Conv(A, B)
+        }
+        """,
+        onnx_targets=["A", "B"],
+        n_inputs=2,
+        torch_fn=lambda x, w: F.conv2d(x, w),
+        shapes=[(1, 2, 4, 4), (3, 2, 3, 3), (1, 3, 2, 2)],
+    ),
+    dict(
+        name="maxpool",
+        onnx_body="""
+        g (float[1,2,4,4] A) => (float[1,2,2,2] Y) {
+          Y = MaxPool <kernel_shape = [2, 2], strides = [2, 2]> (A)
+        }
+        """,
+        onnx_targets=["A"],
+        n_inputs=1,
+        torch_fn=lambda x: F.max_pool2d(x, kernel_size=2, stride=2),
+        shapes=[(1, 2, 4, 4), (1, 2, 2, 2)],
+    ),
+    dict(
+        name="averagepool",
+        onnx_body="""
+        g (float[1,2,4,4] A) => (float[1,2,2,2] Y) {
+          Y = AveragePool <kernel_shape = [2, 2], strides = [2, 2]> (A)
+        }
+        """,
+        onnx_targets=["A"],
+        n_inputs=1,
+        torch_fn=lambda x: F.avg_pool2d(x, kernel_size=2, stride=2),
+        shapes=[(1, 2, 4, 4), (1, 2, 2, 2)],
+    ),
+]
+
+
+def main() -> None:
+    for case in CASES:
+        print(f"=== {case['name']} ===")
+        onnx_ops = _onnxsim_backward_ops(case["onnx_body"], case["onnx_targets"])
+        print(f"onnxsim      ({len(onnx_ops)} nodes): {onnx_ops}")
+        aot_ops = _aot_backward_ops(case["torch_fn"], case["n_inputs"], case["shapes"])
+        if aot_ops is not None:
+            print(f"aot_autograd ({len(aot_ops)} nodes): {aot_ops}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_graph_grad_torch_autograd.py
+++ b/tests/test_graph_grad_torch_autograd.py
@@ -1,0 +1,941 @@
+"""Tests cross-checking onnxsim.graph_grad's *hand-written* gradient rules
+against ``torch.autograd`` on the identical math -- extending the coverage
+tests/test_graph_grad_templates.py established for the templated
+BatchNormalization rule (and tests/test_lora.py for the LoRA composition's
+MatMul/Add) to the rest of :data:`onnxsim.graph_grad.SUPPORTED_OPS`.
+
+tests/test_graph_grad.py already checks every rule against an independent
+finite difference, which is enough to catch a rule that is finite, the right
+shape, and numerically wrong -- but a finite difference is still just a
+different numerical method applied to *the same formula* the rule itself
+computes, so a bug shared between the rule and the reader's mental model of
+it (a wrong factor both "look right") is not something it can catch on its
+own. ``torch.autograd`` is a second, genuinely independent autodiff
+implementation -- not a numerical approximation of the same formula, a
+different system differentiating a different but equivalent graph -- which
+is exactly what caught this repo's own ``BatchNormalization`` dvar-derivation
+bug (see ``graph_grad.py``'s "Templated rules" section). This file applies
+that same check to the rest of the builtin rules, one op family at a time,
+rather than only to the op whose bug motivated it.
+
+Reuses tests/test_graph_grad.py's ``_model``/``_static_shapes``/
+``_backward_model``/``_feeds``/``_positive``/``_away_from_zero`` rather than
+duplicating them -- the same cross-test-module import
+tests/test_graph_grad_registry.py already establishes for this repo.
+
+Not attempted here: ``Add`` and ``BatchNormalization`` (already covered by
+tests/test_graph_grad_templates.py), and a handful of ops
+(``Identity``/``Reshape``/``Transpose``-adjacent plumbing already implied by
+every other case below reaching them through a chain) where a finite
+difference already gives full confidence and there is no independent-formula
+detail left for ``torch.autograd`` to disagree about.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch.nn.functional as F
+from test_graph_grad import (
+    _away_from_zero,
+    _backward_model,
+    _feeds,
+    _model,
+    _positive,
+    _static_shapes,
+)
+
+ort = pytest.importorskip("onnxruntime")
+torch = pytest.importorskip(
+    "torch", reason="this whole module compares against torch.autograd"
+)
+
+
+def _check_against_torch(
+    body, torch_fn, targets=None, overrides=None, seed=0, rtol=2e-3, atol=2e-4
+):
+    """The whole experiment, torch flavored: emit ``body``'s backward with
+    :func:`onnxsim.graph_grad.build_backward` (via
+    ``test_graph_grad._backward_model``, which also re-checks the operator
+    allowlist), run it, and compare against ``torch.autograd.grad`` of
+    ``torch_fn`` -- a plain-torch-ops reimplementation of the same forward --
+    seeded with the same random inputs and the same upstream gradient."""
+    model = _model(body)
+    targets = targets or [value.name for value in model.graph.input]
+    rng = np.random.default_rng(seed)
+    feeds = _feeds(model, rng, overrides)
+
+    backward = _backward_model(model, targets)
+    output_shape = _static_shapes(model)[model.graph.output[0].name]
+    grad_seed = rng.standard_normal(output_shape).astype(np.float32)
+    session = ort.InferenceSession(
+        backward.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    analytic = session.run([f"grad_{t}" for t in targets], dict(feeds, dY=grad_seed))
+
+    tensors = {
+        name: torch.tensor(value, requires_grad=(name in targets))
+        for name, value in feeds.items()
+    }
+    y = torch_fn(tensors)
+    loss = (y * torch.tensor(grad_seed)).sum()
+    torch_grads = torch.autograd.grad(loss, [tensors[t] for t in targets])
+    for target, got, expected in zip(targets, analytic, torch_grads):
+        got = np.asarray(got)
+        expected = expected.detach().numpy()
+        assert got.shape == expected.shape, f"{target}: {got.shape} != {expected.shape}"
+        np.testing.assert_allclose(
+            got, expected, rtol=rtol, atol=atol, err_msg=f"{target}: vs torch.autograd"
+        )
+
+
+# --- Elementwise and structural ops -------------------------------------
+#
+# One small graph each, the same shapes tests/test_graph_grad.py's own
+# _CASES uses, paired with a plain-torch-ops forward that computes the same
+# thing an independent way.
+
+_SIMPLE_CASES = {
+    "relu": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Relu(A)
+        }
+        """,
+        None,
+        lambda t: torch.relu(t["A"]),
+    ),
+    "sigmoid": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Sigmoid(A)
+        }
+        """,
+        None,
+        lambda t: torch.sigmoid(t["A"]),
+    ),
+    "tanh": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Tanh(A)
+        }
+        """,
+        None,
+        lambda t: torch.tanh(t["A"]),
+    ),
+    "exp": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Exp(A)
+        }
+        """,
+        None,
+        lambda t: torch.exp(t["A"]),
+    ),
+    "log": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Log(A)
+        }
+        """,
+        {"A": _positive},
+        lambda t: torch.log(t["A"]),
+    ),
+    "sqrt": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Sqrt(A)
+        }
+        """,
+        {"A": _positive},
+        lambda t: torch.sqrt(t["A"]),
+    ),
+    "erf": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Erf(A)
+        }
+        """,
+        None,
+        lambda t: torch.erf(t["A"]),
+    ),
+    "neg": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Neg(A)
+        }
+        """,
+        None,
+        lambda t: -t["A"],
+    ),
+    "sub": (
+        """
+        g (float[3,4] A, float[3,4] B) => (float[3,4] Y) {
+          Y = Sub(A, B)
+        }
+        """,
+        None,
+        lambda t: t["A"] - t["B"],
+    ),
+    "mul": (
+        """
+        g (float[3,4] A, float[3,4] B) => (float[3,4] Y) {
+          Y = Mul(A, B)
+        }
+        """,
+        None,
+        lambda t: t["A"] * t["B"],
+    ),
+    "div": (
+        """
+        g (float[3,4] A, float[3,4] B) => (float[3,4] Y) {
+          Y = Div(A, B)
+        }
+        """,
+        {"B": _away_from_zero},
+        lambda t: t["A"] / t["B"],
+    ),
+    "reshape": (
+        """
+        g (float[2,3,4] A) => (float[6,4] Y)
+        <int64[2] target = {6, 4}>
+        {
+          Y = Reshape(A, target)
+        }
+        """,
+        None,
+        lambda t: t["A"].reshape(6, 4),
+    ),
+    "transpose_default": (
+        """
+        g (float[2,3,4] A) => (float[4,3,2] Y) {
+          Y = Transpose(A)
+        }
+        """,
+        None,
+        lambda t: t["A"].permute(2, 1, 0),
+    ),
+    "transpose_perm": (
+        """
+        g (float[2,3,4] A) => (float[3,2,4] Y) {
+          Y = Transpose <perm = [1, 0, 2]> (A)
+        }
+        """,
+        None,
+        lambda t: t["A"].permute(1, 0, 2),
+    ),
+    "reducesum_keepdims": (
+        """
+        g (float[2,3,4] A) => (float[2,1,4] Y)
+        <int64[1] axes = {1}>
+        {
+          Y = ReduceSum <keepdims = 1> (A, axes)
+        }
+        """,
+        None,
+        lambda t: t["A"].sum(dim=1, keepdim=True),
+    ),
+    "reducesum_dropdims": (
+        """
+        g (float[2,3,4] A) => (float[2,4] Y)
+        <int64[1] axes = {1}>
+        {
+          Y = ReduceSum <keepdims = 0> (A, axes)
+        }
+        """,
+        None,
+        lambda t: t["A"].sum(dim=1, keepdim=False),
+    ),
+    "reducemean_axes_attribute": (
+        """
+        g (float[2,3,4] A) => (float[2,3,1] Y) {
+          Y = ReduceMean <axes = [2], keepdims = 1> (A)
+        }
+        """,
+        None,
+        lambda t: t["A"].mean(dim=2, keepdim=True),
+    ),
+    "reducemean_dropdims": (
+        """
+        g (float[2,3,4] A) => (float[2,4] Y) {
+          Y = ReduceMean <axes = [1], keepdims = 0> (A)
+        }
+        """,
+        None,
+        lambda t: t["A"].mean(dim=1, keepdim=False),
+    ),
+    "softmax_last_axis": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Softmax (A)
+        }
+        """,
+        None,
+        lambda t: torch.softmax(t["A"], dim=-1),
+    ),
+    "softmax_first_axis": (
+        """
+        g (float[3,4] A) => (float[3,4] Y) {
+          Y = Softmax <axis = 0> (A)
+        }
+        """,
+        None,
+        lambda t: torch.softmax(t["A"], dim=0),
+    ),
+    # Continuous random data is never exactly on a clip bound, so the one
+    # place onnxsim's mask (strict inequality -- see _grad_clip) and torch's
+    # clamp gradient (inclusive of the bound) actually disagree is a
+    # zero-probability event here, not something this comparison risks.
+    "clip": (
+        """
+        g (float[3,4] A) => (float[3,4] Y)
+        <float lo = {-0.5}, float hi = {0.5}>
+        {
+          Y = Clip(A, lo, hi)
+        }
+        """,
+        None,
+        lambda t: torch.clamp(t["A"], min=-0.5, max=0.5),
+    ),
+    "clip_lower_only": (
+        """
+        g (float[3,4] A) => (float[3,4] Y)
+        <float lo = {-0.25}>
+        {
+          Y = Clip(A, lo)
+        }
+        """,
+        None,
+        lambda t: torch.clamp(t["A"], min=-0.25),
+    ),
+}
+
+
+@pytest.mark.parametrize("seed", [0, 1])
+@pytest.mark.parametrize("case", sorted(_SIMPLE_CASES), ids=sorted(_SIMPLE_CASES))
+def test_simple_rule_matches_torch_autograd(case, seed):
+    body, overrides, torch_fn = _SIMPLE_CASES[case]
+    _check_against_torch(body, torch_fn, overrides=overrides, seed=seed)
+
+
+# --- MatMul --------------------------------------------------------------
+
+_MATMUL_CASES = {
+    "matmul": """
+        g (float[3,4] A, float[4,5] B) => (float[3,5] Y) {
+          Y = MatMul(A, B)
+        }
+        """,
+    "matmul_batched": """
+        g (float[2,3,4] A, float[2,4,5] B) => (float[2,3,5] Y) {
+          Y = MatMul(A, B)
+        }
+        """,
+    # Torch's own matmul broadcasts leading batch dims exactly the way
+    # ONNX's MatMul spec (and _grad_matmul's own np.broadcast_shapes call)
+    # does, so the same lambda covers the broadcasting and rank-mixed cases.
+    "matmul_broadcast_batch": """
+        g (float[1,3,4] A, float[2,4,5] B) => (float[2,3,5] Y) {
+          Y = MatMul(A, B)
+        }
+        """,
+    "matmul_rank_mix": """
+        g (float[2,3,4] A, float[4,5] B) => (float[2,3,5] Y) {
+          Y = MatMul(A, B)
+        }
+        """,
+}
+
+
+@pytest.mark.parametrize("case", sorted(_MATMUL_CASES), ids=sorted(_MATMUL_CASES))
+def test_matmul_matches_torch_autograd(case):
+    _check_against_torch(_MATMUL_CASES[case], lambda t: t["A"] @ t["B"])
+
+
+# --- Gemm ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        "",
+        "<alpha = 0.75>",
+        "<beta = 0.5>",
+        "<alpha = 1.5, beta = -0.25>",
+        "<transB = 1>",
+        "<transA = 1>",
+        "<transA = 1, transB = 1, alpha = 0.5, beta = 2.0>",
+    ],
+    ids=["plain", "alpha", "beta", "alpha_beta", "transB", "transA", "everything"],
+)
+def test_gemm_matches_torch_autograd(attributes):
+    trans_a = "transA = 1" in attributes
+    trans_b = "transB = 1" in attributes
+    alpha = (
+        0.75
+        if "alpha = 0.75" in attributes
+        else (
+            1.5
+            if "alpha = 1.5" in attributes
+            else (0.5 if "alpha = 0.5" in attributes else 1.0)
+        )
+    )
+    beta = (
+        0.5
+        if "beta = 0.5" in attributes
+        else (
+            -0.25
+            if "beta = -0.25" in attributes
+            else (2.0 if "beta = 2.0" in attributes else 1.0)
+        )
+    )
+    a_shape = "4,3" if trans_a else "3,4"
+    b_shape = "5,4" if trans_b else "4,5"
+
+    def torch_fn(t):
+        a = t["A"].t() if trans_a else t["A"]
+        b = t["B"].t() if trans_b else t["B"]
+        return alpha * (a @ b) + beta * t["C"]
+
+    _check_against_torch(
+        f"""
+        g (float[{a_shape}] A, float[{b_shape}] B, float[5] C)
+            => (float[3,5] Y) {{
+          Y = Gemm {attributes} (A, B, C)
+        }}
+        """,
+        torch_fn,
+    )
+
+
+# --- Conv --------------------------------------------------------------
+#
+# ONNX Conv and torch's conv{1,2,3}d share both the weight-tensor layout
+# ([out_channels, in_channels/groups, *kernel]) and the padding/stride/
+# dilation/groups semantics, so this is a genuinely different implementation
+# of the *same* op (torch's own native conv + its autodiff, not im2col
+# reconstructed by hand the way _grad_conv is) rather than a reformulation --
+# a strong, cheap cross-check for a rule whose whole design (see _grad_conv's
+# own docstring) is "no convolution op in the backward graph at all". Every
+# case below keeps padding symmetric so a plain ``padding=`` tuple expresses
+# it exactly; the asymmetric SAME_UPPER/SAME_LOWER cases stay covered by
+# tests/test_graph_grad.py's finite differences only.
+_CONV_FN = {1: F.conv1d, 2: F.conv2d, 3: F.conv3d}
+
+_CONV_CASES = {
+    "conv": dict(
+        body="""
+        g (float[1,2,4,4] A, float[3,2,3,3] B) => (float[1,3,2,2] Y) {
+          Y = Conv(A, B)
+        }
+        """,
+        spatial=2,
+        stride=(1, 1),
+        dilation=(1, 1),
+        groups=1,
+        padding=(0, 0),
+        has_bias=False,
+    ),
+    "conv_bias": dict(
+        body="""
+        g (float[1,1,4,4] A, float[2,1,3,3] B, float[2] C)
+            => (float[1,2,2,2] Y) {
+          Y = Conv(A, B, C)
+        }
+        """,
+        spatial=2,
+        stride=(1, 1),
+        dilation=(1, 1),
+        groups=1,
+        padding=(0, 0),
+        has_bias=True,
+    ),
+    "conv_pointwise": dict(
+        body="""
+        g (float[1,2,3,3] A, float[3,2,1,1] B) => (float[1,3,3,3] Y) {
+          Y = Conv(A, B)
+        }
+        """,
+        spatial=2,
+        stride=(1, 1),
+        dilation=(1, 1),
+        groups=1,
+        padding=(0, 0),
+        has_bias=False,
+    ),
+    "conv_strided_padded": dict(
+        body="""
+        g (float[1,2,5,5] A, float[2,2,3,3] B) => (float[1,2,3,3] Y) {
+          Y = Conv <strides = [2, 2], pads = [1, 1, 1, 1]> (A, B)
+        }
+        """,
+        spatial=2,
+        stride=(2, 2),
+        dilation=(1, 1),
+        groups=1,
+        padding=(1, 1),
+        has_bias=False,
+    ),
+    "conv_dilated": dict(
+        body="""
+        g (float[1,1,5,5] A, float[1,1,2,2] B) => (float[1,1,3,3] Y) {
+          Y = Conv <dilations = [2, 2]> (A, B)
+        }
+        """,
+        spatial=2,
+        stride=(1, 1),
+        dilation=(2, 2),
+        groups=1,
+        padding=(0, 0),
+        has_bias=False,
+    ),
+    "conv_grouped": dict(
+        body="""
+        g (float[1,4,3,3] A, float[4,2,2,2] B) => (float[1,4,2,2] Y) {
+          Y = Conv <group = 2> (A, B)
+        }
+        """,
+        spatial=2,
+        stride=(1, 1),
+        dilation=(1, 1),
+        groups=2,
+        padding=(0, 0),
+        has_bias=False,
+    ),
+    "conv_depthwise": dict(
+        body="""
+        g (float[1,3,3,3] A, float[3,1,2,2] B, float[3] C)
+            => (float[1,3,2,2] Y) {
+          Y = Conv <group = 3> (A, B, C)
+        }
+        """,
+        spatial=2,
+        stride=(1, 1),
+        dilation=(1, 1),
+        groups=3,
+        padding=(0, 0),
+        has_bias=True,
+    ),
+    "conv_1d": dict(
+        body="""
+        g (float[1,2,7] A, float[2,2,3] B) => (float[1,2,3] Y) {
+          Y = Conv <strides = [2]> (A, B)
+        }
+        """,
+        spatial=1,
+        stride=(2,),
+        dilation=(1,),
+        groups=1,
+        padding=(0,),
+        has_bias=False,
+    ),
+    "conv_3d": dict(
+        body="""
+        g (float[1,1,3,3,3] A, float[2,1,2,2,2] B) => (float[1,2,2,2,2] Y) {
+          Y = Conv(A, B)
+        }
+        """,
+        spatial=3,
+        stride=(1, 1, 1),
+        dilation=(1, 1, 1),
+        groups=1,
+        padding=(0, 0, 0),
+        has_bias=False,
+    ),
+}
+
+
+@pytest.mark.parametrize("case", sorted(_CONV_CASES), ids=sorted(_CONV_CASES))
+def test_conv_matches_torch_autograd(case):
+    spec = _CONV_CASES[case]
+    conv = _CONV_FN[spec["spatial"]]
+
+    def torch_fn(t, spec=spec, conv=conv):
+        bias = t["C"] if spec["has_bias"] else None
+        return conv(
+            t["A"],
+            t["B"],
+            bias=bias,
+            stride=spec["stride"],
+            padding=spec["padding"],
+            dilation=spec["dilation"],
+            groups=spec["groups"],
+        )
+
+    _check_against_torch(spec["body"], torch_fn)
+
+
+# --- MaxPool / AveragePool -----------------------------------------------
+#
+# Same rationale as Conv: torch's own pooling ops share ONNX's geometry
+# attributes directly, so this is an independent implementation of the same
+# op, not a hand-transcription of _grad_maxpool/_grad_averagepool's own
+# col2im construction.
+_MAXPOOL_FN = {1: F.max_pool1d, 2: F.max_pool2d, 3: F.max_pool3d}
+
+_MAXPOOL_CASES = {
+    "maxpool": dict(
+        body="""
+        g (float[1,2,4,4] A) => (float[1,2,2,2] Y) {
+          Y = MaxPool <kernel_shape = [2, 2], strides = [2, 2]> (A)
+        }
+        """,
+        spatial=2,
+        kernel=(2, 2),
+        stride=(2, 2),
+        padding=(0, 0),
+        dilation=(1, 1),
+    ),
+    "maxpool_strided_padded": dict(
+        body="""
+        g (float[1,2,5,5] A) => (float[1,2,3,3] Y) {
+          Y = MaxPool <kernel_shape = [3, 3], strides = [2, 2],
+                       pads = [1, 1, 1, 1]> (A)
+        }
+        """,
+        spatial=2,
+        kernel=(3, 3),
+        stride=(2, 2),
+        padding=(1, 1),
+        dilation=(1, 1),
+    ),
+    "maxpool_dilated": dict(
+        body="""
+        g (float[1,1,5,5] A) => (float[1,1,3,3] Y) {
+          Y = MaxPool <kernel_shape = [2, 2], dilations = [2, 2]> (A)
+        }
+        """,
+        spatial=2,
+        kernel=(2, 2),
+        stride=(1, 1),
+        padding=(0, 0),
+        dilation=(2, 2),
+    ),
+    "maxpool_1d": dict(
+        body="""
+        g (float[1,2,7] A) => (float[1,2,3] Y) {
+          Y = MaxPool <kernel_shape = [3], strides = [2]> (A)
+        }
+        """,
+        spatial=1,
+        kernel=(3,),
+        stride=(2,),
+        padding=(0,),
+        dilation=(1,),
+    ),
+    "maxpool_3d": dict(
+        body="""
+        g (float[1,1,4,4,4] A) => (float[1,1,2,2,2] Y) {
+          Y = MaxPool <kernel_shape = [2, 2, 2], strides = [2, 2, 2]> (A)
+        }
+        """,
+        spatial=3,
+        kernel=(2, 2, 2),
+        stride=(2, 2, 2),
+        padding=(0, 0, 0),
+        dilation=(1, 1, 1),
+    ),
+}
+
+
+@pytest.mark.parametrize("case", sorted(_MAXPOOL_CASES), ids=sorted(_MAXPOOL_CASES))
+def test_maxpool_matches_torch_autograd(case):
+    spec = _MAXPOOL_CASES[case]
+    pool = _MAXPOOL_FN[spec["spatial"]]
+
+    def torch_fn(t, spec=spec, pool=pool):
+        return pool(
+            t["A"],
+            kernel_size=spec["kernel"],
+            stride=spec["stride"],
+            padding=spec["padding"],
+            dilation=spec["dilation"],
+        )
+
+    _check_against_torch(spec["body"], torch_fn)
+
+
+_AVGPOOL_FN = {1: F.avg_pool1d, 2: F.avg_pool2d, 3: F.avg_pool3d}
+
+_AVGPOOL_CASES = {
+    "averagepool": dict(
+        body="""
+        g (float[1,2,4,4] A) => (float[1,2,2,2] Y) {
+          Y = AveragePool <kernel_shape = [2, 2], strides = [2, 2]> (A)
+        }
+        """,
+        spatial=2,
+        kernel=(2, 2),
+        stride=(2, 2),
+        padding=(0, 0),
+        count_include_pad=False,
+    ),
+    "averagepool_count_exclude_pad": dict(
+        body="""
+        g (float[1,2,5,5] A) => (float[1,2,3,3] Y) {
+          Y = AveragePool <kernel_shape = [3, 3], strides = [2, 2],
+                           pads = [1, 1, 1, 1]> (A)
+        }
+        """,
+        spatial=2,
+        kernel=(3, 3),
+        stride=(2, 2),
+        padding=(1, 1),
+        count_include_pad=False,
+    ),
+    "averagepool_count_include_pad": dict(
+        body="""
+        g (float[1,2,5,5] A) => (float[1,2,3,3] Y) {
+          Y = AveragePool <kernel_shape = [3, 3], strides = [2, 2],
+                           pads = [1, 1, 1, 1], count_include_pad = 1> (A)
+        }
+        """,
+        spatial=2,
+        kernel=(3, 3),
+        stride=(2, 2),
+        padding=(1, 1),
+        count_include_pad=True,
+    ),
+    "averagepool_1d": dict(
+        body="""
+        g (float[1,2,7] A) => (float[1,2,3] Y) {
+          Y = AveragePool <kernel_shape = [3], strides = [2]> (A)
+        }
+        """,
+        spatial=1,
+        kernel=(3,),
+        stride=(2,),
+        padding=(0,),
+        count_include_pad=False,
+    ),
+    "averagepool_3d": dict(
+        body="""
+        g (float[1,1,4,4,4] A) => (float[1,1,2,2,2] Y) {
+          Y = AveragePool <kernel_shape = [2, 2, 2], strides = [2, 2, 2]> (A)
+        }
+        """,
+        spatial=3,
+        kernel=(2, 2, 2),
+        stride=(2, 2, 2),
+        padding=(0, 0, 0),
+        count_include_pad=False,
+    ),
+}
+
+
+@pytest.mark.parametrize("case", sorted(_AVGPOOL_CASES), ids=sorted(_AVGPOOL_CASES))
+def test_averagepool_matches_torch_autograd(case):
+    spec = _AVGPOOL_CASES[case]
+    pool = _AVGPOOL_FN[spec["spatial"]]
+
+    def torch_fn(t, spec=spec, pool=pool):
+        return pool(
+            t["A"],
+            kernel_size=spec["kernel"],
+            stride=spec["stride"],
+            padding=spec["padding"],
+            count_include_pad=spec["count_include_pad"],
+        )
+
+    _check_against_torch(spec["body"], torch_fn)
+
+
+# --- LayerNormalization / InstanceNormalization --------------------------
+#
+# Both share BatchNormalization's own risk profile -- dx depends on every
+# element in its normalization group through both a mean and a variance term
+# computed from x itself -- so both get the same torch.autograd cross-check
+# tests/test_graph_grad_templates.py gave BatchNormalization, written out in
+# plain torch ops (mean/var/rsqrt) rather than a fused
+# torch.nn.functional.layer_norm/instance_norm, for the same reason that
+# file's own comment gives: independence from whatever a fused kernel does
+# or does not support differentiating.
+
+
+def _layer_norm_torch_fn(axis, eps, has_bias):
+    def fn(t):
+        x = t["A"]
+        dims = tuple(range(axis, x.dim()))
+        xc = x - x.mean(dim=dims, keepdim=True)
+        var = (xc * xc).mean(dim=dims, keepdim=True)
+        xhat = xc / torch.sqrt(var + eps)
+        y = xhat * t["S"]
+        if has_bias:
+            y = y + t["B"]
+        return y
+
+    return fn
+
+
+_LAYER_NORM_CASES = {
+    "layer_norm": dict(
+        body="""
+        g (float[2,3,4] A, float[4] S, float[4] B) => (float[2,3,4] Y) {
+          Y = LayerNormalization (A, S, B)
+        }
+        """,
+        axis=2,
+        eps=1e-5,
+        has_bias=True,
+    ),
+    "layer_norm_no_bias": dict(
+        body="""
+        g (float[2,3,4] A, float[4] S) => (float[2,3,4] Y) {
+          Y = LayerNormalization (A, S)
+        }
+        """,
+        axis=2,
+        eps=1e-5,
+        has_bias=False,
+    ),
+    "layer_norm_axis_1": dict(
+        body="""
+        g (float[2,3,4] A, float[3,4] S, float[3,4] B) => (float[2,3,4] Y) {
+          Y = LayerNormalization <axis = 1> (A, S, B)
+        }
+        """,
+        axis=1,
+        eps=1e-5,
+        has_bias=True,
+    ),
+    "layer_norm_epsilon": dict(
+        body="""
+        g (float[2,3,4] A, float[4] S, float[4] B) => (float[2,3,4] Y) {
+          Y = LayerNormalization <epsilon = 0.001> (A, S, B)
+        }
+        """,
+        axis=2,
+        eps=0.001,
+        has_bias=True,
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "case", sorted(_LAYER_NORM_CASES), ids=sorted(_LAYER_NORM_CASES)
+)
+def test_layer_normalization_matches_torch_autograd(case):
+    spec = _LAYER_NORM_CASES[case]
+    _check_against_torch(
+        spec["body"],
+        _layer_norm_torch_fn(spec["axis"], spec["eps"], spec["has_bias"]),
+    )
+
+
+def _instance_norm_torch_fn(eps):
+    def fn(t):
+        x = t["X"]
+        spatial = tuple(range(2, x.dim()))
+        xc = x - x.mean(dim=spatial, keepdim=True)
+        var = (xc * xc).mean(dim=spatial, keepdim=True)
+        xhat = xc / torch.sqrt(var + eps)
+        bshape = [1, -1] + [1] * (x.dim() - 2)
+        return xhat * t["S"].reshape(bshape) + t["Bs"].reshape(bshape)
+
+    return fn
+
+
+_INSTANCE_NORM_CASES = {
+    "instance_norm": dict(
+        body="""
+        g (float[2,3,4,4] X, float[3] S, float[3] Bs) => (float[2,3,4,4] Y) {
+          Y = InstanceNormalization(X, S, Bs)
+        }
+        """,
+        eps=1e-5,
+    ),
+    "instance_norm_channel_count": dict(
+        body="""
+        g (float[2,5,3,3] X, float[5] S, float[5] Bs) => (float[2,5,3,3] Y) {
+          Y = InstanceNormalization(X, S, Bs)
+        }
+        """,
+        eps=1e-5,
+    ),
+    "instance_norm_1d_spatial": dict(
+        body="""
+        g (float[2,3,5] X, float[3] S, float[3] Bs) => (float[2,3,5] Y) {
+          Y = InstanceNormalization(X, S, Bs)
+        }
+        """,
+        eps=1e-5,
+    ),
+    "instance_norm_epsilon": dict(
+        body="""
+        g (float[2,3,4,4] X, float[3] S, float[3] Bs) => (float[2,3,4,4] Y) {
+          Y = InstanceNormalization <epsilon = 0.001> (X, S, Bs)
+        }
+        """,
+        eps=0.001,
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "case", sorted(_INSTANCE_NORM_CASES), ids=sorted(_INSTANCE_NORM_CASES)
+)
+def test_instance_normalization_matches_torch_autograd(case):
+    spec = _INSTANCE_NORM_CASES[case]
+    _check_against_torch(spec["body"], _instance_norm_torch_fn(spec["eps"]))
+
+
+# --- Gather ---------------------------------------------------------------
+#
+# torch.index_select is the same embedding-lookup semantics _grad_gather
+# documents itself as implementing (a scatter-add gradient for repeated
+# reads), built by torch's own indexing rather than the one-hot MatMul
+# _grad_gather uses to stay inside BACKWARD_OPS -- an independent
+# implementation of the same rule, not the same construction restated.
+# ``idx``/``axis`` are the model's own initializer/attribute, not a graph
+# input _feeds could randomize, so they are given directly to torch here the
+# same fixed way the ONNX text spells them.
+
+_GATHER_CASES = {
+    "gather_embedding": dict(
+        body="""
+        g (float[5,3] data) => (float[3,3] Y)
+        <int64[3] idx = {0, 2, 4}>
+        {
+          Y = Gather(data, idx)
+        }
+        """,
+        axis=0,
+        index=[0, 2, 4],
+    ),
+    "gather_repeated_index": dict(
+        body="""
+        g (float[4,2] data) => (float[3,2] Y)
+        <int64[3] idx = {1, 1, 3}>
+        {
+          Y = Gather(data, idx)
+        }
+        """,
+        axis=0,
+        index=[1, 1, 3],
+    ),
+    # axis=-2 on a rank-3 input resolves to axis 1 (size 5); idx=-1 resolves
+    # to 4 -- both resolutions done here, by hand, so torch is given the
+    # same lookup in its own positive-axis/positive-index spelling.
+    "gather_negative_axis_and_index": dict(
+        body="""
+        g (float[2,5,3] data) => (float[2,2,3] Y)
+        <int64[2] idx = {-1, 0}>
+        {
+          Y = Gather <axis = -2> (data, idx)
+        }
+        """,
+        axis=1,
+        index=[4, 0],
+    ),
+}
+
+
+@pytest.mark.parametrize("case", sorted(_GATHER_CASES), ids=sorted(_GATHER_CASES))
+def test_gather_matches_torch_autograd(case):
+    spec = _GATHER_CASES[case]
+    idx = torch.tensor(spec["index"], dtype=torch.long)
+
+    def torch_fn(t, axis=spec["axis"], idx=idx):
+        return t["data"].index_select(axis, idx)
+
+    _check_against_torch(spec["body"], torch_fn)


### PR DESCRIPTION
tests/test_graph_grad_templates.py only compared onnxsim.graph_grad's
gradients against torch.autograd for the templated BatchNormalization rule.
Add the same independent cross-check (a genuinely different autodiff
implementation, not just a different numerical method on the same formula --
the kind of check that caught this repo's own dvar-derivation bug) for the
rest of the builtin rules: every elementwise/structural op, MatMul, Gemm's
attribute combinations, Conv (9 geometry variants), MaxPool/AveragePool,
LayerNormalization, InstanceNormalization, and Gather.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T2ZSE2VT84Cr4tryehQvQ8