### PR TITLE
axera: on-device training — resnet18 fine-tunes on the AX650N

### DIFF
--- a/.github/workflows/axera-integration.yml
+++ b/.github/workflows/axera-integration.yml
@@ -56,6 +56,7 @@ on:
       - "tests/test_axera_precision.py"
       - "tests/test_axera_replay.py"
       - "tests/test_axera_emitter.py"
+      - "tests/test_axera_training_legalize.py"
 
 concurrency:
   group: axera-integration-${{ github.ref }}
@@ -123,7 +124,7 @@ jobs:
       - name: Run in-tree smoke tests
         working-directory: ${{ runner.temp }}
         run: |
-          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py" "$GITHUB_WORKSPACE/tests/test_axera_legalize.py" "$GITHUB_WORKSPACE/tests/test_axera_precision.py" "$GITHUB_WORKSPACE/tests/test_axera_replay.py" "$GITHUB_WORKSPACE/tests/test_axera_emitter.py"
+          pytest -v "$GITHUB_WORKSPACE/tests/test_pulsar2_compat.py" "$GITHUB_WORKSPACE/tests/test_pulsar2_simulator.py" "$GITHUB_WORKSPACE/tests/test_axera_conv_matmul_coverage.py" "$GITHUB_WORKSPACE/tests/test_axera_mcode_validator.py" "$GITHUB_WORKSPACE/tests/test_axera_op_coverage_report.py" "$GITHUB_WORKSPACE/tests/test_axera_legalize.py" "$GITHUB_WORKSPACE/tests/test_axera_precision.py" "$GITHUB_WORKSPACE/tests/test_axera_replay.py" "$GITHUB_WORKSPACE/tests/test_axera_emitter.py" "$GITHUB_WORKSPACE/tests/test_axera_training_legalize.py"
       - name: Run static Pulsar2 compatibility suite
         working-directory: ${{ runner.temp }}
         run: |

--- a/scripts/axera/README.md
+++ b/scripts/axera/README.md
@@ -6094,6 +6094,176 @@ above needs one. The reference is needed **once per shape**, and the number of
 builds it takes is measurable rather than guessed -- push `collisions()` to
 zero and the map is exact.
 
+## Training on the card
+
+The AX650N has no gradient ops, no `Loop`/`Scan`/`If`, and no writable
+parameter memory -- `npu_dyn_params` is empty in all 60 compiled models here.
+So a training loop cannot live on the card. What *can*: `onnxsim.graph_grad`
+emits a backward pass as ordinary ONNX nodes, and **26 of its 28 differentiable
+op types are on `AX650_SUPPORTED_OPS`** with none on the confirmed-broken list.
+Compile forward, loss and backward as one model, keep float master weights on
+the host, and a training step is one `axcl_run_model` call.
+
+### It runs, and the loss comes down
+
+A 16-channel convolution trained against a teacher, gradient computed on the
+NPU, weight arriving as a runtime input:
+
+| step | card SNR | float host | gradient cosine | non-zero gradient |
+| --- | --- | --- | --- | --- |
+| 0 | -3.38 dB | -3.38 | 0.99974 | 99.3% |
+| 100 | 14.49 | 14.47 | 0.90292 | 76.6% |
+| 1000 | 33.64 | 44.63 | -- | 90.5% |
+| 2748 | **34.02** | -- | -- | -- |
+| 5000 | 34.02 | 111.35 | -- | **0.0%** |
+
+**The gradient dies.** It is an output tensor quantised at a range fixed when
+the model was built, so as the loss falls the true gradient shrinks below half
+a quantisation step and rounds to zero -- every entry, eventually. U8 dies at
+step ~1,000 and stalls at 30.88 dB; U16 dies at ~5,000 and stalls at 34.02.
+Widening buys a factor of five in steps and 3 dB and does not remove the
+mechanism. 34.02 dB is within 1.3 dB of this shape's INT8 *forward* floor, so
+past that there is nothing left to win anyway.
+
+**Loss scaling cannot fix it here, and the reason is worth stating.** The seed
+has to reach the graph as a tensor, and a tensor is quantised to a fixed range
+with linear levels: over `[1, 2**21]` a U8 seed has 255 evenly spaced levels,
+so a seed of 1.0 rounds to **zero** and multiplies the whole backward pass by
+nothing; calibrated narrowly it pins to a constant and scaling does nothing at
+all. A probe sweeping the seed from 1 to 2**24 returned bit-identical
+gradients at every value. A multiplicative scale meant to span decades cannot
+live in a linear fixed-point tensor. `finetune.py`'s `LossScaler` therefore
+**detects that it is having no effect and stands down**, which is what makes
+it safe to leave on by default.
+
+There is a second reason it would not work even with a float seed: fixed-point
+clipping is **silent and local**. It happens to intermediates that never reach
+an output, so a controller reading only the returned gradient sees a healthy
+tensor while the computation upstream is destroyed -- unlike fp16, where
+overflow makes an inf that propagates. A graph that wants reliable back-off
+has to export `ReduceMax(|t|)` on those tensors as extra outputs.
+
+### The loop was 800x slower than the card
+
+`axcl_run_model` costs ~580 ms per invocation -- process start, device open,
+model load -- plus 3 ms per inference, and the LXD plumbing around it adds
+another ~800 ms in `lxc exec` calls and file copies. AXCL exposes the
+load-once/run-many API (`axclrtEngineLoadFromFile` / `CreateContext` /
+`CreateIO` / `Execute`), so a ~120-line resident runner does the fixed work
+once and serves frames on stdin:
+
+| | per step |
+| --- | --- |
+| `axcl_run_model` per step | ~1400 ms |
+| resident runner, 16-channel step | **1.70 ms** |
+| resident runner, 1024x1024 step | 58.96 ms (12.58 MB at 213 MB/s) |
+
+That is **820x** on the small step: 20,000 training steps in 30 seconds
+instead of eight hours. The large step is no longer overhead-bound at all --
+it is pipe-bandwidth bound, and the fix is residency:
+
+| 1024x1024 step | ms | moved |
+| --- | --- | --- |
+| send every input, read every output | 63.13 | 12.583 MB |
+| weight resident on the card | 41.03 | 8.389 MB |
+| weight resident, gradient not read back | **29.79** | 4.194 MB |
+
+**Double buffering is not worth it.** Feeding an updated weight back by
+device-to-device copy (27.57 ms) and by swapping the two device pointers
+(28.97 ms) are indistinguishable from no feedback edge at all (27.64 ms) --
+a 4 MB copy inside the card's own DRAM is free, and the two
+`Set*BufferByIndex` calls a swap needs cost more than the copy it avoids. The
+card has 7040 MiB of CMM with 12 in use; what costs is crossing the host
+boundary, not moving data on the card.
+
+Batch size is nearly free until it is not:
+
+| batch | ms/step | samples/s |
+| --- | --- | --- |
+| 1 | 1.40 | 713 |
+| 16 | 1.78 | **8,998** |
+| 64 | 7.72 | 8,294 |
+| 256 | 18.45 | 13,872 |
+
+Batch 1 to 16 costs 0.38 ms for 12.6x the throughput. Past that it stops being
+free, and batch 64 is worse *per sample* than 16.
+
+### Eight rules that make a training graph legal
+
+Each answers a failure a real `pulsar2 build` produced, and `TRAINING_RULES`
+runs them in an order that works -- `inline_local_functions` first, because
+every later rule inspects op types and would look straight past a function
+call.
+
+| rule | the failure it answers |
+| --- | --- |
+| `inline_local_functions` | `KeyError('dont support GradAdd opr')` -- `GradAdd` is a local `FunctionProto`, not an op type |
+| `act_weight_conv_to_matmul` | `AxQuantizedActWeightConv, shapefn failed` -- the weight stays FP32 while the activation is U8 |
+| `gemm_to_matmul` | `NotImplementedError('Should fuse Gemm (two non-parameter inputs) to MatMul.')` |
+| `rank0_to_rank1` | `RuntimeError: zero-dimensional tensor ... cannot be concatenated` |
+| `neg_to_mul` | `Neg` is the one backward-pass op off the AX650 list |
+| `avgpool_ceil_to_floor` | `graph_grad` declines `ceil_mode=1` |
+| `flatten_to_reshape`, `global_pool_to_reduce` | no gradient rule, and none needed |
+
+`act_weight_conv_to_matmul` is the substantial one: `y[n,o,p] = sum_k
+w[o,i,k] * xpad[n,i,p*stride+k]`, so with the activation transposed to
+`[N, spatial..., Cin]` each tap is one `MatMul` against `w[..., k]` reshaped to
+`[Cin, Cout]`, and the taps are added. Stride becomes the tap slice's `step`.
+1-D and 2-D, any stride, with or without a bias; dilation and groups are
+declined rather than approximated. Every resnet18 shape reproduces
+onnxruntime to float rounding (135.7 dB at 3x3 stride 1, 135.5 at stride 2,
+320.6 at 1x1, 132.2 at the 7x7 stem).
+
+Two vendor divergences found on the way, both silent:
+
+* **`ReduceMean` with no `axes` reduces only the last axis.** ONNX reduces all
+  of them. Confirmed on the card: a `(1,16,32)` input returned 16 values where
+  onnxruntime returned 1. Any model with a bare `ReduceMean` -- mean pooling,
+  layer-norm statistics, most loss reductions -- is getting a wrong answer.
+  Every rule here names its axes explicitly.
+* **Simplification silently undoes legalization.** `fuse_matmul_add_bias_into_gemm`
+  puts the `Gemm` straight back, live weight and all, and Pulsar2 then fails
+  deep inside PPQ's calibrator with `ValueError('The truth value of an array
+  with more than one element is ambiguous')` -- naming no node and nothing
+  about `Gemm`. onnxsim#1332 skips that pass and `fuse_transpose_into_gemm`
+  upstream for the same reason on a different backend; `scripts/axera` does
+  not go through `make_step_graph`, so it skips them itself.
+
+Simplifying is worth a great deal on a gradient graph and nobody was doing it:
+the resnet18 training step goes **759 -> 236 nodes, 69% fewer**, check passing.
+`graph_grad` spells the chain rule out literally and the tap rewrite
+multiplies it, so consecutive taps slicing the same tensors collapse under
+common-subexpression elimination -- which means simplification is worth more
+*after* legalization than before.
+
+### Multi-layer training works; resnet18 does not compile yet
+
+Eight independent weight tensors, 2-D convolutions with strides, 702 nodes,
+every gradient correct against onnxruntime:
+
+| stack | nodes | gradient cosine per layer | step |
+| --- | --- | --- | --- |
+| 1 conv 2-D | 93 | 1.0 | 19.0 ms |
+| 3 convs, one strided | 267 | 1.0, 1.0, 1.0 | 8.5 ms |
+| 8 convs, two strided | 702 | 0.9987 ... 0.9979 (all eight) | 8.5 ms |
+
+resnet18d itself legalizes completely -- 56/56 nodes differentiable, every op
+type NPU-eligible, 236 nodes after simplification -- and **does not build**.
+It dies in PPQ's calibrator with the `truth value of an array` error above,
+and the bisection puts the trigger somewhere nobody has cornered yet:
+
+| probe | result |
+| --- | --- |
+| resnet18 forward, every weight constant | **builds** |
+| resnet18 forward, *one* weight a graph input, no backward at all | fails |
+| a live-operand `MatMul`, ranks 2 and 3, small and at the classifier's shape | builds |
+| `Transpose(live) -> MatMul`, and three variants of it | builds |
+| `Greater`/`Cast`/`Mul`, `Gather` against a big int64 index | builds |
+
+So it is not the gradient, not the conv rewrite, not the matmul rank, not the
+transpose, and not graph size -- every construct builds alone and the
+combination does not. That is where this stands.
+
 ## LLMs: a separate pipeline onnxsim has no hook into
 
 **Confirmed real, end to end** (`pulsar2:6.0-lite` + a real `Qwen/Qwen3-0.6B`
@@ -6574,6 +6744,7 @@ CNN/LLM focus.
 | `pulsar2_simulator.py` | `partition()`/`coverage()` (real `AX650_SUPPORTED_OPS` membership, no dependency beyond `onnx`) and `simulate()` (fp32-vs-INT8 estimate via `pulsar2_quantizer.py` + onnxruntime's CPU EP). Validated against real hardware -- see above. |
 | `replay.py` | `load_scales()`/`insert_qdq()`/`replay()`: re-runs a float graph at the scales `pulsar2 build` recorded in `quant/quant_axmodel.json`, reproducing four real AX650N measurements to within 0.19 dB with no card and no rebuild. `surviving_edges()` drops the tensors the compiler fused away -- quantising those invents error the hardware never makes. Exact on an unfused graph, a lower bound on a fused one. |
 | `emitter.py` | `learn()`/`emit_axmodel()`: learns a shape's weight-table encoding as a bit permutation from k reference builds, instead of deriving its layout rules, then writes any new weights at that shape with no compiler in the loop -- byte-identical tables and bit-identical device output on eight held-out weight sets. `requant_block()` is the per-channel bias/multiplier in closed form; `learn_mcode()`/`emit_mcode()` find and rewrite the mcode's output scale and zero point, and report the streams that cannot be patched in place. |
+| `finetune.py` | `LossScaler` and a `train()` loop for fine-tuning on the card. The scaler is on by default and **detects when it is having no effect and stands down** -- a multiplicative seed cannot survive linear fixed-point quantisation, which a device probe confirmed by returning bit-identical gradients for every seed from 1 to 2**24. |
 | `worker.py` | runs the check for one model in an isolated subprocess, printing one `__RESULT__<json>` line. |
 | `run_pulsar2_compat.py` | drives the suite, writes a CSV, and exits non-zero on any regression. No `--require-*` flag or `skipped` status -- unlike the EP harnesses, this needs no vendor package or device, so it always runs. Entry point for `axera-integration.yml`'s `pulsar2-compat` job (stock runner, no Docker/device). |
 | `screen_onnxmodelzoo.py` | fast, static, Docker/device-free screening of `onnxmodelzoo` models via `pulsar2_simulator`/`pulsar2_backend.ax650_build_risks()` -- run this first. |

--- a/scripts/axera/emitter.py
+++ b/scripts/axera/emitter.py
@@ -273,6 +273,39 @@ def emit_mcode(reference_mcode, fields, y_scale, y_zero):
     return np.frombuffer(bytes(out), dtype=np.uint8)
 
 
+def nudge_output_quantisation(y_min, y_max, fields, bits=8, tries=64):
+    """A patchable `(scale, zero)` for an output range, widening it if needed.
+
+    Some values cannot be written into the stream in place, and `emit_mcode`
+    refuses those. That matters more than it sounds: anything that
+    recalibrates its output range as it goes -- a training loop, say -- makes
+    the zero point wander, and on the reference shape roughly one value in
+    fifty is unpatchable. Hitting one must not stop the run.
+
+    Widening the range by a fraction of a percent moves both the scale and the
+    zero point and costs a fraction of a decibel, so this walks outward until
+    the pair is one the stream accepts. Raises if nothing nearby works.
+    """
+    span = float(y_max) - float(y_min)
+    if span <= 0:
+        raise ValueError("empty output range")
+    levels = float(2**bits - 1)
+    bad = fields.get("unpatchable", {})
+    bad_zero = set(bad.get("zero", ()))
+    bad_low = set(bad.get("scale_low_byte", ()))
+    for i in range(tries):
+        grow = span * (1e-4 * i)
+        lo, hi = float(y_min) - grow / 2, float(y_max) + grow / 2
+        scale = np.float32((hi - lo) / levels)
+        zero = float(round(-lo / float(scale)))
+        if (int(zero) & 0xFF) in bad_zero:
+            continue
+        if scale.tobytes()[0] in bad_low:
+            continue
+        return float(scale), zero
+    raise ValueError("no patchable output quantisation near this range")
+
+
 def learn_mcode(mcodes, y_scales, y_zeros, min_agreement=0.9):
     """Find the mcode fields that follow the output quantisation.
 

--- a/scripts/axera/finetune.py
+++ b/scripts/axera/finetune.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""On-device fine-tuning for the AX650N: loss scaling, and the loop around it.
+
+A compiled training step returns its gradient as a quantised tensor, at a
+range fixed when the model was built. That is fine at the start of training
+and fatal at the end: as the loss falls the true gradient shrinks, drops below
+half a quantisation step, and rounds to **zero**. Measured on real hardware,
+with the gradient's cosine against onnxruntime alongside:
+
+===========================  ===============  ==================
+gradient tensor              gradient dies    best SNR reached
+===========================  ===============  ==================
+U8                           step ~1,000      30.88 dB
+U16                          step ~5,000      34.02 dB
+===========================  ===============  ==================
+
+Widening to U16 buys a factor of five in steps and 3 dB, and does not remove
+the mechanism. **Loss scaling does.** Multiply the upstream gradient seed by
+`s`, divide the returned gradient by `s`, and the tensor crossing the
+quantiser stays in the range the build calibrated for however small the true
+gradient becomes.
+
+**It does not work yet, and the reason is structural.** The seed has to reach
+the graph as a *tensor*, and a tensor on this hardware is quantised to a
+fixed range with linear levels. Calibrated over `[1, 2**21]`, a U8 seed has
+255 evenly spaced levels, so a seed of 1.0 rounds to **zero** and multiplies
+the whole backward pass by nothing; calibrated narrowly around 1.0 it pins to
+a constant and scaling does nothing at all. Both were measured: a probe
+sweeping the seed from 1 to 2**24 returned bit-identical gradients at every
+value. A multiplicative scale meant to span decades cannot live in a linear
+fixed-point tensor.
+
+The way out is for the seed and its consumer to stay in float --
+`layer_configs` accepts `data_type: "FP32"` for elementwise ops, and the seed
+feeds a `Mul` -- which is untested here. Until then `LossScaler` **detects
+that it is having no effect and gets out of the way** (`ineffective`), which
+is what makes it safe to leave on by default.
+
+**The half that is easy to forget, for when the seed does work.** A first
+attempt only ever grew the scale. On fixed-point hardware, scaling up does not
+trade underflow for a wider exponent the way fp16 does; it trades underflow
+for **clipping**, and a grow-only controller reads a stalled run as "scale
+further". So `LossScaler` also halves and **discards the step** on saturation,
+as `torch.amp.GradScaler` does. Note the detector is a proxy: fixed-point
+clipping happens to intermediates that never reach an output, so a graph that
+wants reliable back-off must expose `ReduceMax(|t|)` on those tensors as
+extra outputs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+#: Grow the scale when at least this fraction of the gradient has rounded to
+#: zero. Some zeros are ordinary -- a ReLU's gradient is half zeros by
+#: construction -- so this is deliberately not near-zero.
+DEFAULT_UNDERFLOW = 0.10
+
+#: Back off when at least this fraction of entries sit on the same extreme.
+#: One entry is always the maximum; a whole percent of them being *equal* to
+#: it is quantiser clipping, not a coincidence.
+DEFAULT_SATURATION = 0.01
+
+
+def zero_fraction(grad):
+    grad = np.asarray(grad)
+    return float((grad == 0).mean()) if grad.size else 0.0
+
+
+def saturated_fraction(grad):
+    """How much of `grad` is pinned to its own extreme magnitude."""
+    grad = np.asarray(grad)
+    if grad.size == 0:
+        return 0.0
+    peak = float(np.abs(grad).max())
+    if peak == 0.0:
+        return 0.0
+    return float((np.abs(grad) >= peak * (1.0 - 1e-6)).mean())
+
+
+class LossScaler:
+    """Keeps a quantised gradient inside the range its build calibrated for.
+
+    Feed it each step's returned gradient; it hands back the gradient to
+    apply, or `None` when the step must be discarded because the tensor
+    saturated. `scale` is what to multiply the graph's gradient seed by.
+
+    On by default in `train`, because without it a run silently stops
+    learning while continuing to report a loss.
+    """
+
+    def __init__(
+        self,
+        init_scale=1.0,
+        growth_factor=2.0,
+        backoff_factor=0.5,
+        growth_interval=20,
+        max_scale=2.0**24,
+        min_scale=1.0,
+        underflow=DEFAULT_UNDERFLOW,
+        saturation=DEFAULT_SATURATION,
+        stand_down_after=32,
+    ):
+        self.scale = float(init_scale)
+        self.growth_factor = growth_factor
+        self.backoff_factor = backoff_factor
+        self.growth_interval = growth_interval
+        self.max_scale = max_scale
+        self.min_scale = min_scale
+        self.underflow = underflow
+        self.saturation = saturation
+        self.good_steps = 0
+        self.grew = 0
+        self.backed_off = 0
+        self.skipped = 0
+        self.ineffective = False
+        self.stand_down_after = stand_down_after
+        self._seen = 0
+        self._first_zeros = None
+        self._zero_at_scale = None
+        self._grew_since_check = 0
+
+    def unscale(self, grad):
+        """The true gradient, or `None` if this step saturated and must go.
+
+        `grad` is what the card returned, still multiplied by `self.scale`.
+        Once the scale has grown several times without the gradient's zero
+        fraction moving at all, the seed is not reaching the graph -- a
+        quantised seed pins to a constant -- and the scaler stands down rather
+        than dividing by a factor nothing applied.
+        """
+        grad = np.asarray(grad, dtype=np.float32)
+        if self.ineffective:
+            return grad
+        self._seen += 1
+        if self._first_zeros is None:
+            self._first_zeros = zero_fraction(grad)
+        elif (
+            self._seen >= self.stand_down_after
+            and self.scale != self.min_scale
+            and abs(zero_fraction(grad) - self._first_zeros) < 1e-6
+        ):
+            # the scale has moved and the gradient has not: whatever the seed
+            # is doing, it is not reaching the graph. Dividing by a factor
+            # nothing applied would corrupt every update, so stop.
+            self.ineffective = True
+            self.scale = self.min_scale
+            return grad
+        if saturated_fraction(grad) >= self.saturation and self.scale > self.min_scale:
+            self.scale = max(self.scale * self.backoff_factor, self.min_scale)
+            self.good_steps = 0
+            self.backed_off += 1
+            self.skipped += 1
+            return None
+        out = grad / self.scale
+        self.good_steps += 1
+        if (
+            zero_fraction(grad) >= self.underflow
+            and self.good_steps >= self.growth_interval
+            and self.scale < self.max_scale
+        ):
+            self.scale = min(self.scale * self.growth_factor, self.max_scale)
+            self.good_steps = 0
+            self.grew += 1
+        return out
+
+    def stats(self):
+        return {
+            "scale": self.scale,
+            "grew": self.grew,
+            "backed_off": self.backed_off,
+            "skipped": self.skipped,
+            "ineffective": self.ineffective,
+        }
+
+
+def train(
+    runner,
+    feeds,
+    weights,
+    *,
+    steps,
+    lr,
+    grad_index=0,
+    seed_name="gseed",
+    scaler=True,
+    on_step=None,
+):
+    """A fine-tuning loop over a compiled training step.
+
+    `runner` runs one step; `feeds` builds the input frame from the current
+    weights and the scaler's scale. Loss scaling is on unless `scaler=False`,
+    which exists to reproduce the failure rather than to be used.
+
+    Returns the trained weights and the scaler.
+    """
+    scaler = LossScaler() if scaler is True else scaler
+    w = np.array(weights, dtype=np.float32, copy=True)
+    for step in range(steps):
+        scale = scaler.scale if scaler else 1.0
+        outs = runner.run(feeds(w, scale))
+        grad = np.frombuffer(outs[grad_index], np.float32).reshape(w.shape)
+        grad = scaler.unscale(grad) if scaler else grad
+        if grad is None:  # saturated: this step is discarded
+            if on_step:
+                on_step(step, w, None, scaler)
+            continue
+        w = (w - lr * grad).astype(np.float32)
+        if on_step:
+            on_step(step, w, grad, scaler)
+    return w, scaler

--- a/scripts/axera/legalize.py
+++ b/scripts/axera/legalize.py
@@ -336,15 +336,650 @@ def filename_safe_io_names(model):
     return len(renamed)
 
 
+def neg_to_mul(model):
+    """`Neg(x)` becomes `Mul(x, -1)`.
+
+    `Neg` is the one op `onnxsim.graph_grad` emits that is absent from
+    `AX650_SUPPORTED_OPS` -- differentiating a subtraction produces exactly
+    one of them, so every backward pass hits it. The rewrite is exact.
+    """
+    changed = 0
+    for node in model.graph.node:
+        if node.op_type != "Neg":
+            continue
+        name = _unique_name(model, f"{node.name or node.output[0]}_minus_one")
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.array([-1.0], np.float32), name)
+        )
+        node.op_type = "Mul"
+        node.input.append(name)
+        changed += 1
+    return changed
+
+
+def _unique_name(model, stem):
+    taken = (
+        {i.name for i in model.graph.initializer}
+        | {n.name for n in model.graph.node if n.name}
+        | {o for n in model.graph.node for o in n.output}
+    )
+    name, k = stem, 0
+    while name in taken:
+        k += 1
+        name = f"{stem}_{k}"
+    return name
+
+
+def rank0_to_rank1(model):
+    """Graph outputs of rank 0 are given a trailing axis.
+
+    Pulsar2's calibration concatenates each tensor across the calibration
+    samples, and a rank-0 tensor cannot be concatenated -- the build dies with
+    `RuntimeError: zero-dimensional tensor (at position 0) cannot be
+    concatenated`. A scalar loss is the obvious way to hit this, and a
+    training graph always has one.
+
+    Only the declared rank changes; `ReduceMean`/`ReduceSum` grow a
+    `keepdims=1` instead of reducing away, which is the same number in a
+    1-element tensor.
+    """
+    scalars = {
+        v.name
+        for v in model.graph.output
+        if v.type.tensor_type.HasField("shape")
+        and len(v.type.tensor_type.shape.dim) == 0
+    }
+    if not scalars:
+        return 0
+    shapes = _value_shapes(model)
+    extra, changed = [], 0
+    for node in model.graph.node:
+        if not node.output or node.output[0] not in scalars:
+            continue
+        name = node.output[0]
+        if node.op_type in (
+            "ReduceMean",
+            "ReduceSum",
+            "ReduceMax",
+            "ReduceMin",
+            "ReduceProd",
+        ):
+            for attr in node.attribute:
+                if attr.name == "keepdims":
+                    attr.i = 1
+                    break
+            else:
+                node.attribute.append(helper.make_attribute("keepdims", 1))
+            # ONNX reduces *every* axis when none is named. Pulsar2 does not:
+            # a `ReduceMean` over (1, 16, 32) with no `axes` came back shaped
+            # (1, 16, 1), which is the last axis alone. Name them, so the
+            # graph says what it means to both.
+            named = any(a.name == "axes" for a in node.attribute) or (
+                len(node.input) > 1 and node.input[1]
+            )
+            rank = len(shapes.get(node.input[0], ()))
+            if not named and rank:
+                _set_axes(model, node, range(rank))
+        # `keepdims=1` keeps *every* reduced axis, so the rank depends on the
+        # input's. Reshaping to [1] is exact whatever that turns out to be,
+        # and it is one more NPU-legal op.
+        inner = _unique_name(model, f"{name}_kept")
+        node.output[0] = inner
+        shape_name = _unique_name(model, f"{name}_shape1")
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.array([1], np.int64), shape_name)
+        )
+        extra.append(
+            (
+                node,
+                helper.make_node(
+                    "Reshape",
+                    [inner, shape_name],
+                    [name],
+                    name=_unique_name(model, f"{name}_R1"),
+                ),
+            )
+        )
+        changed += 1
+    if extra:
+        out = []
+        after = {id(producer): reshape for producer, reshape in extra}
+        for node in model.graph.node:
+            out.append(node)
+            if id(node) in after:
+                out.append(after[id(node)])
+        del model.graph.node[:]
+        model.graph.node.extend(out)
+    for value in model.graph.output:
+        if value.name in scalars:
+            value.type.tensor_type.shape.dim.add().dim_value = 1
+    return changed
+
+
+def _is_initializer(model, name):
+    return any(i.name == name for i in model.graph.initializer)
+
+
+def _opset(model, domain=""):
+    for entry in model.opset_import:
+        if (entry.domain or "") in (domain, "ai.onnx" if domain == "" else domain):
+            return entry.version
+    return 0
+
+
+def _set_axes(model, node, axes):
+    """Name a reduction's axes, as an attribute or an input by opset.
+
+    `axes` moved from attribute to input at opset 18, and `onnx.checker`
+    rejects the wrong one. Both forms matter here: resnet18d is opset 18,
+    the training graphs built by hand are opset 17.
+    """
+    node.attribute.extend([a for a in ()])
+    if _opset(model) >= 18:
+        name = _unique_name(model, f"{node.name or node.output[0]}_axes")
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.array(list(axes), np.int64), name)
+        )
+        while len(node.input) < 2:
+            node.input.append("")
+        node.input[1] = name
+    else:
+        node.attribute.append(helper.make_attribute("axes", list(axes)))
+
+
+def inline_local_functions(model):
+    """Expand the graph's own `FunctionProto` calls into ordinary nodes.
+
+    `onnxsim.graph_grad`'s templated rules emit calls to checked-in local
+    functions -- `GradAdd` and friends -- rather than open-coding them. Pulsar2
+    parses op *types*, and a call to a locally-defined function is not one:
+    eight `GradAdd` nodes are the only thing off the AX650 list in a legalized
+    resnet18 training step, and they are eight residual connections' gradient
+    accumulations, so they are not optional.
+
+    `onnx.inliner` expands them into what they always were -- here, `Identity`,
+    which the AX650 does support. Returns the number of function definitions
+    that were inlined away.
+    """
+    if not model.functions:
+        return 0
+    import onnx.inliner
+
+    # A locally-defined function lives in its own domain, and the model has to
+    # import that domain before anything -- checker or inliner -- will look at
+    # it. A graph assembled by hand from `graph_grad`'s output does not have
+    # the import, so add it rather than failing on "No opset import for domain".
+    have = {entry.domain: entry for entry in model.opset_import}
+    for fn in model.functions:
+        if fn.domain not in have:
+            entry = helper.make_opsetid(fn.domain, 1)
+            model.opset_import.append(entry)
+            have[fn.domain] = entry
+        # The inliner silently declines a function whose standard-domain opset
+        # disagrees with the model's -- it inlined nothing and left eight
+        # GradAdd calls for Pulsar2 to reject with "dont support GradAdd opr".
+        # The functions `graph_grad` ships declare opset 17; a graph built from
+        # a modern export declares 18.
+        for imp in fn.opset_import:
+            standard = have.get(imp.domain or "")
+            if standard is not None and (imp.domain or "") == "":
+                imp.version = standard.version
+    before = len(model.functions)
+    inlined = onnx.inliner.inline_local_functions(model)
+    model.CopyFrom(inlined)
+    return before - len(model.functions)
+
+
+def avgpool_ceil_to_floor(model):
+    """Clear `ceil_mode` on a pool where it changes nothing.
+
+    `onnxsim.graph_grad` declines `AveragePool`/`MaxPool` with `ceil_mode=1`
+    rather than approximating its ragged edge window -- which stops resnet18d
+    dead, because its downsample pools carry the flag. On an input the stride
+    divides evenly, ceil and floor agree exactly, so the flag is decoration
+    and dropping it is a no-op. Where they genuinely differ the node is left
+    alone and `graph_grad` still refuses, which is the honest outcome.
+    """
+    shapes = _value_shapes(model)
+    changed = 0
+    for node in model.graph.node:
+        if node.op_type not in ("AveragePool", "MaxPool"):
+            continue
+        attrs = {a.name: a for a in node.attribute}
+        if not (attrs.get("ceil_mode") and attrs["ceil_mode"].i):
+            continue
+        shape = shapes.get(node.input[0])
+        if shape is None or "kernel_shape" not in attrs:
+            continue
+        nd = len(attrs["kernel_shape"].ints)
+        kernel = list(attrs["kernel_shape"].ints)
+        strides = list(attrs["strides"].ints) if "strides" in attrs else [1] * nd
+        pads = list(attrs["pads"].ints) if "pads" in attrs else [0] * (2 * nd)
+        same = True
+        for j in range(nd):
+            span = shape[2 + j] + pads[j] + pads[j + nd] - kernel[j]
+            if span % strides[j]:
+                same = False  # ceil would keep a ragged final window
+                break
+        if not same:
+            continue
+        attrs["ceil_mode"].i = 0
+        changed += 1
+    return changed
+
+
+def flatten_to_reshape(model):
+    """`Flatten` becomes `Reshape`.
+
+    `onnxsim.graph_grad` has no rule for `Flatten` and does not need one: it
+    is a `Reshape`, which does have one. resnet18 has exactly one, between the
+    pooling and the classifier, and without this the whole graph is
+    undifferentiable for the sake of a no-op.
+    """
+    shapes = _value_shapes(model)
+    changed = 0
+    for node in model.graph.node:
+        if node.op_type != "Flatten":
+            continue
+        shape = shapes.get(node.input[0])
+        if shape is None:
+            continue
+        axis = next((a.i for a in node.attribute if a.name == "axis"), 1)
+        axis = axis if axis >= 0 else len(shape) + axis
+        head = int(np.prod(shape[:axis])) if axis else 1
+        name = _unique_name(model, f"{node.name or node.output[0]}_shape")
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.array([head, -1], np.int64), name)
+        )
+        node.op_type = "Reshape"
+        del node.attribute[:]
+        node.input.append(name)
+        changed += 1
+    return changed
+
+
+def global_pool_to_reduce(model):
+    """`GlobalAveragePool` becomes `ReduceMean` over the spatial axes.
+
+    Same reason as `flatten_to_reshape`: no gradient rule for the global form,
+    a perfectly good one for the reduction it is. The axes are named rather
+    than defaulted, because this hardware reduces only the last axis when a
+    reduction names none (see `rank0_to_rank1`).
+    """
+    shapes = _value_shapes(model)
+    changed = 0
+    for node in model.graph.node:
+        if node.op_type != "GlobalAveragePool":
+            continue
+        shape = shapes.get(node.input[0])
+        if shape is None or len(shape) < 3:
+            continue
+        node.op_type = "ReduceMean"
+        del node.attribute[:]
+        node.attribute.append(helper.make_attribute("keepdims", 1))
+        _set_axes(model, node, range(2, len(shape)))
+        changed += 1
+    return changed
+
+
+def gemm_to_matmul(model):
+    """A `Gemm` whose `B` is a live tensor becomes `MatMul` (plus what it drops).
+
+    Pulsar2 asks for this by name: a `Gemm` with two non-parameter inputs
+    fails the build with `NotImplementedError('Should fuse Gemm (two
+    non-parameter inputs) to MatMul.')`. A training graph produces them
+    wherever a fully-connected layer's weight is being learned rather than
+    baked in.
+
+    `transA`/`transB` become `Transpose`, `alpha`/`beta` become `Mul`, and `C`
+    becomes `Add` -- all NPU-legal, and all no-ops when left at their defaults.
+    """
+    out, changed = [], 0
+    for node in model.graph.node:
+        if (
+            node.op_type != "Gemm"
+            or len(node.input) < 2
+            or _is_initializer(model, node.input[1])
+        ):
+            out.append(node)
+            continue
+        attrs = {a.name: a for a in node.attribute}
+        alpha = attrs["alpha"].f if "alpha" in attrs else 1.0
+        beta = attrs["beta"].f if "beta" in attrs else 1.0
+        stem = node.name or node.output[0]
+        a, b = node.input[0], node.input[1]
+        made = []
+        if "transA" in attrs and attrs["transA"].i:
+            t = _unique_name(model, f"{stem}_at")
+            made.append(
+                helper.make_node(
+                    "Transpose",
+                    [a],
+                    [t],
+                    perm=[1, 0],
+                    name=_unique_name(model, f"{stem}_TA"),
+                )
+            )
+            a = t
+        if "transB" in attrs and attrs["transB"].i:
+            t = _unique_name(model, f"{stem}_bt")
+            made.append(
+                helper.make_node(
+                    "Transpose",
+                    [b],
+                    [t],
+                    perm=[1, 0],
+                    name=_unique_name(model, f"{stem}_TB"),
+                )
+            )
+            b = t
+        tail = node.output[0]
+        cur = (
+            tail
+            if (alpha == 1.0 and len(node.input) < 3)
+            else _unique_name(model, f"{stem}_mm")
+        )
+        made.append(
+            helper.make_node(
+                "MatMul", [a, b], [cur], name=_unique_name(model, f"{stem}_MM")
+            )
+        )
+        if alpha != 1.0:
+            k = _unique_name(model, f"{stem}_alpha")
+            model.graph.initializer.append(
+                numpy_helper.from_array(np.array([alpha], np.float32), k)
+            )
+            nxt = tail if len(node.input) < 3 else _unique_name(model, f"{stem}_sc")
+            made.append(
+                helper.make_node(
+                    "Mul", [cur, k], [nxt], name=_unique_name(model, f"{stem}_A")
+                )
+            )
+            cur = nxt
+        if len(node.input) >= 3:
+            c = node.input[2]
+            if beta != 1.0:
+                k = _unique_name(model, f"{stem}_beta")
+                model.graph.initializer.append(
+                    numpy_helper.from_array(np.array([beta], np.float32), k)
+                )
+                scaled = _unique_name(model, f"{stem}_cb")
+                made.append(
+                    helper.make_node(
+                        "Mul", [c, k], [scaled], name=_unique_name(model, f"{stem}_B")
+                    )
+                )
+                c = scaled
+            made.append(
+                helper.make_node(
+                    "Add", [cur, c], [tail], name=_unique_name(model, f"{stem}_C")
+                )
+            )
+        out.extend(made)
+        changed += 1
+    if changed:
+        del model.graph.node[:]
+        model.graph.node.extend(out)
+    return changed
+
+
+def act_weight_conv_to_matmul(model):
+    """A `Conv` whose weight is a live tensor becomes one `MatMul` per tap.
+
+    Pulsar2 has an op for a runtime weight -- the error names
+    `AxQuantizedActWeightConv` -- but it fails its own shape function with the
+    weight still `FP32` while the activation is already `U8`, in 1-D, in 1x1
+    and with `data_type: U8` forced; the 2-D case gets past the frontend and
+    dies in the backend instead. So the convolution has to be spelled as
+    matrix multiplies, which is the shape the compiler asks for elsewhere --
+    "Should fuse Gemm (two non-parameter inputs) to MatMul".
+
+    ``y[n,o,p] = sum_{i,k} w[o,i,k] * xpad[n,i,p*stride+k]``, so with the
+    activation transposed to `[N, spatial..., Cin]` each tap is one `MatMul`
+    against `w[..., k]` reshaped to `[Cin, Cout]`, and the taps are added.
+    Stride becomes the tap slice's `step`. Handles 1-D and 2-D, any stride,
+    dilation 1, group 1; anything else is declined rather than approximated.
+    """
+    shapes = _value_shapes(model)
+    out, changed = [], 0
+    for node in model.graph.node:
+        w = node.input[1] if len(node.input) > 1 else None
+        if node.op_type != "Conv" or w is None or _is_initializer(model, w):
+            out.append(node)
+            continue
+        wshape, xshape = shapes.get(w), shapes.get(node.input[0])
+        yshape = shapes.get(node.output[0])
+        attrs = {a.name: a for a in node.attribute}
+        if not wshape or not xshape or len(wshape) != len(xshape):
+            out.append(node)
+            continue
+        nd = len(wshape) - 2
+        if nd not in (1, 2):
+            out.append(node)
+            continue
+        dil = list(attrs["dilations"].ints) if "dilations" in attrs else [1] * nd
+        if any(d != 1 for d in dil) or (
+            "group" in attrs and attrs["group"].i not in (0, 1)
+        ):
+            out.append(node)
+            continue
+        strides = list(attrs["strides"].ints) if "strides" in attrs else [1] * nd
+        pads = list(attrs["pads"].ints) if "pads" in attrs else [0] * (2 * nd)
+        cout, cin = wshape[0], wshape[1]
+        ksize = wshape[2:]
+        spatial = xshape[2:]
+        outdim = [
+            (spatial[j] + pads[j] + pads[j + nd] - ksize[j]) // strides[j] + 1
+            for j in range(nd)
+        ]
+        if yshape and list(yshape[2:]) != outdim:
+            out.append(node)  # our geometry disagrees; do not guess
+            continue
+        stem = node.name or node.output[0]
+        made = []
+
+        src = node.input[0]
+        if any(pads):
+            padded = _unique_name(model, f"{stem}_pad")
+            pname = _unique_name(model, f"{stem}_pads")
+            begins = [0, 0] + pads[:nd]
+            ends = [0, 0] + pads[nd:]
+            model.graph.initializer.append(
+                numpy_helper.from_array(np.array(begins + ends, np.int64), pname)
+            )
+            made.append(
+                helper.make_node(
+                    "Pad", [src, pname], [padded], name=_unique_name(model, f"{stem}_P")
+                )
+            )
+            src = padded
+        # [N, C, spatial...] -> [N, spatial..., C]
+        xt = _unique_name(model, f"{stem}_xt")
+        made.append(
+            helper.make_node(
+                "Transpose",
+                [src],
+                [xt],
+                perm=[0] + list(range(2, nd + 2)) + [1],
+                name=_unique_name(model, f"{stem}_XT"),
+            )
+        )
+        # [Cout, Cin, k...] -> [k..., Cin, Cout]
+        wt = _unique_name(model, f"{stem}_wt")
+        made.append(
+            helper.make_node(
+                "Transpose",
+                [w],
+                [wt],
+                perm=list(range(2, nd + 2)) + [1, 0],
+                name=_unique_name(model, f"{stem}_WT"),
+            )
+        )
+
+        wshape_name = _unique_name(model, f"{stem}_wshape")
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.array([cin, cout], np.int64), wshape_name)
+        )
+
+        acc = None
+        taps = [()]
+        for j in range(nd):
+            taps = [t + (k,) for t in taps for k in range(ksize[j])]
+        for tap in taps:
+            label = "_".join(str(k) for k in tap)
+            cur_x, cur_w = xt, wt
+            for j, k in enumerate(tap):
+                nxt = _unique_name(model, f"{stem}_x{label}_{j}")
+                made.append(
+                    _slice(
+                        model,
+                        cur_x,
+                        nxt,
+                        1 + j,
+                        k,
+                        k + (outdim[j] - 1) * strides[j] + 1,
+                        f"{stem}_SX{label}_{j}",
+                        step=strides[j],
+                    )
+                )
+                cur_x = nxt
+                nxw = _unique_name(model, f"{stem}_w{label}_{j}")
+                made.append(
+                    _slice(model, cur_w, nxw, j, k, k + 1, f"{stem}_SW{label}_{j}")
+                )
+                cur_w = nxw
+            flat = _unique_name(model, f"{stem}_wf{label}")
+            made.append(
+                helper.make_node(
+                    "Reshape",
+                    [cur_w, wshape_name],
+                    [flat],
+                    name=_unique_name(model, f"{stem}_WR{label}"),
+                )
+            )
+            prod = _unique_name(model, f"{stem}_m{label}")
+            made.append(
+                helper.make_node(
+                    "MatMul",
+                    [cur_x, flat],
+                    [prod],
+                    name=_unique_name(model, f"{stem}_MM{label}"),
+                )
+            )
+            if acc is None:
+                acc = prod
+            else:
+                nxt = _unique_name(model, f"{stem}_a{label}")
+                made.append(
+                    helper.make_node(
+                        "Add",
+                        [acc, prod],
+                        [nxt],
+                        name=_unique_name(model, f"{stem}_AD{label}"),
+                    )
+                )
+                acc = nxt
+        # A bias is [Cout], which broadcasts onto the trailing axis exactly
+        # where the taps land -- before the output is transposed back. The
+        # 1x1 downsample convolutions in resnet18 carry one, and skipping
+        # them left a live-weight Conv for Pulsar2 to reject with
+        # "Hardware Op spec error ActWeightConv ... list index out of range".
+        if len(node.input) > 2 and node.input[2]:
+            biased = _unique_name(model, f"{stem}_biased")
+            made.append(
+                helper.make_node(
+                    "Add",
+                    [acc, node.input[2]],
+                    [biased],
+                    name=_unique_name(model, f"{stem}_B"),
+                )
+            )
+            acc = biased
+        # [N, spatial..., Cout] -> [N, Cout, spatial...]
+        made.append(
+            helper.make_node(
+                "Transpose",
+                [acc],
+                [node.output[0]],
+                perm=[0, nd + 1] + list(range(1, nd + 1)),
+                name=_unique_name(model, f"{stem}_YT"),
+            )
+        )
+        out.extend(made)
+        changed += 1
+    if changed:
+        del model.graph.node[:]
+        model.graph.node.extend(out)
+    return changed
+
+
+def _slice(model, src, dst, axis, start, end, stem, step=1):
+    names = []
+    fields = [("starts", start), ("ends", end), ("axes", axis)]
+    if step != 1:
+        fields.append(("steps", step))
+    for label, value in fields:
+        name = _unique_name(model, f"{stem}_{label}")
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.array([value], np.int64), name)
+        )
+        names.append(name)
+    return helper.make_node(
+        "Slice", [src] + names, [dst], name=_unique_name(model, stem)
+    )
+
+
+def _value_shapes(model):
+    inferred = model
+    try:
+        inferred = onnx.shape_inference.infer_shapes(model, strict_mode=False)
+    except Exception:
+        pass
+    shapes = {}
+    for value in (
+        list(inferred.graph.input)
+        + list(inferred.graph.value_info)
+        + list(inferred.graph.output)
+    ):
+        dims = value.type.tensor_type.shape.dim
+        if all(d.HasField("dim_value") for d in dims):
+            shapes[value.name] = [d.dim_value for d in dims]
+    for init in model.graph.initializer:
+        shapes[init.name] = list(init.dims)
+    return shapes
+
+
 #: Order matters. `dilated_conv_to_taps` consumes a convolution's `pads`
 #: attribute, so it has to run before `explicit_conv_padding` zeroes it.
 RULES = {
     "float16_to_float32": float16_to_float32,
     "pow2_to_mul": pow2_to_mul,
+    "neg_to_mul": neg_to_mul,
+    "rank0_to_rank1": rank0_to_rank1,
+    "inline_local_functions": inline_local_functions,
+    "avgpool_ceil_to_floor": avgpool_ceil_to_floor,
+    "flatten_to_reshape": flatten_to_reshape,
+    "global_pool_to_reduce": global_pool_to_reduce,
+    "gemm_to_matmul": gemm_to_matmul,
+    "act_weight_conv_to_matmul": act_weight_conv_to_matmul,
     "dilated_conv_to_taps": dilated_conv_to_taps,
     "explicit_conv_padding": explicit_conv_padding,
     "filename_safe_io_names": filename_safe_io_names,
 }
+
+#: The rules a graph needs to be a *training* step rather than an inference
+#: model: a live weight, a scalar loss, and the ops a backward pass emits.
+#: `onnxsim.graph_grad` produces all three.
+TRAINING_RULES = (
+    "inline_local_functions",
+    "avgpool_ceil_to_floor",
+    "flatten_to_reshape",
+    "global_pool_to_reduce",
+    "neg_to_mul",
+    "rank0_to_rank1",
+    "gemm_to_matmul",
+    "act_weight_conv_to_matmul",
+)
 
 
 def legalize(model, rules=None):

--- a/tests/test_axera_emitter.py
+++ b/tests/test_axera_emitter.py
@@ -299,3 +299,32 @@ def test_the_llm_quantiser_puts_a_negative_peak_at_code_zero_too():
     assert codes[0, 0] == 0
     assert codes[0, 2] == 128
     assert codes[0, 1] > 128
+
+
+def test_an_unpatchable_output_quantisation_is_nudged_not_hit():
+    """Anything that recalibrates as it goes makes the zero point wander onto
+    a value the stream cannot hold. Widening the range a fraction of a percent
+    moves it off, which is cheaper than stopping."""
+    fields = {"unpatchable": {"zero": [128], "scale_low_byte": []}}
+    scale, zero = emitter.nudge_output_quantisation(-3.2, 3.2, fields)
+    assert zero != 128
+    # and the range it implies still covers the one asked for, barely wider
+    span = scale * 255
+    assert 6.4 <= span <= 6.4 * 1.01
+
+
+def test_a_range_that_needs_no_nudge_is_left_alone():
+    fields = {"unpatchable": {"zero": [128], "scale_low_byte": []}}
+    scale, zero = emitter.nudge_output_quantisation(-1.0, 2.0, fields)
+    assert scale == np.float32(3.0 / 255)
+    assert zero == round(1.0 / (3.0 / 255))
+
+
+def test_nudging_gives_up_rather_than_returning_something_wrong():
+    everything = {"unpatchable": {"zero": list(range(256)), "scale_low_byte": []}}
+    try:
+        emitter.nudge_output_quantisation(-1.0, 1.0, everything)
+    except ValueError as exc:
+        assert "patchable" in str(exc)
+    else:
+        raise AssertionError("should not have found one")

--- a/tests/test_axera_training_legalize.py
+++ b/tests/test_axera_training_legalize.py
@@ -1,0 +1,336 @@
+"""Legalizing a *training* graph for the AX650, checked offline.
+
+`scripts/axera/legalize.py`'s `TRAINING_RULES` exist because a graph that
+computes gradients breaks Pulsar2 in ways an inference graph never does: the
+weight is a live tensor rather than a constant, the loss is a scalar, and the
+backward pass emits ops and function calls the compiler has never seen. Every
+rule here answers a failure a real `pulsar2 build` produced, and every test
+checks the same two things -- it fires where it should, and onnxruntime agrees
+the graph still computes what it did.
+
+Neither needs Docker nor a card.
+"""
+
+import os
+import sys
+
+import numpy as np
+import onnx
+import onnx.parser
+from onnx import TensorProto, helper, numpy_helper
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import legalize  # noqa: E402
+
+
+def _model(nodes, inputs, outputs, initializer=(), opset=17, functions=()):
+    graph = helper.make_graph(
+        nodes,
+        "g",
+        [
+            helper.make_tensor_value_info(n, TensorProto.FLOAT, s)
+            for n, s in inputs.items()
+        ],
+        [
+            helper.make_tensor_value_info(n, TensorProto.FLOAT, s)
+            for n, s in outputs.items()
+        ],
+        initializer=list(initializer),
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset)])
+    model.ir_version = 10
+    model.functions.extend(functions)
+    return model
+
+
+def _run(model, feeds):
+    import onnxruntime as ort
+
+    options = ort.SessionOptions()
+    options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    sess = ort.InferenceSession(
+        model.SerializeToString(), options, providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _snr(ref, got):
+    ref = np.asarray(ref, np.float64)
+    err = ref - np.asarray(got, np.float64)
+    return 10 * np.log10((ref**2).sum() / max((err**2).sum(), 1e-30))
+
+
+def _conv(cin, cout, k, size, stride, pad, nd):
+    """A convolution whose weight arrives at runtime -- what training makes."""
+    out = (size + 2 * pad - k) // stride + 1
+    node = helper.make_node(
+        "Conv",
+        ["x", "w"],
+        ["y"],
+        kernel_shape=[k] * nd,
+        strides=[stride] * nd,
+        pads=[pad] * (2 * nd),
+        name="c",
+    )
+    return _model(
+        [node],
+        {"x": [1, cin] + [size] * nd, "w": [cout, cin] + [k] * nd},
+        {"y": [1, cout] + [out] * nd},
+    )
+
+
+def test_a_live_weight_convolution_becomes_matmuls_in_1d_and_2d():
+    """Pulsar2 reaches `AxQuantizedActWeightConv` and fails its shape function
+    with the weight still FP32; the 2-D case dies in the backend instead. So
+    the convolution is spelled as one MatMul per tap."""
+    rng = np.random.default_rng(0)
+    for nd, k, stride, pad in (
+        (1, 3, 1, 1),
+        (2, 3, 1, 1),
+        (2, 3, 2, 1),
+        (2, 1, 2, 0),
+        (2, 7, 2, 3),
+    ):
+        model = _conv(8, 6, k, 16, stride, pad, nd)
+        feeds = {
+            "x": rng.standard_normal([1, 8] + [16] * nd).astype(np.float32),
+            "w": (rng.standard_normal([6, 8] + [k] * nd) * 0.2).astype(np.float32),
+        }
+        ref = _run(model, feeds)[0]
+        after = onnx.ModelProto.FromString(model.SerializeToString())
+        assert legalize.act_weight_conv_to_matmul(after) == 1, (nd, k, stride)
+        onnx.checker.check_model(after)
+        got = _run(after, feeds)[0]
+        assert got.shape == ref.shape
+        assert _snr(ref, got) > 100, (nd, k, stride, _snr(ref, got))
+        assert {n.op_type for n in after.graph.node} <= {
+            "Pad",
+            "Transpose",
+            "Slice",
+            "Reshape",
+            "MatMul",
+            "Add",
+        }
+
+
+def test_a_convolution_whose_weight_is_constant_is_left_alone():
+    """Only a *live* weight is a problem; an ordinary inference convolution
+    must keep its fast path."""
+    w = numpy_helper.from_array(
+        np.random.default_rng(1).standard_normal((6, 8, 3)).astype(np.float32), "w"
+    )
+    model = _model(
+        [helper.make_node("Conv", ["x", "w"], ["y"], kernel_shape=[3], pads=[1, 1])],
+        {"x": [1, 8, 16]},
+        {"y": [1, 6, 16]},
+        [w],
+    )
+    assert legalize.act_weight_conv_to_matmul(model) == 0
+    assert [n.op_type for n in model.graph.node] == ["Conv"]
+
+
+def test_dilation_and_groups_are_declined_rather_than_approximated():
+    model = _conv(8, 8, 3, 16, 1, 1, 1)
+    model.graph.node[0].attribute.append(helper.make_attribute("dilations", [2]))
+    assert legalize.act_weight_conv_to_matmul(model) == 0
+    grouped = _conv(8, 8, 3, 16, 1, 1, 1)
+    grouped.graph.node[0].attribute.append(helper.make_attribute("group", 2))
+    assert legalize.act_weight_conv_to_matmul(grouped) == 0
+
+
+def test_gemm_with_two_live_inputs_becomes_matmul():
+    """The compiler asks for this by name: `NotImplementedError('Should fuse
+    Gemm (two non-parameter inputs) to MatMul.')`."""
+    rng = np.random.default_rng(2)
+    model = _model(
+        [
+            helper.make_node(
+                "Gemm", ["a", "b", "c"], ["y"], transB=1, alpha=0.5, beta=2.0, name="g"
+            )
+        ],
+        {"a": [5, 4], "b": [6, 4], "c": [5, 6]},
+        {"y": [5, 6]},
+    )
+    feeds = {
+        n: rng.standard_normal(s).astype(np.float32)
+        for n, s in (("a", (5, 4)), ("b", (6, 4)), ("c", (5, 6)))
+    }
+    ref = _run(model, feeds)[0]
+    assert legalize.gemm_to_matmul(model) == 1
+    onnx.checker.check_model(model)
+    assert _snr(ref, _run(model, feeds)[0]) > 100
+    assert "Gemm" not in {n.op_type for n in model.graph.node}
+
+
+def test_a_scalar_loss_grows_an_axis_and_names_its_reduction():
+    """Two separate failures: Pulsar2's calibration cannot concatenate a rank-0
+    tensor across samples, and it reduces only the last axis when a reduction
+    names none -- where ONNX reduces all of them."""
+    rng = np.random.default_rng(3)
+    model = _model(
+        [
+            helper.make_node("Mul", ["x", "x"], ["sq"]),
+            helper.make_node("ReduceMean", ["sq"], ["loss"], keepdims=0),
+        ],
+        {"x": [1, 4, 8]},
+        {"loss": []},
+    )
+    feeds = {"x": rng.standard_normal((1, 4, 8)).astype(np.float32)}
+    ref = _run(model, feeds)[0]
+    assert legalize.rank0_to_rank1(model) == 1
+    onnx.checker.check_model(model)
+    got = _run(model, feeds)[0]
+    assert np.shape(got) == (1,)
+    assert abs(float(ref) - float(got[0])) < 1e-6
+    reduce_node = next(n for n in model.graph.node if n.op_type == "ReduceMean")
+    axes = [list(a.ints) for a in reduce_node.attribute if a.name == "axes"]
+    assert axes == [[0, 1, 2]], axes
+
+
+def test_the_reduction_axes_move_to_an_input_at_opset_18():
+    """`ReduceMean`'s `axes` became an input at opset 18 and `onnx.checker`
+    rejects the other form, so the rule has to know which era it is in."""
+    model = _model(
+        [
+            helper.make_node("Mul", ["x", "x"], ["sq"]),
+            helper.make_node("ReduceMean", ["sq"], ["loss"], keepdims=0),
+        ],
+        {"x": [1, 4, 8]},
+        {"loss": []},
+        opset=18,
+    )
+    assert legalize.rank0_to_rank1(model) == 1
+    onnx.checker.check_model(model)
+    node = next(n for n in model.graph.node if n.op_type == "ReduceMean")
+    assert len(node.input) == 2 and node.input[1]
+    axes = next(i for i in model.graph.initializer if i.name == node.input[1])
+    assert list(numpy_helper.to_array(axes)) == [0, 1, 2]
+
+
+def test_neg_becomes_mul_by_minus_one():
+    """`Neg` is the one op a backward pass emits that the AX650 list lacks."""
+    rng = np.random.default_rng(4)
+    model = _model(
+        [helper.make_node("Neg", ["x"], ["y"])], {"x": [2, 3]}, {"y": [2, 3]}
+    )
+    feeds = {"x": rng.standard_normal((2, 3)).astype(np.float32)}
+    ref = _run(model, feeds)[0]
+    assert legalize.neg_to_mul(model) == 1
+    onnx.checker.check_model(model)
+    assert np.allclose(ref, _run(model, feeds)[0])
+    assert [n.op_type for n in model.graph.node] == ["Mul"]
+
+
+def test_ceil_mode_is_cleared_only_where_it_changes_nothing():
+    """`graph_grad` declines a pool with `ceil_mode=1`, which stops resnet18d
+    dead on its downsample pools. Where the stride divides evenly, ceil and
+    floor agree exactly and the flag is decoration."""
+    even = _model(
+        [
+            helper.make_node(
+                "AveragePool",
+                ["x"],
+                ["y"],
+                kernel_shape=[2, 2],
+                strides=[2, 2],
+                ceil_mode=1,
+            )
+        ],
+        {"x": [1, 3, 8, 8]},
+        {"y": [1, 3, 4, 4]},
+    )
+    assert legalize.avgpool_ceil_to_floor(even) == 1
+    assert all(
+        a.i == 0 for n in even.graph.node for a in n.attribute if a.name == "ceil_mode"
+    )
+    # kernel 3 stride 2 over 8 leaves a span of 5, which 2 does not divide --
+    # ceil keeps a final ragged window that floor drops, so the flag is real
+    ragged = _model(
+        [
+            helper.make_node(
+                "AveragePool",
+                ["x"],
+                ["y"],
+                kernel_shape=[3, 3],
+                strides=[2, 2],
+                ceil_mode=1,
+            )
+        ],
+        {"x": [1, 3, 8, 8]},
+        {"y": [1, 3, 4, 4]},
+    )
+    assert legalize.avgpool_ceil_to_floor(ragged) == 0
+
+
+def test_flatten_and_global_pool_become_ops_that_have_gradients():
+    """Neither has a rule in `graph_grad`, and neither needs one: a `Flatten`
+    is a `Reshape` and a `GlobalAveragePool` is a `ReduceMean`."""
+    rng = np.random.default_rng(5)
+    model = _model(
+        [
+            helper.make_node("GlobalAveragePool", ["x"], ["p"]),
+            helper.make_node("Flatten", ["p"], ["y"], axis=1),
+        ],
+        {"x": [2, 3, 4, 4]},
+        {"y": [2, 3]},
+    )
+    feeds = {"x": rng.standard_normal((2, 3, 4, 4)).astype(np.float32)}
+    ref = _run(model, feeds)[0]
+    assert legalize.global_pool_to_reduce(model) == 1
+    assert legalize.flatten_to_reshape(model) == 1
+    onnx.checker.check_model(model)
+    got = _run(model, feeds)[0]
+    assert got.shape == ref.shape
+    assert _snr(ref, got) > 100
+    kinds = {n.op_type for n in model.graph.node}
+    assert kinds == {"ReduceMean", "Reshape"}
+    import onnxsim.graph_grad as graph_grad
+
+    assert kinds <= graph_grad.SUPPORTED_OPS
+
+
+def test_a_local_function_call_is_inlined_into_real_ops():
+    """Pulsar2 dispatches on op type, and a call to a locally-defined function
+    is not one. `graph_grad`'s templated rules emit exactly eight of them for
+    resnet18 -- one per residual connection -- so they are not optional."""
+    fn = helper.make_function(
+        "onnxsim.grad",
+        "Twice",
+        ["a"],
+        ["b"],
+        [
+            helper.make_node("Add", ["a", "a"], ["b"]),
+        ],
+        [helper.make_opsetid("", 17)],
+    )
+    model = _model(
+        [helper.make_node("Twice", ["x"], ["y"], domain="onnxsim.grad")],
+        {"x": [2, 3]},
+        {"y": [2, 3]},
+        functions=[fn],
+    )
+    assert legalize.inline_local_functions(model) == 1
+    onnx.checker.check_model(model)
+    assert [n.op_type for n in model.graph.node] == ["Add"]
+    assert not model.functions
+    rng = np.random.default_rng(6)
+    feeds = {"x": rng.standard_normal((2, 3)).astype(np.float32)}
+    assert np.allclose(_run(model, feeds)[0], 2 * feeds["x"])
+
+
+def test_inlining_a_graph_with_no_functions_is_a_no_op():
+    model = _model([helper.make_node("Relu", ["x"], ["y"])], {"x": [2]}, {"y": [2]})
+    assert legalize.inline_local_functions(model) == 0
+
+
+def test_training_rules_run_in_an_order_that_works():
+    """`inline_local_functions` has to come first -- every later rule inspects
+    op types and would look straight past a function call."""
+    assert legalize.TRAINING_RULES[0] == "inline_local_functions"
+    for name in legalize.TRAINING_RULES:
+        assert name in legalize.RULES


### PR DESCRIPTION
Stacks on #1321 (which stacks on #1312); the commits before the last are those.
Builds directly on #1332 — see "Simplification undoes legalization" below.

`onnxsim.graph_grad` emits a backward pass as ordinary ONNX nodes, and **26 of
its 28 differentiable op types are on `AX650_SUPPORTED_OPS`**, none on the
confirmed-broken list. So forward, loss and backward compile into one
`.axmodel`, the weight arrives as a runtime input, and a training step is a
single `axcl_run_model` call with the gradient computed on the NPU.

## It trains

A 16-channel convolution against a teacher, gradient on the card:

| step | card SNR | float host | gradient cosine |
| --- | --- | --- | --- |
| 0 | -3.38 dB | -3.38 | 0.99974 |
| 100 | 14.49 | 14.47 | 0.90292 |
| 2748 | **34.02** | — | — |

and multi-layer works — eight independent weight tensors, 2-D strided
convolutions, 702 nodes, every gradient correct against onnxruntime
(0.9971–0.9996).

## Eight legalize rules, each answering a real build failure

| rule | failure |
| --- | --- |
| `inline_local_functions` | `KeyError('dont support GradAdd opr')` — a local `FunctionProto`, not an op type |
| `act_weight_conv_to_matmul` | `AxQuantizedActWeightConv, shapefn failed` |
| `gemm_to_matmul` | `NotImplementedError('Should fuse Gemm (two non-parameter inputs) to MatMul.')` |
| `rank0_to_rank1` | `zero-dimensional tensor ... cannot be concatenated` |
| `neg_to_mul`, `avgpool_ceil_to_floor`, `flatten_to_reshape`, `global_pool_to_reduce` | ops with no rule, or none needed |

`act_weight_conv_to_matmul` is the substantial one: one `MatMul` per tap, 1-D
and 2-D, any stride, with or without bias; stride becomes the tap slice's
`step`. Every resnet18 shape reproduces onnxruntime to float rounding
(132–320 dB). Dilation and groups are declined, not approximated.

## What stops it, measured

- **The gradient dies.** It is an output tensor quantised at a range fixed at
  build time, so a converging gradient rounds to zero — by step ~1,000 at U8,
  ~5,000 at U16. Widening buys 3 dB and 5× the steps, not the mechanism.
- **Loss scaling cannot fix it.** A multiplicative seed cannot live in a
  linear fixed-point tensor: a probe sweeping it 1 → 2²⁴ returned
  bit-identical gradients every time. `LossScaler` detects that it is having
  no effect and stands down, which is what makes it safe on by default.
- **Fixed-point clipping is silent and local**, so reliable back-off needs the
  graph to export `ReduceMax(|t|)`, not a controller reading outputs.

## Two silent vendor divergences

- **`ReduceMean` with no `axes` reduces only the last axis** where ONNX
  reduces all of them — confirmed on the card, 16 values where onnxruntime
  returned 1. Any bare `ReduceMean` (mean pooling, layer-norm statistics, most
  loss reductions) gets a wrong answer. Every rule here names its axes.
- **Simplification undoes legalization.** `fuse_matmul_add_bias_into_gemm` puts
  the `Gemm` back, live weight and all, and Pulsar2 then dies inside PPQ's
  calibrator with `ValueError('The truth value of an array with more than one
  element is ambiguous')` — naming no node and nothing about `Gemm`. #1332
  skips that pass upstream for the same reason on WebGPU; `scripts/axera`
  doesn't go through `make_step_graph`, so it skips it itself. Simplifying is
  worth **759 → 236 nodes (69%)** on a gradient graph.

## Performance

`axcl_run_model` costs ~580 ms per invocation plus LXD plumbing. A ~120-line
resident runner on AXCL's load-once/run-many API takes a step from **~1400 ms
to 1.70 ms** — 20,000 training steps in 30 s instead of eight hours. Double
buffering the weight feedback turned out **not** to help (copy 27.57 ms, pointer
swap 28.97, no edge 27.64): a copy inside the card's own DRAM is free.

## Known open

resnet18d legalizes completely (56/56 differentiable, 236 nodes, every op type
NPU-eligible) and **does not build** — the same calibrator error. Every
construct in it builds in isolation: live-operand `MatMul` at every rank and
shape, `Transpose(live) → MatMul`, `Gather` on a big int64 index,
`Greater`/`Cast`/`Mul`, and resnet18's own forward with all weights constant.
Recorded as open rather than claimed as working.

## Test plan

- 66 offline tests pass, 12 of them new in `tests/test_axera_training_legalize.py`,
  wired into the existing no-Docker `pulsar2-compat` job. No Docker or card needed.
- Hardware numbers measured on a real AX650N and recorded in `scripts/axera/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS