### PR TITLE
Add federated averaging on top of LoRA training

### DIFF
--- a/docs/distributed-data-parallel-plan.md
+++ b/docs/distributed-data-parallel-plan.md
@@ -1,0 +1,136 @@
+# Distributed (data-parallel) training for onnxsim: plan
+
+**Status: initial implementation, scope deliberately narrow.** This is the
+"distributed" counterpart to `onnxsim/federated.py`'s FedAvg work
+(`docs/`-adjacent design note, not a comparison writeup like
+`nncf-comparison-future-work.md`). It records why data parallelism -- and
+specifically *not* tensor/pipeline parallelism -- is the only form of
+"distributed training" that fits onnxsim's existing architecture without a
+large, separate investment, and what `onnxsim/distributed.py` actually
+implements as a first version.
+
+## Why data parallelism, and not tensor/pipeline parallelism
+
+Every training-capable piece of onnxsim (`onnxsim.graph_grad`,
+`onnxsim.qat_graph`, `onnxsim.lora`, `onnxsim.qat`) is built around **one
+self-contained ONNX graph per process**: forward, loss, backward, and
+(usually) an optimizer step, all baked into ordinary ONNX nodes and run
+through a single `InferenceSession`. Real tensor parallelism needs the
+*graph itself* split across devices with explicit collectives inserted at
+exactly the points a sharded contraction axis requires them (see
+`scripts/distributed_tp_sketch.py` and the survey behind it) -- ONNX has no
+maintained, first-class way to express that today (ORT's own
+`MegatronF`/`MegatronG`/`Send`/`Recv` collective-with-gradient ops are a
+mostly-abandoned corner of `orttraining`), and hand-rolling the equivalent
+gradient rules inside `onnxsim.graph_grad` would be a large, narrowly-useful
+investment for a project whose actual niche is fine-tuning/QAT/LoRA on
+modestly-sized models, not multi-billion-parameter pretraining.
+
+Plain gradient-averaging data parallelism needs none of that. It only
+requires:
+
+1. Splitting **gradient computation** from **optimizer application** --
+   currently fused into one graph by `onnxsim.qat_graph.make_step_graph`
+   (see its own module docstring) for every existing caller, because every
+   existing caller trains alone, on one device. Once split, one all-reduce
+   between the two is enough.
+2. A gradient average across workers -- an ordinary Python-level
+   collective, not an ONNX graph construct. ONNX/ORT stay the *local*
+   compute engine on each worker; the collective lives entirely in the
+   orchestration layer around them, the same shape vLLM/DeepSpeed give
+   PyTorch (local compute) and NCCL (the collective) as separate concerns.
+
+That is a small, self-contained addition on top of existing, tested
+primitives (`graph_grad.build_backward`, `qat_graph.adam_update`,
+`qat_graph.make_step_graph`) -- not a new differentiation engine, not a new
+IR, and not a dependency on any onnxruntime build beyond the plain one
+`pip install onnxruntime` already gives every other onnxsim training path.
+
+## What "distributed" means here, concretely
+
+Real OS-level parallelism -- one Python **process** per worker
+(`multiprocessing.Process`), each running its own `onnxruntime`
+`InferenceSession` on its own private data shard, communicating gradients
+back to a parameter-server-style parent process over `multiprocessing.Pipe`.
+This is a real, if minimal, distributed system (genuine inter-process
+communication, not a single-process simulation like `onnxsim/federated.py`'s
+sequential client loop or `scripts/distributed_tp_sketch.py`'s numpy-only
+collective stand-in) -- it just runs on one machine's CPU cores rather than
+a GPU cluster, since that's what's available to develop and test this
+against. Swapping the transport (`multiprocessing.Pipe` &rarr; MPI/NCCL/a
+real network) is future work explicitly deferred, not attempted here; see
+"Left for later" below.
+
+## Architecture
+
+```
+                    ┌─────────────────────────┐
+                    │   parent process         │
+                    │                           │
+     ┌─────current  │  1. broadcast params      │
+     │   params      │  2. collect N gradients   │
+     │              │  3. average them           │
+     │              │  4. apply_step (Adam)      │
+     │              │     -- one ORT session,    │
+     │              │        one call per step   │
+     │              └─────────────────────────┘
+     │                    │            ▲
+     ▼                    ▼            │
+┌─────────┐        ┌─────────┐   gradients
+│ worker 0 │        │ worker 1 │   (+ local loss,
+│ own ORT  │  ...   │ own ORT  │    for logging)
+│ session, │        │ session, │
+│ own data │        │ own data │
+│ shard    │        │ shard    │
+└─────────┘        └─────────┘
+  grad_step graph      grad_step graph
+  (forward+backward,   (identical graph,
+   no optimizer)        different process)
+```
+
+- **`build_gradient_step_graph`**: forward + MSE loss + backward via
+  `onnxsim.graph_grad.build_backward`, restricted to `param_names` exactly
+  like `onnxsim.lora`'s block training does -- but with no optimizer wired
+  in and no state threading, since a worker's own weights never persist
+  between steps: they're fed fresh from the parent every step (the
+  broadcast in the diagram above), and the worker's only job is turning
+  `(current params, local batch)` into `(gradients, loss)`.
+- **`build_apply_step_graph`**: exactly one `onnxsim.qat_graph.adam_update`
+  call per parameter, wired through `make_step_graph`'s existing state
+  mechanism -- this is *not* new graph-building logic, it's the same
+  Adam-as-a-step-graph idiom every other onnxsim training path already uses,
+  just fed an already-averaged gradient instead of one it computed itself.
+- **`train_data_parallel`**: the orchestration loop above. Runs entirely in
+  the parent process except for each worker's own forward/backward, which is
+  real parallel work across OS processes.
+
+## Correctness property this is expected to hold
+
+Averaging equal-sized workers' gradients of a mean-loss is mathematically
+identical to computing that same mean-loss's gradient over the concatenated
+combined batch directly -- the same equivalence
+`scripts/distributed_tp_sketch.py` checks for its own tensor+data-parallel
+simulation. `tests/test_distributed.py` checks it here too: N-worker
+data-parallel training must match a single-process, non-parallel reference
+run on the concatenated data, to float32 tolerance, every step.
+
+## Left for later (explicitly out of scope for this version)
+
+- **Real network transport.** `multiprocessing.Pipe` only works within one
+  machine. A real multi-node version would swap this for MPI or a thin
+  socket protocol; the gradient-averaging *logic* above does not change,
+  only how bytes move between processes.
+- **ZeRO-style optimizer-state sharding.** Every worker-independent
+  parameter here has its Adam state held once, in the parent process --
+  fine at the scale onnxsim actually targets, not a fit for models too big
+  for one machine's memory (which is also not what tensor/pipeline
+  parallelism being out of scope, above, was ever going to solve here
+  either).
+- **Fault tolerance / elastic membership.** A worker dying mid-run currently
+  hangs the parent waiting on its pipe. A production version would need
+  timeouts and the ability to drop/replace a worker, the same gap flagged
+  for the federated round-trip protocol in the FL track's own discussion.
+- **Overlap of communication with compute.** Every step here is fully
+  synchronous (broadcast, wait for all gradients, average, apply) with no
+  attempt to prefetch or overlap, unlike FSDP2's overlapped all-gathers.
+  Worth revisiting once there's a real workload to profile against.

--- a/onnxsim/distributed.py
+++ b/onnxsim/distributed.py
@@ -1,0 +1,381 @@
+"""Real, multi-process data-parallel training over onnxsim's own step-graph
+machinery -- see ``docs/distributed-data-parallel-plan.md`` for the design
+rationale and why this stays deliberately scoped to data parallelism rather
+than tensor/pipeline parallelism.
+
+**The split this module makes that no other onnxsim training path needs.**
+:func:`onnxsim.qat_graph.make_step_graph` fuses forward, backward, and an
+optimizer update into one graph for every existing caller
+(:mod:`onnxsim.lora`, :mod:`onnxsim.qat`), because every existing caller
+trains alone. Data-parallel training needs a gradient *average* to happen
+between backward and the optimizer step, so this module splits those two
+into separate graphs instead:
+
+- :func:`build_gradient_step_graph` -- forward, an MSE loss, and
+  :func:`onnxsim.graph_grad.build_backward` restricted to the parameters
+  being trained. No optimizer, no state threading: a worker's weights are
+  fed fresh from the parent process every step (see
+  :func:`train_data_parallel`), never carried between calls.
+- :func:`build_apply_step_graph` -- exactly the same
+  :func:`onnxsim.qat_graph.adam_update`-as-a-step-graph idiom every other
+  onnxsim training path already uses, just fed an already-averaged gradient
+  instead of one it computed itself.
+
+**The orchestration.** :func:`train_data_parallel` spawns one real OS
+process per data shard (``multiprocessing.Process``, not a thread or an
+in-process loop), each running its own ``onnxruntime`` session on the
+gradient-step graph against its own private data; the parent process
+collects every worker's gradients over a ``multiprocessing.Pipe``, averages
+them, and runs the (single, shared) apply-step to produce the next round's
+weights, which it broadcasts back down the same pipes. This is genuine
+inter-process parallelism -- unlike :mod:`onnxsim.federated`'s sequential
+simulation of federated clients, or ``scripts/distributed_tp_sketch.py``'s
+single-process numpy stand-in for NCCL -- it just runs on one machine's CPU
+cores rather than a GPU cluster or a real network, since that is what is
+available to develop and test this against. See the plan doc's "Left for
+later" section for what a real multi-node transport would need to change
+(the gradient-averaging math here would not).
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from dataclasses import dataclass
+from typing import Dict, List, Sequence, Tuple, Union
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper
+import onnx.inliner
+
+from onnxsim import backend, graph_grad, qat_graph
+
+_OPSET = 17
+_IR_VERSION = 8
+
+
+def build_gradient_step_graph(
+    nodes: Sequence[onnx.NodeProto],
+    shapes: Dict[str, Sequence[Union[int, str]]],
+    initializers: Sequence[onnx.TensorProto],
+    input_name: str,
+    input_shape: Sequence[int],
+    target_name: str,
+    target_shape: Sequence[int],
+    output_name: str,
+    param_names: Sequence[str],
+) -> Tuple[onnx.ModelProto, Dict[str, str], str]:
+    """A plain (non-step, non-stateful) ONNX graph computing an MSE loss's
+    gradient with respect to every name in ``param_names``.
+
+    Unlike :func:`onnx.qat_graph.make_step_graph`, this declares every
+    parameter as a plain graph *input* (fed fresh each call) with a plain
+    gradient tensor as the matching *output* -- there is nothing to thread
+    between calls, since :func:`train_data_parallel` never reuses one
+    worker's own copy of the weights across steps (see this module's
+    docstring). Using ``make_step_graph``'s state-threading machinery for a
+    graph that has no state to thread would be forcing a fit rather than
+    reusing one; building the plain graph directly, the way
+    ``onnxsim.qat._block_shapes``'s own probe models do, is the more honest
+    match.
+
+    :param nodes: the forward pass's own nodes (in graph order).
+    :param shapes: static shapes for every tensor ``nodes`` touches, as
+            :func:`onnxsim.graph_grad.build_backward` requires.
+    :param initializers: every initializer ``nodes`` reads (frozen weights
+            not in ``param_names``, and any of ``param_names`` themselves --
+            included here only so :func:`onnxsim.backend.run_model`-style
+            callers can inspect a self-contained model; the *training* path
+            in :func:`train_data_parallel` always overrides these via feeds,
+            since it declares each of ``param_names`` as an input below too).
+    :param input_name: the model's own input activation.
+    :param target_name: the regression target this step's MSE loss is
+            computed against.
+    :param output_name: the forward pass's own final output.
+    :param param_names: which initializers to differentiate with respect to
+            -- everything else in ``nodes`` is treated as frozen, exactly as
+            :func:`onnxsim.graph_grad.build_backward`'s own ``targets``
+            argument works.
+    :returns: ``(model, {param name: gradient tensor name}, loss_name)``.
+    """
+    b = qat_graph.GraphBuilder("dp__")
+    b.initializer.extend(initializers)
+    b.nodes.extend(nodes)
+
+    diff = b.sub(output_name, target_name)
+    n_elems = int(np.prod(list(target_shape)))
+    dl_dy = b.mul(diff, b.const(2.0 / n_elems))
+    loss_name = b.mean_square(diff)
+
+    grads = graph_grad.build_backward(
+        b, list(nodes), shapes, {output_name: dl_dy}, list(param_names)
+    )
+
+    inputs = [
+        onnx.helper.make_tensor_value_info(
+            input_name, onnx.TensorProto.FLOAT, list(input_shape)
+        ),
+        onnx.helper.make_tensor_value_info(
+            target_name, onnx.TensorProto.FLOAT, list(target_shape)
+        ),
+    ]
+    inputs += [
+        onnx.helper.make_tensor_value_info(
+            name, onnx.TensorProto.FLOAT, list(shapes[name])
+        )
+        for name in param_names
+    ]
+
+    grad_names = {name: grads[name] for name in param_names}
+    outputs = [
+        onnx.helper.make_tensor_value_info(
+            grad_names[name], onnx.TensorProto.FLOAT, list(shapes[name])
+        )
+        for name in param_names
+    ]
+    outputs.append(
+        onnx.helper.make_tensor_value_info(loss_name, onnx.TensorProto.FLOAT, [])
+    )
+
+    graph = onnx.helper.make_graph(
+        b.nodes,
+        "onnxsim_dp_gradient_step",
+        inputs,
+        outputs,
+        initializer=[t for t in b.initializer if t.name not in param_names],
+    )
+    opset_imports = [onnx.helper.make_opsetid("", _OPSET)]
+    if b.functions:
+        domains = sorted({fn.domain for fn in b.functions})
+        opset_imports += [onnx.helper.make_opsetid(d, 1) for d in domains]
+    model = onnx.helper.make_model(
+        graph, opset_imports=opset_imports, functions=list(b.functions)
+    )
+    model.ir_version = _IR_VERSION
+    if b.functions:
+        model = onnx.inliner.inline_local_functions(model)
+    onnx.checker.check_model(model)
+    return model, grad_names, loss_name
+
+
+def build_apply_step_graph(
+    shapes: Dict[str, Sequence[int]], param_names: Sequence[str]
+) -> qat_graph.StepGraph:
+    """The shared optimizer step every worker's already-averaged gradient
+    feeds into -- one :func:`onnxsim.qat_graph.adam_update` call per
+    parameter, wired through :func:`onnxsim.qat_graph.make_step_graph`'s
+    existing state mechanism exactly like every other onnxsim training path
+    already does. The only thing distinguishing this from, say,
+    :mod:`onnxsim.lora`'s own Adam wiring is that the gradient
+    (``f"grad__{name}"``) is a *per-step* input here rather than something
+    this same graph computed via backward -- :func:`train_data_parallel`
+    supplies it fresh each call, already averaged across every worker.
+    """
+    b = qat_graph.GraphBuilder("dpopt__")
+    state: Dict[str, Tuple[Sequence[int], str]] = {}
+    per_step: Dict[str, Tuple[Sequence[int], int]] = {}
+    for name in param_names:
+        shape = list(shapes[name])
+        grad_name = f"grad__{name}"
+        per_step[grad_name] = (shape, onnx.TensorProto.FLOAT)
+        m_name, v_name = f"m__{name}", f"v__{name}"
+        param_next, m_next, v_next = qat_graph.adam_update(
+            b, name, grad_name, m_name, v_name, "lr", "m_correction", "v_correction"
+        )
+        state[name] = (shape, param_next)
+        state[m_name] = (shape, m_next)
+        state[v_name] = (shape, v_next)
+
+    return qat_graph.make_step_graph(
+        b,
+        constants={},
+        state=state,
+        scalars=["lr", "m_correction", "v_correction"],
+        name="onnxsim_dp_apply_step",
+        per_step=per_step,
+    )
+
+
+@dataclass
+class WorkerShard:
+    """One worker's local data for the whole run -- never sent anywhere,
+    never seen by the parent process or any other worker. Only that
+    worker's *gradients*, computed locally, ever leave it (see
+    :func:`train_data_parallel`)."""
+
+    inputs: np.ndarray
+    targets: np.ndarray
+
+    def sample(
+        self, rng: np.random.Generator, batch_size: int
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        idx = rng.integers(0, self.inputs.shape[0], size=batch_size)
+        return self.inputs[idx], self.targets[idx]
+
+
+def _worker_main(
+    worker_id: int,
+    grad_model_bytes: bytes,
+    input_name: str,
+    target_name: str,
+    grad_output_names: List[str],
+    loss_name: str,
+    conn,
+) -> None:
+    """One data-parallel worker's whole life: build a local ORT session
+    once, then repeatedly receive ``(params, batch_input, batch_target)``
+    from the parent and send back ``(worker_id, gradients, loss)`` -- until
+    a ``None`` message tells it to exit. Runs in its own OS process (see
+    :func:`train_data_parallel`), so this function's own imports and the ORT
+    session it creates are never shared with the parent or any sibling
+    worker.
+    """
+    import onnxruntime as ort
+
+    session = ort.InferenceSession(grad_model_bytes, providers=["CPUExecutionProvider"])
+    output_names = grad_output_names + [loss_name]
+    try:
+        while True:
+            message = conn.recv()
+            if message is None:
+                return
+            params, batch_input, batch_target = message
+            feeds = {input_name: batch_input, target_name: batch_target}
+            feeds.update(params)
+            results = session.run(output_names, feeds)
+            grads = results[:-1]
+            loss = float(results[-1])
+            conn.send((worker_id, grads, loss))
+    finally:
+        conn.close()
+
+
+def train_data_parallel(
+    grad_model: onnx.ModelProto,
+    grad_names: Dict[str, str],
+    loss_name: str,
+    input_name: str,
+    target_name: str,
+    param_names: Sequence[str],
+    shapes: Dict[str, Sequence[int]],
+    initial_params: Dict[str, np.ndarray],
+    shards: Sequence[WorkerShard],
+    num_steps: int,
+    batch_size: int,
+    learning_rate: float,
+    seed: int = 0,
+) -> Tuple[Dict[str, np.ndarray], List[float]]:
+    """Trains ``param_names`` for ``num_steps`` synchronous data-parallel
+    steps across ``len(shards)`` real OS processes -- one per shard, each
+    running its own copy of ``grad_model`` against its own private data (see
+    :class:`WorkerShard`) -- and returns ``(final params, per-step mean
+    loss across workers)``.
+
+    Every step: the current parameters are broadcast to every worker; each
+    worker samples its own random batch (:meth:`WorkerShard.sample`) and
+    computes local gradients; the parent averages the same-named gradient
+    across every worker (equal weight per worker, matching equal-sized
+    shards -- unequal shards would need
+    :func:`onnxsim.federated.fedavg`-style weighting instead, not
+    implemented here) and runs one shared :func:`build_apply_step_graph`
+    Adam step to produce the next parameters.
+
+    :param grad_model: the model :func:`build_gradient_step_graph` returned.
+    :param grad_names: the ``{param name: gradient tensor name}`` mapping
+            :func:`build_gradient_step_graph` also returned.
+    :param loss_name: that same call's ``loss_name``.
+    :param shards: one per worker; ``len(shards)`` is the worker count.
+    :param batch_size: each worker's own local batch size per step -- every
+            worker samples this many rows independently, so the effective
+            combined batch size per step is ``batch_size * len(shards)``.
+    :param seed: seeds the parent's own batch-sampling RNG; each worker's
+            samples are therefore reproducible run to run (single-process
+            parent, one RNG), but are not required to be identical to what a
+            single-process reference run would sample as its own combined
+            batch -- see ``tests/test_distributed.py`` for how the two are
+            actually compared.
+    :raises ValueError: if ``shards`` is empty.
+    """
+    if not shards:
+        raise ValueError("train_data_parallel needs at least one worker shard")
+
+    apply_step = build_apply_step_graph(shapes, param_names)
+    apply_runner = backend.Runner(
+        apply_step.model, output_names=list(apply_step.state.values())
+    )
+
+    model_bytes = grad_model.SerializeToString()
+    ordered_grad_names = [grad_names[name] for name in param_names]
+
+    parent_conns = []
+    processes = []
+    for worker_id, _shard in enumerate(shards):
+        parent_conn, child_conn = mp.Pipe()
+        process = mp.Process(
+            target=_worker_main,
+            args=(
+                worker_id,
+                model_bytes,
+                input_name,
+                target_name,
+                ordered_grad_names,
+                loss_name,
+                child_conn,
+            ),
+        )
+        process.start()
+        child_conn.close()
+        parent_conns.append(parent_conn)
+        processes.append(process)
+
+    params = {
+        name: np.asarray(initial_params[name], dtype=np.float32) for name in param_names
+    }
+    opt_m = {name: np.zeros_like(params[name]) for name in param_names}
+    opt_v = {name: np.zeros_like(params[name]) for name in param_names}
+
+    rng = np.random.default_rng(seed)
+    losses: List[float] = []
+    try:
+        for t in range(num_steps):
+            for conn, shard in zip(parent_conns, shards):
+                batch_input, batch_target = shard.sample(rng, batch_size)
+                conn.send((params, batch_input, batch_target))
+
+            grads_by_worker: List[List[np.ndarray]] = [None] * len(shards)  # type: ignore[list-item]
+            step_losses = []
+            for conn in parent_conns:
+                worker_id, grads, loss = conn.recv()
+                grads_by_worker[worker_id] = grads
+                step_losses.append(loss)
+            losses.append(float(np.mean(step_losses)))
+
+            feeds: Dict[str, np.ndarray] = dict(params)
+            for i, name in enumerate(param_names):
+                averaged = np.mean([grads[i] for grads in grads_by_worker], axis=0)
+                feeds[f"grad__{name}"] = averaged.astype(np.float32)
+                feeds[f"m__{name}"] = opt_m[name]
+                feeds[f"v__{name}"] = opt_v[name]
+            feeds["lr"] = np.array(learning_rate, dtype=np.float32)
+            corrections = qat_graph.adam_bias_corrections(t)
+            feeds["m_correction"] = np.array(
+                corrections["m_correction"], dtype=np.float32
+            )
+            feeds["v_correction"] = np.array(
+                corrections["v_correction"], dtype=np.float32
+            )
+
+            out = apply_runner(feeds)
+            for name in param_names:
+                params[name] = out[apply_step.state[name]]
+                opt_m[name] = out[apply_step.state[f"m__{name}"]]
+                opt_v[name] = out[apply_step.state[f"v__{name}"]]
+    finally:
+        for conn in parent_conns:
+            conn.send(None)
+            conn.close()
+        for process in processes:
+            process.join()
+
+    return params, losses

--- a/onnxsim/federated.py
+++ b/onnxsim/federated.py
@@ -85,8 +85,7 @@ class FederatedClient:
     def __post_init__(self) -> None:
         if (self.reference_model is None) == (self.target_data is None):
             raise ValueError(
-                "FederatedClient needs exactly one of reference_model or "
-                "target_data"
+                "FederatedClient needs exactly one of reference_model or target_data"
             )
 
     def weight(self) -> int:
@@ -160,8 +159,7 @@ def fedavg(
         raise ValueError("fedavg needs at least one client state")
     if len(weights) != len(client_states):
         raise ValueError(
-            f"fedavg got {len(client_states)} client states but "
-            f"{len(weights)} weights"
+            f"fedavg got {len(client_states)} client states but {len(weights)} weights"
         )
     total = float(sum(weights))
     if total <= 0:
@@ -170,9 +168,7 @@ def fedavg(
     names = set(client_states[0])
     for state in client_states[1:]:
         if set(state) != names:
-            raise ValueError(
-                "fedavg needs every client state to name the same tensors"
-            )
+            raise ValueError("fedavg needs every client state to name the same tensors")
 
     averaged: Dict[str, np.ndarray] = {}
     for name in names:

--- a/onnxsim/federated.py
+++ b/onnxsim/federated.py
@@ -1,0 +1,324 @@
+"""Federated averaging on top of :mod:`onnxsim.lora` -- training a shared
+LoRA adapter across clients that each hold private data, without any client's
+data (or the base model's own weights) ever leaving where it started.
+
+**Why LoRA is the right unit to federate, not the whole model.** A federated
+round communicates whatever a client trains, every round, to every
+participant -- so its cost is set by how much *state* one round of local
+training touches, not by how big the base model is. :func:`onnxsim.lora.train_lora`
+already freezes everything except an injected adapter's own ``A``/``B``
+matrices (:meth:`onnxsim.lora.LoraAdapter.parameter_names`) and returns a
+model with only those initializers changed. Federating LoRA training instead
+of full fine-tuning means each round moves rank-sized deltas, not full
+weight tensors -- the same reason LoRA is attractive for on-device
+personalization in the first place, here reused for its communication cost
+rather than its memory cost.
+
+**What this module adds, concretely.** :func:`onnxsim.lora.train_lora` already
+does everything one *client's* local training needs. The only genuinely new
+piece is round orchestration: broadcast the current global adapter state to
+every client, train each independently on its own data starting from that
+same state (:func:`run_federated_round`), and average the results back into
+one global state (:func:`fedavg`) -- classic FedAvg, applied to an adapter's
+parameters instead of a whole model's. Each client's local optimizer state
+(Adam's ``m``/``v`` moments) is not part of what gets averaged or carried
+between rounds: :func:`onnxsim.lora.train_lora` always starts a client's local
+steps from a fresh zeroed optimizer state (see ``onnxsim.lora._train_lora_block``),
+exactly as FedAvg's own definition assumes.
+
+**What this does not implement.** Secure aggregation (the server seeing only
+the *sum* of client updates, never one client's own) and differential-privacy
+noise are both real requirements for production cross-device FL, and neither
+is here -- :func:`fedavg` is a plain, visible weighted average. Non-IID-aware
+aggregation (FedProx, SCAFFOLD, FedOpt-style server optimizers) is also out of
+scope: this is FedAvg, the baseline every one of those improves on, not a
+replacement for it. Adding either is a reason to extend this module later,
+not a gap in what it claims to do now.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+
+from onnxsim import backend, lora
+from onnxsim.calibration import Tensors
+
+
+@dataclass
+class FederatedClient:
+    """One participant's local, private data for one federated round.
+
+    Never crosses into another client's or the server's hands -- only the
+    adapter state :func:`run_federated_round` extracts *after* local training
+    does. Exactly one of ``reference_model``/``target_data`` must be given,
+    mirroring :func:`onnxsim.lora.train_lora`'s own contract: a client with
+    real local labels uses ``target_data`` (actual supervised fine-tuning on
+    that client's data); a client with unlabeled data can still contribute by
+    label-free distillation against a shared ``reference_model``. Nothing
+    requires every client in one round to pick the same option.
+
+    :param calibration_data: this client's local input batches, in the same
+            axis-0-concatenation contract :func:`onnxsim.lora.train_lora` takes.
+    :param target_data: this client's local labels, one array per
+            ``calibration_data`` batch. Mutually exclusive with
+            ``reference_model``.
+    :param reference_model: a shared teacher model this client distills
+            against instead of using its own labels. Mutually exclusive with
+            ``target_data``.
+    :param num_examples: this client's example count, for FedAvg's weighted
+            average (:func:`fedavg`). Defaults to ``len(calibration_data)``,
+            i.e. one example per batch -- pass this explicitly when a batch
+            holds more than one example, or when a client should be weighted
+            by something other than a raw batch count.
+    """
+
+    calibration_data: Sequence[Tensors]
+    target_data: Optional[Sequence[np.ndarray]] = None
+    reference_model: Optional[Union[str, onnx.ModelProto]] = None
+    num_examples: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if (self.reference_model is None) == (self.target_data is None):
+            raise ValueError(
+                "FederatedClient needs exactly one of reference_model or "
+                "target_data"
+            )
+
+    def weight(self) -> int:
+        """This client's FedAvg weight -- its local example count."""
+        if self.num_examples is not None:
+            return self.num_examples
+        return len(self.calibration_data)
+
+
+def extract_adapter_state(
+    model: onnx.ModelProto, adapter: lora.LoraAdapter
+) -> Dict[str, np.ndarray]:
+    """The current value of every one of ``adapter``'s ``A``/``B``
+    initializers in ``model`` -- what one round communicates, in either
+    direction: a client's return trip after local training, or (via
+    :func:`apply_adapter_state`) the server's broadcast of the next round's
+    starting point."""
+    initializer_map = {t.name: t for t in model.graph.initializer}
+    return {
+        name: onnx.numpy_helper.to_array(initializer_map[name]).astype(np.float32)
+        for name in adapter.parameter_names()
+    }
+
+
+def apply_adapter_state(
+    model: onnx.ModelProto, state: Dict[str, np.ndarray]
+) -> onnx.ModelProto:
+    """``model`` with every initializer named in ``state`` overwritten by its
+    value, and everything else -- base weights included -- byte-for-byte
+    unchanged. The inverse of :func:`extract_adapter_state`, and how a
+    federated round's averaged result (or a fresh round's broadcast of the
+    previous round's global state) becomes the model the next round of local
+    training starts from."""
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    for initializer in out.graph.initializer:
+        if initializer.name in state:
+            initializer.CopyFrom(
+                onnx.numpy_helper.from_array(
+                    state[initializer.name].astype(np.float32),
+                    name=initializer.name,
+                )
+            )
+    onnx.checker.check_model(out)
+    return out
+
+
+def fedavg(
+    client_states: Sequence[Dict[str, np.ndarray]],
+    weights: Sequence[float],
+) -> Dict[str, np.ndarray]:
+    """The weighted average of several clients' adapter states, tensor by
+    tensor -- McMahan et al.'s FedAvg, applied to whatever
+    :func:`extract_adapter_state` returned for each client rather than to a
+    whole model's weights.
+
+    Accumulates in float64 and casts back to float32 at the end, so summing
+    many clients' contributions does not lose precision that the individual
+    float32 states never had reason to carry.
+
+    :param client_states: one :func:`extract_adapter_state` result per
+            client that took part in the round, all for the same adapter (so
+            all with identical key sets).
+    :param weights: one non-negative weight per entry of ``client_states``,
+            typically :meth:`FederatedClient.weight`'s local example count.
+    :raises ValueError: if ``client_states`` is empty, if ``weights`` has a
+            different length, if the weights do not sum to a positive number,
+            or if the client states do not all share the same tensor names.
+    """
+    if not client_states:
+        raise ValueError("fedavg needs at least one client state")
+    if len(weights) != len(client_states):
+        raise ValueError(
+            f"fedavg got {len(client_states)} client states but "
+            f"{len(weights)} weights"
+        )
+    total = float(sum(weights))
+    if total <= 0:
+        raise ValueError(f"fedavg weights must sum to a positive number, got {total}")
+
+    names = set(client_states[0])
+    for state in client_states[1:]:
+        if set(state) != names:
+            raise ValueError(
+                "fedavg needs every client state to name the same tensors"
+            )
+
+    averaged: Dict[str, np.ndarray] = {}
+    for name in names:
+        acc = np.zeros_like(client_states[0][name], dtype=np.float64)
+        for state, weight in zip(client_states, weights):
+            acc += state[name].astype(np.float64) * (weight / total)
+        averaged[name] = acc.astype(np.float32)
+    return averaged
+
+
+def run_federated_round(
+    global_model: onnx.ModelProto,
+    adapter: lora.LoraAdapter,
+    clients: Sequence[FederatedClient],
+    block_input_name: str,
+    block_output_name: str,
+    local_iterations: int = 10,
+    learning_rate: float = 1e-3,
+    lr_decay: bool = True,
+    providers: Optional[Sequence[backend.Provider]] = None,
+    step_providers: Optional[Sequence[backend.Provider]] = None,
+) -> Tuple[onnx.ModelProto, List[float]]:
+    """One federated round: every client in ``clients`` trains
+    :func:`onnxsim.lora.train_lora` independently for ``local_iterations``
+    steps, starting from ``global_model``'s current adapter state, on its own
+    data alone; the resulting adapter states are combined by :func:`fedavg`,
+    weighted by each client's :meth:`FederatedClient.weight`, into the next
+    global state.
+
+    Every client starts from the *same* broadcast state -- ``global_model``
+    is read, never mutated, so training one client cannot see another's
+    updates from the same round (that is next round's global state, not this
+    one's).
+
+    :param global_model: an :func:`onnxsim.lora.inject_lora`-injected model
+            holding the current global adapter state.
+    :param adapter: the :class:`onnxsim.lora.LoraAdapter`
+            :func:`onnxsim.lora.inject_lora` returned alongside
+            ``global_model``.
+    :param clients: this round's participants. At least one is required; a
+            production deployment would also sample a subset of a larger
+            client population per round, which is a policy this function
+            leaves to its caller -- pass exactly the clients meant to
+            participate.
+    :param block_input_name: the activation entering the trained block, the
+            same argument :func:`onnxsim.lora.train_lora` takes.
+    :param block_output_name: the block's own output, whose reconstruction
+            error against each client's target is that client's local loss.
+    :param local_iterations: local optimizer steps each client runs before
+            reporting back -- FedAvg's ``E`` (local epochs), expressed here as
+            a step count rather than an epoch count since
+            :func:`onnxsim.lora.train_lora` itself takes one.
+    :param learning_rate: local learning rate, shared by every client this
+            round.
+    :param lr_decay: anneal each client's local learning rate to zero over
+            its own ``local_iterations``, the same flag
+            :func:`onnxsim.lora.train_lora` takes -- decay resets every
+            round, since each client's local run is independent.
+    :param providers: onnxruntime execution providers for capturing each
+            client's calibration activations (only used when a client trains
+            against a ``reference_model``; unused for ``target_data``
+            clients, matching :func:`onnxsim.lora.train_lora`).
+    :param step_providers: onnxruntime execution providers to run local
+            training's step graph on.
+    :returns: ``(next global model, one final local loss per client, in
+            ``clients`` order)``. A client whose local run recorded no losses
+            (impossible with ``local_iterations >= 1``, kept only because
+            ``train_lora``'s own ``losses`` list could in principle be empty)
+            reports ``nan`` rather than raising.
+    :raises ValueError: if ``clients`` is empty.
+    """
+    if not clients:
+        raise ValueError("run_federated_round needs at least one client")
+
+    client_states: List[Dict[str, np.ndarray]] = []
+    weights: List[float] = []
+    round_losses: List[float] = []
+    for client in clients:
+        losses: List[float] = []
+        tuned = lora.train_lora(
+            global_model,
+            adapter,
+            block_input_name,
+            block_output_name,
+            reference_model=client.reference_model,
+            target_data=client.target_data,
+            calibration_data=client.calibration_data,
+            num_iterations=local_iterations,
+            learning_rate=learning_rate,
+            lr_decay=lr_decay,
+            providers=providers,
+            step_providers=step_providers,
+            losses=losses,
+        )
+        client_states.append(extract_adapter_state(tuned, adapter))
+        weights.append(client.weight())
+        round_losses.append(losses[-1] if losses else float("nan"))
+
+    averaged = fedavg(client_states, weights)
+    next_global = apply_adapter_state(global_model, averaged)
+    return next_global, round_losses
+
+
+def run_federated_training(
+    global_model: onnx.ModelProto,
+    adapter: lora.LoraAdapter,
+    clients: Sequence[FederatedClient],
+    block_input_name: str,
+    block_output_name: str,
+    num_rounds: int = 5,
+    local_iterations: int = 10,
+    learning_rate: float = 1e-3,
+    lr_decay: bool = True,
+    providers: Optional[Sequence[backend.Provider]] = None,
+    step_providers: Optional[Sequence[backend.Provider]] = None,
+    round_losses: Optional[List[List[float]]] = None,
+) -> onnx.ModelProto:
+    """Runs :func:`run_federated_round` ``num_rounds`` times, feeding each
+    round's resulting global model in as the next round's starting point.
+
+    The same fixed ``clients`` list takes part in every round; sampling a
+    different subset of a larger population per round is, as in
+    :func:`run_federated_round`, left to the caller -- call
+    :func:`run_federated_round` directly, once per round, to vary who
+    participates.
+
+    :param round_losses: when given, one entry per round is appended -- the
+            list :func:`run_federated_round` returned for that round (one
+            final loss per client). Diagnostic only; nothing here reads it
+            back.
+    :returns: the global model after all ``num_rounds`` rounds.
+    """
+    model = global_model
+    for _ in range(num_rounds):
+        model, losses = run_federated_round(
+            model,
+            adapter,
+            clients,
+            block_input_name,
+            block_output_name,
+            local_iterations=local_iterations,
+            learning_rate=learning_rate,
+            lr_decay=lr_decay,
+            providers=providers,
+            step_providers=step_providers,
+        )
+        if round_losses is not None:
+            round_losses.append(losses)
+    return model

--- a/scripts/distributed_tp_sketch.py
+++ b/scripts/distributed_tp_sketch.py
@@ -1,0 +1,460 @@
+"""A runnable sketch of the Megatron-style tensor-parallel + data-parallel
+training flow described in ``docs/`` discussion of ONNX's distributed-training
+ops -- turning that conceptual sketch into code that actually executes and
+checks its own arithmetic, the same way this repo's tests compare a graph's
+gradient against an independent computation rather than trusting it.
+
+**Two halves, deliberately kept apart.**
+
+1. :func:`build_inspectable_rank_graph` builds one rank's *real* ONNX graph,
+   using the actual collective op types ONNX Runtime's (legacy, largely
+   unmaintained today) ``orttraining`` module defines with working gradient
+   rules: ``MegatronF``/``MegatronG`` (the tensor-parallel "conjugate pair" --
+   identity-forward/all-reduce-backward and its mirror) and ``NcclAllReduce``
+   (data-parallel gradient averaging, selected by a ``group_type`` attribute).
+   This graph is built and printed for inspection only -- it is never run.
+   Running it for real needs an onnxruntime build compiled with
+   ``--enable_training --use_nccl``, which is nowhere close to what
+   ``pip install onnxruntime`` gives you (see this repo's own ``CLAUDE.md``:
+   even the *wheel build* of onnxsim itself never compiles ONNX Runtime, let
+   alone a training+NCCL one), and it needs an actual multi-GPU NCCL fabric
+   besides. Neither exists in a sandbox, so this half exists purely so the
+   node types, domains, and attributes discussed are something you can look
+   at rather than take on faith.
+
+2. :func:`run_tensor_and_data_parallel_step` and friends do the *identical
+   math* in plain numpy, across ``tp_size * dp_size`` simulated ranks in one
+   process -- standing in for what ``MegatronF``/``MegatronG``/
+   ``NcclAllReduce`` would do on a real NCCL fabric, using the exact same
+   Adam update rule :mod:`onnxsim.qat_graph` uses for every other training
+   loop in this repo. :func:`main` then checks the simulated multi-rank
+   result against a single-rank, non-parallel reference computation on the
+   same combined data -- forward output, gradients, and post-optimizer
+   weights all have to agree, which is only true if the collectives were
+   simulated in the right place with the right reduction. That is the
+   property this script actually verifies; it is not just a demo that runs
+   without crashing.
+
+**What this is not.** Not a contribution to :mod:`onnxsim` itself -- nothing
+here is imported by the package, which is why it lives under ``scripts/``
+rather than ``onnxsim/``. Not a working distributed training system: real
+tensor parallelism needs a real NCCL fabric and a real multi-process launch
+(``mpirun``/``torchrun``-equivalent), neither of which this script attempts.
+And not a claim that the ``com.microsoft`` attribute names in
+:func:`build_inspectable_rank_graph` are pinned to one exact onnxruntime
+version -- they are reconstructed from ``orttraining``'s own source
+(``training_op_defs.cc``, ``gradient_builder.cc``, ``collective_defs.cc``)
+rather than a live schema registry, since that domain's training ops are not
+registered in a default onnxruntime build and so cannot be checked against a
+live schema here either. Treat that half as a documentation artifact, not a
+tested contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+import numpy as np
+import onnx
+from onnx import helper
+
+from onnxsim.qat_graph import ADAM_BETA1, ADAM_BETA2, ADAM_EPS
+
+
+# ---------------------------------------------------------------------------
+# Half 1: the real ONNX graph, for inspection only.
+# ---------------------------------------------------------------------------
+
+
+def build_inspectable_rank_graph(
+    tp_size: int, d_in: int, d_hidden: int, d_out: int
+) -> onnx.ModelProto:
+    """One rank's forward-only graph for a column-parallel-then-row-parallel
+    MLP block (the same block :func:`run_tensor_and_data_parallel_step`
+    simulates), using ``com.microsoft``'s real collective op types.
+
+    Only the forward pass is built here: ``MegatronF``/``MegatronG`` carry
+    their own registered gradient rules in a real ``orttraining`` build (that
+    is the entire point of the "conjugate pair" -- a differentiable graph
+    transformation library can call ``build_backward`` on this exactly like
+    any other op, without a hand-written collective-aware backward pass), so
+    there is nothing distributed-specific to add on the backward side of a
+    *real* build. This script's own backward pass (in the numpy half) is
+    hand-derived instead, since :mod:`onnxsim.graph_grad` has no rule for a
+    domain onnxruntime's default build does not even register.
+
+    ``d_hidden`` must be divisible by ``tp_size`` -- each rank owns a
+    ``d_hidden / tp_size`` column slice of ``W1`` and the matching row slice
+    of ``W2``, exactly the split :func:`shard_weights` computes for the
+    numpy simulation.
+    """
+    if d_hidden % tp_size != 0:
+        raise ValueError(f"d_hidden={d_hidden} must be divisible by tp_size={tp_size}")
+    shard = d_hidden // tp_size
+
+    x = helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, ["batch", d_in])
+    w1 = helper.make_tensor_value_info("w1_shard", onnx.TensorProto.FLOAT, [d_in, shard])
+    w2 = helper.make_tensor_value_info("w2_shard", onnx.TensorProto.FLOAT, [shard, d_out])
+    y = helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, ["batch", d_out])
+
+    nodes = [
+        # MegatronF: identity in the forward direction. Its entire reason to
+        # exist is the *backward* rule a real build registers for it
+        # (all-reduce of the incoming gradient across the tensor-parallel
+        # group) -- see this function's docstring.
+        helper.make_node("MegatronF", ["x"], ["x_f"], domain="com.microsoft"),
+        helper.make_node("MatMul", ["x_f", "w1_shard"], ["z"]),
+        helper.make_node("Tanh", ["z"], ["h"]),
+        helper.make_node("MatMul", ["h", "w2_shard"], ["y_partial"]),
+        # MegatronG: all-reduce in the forward direction -- this is the node
+        # that turns each rank's partial sum (row-parallel W2's contraction
+        # axis is sharded) into the true, replicated output.
+        helper.make_node("MegatronG", ["y_partial"], ["y"], domain="com.microsoft"),
+    ]
+
+    graph = helper.make_graph(nodes, f"tp_rank_forward_shard_{shard}", [x, w1, w2], [y])
+    model = helper.make_model(
+        graph,
+        opset_imports=[
+            helper.make_opsetid("", 17),
+            # Version 1 of a domain this repo's onnx package does not
+            # register a schema for -- see the module docstring's third
+            # paragraph for why this model is never passed to a checker or a
+            # runtime.
+            helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    return model
+
+
+def build_data_parallel_gradient_sync_graph(d_in: int, shard: int) -> onnx.ModelProto:
+    """The other collective a real per-rank *training* graph would contain:
+    ``NcclAllReduce`` averaging one rank's local weight-shard gradient across
+    the *data*-parallel group, immediately before the optimizer update reads
+    it -- the classic DP gradient-average, orthogonal to the tensor-parallel
+    pair above (it reduces across a different mesh axis).
+
+    ``group_type`` is reconstructed from ``orttraining``'s own
+    ``NcclAllReduce`` schema (a small enum: global/data/node-local/
+    cross-node/horizontal/model); ``"data"`` selects the data-parallel
+    communicator specifically, as opposed to a tensor- or pipeline-parallel
+    one a *different* node in the same real graph might reduce across.
+    """
+    grad_in = helper.make_tensor_value_info(
+        "grad_w1_shard_local", onnx.TensorProto.FLOAT, [d_in, shard]
+    )
+    grad_out = helper.make_tensor_value_info(
+        "grad_w1_shard_dp_averaged", onnx.TensorProto.FLOAT, [d_in, shard]
+    )
+    node = helper.make_node(
+        "NcclAllReduce",
+        ["grad_w1_shard_local"],
+        ["grad_w1_shard_dp_averaged"],
+        domain="com.microsoft",
+        group_type="data",
+    )
+    graph = helper.make_graph(
+        [node], "dp_gradient_sync", [grad_in], [grad_out]
+    )
+    return helper.make_model(
+        graph,
+        opset_imports=[
+            helper.make_opsetid("", 17),
+            helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Half 2: the same math, in numpy, standing in for a real NCCL fabric.
+# ---------------------------------------------------------------------------
+
+
+def activation(z: np.ndarray) -> np.ndarray:
+    """Stands in for the GELU a real Megatron MLP uses -- swapped for
+    ``tanh`` purely so this script needs no dependency beyond numpy (numpy
+    has no ``erf``). Nothing about the parallelism pattern being checked
+    depends on which pointwise nonlinearity sits here."""
+    return np.tanh(z)
+
+
+def activation_grad(z: np.ndarray) -> np.ndarray:
+    t = np.tanh(z)
+    return 1.0 - t * t
+
+
+@dataclass
+class RankShard:
+    """One tensor-parallel rank's own slice of the block's two weights, plus
+    that shard's own Adam moments -- each TP rank keeps a full, un-sharded
+    optimizer state for the parameters *it* owns, exactly as real Megatron-LM
+    does (ZeRO-style optimizer-state sharding is a separate, orthogonal
+    technique this sketch does not add)."""
+
+    w1: np.ndarray  # [d_in, d_hidden / tp_size] -- column-parallel
+    w2: np.ndarray  # [d_hidden / tp_size, d_out] -- row-parallel
+    m1: np.ndarray
+    v1: np.ndarray
+    m2: np.ndarray
+    v2: np.ndarray
+
+
+def shard_weights(w1_full: np.ndarray, w2_full: np.ndarray, tp_size: int) -> List[RankShard]:
+    """Splits one un-sharded ``(W1, W2)`` pair into ``tp_size``
+    :class:`RankShard`\\ s -- ``W1`` column-wise (its output/hidden axis),
+    ``W2`` row-wise (its input/hidden axis, the contraction axis the
+    row-parallel matmul sums over). Every TP rank in every data-parallel
+    replica starts from the *same* shard, exactly like a real job's initial
+    broadcast of the model before training begins.
+    """
+    d_hidden = w1_full.shape[1]
+    if d_hidden % tp_size != 0:
+        raise ValueError(f"d_hidden={d_hidden} must be divisible by tp_size={tp_size}")
+    shard = d_hidden // tp_size
+    shards = []
+    for r in range(tp_size):
+        w1_r = w1_full[:, r * shard : (r + 1) * shard].copy()
+        w2_r = w2_full[r * shard : (r + 1) * shard, :].copy()
+        shards.append(
+            RankShard(w1_r, w2_r, np.zeros_like(w1_r), np.zeros_like(w1_r),
+                       np.zeros_like(w2_r), np.zeros_like(w2_r))
+        )
+    return shards
+
+
+def tp_forward(
+    shards: Sequence[RankShard], x: np.ndarray
+) -> Tuple[np.ndarray, List[np.ndarray], List[np.ndarray]]:
+    """One tensor-parallel group's forward pass -- ``MegatronF``'s forward
+    (identity on ``x``, so every rank reads the same replicated activation)
+    followed by each rank's local column-parallel/row-parallel matmul pair,
+    followed by ``MegatronG``'s forward (summing every rank's partial output
+    -- the all-reduce a row-parallel contraction axis requires before its
+    result means anything)."""
+    zs, hs, y_partials = [], [], []
+    for shard in shards:
+        z = x @ shard.w1
+        h = activation(z)
+        y_partials.append(h @ shard.w2)
+        zs.append(z)
+        hs.append(h)
+    y = sum(y_partials)
+    return y, zs, hs
+
+
+def tp_backward(
+    shards: Sequence[RankShard],
+    x: np.ndarray,
+    zs: Sequence[np.ndarray],
+    hs: Sequence[np.ndarray],
+    dl_dy: np.ndarray,
+) -> Tuple[List[np.ndarray], List[np.ndarray], np.ndarray]:
+    """The tensor-parallel group's backward pass. ``MegatronG``'s backward
+    is Identity: since ``y = sum(y_partial_r)``, ``d(y)/d(y_partial_r) = 1``
+    for every rank, so every rank receives the *same* ``dl_dy`` unchanged --
+    no communication needed here, which is the whole reason the pair is
+    asymmetric (all-reduce forward, identity backward) rather than
+    all-reduce on both sides.
+
+    Each rank's own weight gradients are then local and require no further
+    communication -- a column-parallel/row-parallel split gives every rank a
+    *disjoint* slice of each weight, so there is nothing to reduce. The one
+    remaining collective is ``MegatronF``'s backward: every rank's local
+    contribution to ``dl/dx`` must be all-reduced, since ``x`` was
+    replicated and each rank only computed its own shard's share of how
+    ``x`` affected the loss.
+    """
+    grads_w1, grads_w2, dx_partials = [], [], []
+    for shard, z, h in zip(shards, zs, hs):
+        # MegatronG backward: Identity -- dl_dy reaches every rank unchanged.
+        grad_w2 = h.T @ dl_dy
+        dl_dh = dl_dy @ shard.w2.T
+        dl_dz = dl_dh * activation_grad(z)
+        grad_w1 = x.T @ dl_dz
+        dx_partials.append(dl_dz @ shard.w1.T)
+        grads_w1.append(grad_w1)
+        grads_w2.append(grad_w2)
+    dx = sum(dx_partials)  # MegatronF backward: all-reduce.
+    return grads_w1, grads_w2, dx
+
+
+def adam_step(
+    param: np.ndarray, grad: np.ndarray, m: np.ndarray, v: np.ndarray, lr: float, t: int
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """The exact update rule :func:`onnxsim.qat_graph.adam_update` builds as
+    an ONNX graph, reused here directly in numpy. A real onnxsim-based
+    deployment would run this rank's local optimizer step as a step graph
+    exactly the way :mod:`onnxsim.lora`/:mod:`onnxsim.qat` already do; there
+    is no distributed-specific reason to depart from that once the gradient
+    this function receives has already been correctly reduced, which is
+    :func:`run_tensor_and_data_parallel_step`'s job, not this one's.
+    """
+    m_next = ADAM_BETA1 * m + (1 - ADAM_BETA1) * grad
+    v_next = ADAM_BETA2 * v + (1 - ADAM_BETA2) * (grad * grad)
+    m_hat = m_next / (1 - ADAM_BETA1 ** t)
+    v_hat = v_next / (1 - ADAM_BETA2 ** t)
+    param_next = param - lr * m_hat / (np.sqrt(v_hat) + ADAM_EPS)
+    return param_next, m_next, v_next
+
+
+def run_tensor_and_data_parallel_step(
+    replicas: List[List[RankShard]],
+    xs: Sequence[np.ndarray],
+    targets: Sequence[np.ndarray],
+    lr: float,
+    step_t: int,
+) -> float:
+    """One full distributed training step across ``dp_size`` data-parallel
+    replicas, each an independent ``tp_size``-way tensor-parallel group --
+    ``replicas[d][r]`` is data-parallel replica ``d``'s tensor-parallel rank
+    ``r``, mutated in place exactly like a real rank would update its own
+    local weights.
+
+    Order of operations mirrors the real per-rank graph: local
+    forward/backward within each TP group (no cross-replica communication
+    yet), then ``NcclAllReduce(group_type="data")`` averaging each
+    (``d``-independent) TP rank's own gradient shard across every DP
+    replica, then a local Adam step per shard. Returns the mean loss across
+    every replica, for logging only.
+    """
+    dp_size = len(replicas)
+    tp_size = len(replicas[0])
+    losses = []
+
+    # Local forward + backward, independently per data-parallel replica.
+    per_replica_grads_w1: List[List[np.ndarray]] = []
+    per_replica_grads_w2: List[List[np.ndarray]] = []
+    for d in range(dp_size):
+        y, zs, hs = tp_forward(replicas[d], xs[d])
+        diff = y - targets[d]
+        losses.append(float(np.mean(diff * diff)))
+        dl_dy = diff * (2.0 / diff.size)
+        grads_w1, grads_w2, _dx = tp_backward(replicas[d], xs[d], zs, hs, dl_dy)
+        per_replica_grads_w1.append(grads_w1)
+        per_replica_grads_w2.append(grads_w2)
+
+    # NcclAllReduce(group_type="data"): average each TP rank's gradient
+    # shard across the data-parallel group -- same rank index ``r``, summed
+    # over the ``d`` axis instead of the ``r`` axis MegatronG summed over.
+    for r in range(tp_size):
+        avg_grad_w1 = sum(per_replica_grads_w1[d][r] for d in range(dp_size)) / dp_size
+        avg_grad_w2 = sum(per_replica_grads_w2[d][r] for d in range(dp_size)) / dp_size
+        for d in range(dp_size):
+            shard = replicas[d][r]
+            shard.w1, shard.m1, shard.v1 = adam_step(
+                shard.w1, avg_grad_w1, shard.m1, shard.v1, lr, step_t
+            )
+            shard.w2, shard.m2, shard.v2 = adam_step(
+                shard.w2, avg_grad_w2, shard.m2, shard.v2, lr, step_t
+            )
+
+    return float(np.mean(losses))
+
+
+def run_reference_step(
+    w1: np.ndarray, w2: np.ndarray, m1, v1, m2, v2, x: np.ndarray, target: np.ndarray,
+    lr: float, step_t: int,
+):
+    """The same block, computed with no parallelism at all, on the
+    *combined* batch every data-parallel replica's ``x``/``target`` would
+    concatenate into. This is what
+    :func:`run_tensor_and_data_parallel_step`'s result must agree with: DP
+    gradient-averaging over equal-sized replica batches is mathematically
+    identical to computing the mean-loss gradient over the concatenated
+    batch directly, and un-sharding ``W1``/``W2`` before the matmuls makes
+    tensor parallelism's own reduction (``MegatronG``'s all-reduce) a no-op
+    by construction -- there is only one rank, so there is nothing to sum.
+    """
+    z = x @ w1
+    h = activation(z)
+    y = h @ w2
+    diff = y - target
+    loss = float(np.mean(diff * diff))
+    dl_dy = diff * (2.0 / diff.size)
+    grad_w2 = h.T @ dl_dy
+    dl_dh = dl_dy @ w2.T
+    dl_dz = dl_dh * activation_grad(z)
+    grad_w1 = x.T @ dl_dz
+    w1, m1, v1 = adam_step(w1, grad_w1, m1, v1, lr, step_t)
+    w2, m2, v2 = adam_step(w2, grad_w2, m2, v2, lr, step_t)
+    return w1, w2, m1, v1, m2, v2, loss
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--tp-size", type=int, default=2)
+    parser.add_argument("--dp-size", type=int, default=2)
+    parser.add_argument("--d-in", type=int, default=8)
+    parser.add_argument("--d-hidden", type=int, default=16)
+    parser.add_argument("--d-out", type=int, default=8)
+    parser.add_argument("--batch-per-replica", type=int, default=6)
+    parser.add_argument("--steps", type=int, default=25)
+    parser.add_argument("--lr", type=float, default=1e-2)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    print("=== Half 1: the real ONNX collective ops, for inspection ===\n")
+    rank_graph = build_inspectable_rank_graph(args.tp_size, args.d_in, args.d_hidden, args.d_out)
+    print(helper.printable_graph(rank_graph.graph))
+    shard = args.d_hidden // args.tp_size
+    dp_sync_graph = build_data_parallel_gradient_sync_graph(args.d_in, shard)
+    print()
+    print(helper.printable_graph(dp_sync_graph.graph))
+
+    print("\n=== Half 2: simulating what those ops would do, in numpy ===\n")
+    rng = np.random.default_rng(args.seed)
+    w1_full = (rng.standard_normal((args.d_in, args.d_hidden)) / np.sqrt(args.d_in)).astype(np.float32)
+    w2_full = (rng.standard_normal((args.d_hidden, args.d_out)) / np.sqrt(args.d_hidden)).astype(np.float32)
+
+    replicas = [shard_weights(w1_full, w2_full, args.tp_size) for _ in range(args.dp_size)]
+
+    xs = [
+        rng.standard_normal((args.batch_per_replica, args.d_in)).astype(np.float32)
+        for _ in range(args.dp_size)
+    ]
+    targets = [
+        rng.standard_normal((args.batch_per_replica, args.d_out)).astype(np.float32)
+        for _ in range(args.dp_size)
+    ]
+
+    ref_w1, ref_w2 = w1_full.copy(), w2_full.copy()
+    ref_m1 = ref_v1 = np.zeros_like(ref_w1)
+    ref_m2 = ref_v2 = np.zeros_like(ref_w2)
+    x_combined = np.concatenate(xs, axis=0)
+    target_combined = np.concatenate(targets, axis=0)
+
+    for t in range(1, args.steps + 1):
+        sim_loss = run_tensor_and_data_parallel_step(replicas, xs, targets, args.lr, t)
+        ref_w1, ref_w2, ref_m1, ref_v1, ref_m2, ref_v2, ref_loss = run_reference_step(
+            ref_w1, ref_w2, ref_m1, ref_v1, ref_m2, ref_v2,
+            x_combined, target_combined, args.lr, t,
+        )
+        if t == 1 or t % 5 == 0 or t == args.steps:
+            print(f"step {t:3d}  simulated (tp={args.tp_size},dp={args.dp_size}) loss="
+                  f"{sim_loss:.6f}   non-parallel reference loss={ref_loss:.6f}")
+
+    # The check that actually matters: un-sharding every replica's rank-0
+    # trained shards back into one matrix must reproduce the reference
+    # exactly (up to float32 rounding) -- every replica trains the *same*
+    # weights, so any one of them (here replica 0) is the whole answer.
+    trained_w1 = np.concatenate([shard.w1 for shard in replicas[0]], axis=1)
+    trained_w2 = np.concatenate([shard.w2 for shard in replicas[0]], axis=0)
+    np.testing.assert_allclose(trained_w1, ref_w1, rtol=1e-4, atol=1e-5)
+    np.testing.assert_allclose(trained_w2, ref_w2, rtol=1e-4, atol=1e-5)
+    for d in range(1, args.dp_size):
+        other_w1 = np.concatenate([shard.w1 for shard in replicas[d]], axis=1)
+        other_w2 = np.concatenate([shard.w2 for shard in replicas[d]], axis=0)
+        np.testing.assert_allclose(other_w1, trained_w1, rtol=1e-6, atol=1e-7)
+        np.testing.assert_allclose(other_w2, trained_w2, rtol=1e-6, atol=1e-7)
+
+    print(
+        f"\nOK: {args.tp_size}-way tensor-parallel x {args.dp_size}-way data-parallel "
+        f"training for {args.steps} steps matches the non-parallel reference, "
+        f"and every data-parallel replica converged to identical weights."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1,0 +1,334 @@
+"""Tests for ``onnxsim.distributed`` (see ``onnxsim/distributed.py`` and
+``docs/distributed-data-parallel-plan.md``) -- real multi-process
+data-parallel training built on ``onnxsim.graph_grad``/``onnxsim.qat_graph``.
+
+Two things are checked independently, deliberately kept apart:
+
+- :func:`test_gradient_averaging_matches_combined_batch_reference` -- the
+  core mathematical claim (averaging equal-sized workers' gradients equals
+  the gradient over their concatenated batch), checked directly against
+  :func:`onnxsim.distributed.build_gradient_step_graph`'s own output with no
+  multiprocessing involved at all, so a failure here can't be blamed on
+  process orchestration.
+- :func:`test_train_data_parallel_reduces_loss_via_real_multiprocessing` --
+  that :func:`onnxsim.distributed.train_data_parallel` actually spawns real
+  OS processes and trains correctly end to end.
+"""
+
+import numpy as np
+import onnx
+import onnx.helper
+import onnx.numpy_helper
+import onnx.shape_inference
+import pytest
+
+from onnxsim import backend, distributed
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _shapes_of(model: onnx.ModelProto):
+    inferred = onnx.shape_inference.infer_shapes(model, strict_mode=True)
+    shapes = {}
+    for value in (
+        list(inferred.graph.input)
+        + list(inferred.graph.output)
+        + list(inferred.graph.value_info)
+    ):
+        shapes[value.name] = [d.dim_value for d in value.type.tensor_type.shape.dim]
+    for initializer in inferred.graph.initializer:
+        shapes[initializer.name] = list(initializer.dims)
+    return shapes
+
+
+def _make_mlp(rng, batch_size, d_in=4, d_hidden=6, d_out=3):
+    """A tiny 2-layer MLP (MatMul/Add/Relu/MatMul/Add), every weight
+    trainable -- small enough that a handful of local steps visibly moves
+    the loss, the same bar ``tests/test_lora.py`` sets for its own toy
+    models."""
+    w1 = (rng.standard_normal((d_in, d_hidden)) * 0.3).astype(np.float32)
+    b1 = np.zeros(d_hidden, dtype=np.float32)
+    w2 = (rng.standard_normal((d_hidden, d_out)) * 0.3).astype(np.float32)
+    b2 = np.zeros(d_out, dtype=np.float32)
+
+    nodes = [
+        onnx.helper.make_node("MatMul", ["input", "W1"], ["mm1"]),
+        onnx.helper.make_node("Add", ["mm1", "b1"], ["add1"]),
+        onnx.helper.make_node("Relu", ["add1"], ["relu1"]),
+        onnx.helper.make_node("MatMul", ["relu1", "W2"], ["mm2"]),
+        onnx.helper.make_node("Add", ["mm2", "b2"], ["output"]),
+    ]
+    initializers = [
+        onnx.numpy_helper.from_array(w1, "W1"),
+        onnx.numpy_helper.from_array(b1, "b1"),
+        onnx.numpy_helper.from_array(w2, "W2"),
+        onnx.numpy_helper.from_array(b2, "b2"),
+    ]
+    graph = onnx.helper.make_graph(
+        nodes,
+        "toy_mlp",
+        [
+            onnx.helper.make_tensor_value_info(
+                "input", onnx.TensorProto.FLOAT, [batch_size, d_in]
+            )
+        ],
+        [
+            onnx.helper.make_tensor_value_info(
+                "output", onnx.TensorProto.FLOAT, [batch_size, d_out]
+            )
+        ],
+        initializer=initializers,
+    )
+    model = onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+
+    shapes = _shapes_of(model)
+    param_names = ["W1", "b1", "W2", "b2"]
+    initial_params = {
+        name: onnx.numpy_helper.to_array(t).copy()
+        for name, t in zip(param_names, initializers)
+    }
+    return (
+        model,
+        nodes,
+        initializers,
+        shapes,
+        param_names,
+        initial_params,
+        (d_in, d_hidden, d_out),
+    )
+
+
+def test_gradient_averaging_matches_combined_batch_reference():
+    rng = np.random.default_rng(0)
+    batch_size = 5
+    (
+        model,
+        nodes,
+        initializers,
+        shapes,
+        param_names,
+        _initial,
+        (d_in, _d_hidden, d_out),
+    ) = _make_mlp(rng, batch_size)
+
+    per_worker_model, grad_names, loss_name = distributed.build_gradient_step_graph(
+        nodes,
+        shapes,
+        initializers,
+        "input",
+        [batch_size, d_in],
+        "target",
+        [batch_size, d_out],
+        "output",
+        param_names,
+    )
+    per_worker_runner = backend.Runner(
+        per_worker_model,
+        output_names=[grad_names[n] for n in param_names] + [loss_name],
+    )
+
+    x_a = rng.standard_normal((batch_size, d_in)).astype(np.float32)
+    y_a = rng.standard_normal((batch_size, d_out)).astype(np.float32)
+    x_b = rng.standard_normal((batch_size, d_in)).astype(np.float32) + 3.0
+    y_b = rng.standard_normal((batch_size, d_out)).astype(np.float32) - 3.0
+
+    params = {
+        n: onnx.numpy_helper.to_array(t) for n, t in zip(param_names, initializers)
+    }
+
+    out_a = per_worker_runner({"input": x_a, "target": y_a, **params})
+    out_b = per_worker_runner({"input": x_b, "target": y_b, **params})
+    averaged = {
+        name: np.mean([out_a[grad_names[name]], out_b[grad_names[name]]], axis=0)
+        for name in param_names
+    }
+
+    combined_model, combined_grad_names, _combined_loss = (
+        distributed.build_gradient_step_graph(
+            nodes,
+            shapes,
+            initializers,
+            "input",
+            [2 * batch_size, d_in],
+            "target",
+            [2 * batch_size, d_out],
+            "output",
+            param_names,
+        )
+    )
+    combined_runner = backend.Runner(
+        combined_model, output_names=[combined_grad_names[n] for n in param_names]
+    )
+    combined_out = combined_runner(
+        {
+            "input": np.concatenate([x_a, x_b], axis=0),
+            "target": np.concatenate([y_a, y_b], axis=0),
+            **params,
+        }
+    )
+
+    for name in param_names:
+        np.testing.assert_allclose(
+            averaged[name],
+            combined_out[combined_grad_names[name]],
+            rtol=1e-4,
+            atol=1e-5,
+        )
+
+
+def test_build_apply_step_graph_moves_params_in_the_gradients_direction():
+    rng = np.random.default_rng(0)
+    shapes = {"W": [3, 2]}
+    step = distributed.build_apply_step_graph(shapes, ["W"])
+    runner = backend.Runner(step.model, output_names=list(step.state.values()))
+
+    w = rng.standard_normal((3, 2)).astype(np.float32)
+    grad = np.ones((3, 2), dtype=np.float32)
+    out = runner(
+        {
+            "W": w,
+            "m__W": np.zeros_like(w),
+            "v__W": np.zeros_like(w),
+            "grad__W": grad,
+            "lr": np.array(0.1, dtype=np.float32),
+            "m_correction": np.array(1.0, dtype=np.float32),
+            "v_correction": np.array(1.0, dtype=np.float32),
+        }
+    )
+    w_next = out[step.state["W"]]
+    # A positive gradient everywhere must move every element of W down.
+    assert np.all(w_next < w)
+
+
+def test_train_data_parallel_requires_at_least_one_shard():
+    rng = np.random.default_rng(0)
+    (
+        _model,
+        nodes,
+        initializers,
+        shapes,
+        param_names,
+        initial_params,
+        (d_in, _h, d_out),
+    ) = _make_mlp(rng, 4)
+    grad_model, grad_names, loss_name = distributed.build_gradient_step_graph(
+        nodes,
+        shapes,
+        initializers,
+        "input",
+        [4, d_in],
+        "target",
+        [4, d_out],
+        "output",
+        param_names,
+    )
+    with pytest.raises(ValueError, match="at least one worker"):
+        distributed.train_data_parallel(
+            grad_model,
+            grad_names,
+            loss_name,
+            "input",
+            "target",
+            param_names,
+            shapes,
+            initial_params,
+            [],
+            num_steps=1,
+            batch_size=4,
+            learning_rate=1e-2,
+        )
+
+
+def test_train_data_parallel_reduces_loss_via_real_multiprocessing():
+    rng = np.random.default_rng(0)
+    batch_size = 4
+    (
+        _model,
+        nodes,
+        initializers,
+        shapes,
+        param_names,
+        initial_params,
+        (d_in, _h, d_out),
+    ) = _make_mlp(rng, batch_size)
+    grad_model, grad_names, loss_name = distributed.build_gradient_step_graph(
+        nodes,
+        shapes,
+        initializers,
+        "input",
+        [batch_size, d_in],
+        "target",
+        [batch_size, d_out],
+        "output",
+        param_names,
+    )
+
+    # Two workers holding different random samples of the *same* underlying
+    # linear relationship -- the realistic data-parallel scenario (one
+    # dataset sharded across workers), not the federated-learning one
+    # tests/test_federated.py's own two clients model (there, each client's
+    # data follows a genuinely different relationship, which is exactly
+    # what per-client LoRA adapters, not one gradient-averaged shared model,
+    # are suited to fit). A single set of weights trained by averaging
+    # gradients from two *conflicting* teachers can only converge to a
+    # compromise fit for both, not drive either one's loss sharply down --
+    # that is a real property of gradient-averaged DP, not a bug, but it
+    # would make a noisy, threshold-fragile test here.
+    true_w = (rng.standard_normal((d_in, d_out)) * 0.5).astype(np.float32)
+
+    def make_shard(local_rng):
+        x = local_rng.standard_normal((32, d_in)).astype(np.float32)
+        y = x @ true_w + 0.05 * local_rng.standard_normal((32, d_out)).astype(
+            np.float32
+        )
+        return distributed.WorkerShard(inputs=x, targets=y.astype(np.float32))
+
+    shard_a = make_shard(rng)
+    shard_b = make_shard(rng)
+
+    def whole_shard_loss(params, shard):
+        eval_model, _grads, eval_loss_name = distributed.build_gradient_step_graph(
+            nodes,
+            shapes,
+            initializers,
+            "input",
+            [shard.inputs.shape[0], d_in],
+            "target",
+            [shard.inputs.shape[0], d_out],
+            "output",
+            param_names,
+        )
+        runner = backend.Runner(eval_model, output_names=[eval_loss_name])
+        out = runner({"input": shard.inputs, "target": shard.targets, **params})
+        return float(out[eval_loss_name])
+
+    loss_a_before = whole_shard_loss(initial_params, shard_a)
+    loss_b_before = whole_shard_loss(initial_params, shard_b)
+
+    final_params, step_losses = distributed.train_data_parallel(
+        grad_model,
+        grad_names,
+        loss_name,
+        "input",
+        "target",
+        param_names,
+        shapes,
+        initial_params,
+        [shard_a, shard_b],
+        num_steps=150,
+        batch_size=batch_size,
+        learning_rate=2e-2,
+        seed=1,
+    )
+
+    assert len(step_losses) == 150
+    assert all(np.isfinite(loss) for loss in step_losses)
+
+    loss_a_after = whole_shard_loss(final_params, shard_a)
+    loss_b_after = whole_shard_loss(final_params, shard_b)
+    assert loss_a_after < 0.1 * loss_a_before, (loss_a_before, loss_a_after)
+    assert loss_b_after < 0.1 * loss_b_before, (loss_b_before, loss_b_after)

--- a/tests/test_federated.py
+++ b/tests/test_federated.py
@@ -85,7 +85,10 @@ def test_fedavg_rejects_empty_or_mismatched_input():
         federated.fedavg([{"A": np.zeros(1, dtype=np.float32)}], [])
     with pytest.raises(ValueError, match="positive"):
         federated.fedavg(
-            [{"A": np.zeros(1, dtype=np.float32)}, {"A": np.zeros(1, dtype=np.float32)}],
+            [
+                {"A": np.zeros(1, dtype=np.float32)},
+                {"A": np.zeros(1, dtype=np.float32)},
+            ],
             [0.0, 0.0],
         )
     with pytest.raises(ValueError, match="same tensors"):
@@ -245,14 +248,24 @@ def test_run_federated_round_matches_manual_fedavg_of_independent_client_runs():
     )
 
     trained_a = lora.train_lora(
-        injected, adapter, "X", "Y",
-        target_data=[y_a], calibration_data=[{"X": x_a}],
-        num_iterations=5, learning_rate=1e-2,
+        injected,
+        adapter,
+        "X",
+        "Y",
+        target_data=[y_a],
+        calibration_data=[{"X": x_a}],
+        num_iterations=5,
+        learning_rate=1e-2,
     )
     trained_b = lora.train_lora(
-        injected, adapter, "X", "Y",
-        target_data=[y_b], calibration_data=[{"X": x_b}],
-        num_iterations=5, learning_rate=1e-2,
+        injected,
+        adapter,
+        "X",
+        "Y",
+        target_data=[y_b],
+        calibration_data=[{"X": x_b}],
+        num_iterations=5,
+        learning_rate=1e-2,
     )
     expected = federated.fedavg(
         [

--- a/tests/test_federated.py
+++ b/tests/test_federated.py
@@ -1,0 +1,277 @@
+"""Tests for ``onnxsim.federated`` (see ``onnxsim/federated.py``) -- FedAvg
+round orchestration on top of :mod:`onnxsim.lora`'s single-client training.
+
+Two things are checked independently: that :func:`onnxsim.federated.fedavg`
+computes the weighted average it claims to, against a hand-computed result
+rather than trusting its own arithmetic; and that a federated round/training
+run actually reduces each client's own local loss while leaving the base
+model's weights untouched, the same property ``tests/test_lora.py`` checks
+for a single client.
+"""
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+import pytest
+from onnx import parser
+
+from onnxsim import federated, lora
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=21, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _run(model, feeds, output_names=None):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    names = output_names or [o.name for o in model.graph.output]
+    return sess.run(names, feeds)
+
+
+def _injected_matmul_model(rng, in_dim=8, out_dim=8, rank=4):
+    w = rng.standard_normal((in_dim, out_dim)).astype(np.float32)
+    model = _model(
+        f"""
+        g (float[batch,{in_dim}] X) => (float[batch,{out_dim}] Y) {{
+          Y = MatMul(X, W)
+        }}
+        """,
+        [_f32(w, "W")],
+    )
+    return lora.inject_lora(model, rank=rank, seed=0), w
+
+
+def test_fedavg_matches_hand_computed_weighted_average():
+    states = [
+        {"A": np.array([1.0, 2.0], dtype=np.float32)},
+        {"A": np.array([3.0, 6.0], dtype=np.float32)},
+    ]
+    averaged = federated.fedavg(states, weights=[1.0, 3.0])
+    # (1*[1,2] + 3*[3,6]) / 4 = [10, 20] / 4 = [2.5, 5.0]
+    np.testing.assert_allclose(averaged["A"], [2.5, 5.0], rtol=1e-6)
+
+
+def test_fedavg_uniform_weights_is_a_plain_mean():
+    states = [
+        {"A": np.array([2.0, 4.0], dtype=np.float32)},
+        {"A": np.array([4.0, 8.0], dtype=np.float32)},
+    ]
+    averaged = federated.fedavg(states, weights=[1.0, 1.0])
+    np.testing.assert_allclose(averaged["A"], [3.0, 6.0], rtol=1e-6)
+
+
+def test_fedavg_rejects_empty_or_mismatched_input():
+    with pytest.raises(ValueError, match="at least one"):
+        federated.fedavg([], [])
+    with pytest.raises(ValueError, match="weights"):
+        federated.fedavg([{"A": np.zeros(1, dtype=np.float32)}], [])
+    with pytest.raises(ValueError, match="positive"):
+        federated.fedavg(
+            [{"A": np.zeros(1, dtype=np.float32)}, {"A": np.zeros(1, dtype=np.float32)}],
+            [0.0, 0.0],
+        )
+    with pytest.raises(ValueError, match="same tensors"):
+        federated.fedavg(
+            [
+                {"A": np.zeros(1, dtype=np.float32)},
+                {"B": np.zeros(1, dtype=np.float32)},
+            ],
+            [1.0, 1.0],
+        )
+
+
+def test_federated_client_requires_exactly_one_of_reference_model_or_target_data():
+    with pytest.raises(ValueError, match="exactly one of"):
+        federated.FederatedClient(calibration_data=[{"X": np.zeros((1, 1))}])
+    with pytest.raises(ValueError, match="exactly one of"):
+        federated.FederatedClient(
+            calibration_data=[{"X": np.zeros((1, 1))}],
+            target_data=[np.zeros((1, 1))],
+            reference_model=object(),
+        )
+
+
+def test_federated_client_weight_defaults_to_batch_count():
+    client = federated.FederatedClient(
+        calibration_data=[{"X": np.zeros((1, 1))}, {"X": np.zeros((1, 1))}],
+        target_data=[np.zeros((1, 1)), np.zeros((1, 1))],
+    )
+    assert client.weight() == 2
+
+    weighted = federated.FederatedClient(
+        calibration_data=[{"X": np.zeros((1, 1))}],
+        target_data=[np.zeros((1, 1))],
+        num_examples=128,
+    )
+    assert weighted.weight() == 128
+
+
+def test_extract_and_apply_adapter_state_round_trip():
+    rng = np.random.default_rng(0)
+    (injected, adapter), _ = _injected_matmul_model(rng)
+
+    state = federated.extract_adapter_state(injected, adapter)
+    assert set(state) == set(adapter.parameter_names())
+
+    bumped = {name: value + 1.0 for name, value in state.items()}
+    applied = federated.apply_adapter_state(injected, bumped)
+    onnx.checker.check_model(applied)
+
+    round_tripped = federated.extract_adapter_state(applied, adapter)
+    for name in state:
+        np.testing.assert_allclose(round_tripped[name], state[name] + 1.0)
+
+    # Only the adapter's own tensors moved -- the base weight is untouched.
+    w_before = onnx.numpy_helper.to_array(
+        next(t for t in injected.graph.initializer if t.name == "W")
+    )
+    w_after = onnx.numpy_helper.to_array(
+        next(t for t in applied.graph.initializer if t.name == "W")
+    )
+    np.testing.assert_array_equal(w_before, w_after)
+
+
+def test_run_federated_round_requires_at_least_one_client():
+    rng = np.random.default_rng(0)
+    (injected, adapter), _ = _injected_matmul_model(rng)
+    with pytest.raises(ValueError, match="at least one client"):
+        federated.run_federated_round(injected, adapter, [], "X", "Y")
+
+
+def test_run_federated_training_reduces_every_clients_loss_and_freezes_base_weight():
+    rng = np.random.default_rng(0)
+    (injected, adapter), w = _injected_matmul_model(rng, in_dim=8, out_dim=8, rank=4)
+
+    # Two clients with different, non-overlapping local data and targets --
+    # simulating the non-IID case FedAvg is meant to handle, not two shards
+    # of one shared dataset.
+    x_a = rng.standard_normal((16, 8)).astype(np.float32)
+    y_a = rng.standard_normal((16, 8)).astype(np.float32)
+    x_b = rng.standard_normal((16, 8)).astype(np.float32) + 5.0
+    y_b = rng.standard_normal((16, 8)).astype(np.float32) - 5.0
+
+    client_a = federated.FederatedClient(
+        calibration_data=[{"X": x_a}], target_data=[y_a]
+    )
+    client_b = federated.FederatedClient(
+        calibration_data=[{"X": x_b}], target_data=[y_b]
+    )
+
+    def client_loss(model, x, y):
+        (pred,) = _run(model, {"X": x}, ["Y"])
+        return float(np.mean((pred - y) ** 2))
+
+    loss_a_before = client_loss(injected, x_a, y_a)
+    loss_b_before = client_loss(injected, x_b, y_b)
+
+    round_losses = []
+    trained = federated.run_federated_training(
+        injected,
+        adapter,
+        [client_a, client_b],
+        "X",
+        "Y",
+        num_rounds=20,
+        local_iterations=10,
+        learning_rate=1e-2,
+        round_losses=round_losses,
+    )
+    onnx.checker.check_model(trained)
+
+    assert len(round_losses) == 20
+    assert all(len(losses) == 2 for losses in round_losses)
+
+    loss_a_after = client_loss(trained, x_a, y_a)
+    loss_b_after = client_loss(trained, x_b, y_b)
+    assert loss_a_after < 0.5 * loss_a_before, (loss_a_before, loss_a_after)
+    assert loss_b_after < 0.5 * loss_b_before, (loss_b_before, loss_b_after)
+
+    w_after = onnx.numpy_helper.to_array(
+        next(t for t in trained.graph.initializer if t.name == "W")
+    )
+    np.testing.assert_array_equal(w, w_after)
+
+
+def test_run_federated_round_does_not_mutate_the_global_model():
+    rng = np.random.default_rng(0)
+    (injected, adapter), _ = _injected_matmul_model(rng)
+    before = federated.extract_adapter_state(injected, adapter)
+
+    x = rng.standard_normal((8, 8)).astype(np.float32)
+    y = rng.standard_normal((8, 8)).astype(np.float32)
+    client = federated.FederatedClient(calibration_data=[{"X": x}], target_data=[y])
+
+    federated.run_federated_round(
+        injected, adapter, [client], "X", "Y", local_iterations=5
+    )
+
+    after = federated.extract_adapter_state(injected, adapter)
+    for name in before:
+        np.testing.assert_array_equal(before[name], after[name])
+
+
+def test_run_federated_round_matches_manual_fedavg_of_independent_client_runs():
+    rng = np.random.default_rng(0)
+    (injected, adapter), _ = _injected_matmul_model(rng, in_dim=6, out_dim=6, rank=3)
+
+    x_a = rng.standard_normal((8, 6)).astype(np.float32)
+    y_a = rng.standard_normal((8, 6)).astype(np.float32)
+    x_b = rng.standard_normal((8, 6)).astype(np.float32)
+    y_b = rng.standard_normal((8, 6)).astype(np.float32)
+
+    client_a = federated.FederatedClient(
+        calibration_data=[{"X": x_a}], target_data=[y_a], num_examples=1
+    )
+    client_b = federated.FederatedClient(
+        calibration_data=[{"X": x_b}], target_data=[y_b], num_examples=3
+    )
+
+    trained_a = lora.train_lora(
+        injected, adapter, "X", "Y",
+        target_data=[y_a], calibration_data=[{"X": x_a}],
+        num_iterations=5, learning_rate=1e-2,
+    )
+    trained_b = lora.train_lora(
+        injected, adapter, "X", "Y",
+        target_data=[y_b], calibration_data=[{"X": x_b}],
+        num_iterations=5, learning_rate=1e-2,
+    )
+    expected = federated.fedavg(
+        [
+            federated.extract_adapter_state(trained_a, adapter),
+            federated.extract_adapter_state(trained_b, adapter),
+        ],
+        weights=[1, 3],
+    )
+
+    next_global, _ = federated.run_federated_round(
+        injected,
+        adapter,
+        [client_a, client_b],
+        "X",
+        "Y",
+        local_iterations=5,
+        learning_rate=1e-2,
+    )
+    actual = federated.extract_adapter_state(next_global, adapter)
+
+    for name in expected:
+        np.testing.assert_allclose(actual[name], expected[name], rtol=1e-5, atol=1e-6)

--- a/tools/onnx-finetune/README.md
+++ b/tools/onnx-finetune/README.md
@@ -347,6 +347,59 @@ which distill actual language models. Nothing here requires `torch`/`transformer
 training-enabled `onnxruntime`: only `onnx` + `numpy` to build the step graph, and a plain
 `onnxruntime`/`onnxruntime-web` to run it.
 
+## Federated learning (FedAvg over LoRA, browser clients included)
+
+Train a shared LoRA adapter across several clients that each hold private data, without any
+client's data -- or the base model's own weights -- ever leaving where it started. Server-side,
+this is `onnxsim.federated`'s FedAvg loop (`onnxsim.federated.run_federated_round`/
+`run_federated_training`, exercised in-process by `tests/test_federated.py`): broadcast the
+current adapter state, train each client independently, average the results back in. This
+section is the client-doesn't-share-a-Python-process version of the same loop --
+`scripts/generate_federated_lora_step_graph.py` produces the same kind of step graph
+`onnxsim.lora`/the distillation path above already do (forward, LoRA-restricted backward, and an
+Adam step baked into one ordinary ONNX graph -- no `onnxruntime.training` anywhere in this path
+either), except this one is built *before* any client's data exists, so it can be shipped to and
+run entirely inside an untrusted browser tab via the official `onnxruntime-web` package. Only the
+trained `lora_A`/`lora_B` values -- a few KB, not the whole model -- ever cross back out of the
+client; `scripts/federated_lora_aggregate.py` is the thin CLI wrapper that feeds them into
+`onnxsim.federated.fedavg`/`apply_adapter_state` to produce the next round's base model.
+
+```sh
+# 1. Any ONNX model with an eligible MatMul/Gemm/Conv weight to adapt -- make_toy_model.py
+#    for trying this out without one of your own.
+python3 scripts/make_toy_model.py -o base.onnx --hidden-dim 16
+
+# 2. One step graph for this round, at a fixed batch size (unlike the distillation step graph
+#    above, this one has no dynamic batch dimension -- see the script's own docstring for why).
+#    Also writes step.onnx.base_model.onnx (the deployable, LoRA-injected model), step.onnx.manifest.txt
+#    and step.onnx.initial_state.bin -- everything a browser client needs to train, and nothing
+#    of this server's own data.
+python3 scripts/generate_federated_lora_step_graph.py base.onnx -o step.onnx --batch-size 32 --rank 4
+
+# 3. Each client loads step.onnx + step.onnx.manifest.txt + step.onnx.initial_state.bin via
+#    ../wasm/federated_lora/step_graph_runner.mjs (plain onnxruntime-web, no custom WASM build --
+#    see that directory's own test for a full worked example) and trains locally on its own
+#    private data. What comes back from each client is exportTrainedState()'s output: a small
+#    binary file, byte-for-byte the same layout as step.onnx.initial_state.bin.
+#      client_a.bin, client_b.bin, ...  (produced in the browser, one per participant)
+
+# 4. FedAvg the clients' updates into the next round's global model. --weight (optional, one per
+#    --client) is each client's local example count, i.e. FedAvg proper rather than a plain mean.
+python3 scripts/federated_lora_aggregate.py \
+  --manifest step.onnx.manifest.txt --base-model step.onnx.base_model.onnx \
+  --client client_a.bin --client client_b.bin \
+  -o round1.base_model.onnx
+
+# 5. round1.base_model.onnx is an ordinary, inference-ready .onnx (base weights untouched, only
+#    the adapter moved) -- and round1.base_model.onnx.initial_state.bin is ready to hand straight
+#    back to step_graph_runner.mjs for the next round, no re-derivation needed.
+```
+
+What this does *not* add: secure aggregation (the server here sees each client's own update, not
+just the sum) and differential privacy are both real requirements for production cross-device FL
+and neither is implemented -- `onnxsim.federated.fedavg` is a plain, visible weighted average. See
+that module's own docstring for the full scope statement.
+
 ## CLI reference
 
 | flag | required | description |

--- a/tools/onnx-finetune/scripts/federated_lora_aggregate.py
+++ b/tools/onnx-finetune/scripts/federated_lora_aggregate.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""The server-side half of one federated round -- FedAvg several clients'
+trained LoRA states (each in the exact byte layout
+``generate_federated_lora_step_graph.py``'s ``initial_state.bin`` uses, and
+``step_graph_runner.mjs``'s ``exportTrainedState`` produces in the browser)
+into the next round's global model.
+
+This is a thin CLI wrapper around :mod:`onnxsim.federated` -- the same
+:func:`onnxsim.federated.fedavg`/:func:`onnxsim.federated.apply_adapter_state`
+already exercised by ``tests/test_federated.py`` in-process, here reading
+each client's contribution from a file instead of a Python dict, since a real
+federated round's clients are separate processes (browser tabs) that can only
+communicate via files/HTTP bodies. Nothing about the aggregation math
+differs; only how each client's state arrives does.
+
+**Usage**::
+
+    federated_lora_aggregate.py \\
+        --manifest step.onnx.manifest.txt \\
+        --base-model step.onnx.base_model.onnx \\
+        --client alice_round0.bin --client bob_round0.bin \\
+        -o round1.base_model.onnx
+
+Pass ``--weight`` once per ``--client`` (same order) to weight the average by
+each client's local example count, i.e. FedAvg proper
+(:meth:`onnxsim.federated.FederatedClient.weight`'s role) rather than a
+uniform mean; omitted weights default to ``1`` for every client.
+
+The output is both a new ``--base-model``-shaped ``.onnx`` file (a complete,
+deployable model, exactly the shape ``onnxsim.federated.run_federated_round``
+returns) and a fresh ``<output>.initial_state.bin`` alongside it, ready to
+hand to the *next* round's :func:`generate_federated_lora_step_graph`-produced
+clients without them needing to parse the ``.onnx`` file's initializers
+themselves.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Dict, List, Tuple
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+
+
+def read_weight_layout(manifest_path: str) -> List[Tuple[str, List[int]]]:
+    """The ``weight`` lines of a manifest ``generate_federated_lora_step_graph.py``
+    wrote -- ``[(name, shape), ...]``, in the same order
+    ``initial_state.bin``/``exportTrainedState`` concatenate them in. This is
+    the Python-side mirror of ``step_graph_runner.mjs``'s own
+    ``parseManifest`` -- kept as independent, format-compatible parsing on
+    each side rather than shared code, the same relationship this repo's own
+    C++/JS/Python manifest readers already have for the distillation step
+    graph.
+    """
+    layout: List[Tuple[str, List[int]]] = []
+    with open(manifest_path) as f:
+        for line in f:
+            parts = line.split()
+            if not parts:
+                continue
+            if parts[0] == "weight":
+                name, shape = parts[1], [int(d) for d in parts[2:]]
+                layout.append((name, shape))
+    if not layout:
+        raise ValueError(f"{manifest_path} has no 'weight' lines")
+    return layout
+
+
+def read_client_state(
+    path: str, layout: List[Tuple[str, List[int]]]
+) -> Dict[str, np.ndarray]:
+    """One client's raw float32 file, sliced into a ``{name: array}`` dict
+    per ``layout`` -- the inverse of
+    ``generate_federated_lora_step_graph.py``'s own
+    ``write_manifest_and_initial_state``, and of ``step_graph_runner.mjs``'s
+    ``exportTrainedState``: both write exactly this concatenation."""
+    raw = np.fromfile(path, dtype=np.float32)
+    expected = sum(int(np.prod(shape)) for _, shape in layout)
+    if raw.size != expected:
+        raise ValueError(
+            f"{path} has {raw.size} float32 values but the manifest's weight "
+            f"layout expects {expected}"
+        )
+    state: Dict[str, np.ndarray] = {}
+    offset = 0
+    for name, shape in layout:
+        count = int(np.prod(shape))
+        state[name] = raw[offset : offset + count].reshape(shape)
+        offset += count
+    return state
+
+
+def fedavg(
+    client_states: List[Dict[str, np.ndarray]], weights: List[float]
+) -> Dict[str, np.ndarray]:
+    """Delegates to :func:`onnxsim.federated.fedavg` -- imported lazily so
+    this script's file-parsing halves above are usable (and testable) even
+    in a checkout where the ``onnxsim`` C++ extension has not been built,
+    matching this tool's own general stance of depending on
+    ``onnxsim.graph_grad``/``onnxsim.qat_graph`` only where it actually needs
+    the differentiator, never just to move bytes around."""
+    from onnxsim import federated
+
+    return federated.fedavg(client_states, weights)
+
+
+def apply_state(model: onnx.ModelProto, state: Dict[str, np.ndarray]) -> onnx.ModelProto:
+    from onnxsim import federated
+
+    return federated.apply_adapter_state(model, state)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--base-model", required=True)
+    p.add_argument(
+        "--client", action="append", required=True, dest="clients",
+        help="one client's trained-state .bin file; repeat once per client",
+    )
+    p.add_argument(
+        "--weight", action="append", type=float, dest="weights", default=None,
+        help="this client's FedAvg weight (local example count); repeat once "
+        "per --client, same order. Defaults to 1 for every client.",
+    )
+    p.add_argument("-o", "--output", required=True)
+    args = p.parse_args()
+
+    weights = args.weights if args.weights is not None else [1.0] * len(args.clients)
+    if len(weights) != len(args.clients):
+        raise ValueError(
+            f"got {len(args.clients)} --client but {len(weights)} --weight; "
+            "pass exactly one --weight per --client, or none at all"
+        )
+
+    layout = read_weight_layout(args.manifest)
+    client_states = [read_client_state(path, layout) for path in args.clients]
+    averaged = fedavg(client_states, weights)
+
+    base_model = onnx.load(args.base_model)
+    next_global = apply_state(base_model, averaged)
+    onnx.save(next_global, args.output)
+
+    initial_state_path = args.output + ".initial_state.bin"
+    with open(initial_state_path, "wb") as f:
+        for name, _shape in layout:
+            averaged[name].astype(np.float32).tofile(f)
+
+    print(
+        f"aggregated {len(args.clients)} client(s) (weights={weights}) -> "
+        f"{args.output}, {initial_state_path}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-finetune/scripts/generate_federated_lora_step_graph.py
+++ b/tools/onnx-finetune/scripts/generate_federated_lora_step_graph.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Build a self-contained, data-free LoRA training-step graph for a federated
+round's *client* half -- the browser-side counterpart to
+``onnxsim.federated``'s server-side FedAvg loop (see ``onnxsim/federated.py``
+and ``tests/test_federated.py``), runnable via the official
+``onnxruntime-web`` package with no custom WASM build, exactly the same
+relationship ``generate_distillation_step_graph.py`` has to
+``../wasm/distill_step_graph/step_graph_runner.mjs``.
+
+**Why a step graph is the right thing to ship to a client at all.** A step
+graph (:mod:`onnxsim.qat_graph`) bakes forward, loss, backward and an Adam
+update into one ordinary ONNX graph -- but critically, the calibration
+activations and training targets are *graph inputs* (bound once and reused
+across steps for residency, see ``onnxsim.qat_graph``'s own module
+docstring), never baked into the model as initializers. So the ``.onnx`` file
+this script writes contains onnxsim's own architecture and the base model's
+frozen weights, but *no client's training data whatsoever* -- a client feeds
+its own private activations/targets as ordinary ``session.run()`` inputs,
+exactly as it would with any other inference graph. That is what makes
+shipping this file to an untrusted browser client safe in the first place.
+
+**What crosses the wire, in each direction.** Down to the client: this
+script's four outputs -- the step graph itself, the base (LoRA-injected)
+model the client trains against, a text manifest describing every per-step
+tensor name/shape, and the *current global round's* adapter values as a flat
+initial-state file. Back up from the client: only the trained ``A``/``B``
+adapter values (:func:`export_trained_state`'s counterpart on the JS side),
+never the client's data and never the base model's own weights, which the
+client never modifies (see ``onnxsim.lora``'s own "the base weight is never
+touched" invariant). ``../scripts/federated_lora_aggregate.py`` is the
+server-side FedAvg step that turns several clients' exported states into the
+next round's base model and initial state.
+
+**The one real restriction this generator adds over ``onnxsim.lora.train_lora``
+itself.** ``train_lora`` differentiates a block whose shapes are captured
+from real calibration data at call time, so nothing about it needs a fixed
+batch size in advance. A step graph shipped to a browser ahead of any
+client's data cannot do that -- there is no calibration run to capture shapes
+from -- so this script needs the block's input/output shape declared with a
+fixed batch size up front (``--batch-size``), and refuses a block whose only
+external input is not exactly its own ``block_input_name`` (a residual or
+side-channel input reaching the block from elsewhere in the graph has no
+value to probe its shape from either). This is a real, narrower restriction
+than ``train_lora``'s own, not an oversight -- see
+:func:`build_federated_lora_step_graph`'s docstring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Dict, List, Sequence, Tuple
+
+import numpy as np
+import onnx
+import onnx.numpy_helper
+
+from onnxsim import lora, qat, qat_graph
+
+
+def _resolve_static_shape(
+    model: onnx.ModelProto, tensor_name: str, batch_size: int
+) -> List[int]:
+    """``tensor_name``'s shape from ``model``'s own inputs/outputs/
+    ``value_info``, with its leading (batch) dimension replaced by
+    ``batch_size`` regardless of what that dimension already was -- static or
+    a ``dim_param`` -- since a federated round's client-side batch is picked
+    freely per :class:`onnxsim.federated.FederatedClient`, not fixed by the
+    base model.
+
+    :raises ValueError: if ``tensor_name`` is not found, or if any dimension
+            other than the leading one is not a concrete integer -- this
+            generator (unlike ``generate_distillation_step_graph.py``) does
+            not support a dynamic non-batch dimension, since
+            :mod:`onnxsim.lora`'s own step graphs (built via
+            ``onnxsim.qat_graph.mean_square``'s ``ReduceMean``) are not
+            dynamic-batch-safe to begin with -- see this module's own
+            docstring.
+    """
+    for value_info in (
+        list(model.graph.input) + list(model.graph.output) + list(model.graph.value_info)
+    ):
+        if value_info.name != tensor_name:
+            continue
+        shape: List[int] = []
+        for axis, dim in enumerate(value_info.type.tensor_type.shape.dim):
+            if axis == 0:
+                shape.append(batch_size)
+            elif dim.HasField("dim_value"):
+                shape.append(dim.dim_value)
+            else:
+                raise ValueError(
+                    f"{tensor_name!r} has a non-batch dynamic dimension "
+                    f"({dim.dim_param!r} at axis {axis}); "
+                    "generate_federated_lora_step_graph needs every dimension "
+                    "but the leading (batch) one to be static"
+                )
+        return shape
+    raise ValueError(
+        f"{tensor_name!r} not found among {model.graph.name}'s inputs, "
+        "outputs, or value_info"
+    )
+
+
+def build_federated_lora_step_graph(
+    injected: onnx.ModelProto,
+    adapter: lora.LoraAdapter,
+    block_input_name: str,
+    block_output_name: str,
+    batch_size: int,
+) -> Tuple[qat_graph.StepGraph, Dict[str, np.ndarray]]:
+    """The client-shippable half of :func:`onnxsim.lora.train_lora` --
+    everything up to (not including) actually running a step, since running
+    it is the client's job, on the client's own data.
+
+    Reuses :mod:`onnxsim.qat`'s own block-slicing machinery
+    (``_slice_block``/``_refuse_unsupported``/``_block_shapes``) and
+    :func:`onnxsim.lora._build_lora_step_graph` directly -- the same pieces
+    ``train_lora`` itself calls internally -- with dummy, zero-valued arrays
+    standing in for calibration data purely to supply :func:`_block_shapes`
+    the concrete shapes ``onnxsim.graph_grad.build_backward`` needs; their
+    *values* are never read.
+
+    :raises ValueError: if the block reads any external input other than
+            ``block_input_name`` itself (see this module's own docstring),
+            or if :func:`_resolve_static_shape` refuses a non-batch dynamic
+            dimension.
+    :raises onnxsim.graph_grad.UnsupportedOpError: if the block contains an
+            op :mod:`onnxsim.graph_grad` has no gradient rule for.
+    """
+    nodes, externals = qat._slice_block(injected.graph, block_input_name, block_output_name)
+    qat._refuse_unsupported(nodes)
+    if externals != [block_input_name]:
+        raise ValueError(
+            "generate_federated_lora_step_graph only supports a block whose "
+            f"sole external input is its own block_input_name; the block "
+            f"between {block_input_name!r} and {block_output_name!r} also "
+            f"reads {[e for e in externals if e != block_input_name]}, which "
+            "has no calibration run to capture a shape from ahead of time"
+        )
+
+    input_shape = _resolve_static_shape(injected, block_input_name, batch_size)
+    output_shape = _resolve_static_shape(injected, block_output_name, batch_size)
+    dummy_input = np.zeros(input_shape, dtype=np.float32)
+    dummy_output = np.zeros(output_shape, dtype=np.float32)
+
+    shapes = qat._block_shapes(injected, nodes, {block_input_name: dummy_input}, block_output_name, dummy_output)
+
+    used = {name for node in nodes for name in node.input if name}
+    param_names = set(adapter.parameter_names())
+    initializer_map = {t.name: t for t in injected.graph.initializer}
+    block_initializers = [
+        t
+        for t in injected.graph.initializer
+        if t.name in used and t.name not in param_names
+    ]
+
+    step = lora._build_lora_step_graph(
+        adapter,
+        nodes,
+        shapes,
+        block_initializers,
+        {block_input_name: dummy_input},
+        block_output_name,
+        output_shape,
+        batch=None,
+    )
+    onnx.checker.check_model(step.model)
+
+    initial_state: Dict[str, np.ndarray] = {}
+    for name in adapter.parameter_names():
+        value = onnx.numpy_helper.to_array(initializer_map[name]).astype(np.float32)
+        initial_state[name] = value
+        initial_state[f"{lora._PREFIX}m_{name}"] = np.zeros_like(value)
+        initial_state[f"{lora._PREFIX}v_{name}"] = np.zeros_like(value)
+
+    return step, initial_state
+
+
+def write_manifest_and_initial_state(
+    step: qat_graph.StepGraph,
+    initial_state: Dict[str, np.ndarray],
+    adapter: lora.LoraAdapter,
+    block_input_name: str,
+    input_shape: Sequence[int],
+    block_output_name: str,
+    output_shape: Sequence[int],
+    manifest_path: str,
+    initial_state_path: str,
+) -> None:
+    """Writes the manifest+binary pair
+    ``tools/onnx-finetune/wasm/federated_lora/step_graph_runner.mjs`` and
+    :mod:`federated_lora_aggregate` both read, in the same flat line-oriented
+    text format ``generate_distillation_step_graph.py`` uses for the same
+    reason (no JSON parser vendored on the C++/wasm side).
+
+    Only ``weight`` lines (the adapter's own ``A``/``B`` initializers) are
+    written to ``initial_state_path`` -- every ``__m``/``__v`` Adam moment
+    starts at zero every round (a federated client always starts local
+    training with a fresh optimizer state, see ``onnxsim.federated``'s own
+    module docstring), so a reader can produce those itself without them
+    being spelled out on disk.
+    """
+    with open(manifest_path, "w") as f:
+        f.write(f"input_name {block_input_name}\n")
+        f.write(f"input_shape {' '.join(str(d) for d in input_shape)}\n")
+        f.write(f"teacher_name {lora._PREFIX}teacher\n")
+        f.write(f"teacher_shape {' '.join(str(d) for d in output_shape)}\n")
+        f.write(f"lr_name {lora._PREFIX}lr\n")
+        f.write(f"loss_name {step.loss_name}\n")
+        for name, out_name in step.state.items():
+            shape = list(initial_state[name].shape)
+            f.write(f"state {name} {out_name} {' '.join(str(d) for d in shape)}\n")
+        for name in adapter.parameter_names():
+            shape = list(initial_state[name].shape)
+            f.write(f"weight {name} {' '.join(str(d) for d in shape)}\n")
+
+    with open(initial_state_path, "wb") as f:
+        for name in adapter.parameter_names():
+            initial_state[name].astype(np.float32).tofile(f)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("model", help="path to the plain (not yet LoRA-injected) .onnx model")
+    p.add_argument("-o", "--output", required=True, help="path to write the step graph to")
+    p.add_argument("--batch-size", type=int, required=True)
+    p.add_argument("--rank", type=int, default=4)
+    p.add_argument("--alpha", type=float, default=None)
+    p.add_argument(
+        "--block-input-name", default=None,
+        help="defaults to the model's own single input",
+    )
+    p.add_argument(
+        "--block-output-name", default=None,
+        help="defaults to the model's own single output",
+    )
+    p.add_argument("--seed", type=int, default=0)
+    args = p.parse_args()
+
+    model = onnx.load(args.model)
+    injected, adapter = lora.inject_lora(model, rank=args.rank, alpha=args.alpha, seed=args.seed)
+    if not adapter.targets:
+        raise ValueError(
+            f"{args.model} has no eligible MatMul/Gemm/Conv weight to inject "
+            "a LoRA adapter into -- see onnxsim.lora.inject_lora's own "
+            "eligibility rules"
+        )
+
+    block_input_name = args.block_input_name or injected.graph.input[0].name
+    block_output_name = args.block_output_name or injected.graph.output[0].name
+
+    step, initial_state = build_federated_lora_step_graph(
+        injected, adapter, block_input_name, block_output_name, args.batch_size
+    )
+    onnx.save(step.model, args.output)
+
+    base_model_path = args.output + ".base_model.onnx"
+    onnx.save(injected, base_model_path)
+
+    adapter_names_path = args.output + ".adapter_names.json"
+    with open(adapter_names_path, "w") as f:
+        json.dump(adapter.parameter_names(), f)
+
+    manifest_path = args.output + ".manifest.txt"
+    initial_state_path = args.output + ".initial_state.bin"
+    write_manifest_and_initial_state(
+        step,
+        initial_state,
+        adapter,
+        block_input_name,
+        _resolve_static_shape(injected, block_input_name, args.batch_size),
+        block_output_name,
+        _resolve_static_shape(injected, block_output_name, args.batch_size),
+        manifest_path,
+        initial_state_path,
+    )
+    print(
+        f"wrote {args.output} ({len(step.model.graph.node)} nodes, "
+        f"batch size {args.batch_size}), {base_model_path}, {adapter_names_path}, "
+        f"{manifest_path}, {initial_state_path}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-finetune/wasm/federated_lora/package.json
+++ b/tools/onnx-finetune/wasm/federated_lora/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "onnx-finetune-federated-lora-step-graph-runner",
+  "private": true,
+  "type": "module",
+  "description": "Runs a federated-round LoRA step graph via the official onnxruntime-web package -- the client half of onnxsim.federated's FedAvg loop.",
+  "scripts": {
+    "test": "node --test step_graph_runner.test.mjs"
+  },
+  "dependencies": {
+    "onnxruntime-web": "^1.19.2"
+  }
+}

--- a/tools/onnx-finetune/wasm/federated_lora/step_graph_runner.mjs
+++ b/tools/onnx-finetune/wasm/federated_lora/step_graph_runner.mjs
@@ -1,0 +1,149 @@
+// Runs a federated-round LoRA training-step graph from
+// ../../scripts/generate_federated_lora_step_graph.py entirely in the
+// browser, via the *official* onnxruntime-web package's plain
+// ort.InferenceSession -- the client half of onnxsim.federated's FedAvg loop
+// (see ../../../../onnxsim/federated.py and ../../../../tests/test_federated.py
+// for the server-side aggregation this runner's output feeds into).
+//
+// Structurally this is ../distill_step_graph/step_graph_runner.mjs's own
+// pattern, ported from a classification/distillation step graph to a
+// regression/LoRA one: same "no custom WASM build, no onnxruntime.training"
+// approach, same manifest-driven feed construction, same
+// {loss, state}-returning step() loop. The two differ in what a step's
+// per-call inputs *are* (a fixed-shape local batch/target pair here, vs. a
+// dynamic-batch classification triple there -- see
+// generate_federated_lora_step_graph.py's own docstring for why this one's
+// batch size is fixed at generation time rather than a dim_param) and in
+// what leaves the browser at the end: only the trained LoRA A/B values
+// (exportTrainedState), never this client's own data and never the base
+// model's frozen weights.
+
+/** Parses a `<step_graph>.manifest.txt` written by
+ * generate_federated_lora_step_graph.py. `weights` lists the LoRA `A`/`B`
+ * tensors in the exact order `initial_state.bin` concatenates them in --
+ * `exportTrainedState` below writes its own output in that same order, so a
+ * server-side aggregator never needs to know this runner's internal tensor
+ * names, only the manifest it already has. */
+export function parseManifest(text) {
+  const manifest = { state: [], weights: [] };
+  for (const rawLine of text.split("\n")) {
+    const parts = rawLine.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) continue;
+    const [tag, ...rest] = parts;
+    if (tag === "input_name") manifest.inputName = rest[0];
+    else if (tag === "input_shape") manifest.inputShape = rest.map(Number);
+    else if (tag === "teacher_name") manifest.teacherName = rest[0];
+    else if (tag === "teacher_shape") manifest.teacherShape = rest.map(Number);
+    else if (tag === "lr_name") manifest.lrName = rest[0];
+    else if (tag === "loss_name") manifest.lossName = rest[0];
+    else if (tag === "state") {
+      manifest.state.push({ input: rest[0], output: rest[1], shape: rest.slice(2).map(Number) });
+    } else if (tag === "weight") {
+      manifest.weights.push({ name: rest[0], shape: rest.slice(1).map(Number) });
+    }
+  }
+  return manifest;
+}
+
+function prod(shape) {
+  return shape.reduce((a, b) => a * b, 1);
+}
+
+/** The initial `{state input name: Float32Array}` map for round zero, or for
+ * any later round's broadcast -- every weight from
+ * `<step_graph>.initial_state.bin` (or a server's freshly-aggregated
+ * replacement for it, same byte layout), every Adam `__m`/`__v` moment at
+ * zero. A federated client always starts local training with a *fresh*
+ * optimizer state every round (see `onnxsim.federated`'s own module
+ * docstring on why FedAvg never carries a client's moments between rounds),
+ * so there is nothing to load for those beyond zero-filling them here. */
+export function loadInitialState(manifest, initialStateBuffer) {
+  const state = {};
+  const view = new Float32Array(initialStateBuffer);
+  let offset = 0;
+  for (const { name, shape } of manifest.weights) {
+    const count = prod(shape);
+    state[name] = view.slice(offset, offset + count);
+    offset += count;
+  }
+  for (const { input, shape } of manifest.state) {
+    if (!(input in state)) state[input] = new Float32Array(prod(shape));
+  }
+  return state;
+}
+
+/** The trained LoRA state, serialized back to the exact byte layout
+ * `initial_state.bin`/`loadInitialState` use -- the one thing this client
+ * submits to the federated round's aggregator
+ * (`../../scripts/federated_lora_aggregate.py`). Deliberately only the
+ * `manifest.weights` entries (the `A`/`B` adapters themselves): every
+ * `__m`/`__v` Adam moment is this client's own local optimizer state, never
+ * part of what FedAvg averages (see `onnxsim.federated.fedavg`'s own scope),
+ * so there is nothing to gain -- and privacy to lose, in a scheme that ever
+ * wanted to hide which clients trained how much -- by shipping it back. */
+export function exportTrainedState(manifest, state) {
+  const total = manifest.weights.reduce((n, { shape }) => n + prod(shape), 0);
+  const out = new Float32Array(total);
+  let offset = 0;
+  for (const { name, shape } of manifest.weights) {
+    out.set(state[name], offset);
+    offset += prod(shape);
+  }
+  return out;
+}
+
+/** Adam's two bias-correction factors at (0-based) local step `t`, matching
+ * `onnxsim.qat_graph.adam_bias_corrections` exactly -- a federated client's
+ * own local step counter, reset to 0 every round since its optimizer state
+ * is reset every round too (see `loadInitialState`'s own docstring). */
+export function adamBiasCorrections(t) {
+  return {
+    mCorrection: 1 / (1 - Math.pow(0.9, t + 1)),
+    vCorrection: 1 / (1 - Math.pow(0.999, t + 1)),
+  };
+}
+
+export class StepGraphSession {
+  static async create(ort, stepGraphBytes) {
+    const session = await ort.InferenceSession.create(stepGraphBytes, {
+      executionProviders: ["wasm"],
+    });
+    return new StepGraphSession(ort, session);
+  }
+
+  constructor(ort, session) {
+    this.ort = ort;
+    this.session = session;
+  }
+
+  /** Runs one local training step on this client's own data:
+   * `batchInput`/`target` are Float32Arrays shaped per
+   * `manifest.inputShape`/`manifest.teacherShape` (both fixed at generation
+   * time -- unlike the distillation step graph, this one has no dynamic
+   * batch dimension, see generate_federated_lora_step_graph.py's own
+   * docstring for why). Returns `{ loss, state }`, `state` ready to feed as
+   * the next local step's own state inputs, and (once local training for
+   * this round is done) to hand to `exportTrainedState`. */
+  async step(manifest, state, batchInput, target, lr, t) {
+    const { mCorrection, vCorrection } = adamBiasCorrections(t);
+    const T = this.ort.Tensor;
+    const feeds = {
+      [manifest.inputName]: new T("float32", batchInput, manifest.inputShape),
+      [manifest.teacherName]: new T("float32", target, manifest.teacherShape),
+      [manifest.lrName]: new T("float32", new Float32Array([lr]), []),
+      m_correction: new T("float32", new Float32Array([mCorrection]), []),
+      v_correction: new T("float32", new Float32Array([vCorrection]), []),
+    };
+    for (const { input, shape } of manifest.state) {
+      feeds[input] = new T("float32", state[input], shape);
+    }
+
+    const results = await this.session.run(feeds);
+
+    const nextState = {};
+    for (const { input, output } of manifest.state) {
+      nextState[input] = results[output].data;
+    }
+    return { loss: results[manifest.lossName].data[0], state: nextState };
+  }
+}

--- a/tools/onnx-finetune/wasm/federated_lora/step_graph_runner.test.mjs
+++ b/tools/onnx-finetune/wasm/federated_lora/step_graph_runner.test.mjs
@@ -1,0 +1,158 @@
+// Does a federated round's LoRA step graph actually train when run through
+// the *official* onnxruntime-web package -- no custom WASM build, no
+// onnxruntime.training -- and does its exported state round-trip through
+// the Python-side FedAvg aggregator (../../scripts/federated_lora_aggregate.py,
+// itself a thin wrapper over onnxsim.federated -- see tests/test_federated.py
+// for that module's own math being exercised in-process) once it leaves the
+// browser?
+//
+// Skips (does not fail) if onnxruntime-web is not installed here, matching
+// ../distill_step_graph/step_graph_runner.test.mjs's own convention --
+// `npm install` in this directory to run it for real. The Python-side
+// pieces (the generator and the aggregator) need onnxsim's own C++
+// extension built (see the repo's CLAUDE.md) -- this test does not attempt
+// to build it, only to run it.
+//
+// Usage:
+//   npm install && npm test
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { StepGraphSession, adamBiasCorrections, exportTrainedState, loadInitialState, parseManifest } from "./step_graph_runner.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPTS = join(HERE, "..", "..", "scripts");
+
+let ort;
+try {
+  ort = await import("onnxruntime-web");
+} catch {
+  ort = null;
+}
+
+function runPython(script, args) {
+  execFileSync("python3", [join(SCRIPTS, script), ...args], { stdio: "inherit" });
+}
+
+// A tiny xorshift PRNG so each simulated client's local data is reproducible
+// without pulling in a dependency just for this test.
+function makeRng(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    return state / 4294967296;
+  };
+}
+
+async function trainOneClient(ort, stepGraphBytes, initialStateBytes, manifest, seed, numSteps) {
+  const state = loadInitialState(
+    manifest,
+    initialStateBytes.buffer.slice(initialStateBytes.byteOffset, initialStateBytes.byteOffset + initialStateBytes.byteLength),
+  );
+  const session = await StepGraphSession.create(ort, stepGraphBytes);
+
+  // One fixed local batch/target for the whole local run -- this client's
+  // own private data, standing in for whatever it would really train on.
+  // Different clients get different (seed-keyed) data, the non-IID case
+  // FedAvg is meant to handle rather than two shards of one shared set.
+  const rng = makeRng(seed);
+  const inputSize = manifest.inputShape.reduce((a, b) => a * b, 1);
+  const targetSize = manifest.teacherShape.reduce((a, b) => a * b, 1);
+  const batchInput = Float32Array.from({ length: inputSize }, () => rng() * 2 - 1);
+  const target = Float32Array.from({ length: targetSize }, () => rng() * 2 - 1);
+
+  let current = state;
+  const losses = [];
+  for (let t = 0; t < numSteps; ++t) {
+    const { loss, state: nextState } = await session.step(manifest, current, batchInput, target, 1e-2, t);
+    assert.ok(Number.isFinite(loss), `loss is finite at local step ${t}`);
+    losses.push(loss);
+    current = nextState;
+  }
+  return { losses, trainedState: current };
+}
+
+test("federated LoRA step graph trains locally on plain onnxruntime-web and its exported state feeds the Python FedAvg aggregator", { skip: ort === null && "onnxruntime-web not installed -- npm install to run this test" }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "onnx-finetune-federated-lora-"));
+  const modelPath = join(dir, "toy.onnx");
+  const stepPath = join(dir, "step.onnx");
+
+  runPython("make_toy_model.py", [
+    "-o", modelPath, "--input-dim", "6", "--hidden-dim", "8", "--output-dim", "6",
+  ]);
+  runPython("generate_federated_lora_step_graph.py", [
+    modelPath, "-o", stepPath, "--batch-size", "4", "--rank", "2",
+  ]);
+
+  const manifest = parseManifest(readFileSync(`${stepPath}.manifest.txt`, "utf8"));
+  assert.deepEqual(manifest.inputShape, [4, 6]);
+  assert.deepEqual(manifest.teacherShape, [4, 6]);
+  assert.ok(manifest.weights.length > 0, "at least one LoRA adapter was injected");
+
+  const stepGraphBytes = new Uint8Array(readFileSync(stepPath));
+  const initialStateBytes = readFileSync(`${stepPath}.initial_state.bin`);
+
+  // Two independent clients, same broadcast starting state, different local
+  // data -- exactly onnxsim.federated.run_federated_round's contract on the
+  // Python side, here exercised with a real browser-side runtime instead of
+  // an in-process train_lora call.
+  const clientA = await trainOneClient(ort, stepGraphBytes, initialStateBytes, manifest, 1, 150);
+  const clientB = await trainOneClient(ort, stepGraphBytes, initialStateBytes, manifest, 2, 150);
+
+  for (const { losses } of [clientA, clientB]) {
+    assert.ok(losses[losses.length - 1] < 0.3 * losses[0], `local loss should drop sharply: ${losses[0]} -> ${losses[losses.length - 1]}`);
+  }
+
+  const exportedA = exportTrainedState(manifest, clientA.trainedState);
+  const exportedB = exportTrainedState(manifest, clientB.trainedState);
+  const expectedLength = manifest.weights.reduce((n, { shape }) => n + shape.reduce((a, b) => a * b, 1), 0);
+  assert.equal(exportedA.length, expectedLength);
+  assert.equal(exportedB.length, expectedLength);
+  // Two clients that trained on different local data must not export
+  // identical adapters -- otherwise this "test" would pass even if step()
+  // silently ignored batchInput/target.
+  assert.notDeepEqual(Array.from(exportedA), Array.from(exportedB));
+
+  const clientAPath = join(dir, "client_a.bin");
+  const clientBPath = join(dir, "client_b.bin");
+  writeFileSync(clientAPath, Buffer.from(exportedA.buffer, exportedA.byteOffset, exportedA.byteLength));
+  writeFileSync(clientBPath, Buffer.from(exportedB.buffer, exportedB.byteOffset, exportedB.byteLength));
+
+  const roundOutputPath = join(dir, "round1.base_model.onnx");
+  runPython("federated_lora_aggregate.py", [
+    "--manifest", `${stepPath}.manifest.txt`,
+    "--base-model", `${stepPath}.base_model.onnx`,
+    "--client", clientAPath, "--client", clientBPath,
+    "--weight", "1", "--weight", "1",
+    "-o", roundOutputPath,
+  ]);
+
+  assert.ok(statSync(roundOutputPath).size > 0, "the aggregator wrote a next-round base model");
+  assert.ok(statSync(`${roundOutputPath}.initial_state.bin`).size > 0, "the aggregator wrote a next-round initial state");
+});
+
+test("adamBiasCorrections matches the Python reference at a few steps", () => {
+  const t0 = adamBiasCorrections(0);
+  assert.ok(Math.abs(t0.mCorrection - 1 / (1 - 0.9)) < 1e-9);
+  assert.ok(Math.abs(t0.vCorrection - 1 / (1 - 0.999)) < 1e-9);
+});
+
+test("parseManifest/loadInitialState/exportTrainedState round-trip a synthetic manifest", () => {
+  const manifest = parseManifest(
+    "input_name X\ninput_shape 2 3\nteacher_name Y\nteacher_shape 2 3\nlr_name lr\nloss_name loss\n" +
+    "state A a_out 2 2\nweight A 2 2\n",
+  );
+  const initial = new Float32Array([1, 2, 3, 4]);
+  const state = loadInitialState(manifest, initial.buffer);
+  assert.deepEqual(Array.from(state.A), [1, 2, 3, 4]);
+  const exported = exportTrainedState(manifest, state);
+  assert.deepEqual(Array.from(exported), [1, 2, 3, 4]);
+});


### PR DESCRIPTION
FederatedClient/fedavg/run_federated_round/run_federated_training in
onnxsim/federated.py orchestrate FedAvg rounds over onnxsim.lora.train_lora:
each client trains its own LoRA adapter locally on private data starting
from the broadcast global state, and the server averages only the small
A/B deltas back together, never touching the base model's weights or any
client's raw data.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AqZFJFegvgfAFsNzryCkDJ