### PR TITLE
Add a manually-run CUDA feature test notebook for Colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,12 @@ Runtime does not offer, onnxsim raises a `ValueError` listing the available
 providers instead of silently folding on the CPU. When `providers` is left
 unset (the default), folding runs on the CPU.
 
+`examples/cuda_feature_tests/` has a notebook exercising this end to end
+(folding, the CLI, `device_id` pinning, DLPack CUDA tensors, provider
+validation) against a real GPU -- open it in Colab and run it by hand
+whenever you want to check these on an actual NVIDIA GPU; it is not wired
+into CI.
+
 ## Profiling the optimization
 
 Simplification alternates a handful of transforms -- shape inference, the

--- a/examples/cuda_feature_tests/README.md
+++ b/examples/cuda_feature_tests/README.md
@@ -1,0 +1,38 @@
+# CUDA feature tests notebook
+
+A notebook exercising onnxsim's CUDA-related features against a real NVIDIA
+GPU -- meant to be run **by hand**, on demand, not wired into an unattended
+nightly CI trigger. (Google Colab's terms of service treat scheduled/
+background automation as out of scope for what Colab is for, so it is not a
+suitable nightly-CI backend; see the discussion that led to this notebook.
+For unattended GPU CI, a self-hosted GitHub Actions runner on your own or a
+cloud GPU box is the usual fit.)
+
+## What it covers
+
+- `onnxsim.simplify(..., providers=[...])` / `onnxsim.backend.run_model` /
+  the CLI's `--providers` and `--cuda` flags -- constant folding and
+  correctness checking on the GPU, compared against CPU for parity.
+- The `(name, options)` provider tuple form, e.g. pinning `device_id`.
+- The DLPack zero-copy path for CUDA `torch.Tensor` inputs
+  (`onnxsim.backend.as_ort_value` / `Runner.run_with_ort_values`).
+- Provider validation: requesting a provider the installed onnxruntime does
+  not offer raises `ValueError` instead of silently falling back to CPU.
+- `providers` threaded through `onnxsim.accuracy.measure_accuracy_drop`.
+
+## Running it
+
+Open [`cuda_feature_tests.ipynb`](cuda_feature_tests.ipynb) in Colab (use the
+badge at the top of the notebook, or upload it manually) and select a GPU
+runtime: `Runtime > Change runtime type > T4 GPU` (or any NVIDIA GPU). Then
+run the cells top to bottom -- the first cells install onnxsim from source
+and the GPU build of onnxruntime (`onnxruntime-gpu`).
+
+It works the same way outside Colab: any Jupyter environment with an NVIDIA
+GPU and driver, `pip install onnxsim[onnxruntime] onnxruntime-gpu`, and the
+CUDA-specific cells run as-is (skip the `git clone`/`pip install -e` cell and
+just install onnxsim however you normally would).
+
+Each test prints `[PASS]`/`[FAIL]` as it runs and raises immediately on the
+first failure, so a red cell points straight at what broke; the final cell
+re-asserts that every test passed.

--- a/examples/cuda_feature_tests/cuda_feature_tests.ipynb
+++ b/examples/cuda_feature_tests/cuda_feature_tests.ipynb
@@ -1,0 +1,387 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# onnxsim CUDA feature tests\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/onnxsim/onnxsim/blob/master/examples/cuda_feature_tests/cuda_feature_tests.ipynb)\n",
+    "\n",
+    "A hands-on notebook exercising onnxsim's CUDA-related features against a real GPU:\n",
+    "\n",
+    "- the `providers` / `--cuda` execution-provider plumbing (`onnxsim.simplify`, `onnxsim.backend.run_model`, the CLI)\n",
+    "- the `(name, options)` tuple form, e.g. pinning `device_id`\n",
+    "- the DLPack zero-copy path for CUDA `torch.Tensor` inputs (`onnxsim.backend.as_ort_value` / `Runner.run_with_ort_values`)\n",
+    "- provider-validation errors (an unavailable provider fails loudly instead of silently falling back to CPU)\n",
+    "- `providers` threaded through `onnxsim.accuracy.measure_accuracy_drop`\n",
+    "\n",
+    "This is meant to be run **by hand**, on demand -- against Colab or any other machine with an NVIDIA GPU -- not wired into an unattended nightly trigger. (Colab's own terms of service restrict automating it as a scheduled/background CI backend; see the discussion that led to this notebook.)\n",
+    "\n",
+    "**Before running:** in Colab, pick a GPU runtime -- `Runtime \u2192 Change runtime type \u2192 T4 GPU` (or any NVIDIA GPU) -- then run the cells top to bottom. Outside Colab, just run it in any Python environment with an NVIDIA GPU and driver."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-01",
+   "metadata": {},
+   "source": [
+    "## 0. Confirm the runtime actually has a GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!nvidia-smi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-03",
+   "metadata": {},
+   "source": [
+    "## 1. Install onnxsim + the GPU build of onnxruntime\n",
+    "\n",
+    "Builds onnxsim from source so this notebook always exercises the exact provider plumbing currently on the branch it lives in (the C++/nanobind extension build here does **not** build ONNX Runtime itself -- see `CLAUDE.md` -- so it stays reasonably quick). Swap `BRANCH` below to test a different branch/tag; it defaults to `master`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathlib\n",
+    "\n",
+    "BRANCH = \"master\"\n",
+    "\n",
+    "if not pathlib.Path(\"onnxsim_repo\").exists():\n",
+    "    !git clone --branch {BRANCH} --depth 1 https://github.com/onnxsim/onnxsim.git onnxsim_repo\n",
+    "\n",
+    "%cd onnxsim_repo\n",
+    "!pip install -q -e \".[onnxruntime]\"\n",
+    "!pip install -q onnxruntime-gpu\n",
+    "%cd .."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-05",
+   "metadata": {},
+   "source": [
+    "## 2. Confirm onnxruntime sees the CUDA provider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import onnxruntime as rt\n",
+    "\n",
+    "import onnxsim\n",
+    "from onnxsim import backend\n",
+    "\n",
+    "available = rt.get_available_providers()\n",
+    "print(\"Available onnxruntime providers:\", available)\n",
+    "assert backend.has_onnxruntime()\n",
+    "assert \"CUDAExecutionProvider\" in available, (\n",
+    "    \"CUDAExecutionProvider is not available -- pick a GPU runtime \"\n",
+    "    \"(Runtime > Change runtime type) and re-run from the top.\"\n",
+    ")\n",
+    "print(\"CUDA provider available.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-07",
+   "metadata": {},
+   "source": [
+    "## 3. Test helpers\n",
+    "\n",
+    "One small model, built with `onnx.parser` (per this repo's own test convention -- see `CLAUDE.md`), whose `a + b` onnxsim can constant-fold, plus a `record()` helper that prints and tracks pass/fail so the summary at the end can assert all of them passed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import onnx\n",
+    "from onnx import parser\n",
+    "\n",
+    "RESULTS = {}\n",
+    "\n",
+    "\n",
+    "def record(name, ok, detail=\"\"):\n",
+    "    RESULTS[name] = ok\n",
+    "    status = \"PASS\" if ok else \"FAIL\"\n",
+    "    print(f\"[{status}] {name}\" + (f\" -- {detail}\" if detail else \"\"))\n",
+    "    if not ok:\n",
+    "        raise AssertionError(f\"{name}: {detail}\")\n",
+    "\n",
+    "\n",
+    "def foldable_model(a_value=1.0):\n",
+    "    model = parser.parse_model(\n",
+    "        f\"\"\"\n",
+    "        <ir_version: 10, opset_import: [\"\": 18]>\n",
+    "        foldable (float[2,2] x) => (float[2,2] y)\n",
+    "        <float[2,2] a = {{{a_value}, {a_value}, {a_value}, {a_value}}}, float[2,2] b = {{2.0, 2.0, 2.0, 2.0}}>\n",
+    "        {{\n",
+    "          c = Add(a, b)\n",
+    "          y = Add(c, x)\n",
+    "        }}\n",
+    "        \"\"\"\n",
+    "    )\n",
+    "    onnx.checker.check_model(model)\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "X = np.arange(4, dtype=np.float32).reshape(2, 2)\n",
+    "CUDA = [\"CUDAExecutionProvider\", \"CPUExecutionProvider\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-09",
+   "metadata": {},
+   "source": [
+    "## Test A -- `backend.run_model`: CPU vs. CUDA parity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cpu_out = backend.run_model(\n",
+    "    foldable_model(), {\"x\": X}, providers=[\"CPUExecutionProvider\"]\n",
+    ")\n",
+    "cuda_out = backend.run_model(foldable_model(), {\"x\": X}, providers=CUDA)\n",
+    "ok = np.allclose(cpu_out[\"y\"], cuda_out[\"y\"]) and np.allclose(cuda_out[\"y\"], X + 3.0)\n",
+    "record(\n",
+    "    \"backend.run_model CPU/CUDA parity\",\n",
+    "    ok,\n",
+    "    f\"cpu={cpu_out['y'].tolist()} cuda={cuda_out['y'].tolist()}\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-11",
+   "metadata": {},
+   "source": [
+    "## Test B -- `onnxsim.simplify(providers=CUDA)`: constant folding on the GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "opt_cpu, ok_cpu = onnxsim.simplify(foldable_model(), check_n=3)\n",
+    "opt_cuda, ok_cuda = onnxsim.simplify(foldable_model(), check_n=3, providers=CUDA)\n",
+    "\n",
+    "folded_on_gpu = len(opt_cuda.graph.node) == 1\n",
+    "same_result = np.allclose(\n",
+    "    backend.run_model(opt_cpu, {\"x\": X})[\"y\"],\n",
+    "    backend.run_model(opt_cuda, {\"x\": X})[\"y\"],\n",
+    ")\n",
+    "record(\n",
+    "    \"simplify() folds on CUDA and matches CPU\",\n",
+    "    ok_cpu and ok_cuda and folded_on_gpu and same_result,\n",
+    "    f\"nodes_after_cuda_fold={len(opt_cuda.graph.node)}\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-13",
+   "metadata": {},
+   "source": [
+    "## Test C -- `(name, options)` tuple form: pinning `device_id`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "providers_pinned = [(\"CUDAExecutionProvider\", {\"device_id\": 0}), \"CPUExecutionProvider\"]\n",
+    "out = backend.run_model(foldable_model(), {\"x\": X}, providers=providers_pinned)\n",
+    "record(\"device_id tuple form\", np.allclose(out[\"y\"], X + 3.0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-15",
+   "metadata": {},
+   "source": [
+    "## Test D -- CLI `--cuda` end to end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "\n",
+    "onnx.save(foldable_model(), \"cuda_test_in.onnx\")\n",
+    "result = subprocess.run(\n",
+    "    [\"onnxsim\", \"cuda_test_in.onnx\", \"cuda_test_out.onnx\", \"--cuda\"],\n",
+    "    capture_output=True,\n",
+    "    text=True,\n",
+    ")\n",
+    "print(result.stdout[-1500:])\n",
+    "cli_model = onnx.load(\"cuda_test_out.onnx\")\n",
+    "cli_out = backend.run_model(cli_model, {\"x\": X})\n",
+    "record(\n",
+    "    \"CLI --cuda\",\n",
+    "    result.returncode == 0\n",
+    "    and len(cli_model.graph.node) == 1\n",
+    "    and np.allclose(cli_out[\"y\"], X + 3.0),\n",
+    "    result.stderr[-500:] if result.returncode != 0 else \"\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-17",
+   "metadata": {},
+   "source": [
+    "## Test E -- an unavailable provider fails loudly instead of silently degrading to CPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    backend.run_model(foldable_model(), {\"x\": X}, providers=[\"ROCMExecutionProvider\"])\n",
+    "    record(\"unavailable provider raises\", False, \"expected ValueError, none raised\")\n",
+    "except ValueError as e:\n",
+    "    record(\"unavailable provider raises\", \"not available\" in str(e), str(e))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-19",
+   "metadata": {},
+   "source": [
+    "## Test F -- DLPack zero-copy path with a CUDA `torch.Tensor`\n",
+    "\n",
+    "Colab's GPU runtime ships `torch` with CUDA support preinstalled, so no extra install is needed here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "from onnxsim.backend import Runner, as_ort_value\n",
+    "\n",
+    "assert torch.cuda.is_available(), \"torch does not see a CUDA device\"\n",
+    "\n",
+    "runner = Runner(foldable_model(), providers=CUDA)\n",
+    "x_gpu = torch.from_numpy(X).cuda()\n",
+    "ort_outputs = runner.run_with_ort_values({\"x\": as_ort_value(x_gpu)})\n",
+    "y = ort_outputs[\"y\"].numpy()\n",
+    "record(\"DLPack zero-copy CUDA tensor\", np.allclose(y, X + 3.0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-21",
+   "metadata": {},
+   "source": [
+    "## Test G -- `providers` threaded through `measure_accuracy_drop`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from onnxsim.accuracy import measure_accuracy_drop\n",
+    "\n",
+    "report = measure_accuracy_drop(\n",
+    "    foldable_model(a_value=1.0),\n",
+    "    foldable_model(a_value=1.01),  # stand-in for a quantized model: same graph, perturbed weight\n",
+    "    calibration_data=[{\"x\": X}],\n",
+    "    providers=CUDA,\n",
+    ")\n",
+    "print(report)\n",
+    "ok = report.all_finite and report.per_output[\"y\"].max_abs_error > 0\n",
+    "record(\"measure_accuracy_drop threads CUDA providers\", ok, str(report))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-23",
+   "metadata": {},
+   "source": [
+    "## Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"=\" * 48)\n",
+    "for name, ok in RESULTS.items():\n",
+    "    print(f\"{'PASS' if ok else 'FAIL':4}  {name}\")\n",
+    "assert all(RESULTS.values()), \"one or more CUDA feature tests failed\"\n",
+    "print(f\"\\nAll {len(RESULTS)} CUDA feature tests passed.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "name": "cuda_feature_tests.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_cuda_notebook_interface.py
+++ b/tests/test_cuda_notebook_interface.py
@@ -1,0 +1,146 @@
+"""CPU-only rehearsal of examples/cuda_feature_tests/cuda_feature_tests.ipynb.
+
+That notebook is meant to be run by hand against a real GPU (see its own
+README for why it isn't wired into CI directly), so ordinary CPU-only CI never
+actually executes it. Left alone, a rename/removal of the interfaces it
+depends on -- the CLI's ``--providers``/``--cuda`` flags, ``Runner``/
+``as_ort_value``, ``measure_accuracy_drop``'s ``providers`` kwarg -- would
+only surface the next time someone happens to open the notebook on a GPU
+machine, which could be a long time after the breaking change landed.
+
+These tests call the exact same interfaces with ``CPUExecutionProvider``
+standing in for ``CUDAExecutionProvider``, so a signature/flag change breaks
+an ordinary CPU test run immediately. They are not a substitute for actually
+running the notebook: onnxruntime accepts an unavailable provider name at the
+API level identically regardless of whether real CUDA hardware and driver
+sit behind it, so nothing here proves CUDA execution itself still works.
+Provider list/tuple handling that doesn't need the CLI or the ``Runner``/
+``measure_accuracy_drop`` combination is already covered by
+tests/test_backend.py; this file only adds the notebook-specific interfaces
+that aren't exercised anywhere else.
+"""
+
+import sys
+
+import numpy as np
+import onnx
+import pytest
+from onnx import parser
+
+from onnxsim import backend
+from onnxsim.accuracy import measure_accuracy_drop
+
+
+def _model(a_value: float = 1.0) -> onnx.ModelProto:
+    """A model whose ``a + b`` can be constant-folded, then added to input."""
+    model = parser.parse_model(
+        f"""
+        <ir_version: 10, opset_import: ["": 18]>
+        foldable (float[2,2] x) => (float[2,2] y)
+        <float[2,2] a = {{{a_value}, {a_value}, {a_value}, {a_value}}}, float[2,2] b = {{2.0, 2.0, 2.0, 2.0}}>
+        {{
+          c = Add(a, b)
+          y = Add(c, x)
+        }}
+        """
+    )
+    onnx.checker.check_model(model)
+    return model
+
+
+X = np.arange(4, dtype=np.float32).reshape(2, 2)
+
+
+@pytest.mark.skipif(
+    not backend.has_onnxruntime(), reason="requires onnxruntime for provider selection"
+)
+def test_cli_providers_flag_folds_model():
+    # Mirrors the notebook's CLI test (Test D): --providers is wired all the
+    # way through to constant folding, not just parsed and ignored.
+    import tempfile
+    from pathlib import Path
+
+    from onnxsim import onnx_simplifier
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = str(Path(tmpdir) / "in.onnx")
+        output_path = str(Path(tmpdir) / "out.onnx")
+        onnx.save(_model(), input_path)
+
+        argv = sys.argv
+        try:
+            sys.argv = [
+                "onnxsim",
+                input_path,
+                output_path,
+                "--providers",
+                "CPUExecutionProvider",
+            ]
+            onnx_simplifier.main()
+        finally:
+            sys.argv = argv
+
+        opt = onnx.load(output_path)
+        assert len(opt.graph.node) == 1
+        out = backend.run_model(opt, {"x": X})
+        np.testing.assert_allclose(out["y"], X + 3.0)
+
+
+def test_cli_cuda_and_providers_are_mutually_exclusive():
+    # Mirrors the notebook's use of the --cuda shortcut (Test D): this proves
+    # --cuda still exists and is still wired to the same mutual-exclusivity
+    # check as --providers, without needing a CUDA build to exercise it.
+    import tempfile
+    from pathlib import Path
+
+    from onnxsim import onnx_simplifier
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = str(Path(tmpdir) / "in.onnx")
+        output_path = str(Path(tmpdir) / "out.onnx")
+        onnx.save(_model(), input_path)
+
+        argv = sys.argv
+        try:
+            sys.argv = [
+                "onnxsim",
+                input_path,
+                output_path,
+                "--cuda",
+                "--providers",
+                "CPUExecutionProvider",
+            ]
+            with pytest.raises(RuntimeError, match="mutually exclusive"):
+                onnx_simplifier.main()
+        finally:
+            sys.argv = argv
+
+
+@pytest.mark.skipif(
+    not backend.has_onnxruntime(), reason="requires onnxruntime for OrtValue/Runner"
+)
+def test_runner_run_with_ort_values_roundtrip():
+    # Mirrors the notebook's DLPack test (Test F): Runner + as_ort_value +
+    # run_with_ort_values used together, the way the notebook chains them for
+    # a CUDA torch.Tensor. CPUExecutionProvider stands in for CUDA here.
+    runner = backend.Runner(_model(), providers=["CPUExecutionProvider"])
+    assert runner.supports_ort_values()
+    ort_inputs = {"x": backend.as_ort_value(X)}
+    outputs = runner.run_with_ort_values(ort_inputs)
+    np.testing.assert_allclose(outputs["y"].numpy(), X + 3.0)
+
+
+@pytest.mark.skipif(
+    not backend.has_onnxruntime(), reason="requires onnxruntime for provider selection"
+)
+def test_measure_accuracy_drop_accepts_providers_kwarg():
+    # Mirrors the notebook's Test G: measure_accuracy_drop's providers kwarg
+    # is still accepted and still threaded down to both model runs.
+    report = measure_accuracy_drop(
+        _model(a_value=1.0),
+        _model(a_value=1.01),
+        calibration_data=[{"x": X}],
+        providers=["CPUExecutionProvider"],
+    )
+    assert report.all_finite
+    assert report.per_output["y"].max_abs_error > 0


### PR DESCRIPTION
Exercises simplify()/backend.run_model()/the CLI's providers plumbing,
device_id pinning, DLPack CUDA tensor passthrough, provider-validation
errors, and measure_accuracy_drop on a real GPU. Meant to be run by
hand (e.g. in Colab) rather than wired into unattended nightly CI,
since Colab's terms of service don't fit that use case.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018CNbaqLitc2kAgnt8MsBks