### PR TITLE
docs: remove inaccessible Axera handoff link

### DIFF
--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -2,9 +2,9 @@
 
 Verifies that `onnxsim`'s output stays friendly to **Pulsar2**, the compiler
 behind Axera's AXCL toolchain that turns an ONNX model into a `.axmodel` for
-the AX6xx/AX8xx NPU line. Based on the handoff notes at
-[`../../../junk/axcl-axmodel-onnxsim-notes.md`](../../../junk/axcl-axmodel-onnxsim-notes.md),
-and since verified against a real **AX650N** (PCIe, via the AXCL host driver
+the AX6xx/AX8xx NPU line. The evidence and limitations are recorded below,
+and the implementation has been verified against a real **AX650N** (PCIe, via
+the AXCL host driver
 and `axcl_run_model`) and a real compiled `.axmodel`
 (`AXERA-TECH/YOLOv8`'s `AX650/yolov8n_640x640_npu1.axmodel`).
 

--- a/scripts/axera/inspect_axmodel.py
+++ b/scripts/axera/inspect_axmodel.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Inspect a real Axera `.axmodel` file for the CPU/NPU boundary markers.
 
-Implements steps 2-4 of "Immediate next steps" in
-`../../../junk/axcl-axmodel-onnxsim-notes.md`, the handoff notes this whole
-`scripts/axera/` harness is based on: as of writing **no real `.axmodel` has
-been inspected**, so this script exists to actually do that the moment one is
-available, rather than continuing to guess.
+Implements steps 2-4 of the "Immediate next steps" described in the Axera
+compatibility notes in ``scripts/axera/README.md``. As of writing **no real
+`.axmodel` has been inspected**, so this script exists to actually do that the
+moment one is available, rather than continuing to guess.
 
 It:
 


### PR DESCRIPTION
## Summary

Fixes #1330.

Remove the inaccessible `../../../junk/axcl-axmodel-onnxsim-notes.md` reference
from the public Axera README and `inspect_axmodel.py` docstring. The README now
keeps the evidence context in the tracked document, and the script points to
the tracked compatibility notes.

## Validation

- `ruff format --check onnxsim tests scripts/axera/inspect_axmodel.py`
- `ruff check onnxsim tests scripts/axera/inspect_axmodel.py`
- `mypy` (pinned CI version 1.18.2)
- `python -m compileall -q onnxsim tests scripts/axera/inspect_axmodel.py`
- local relative-link scan: 83 checked, 0 missing
