### PR TITLE
axera: resnet18 fine-tunes on the AX650N — the last blocker was ours

### DIFF
--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -1,0 +1,218 @@
+# On-device training on the Axera AX650N: handoff note
+
+**Status: working, with measured limits.** A resnet18 fine-tuning step compiles
+and runs on real AX650N hardware with its gradients computed on the NPU. This
+records what works, what the ceiling is, and which walls are the vendor's
+rather than ours, so none of it has to be rediscovered.
+
+Companion to `docs/ozaki-scheme-axera-handoff.md`, whose conclusion this work
+overturned: that note said the toolchain could not host a split-and-correct
+matmul because every documented way to pin a per-matmul scale is broken. It
+can, by not asking for one.
+
+## What runs
+
+resnet18d, last four layers trainable, 64x64 input, on the card:
+
+| output | cosine vs onnxruntime | SNR |
+| --- | --- | --- |
+| `layer4.0.downsample` weight gradient | 0.97676 | 13.35 dB |
+| `layer4.1.conv2` weight gradient | 0.97272 | 12.60 dB |
+| `layer4.1.conv1` weight gradient | 0.98140 | 14.23 dB |
+| classifier weight gradient | 0.99710 | 22.14 dB |
+| loss | 1.00000 | 37.23 dB |
+
+5,361,664 trainable parameters, 731 nodes reduced to 210 by `onnxsim.simplify`,
+compiled in 97 s to a 7.0 MB `.axmodel`, **200.6 ms per step** moving 21.5 MB in
+and 21.4 MB out. The gradients are directionally right but not precise -- 12-14
+dB on the convolutions -- which is the INT8 backward pass, not a bug.
+
+Smaller graphs are exact: eight independent weight tensors through 702 nodes
+return gradients at cosine 0.9971-0.9996, and a 16-channel convolution trains
+from -3.38 dB to 34.02 dB against a teacher.
+
+## How it is put together
+
+1. `onnxsim.graph_grad.build_backward()` emits the backward pass as ordinary
+   ONNX nodes. **26 of its 28 differentiable op types are on
+   `AX650_SUPPORTED_OPS`**, none on the confirmed-broken list.
+2. Every trainable weight is promoted from initializer to **graph input**, so
+   the compiler never bakes it in and the host can change it per step.
+3. `legalize.TRAINING_RULES` makes the result compilable (below).
+4. `onnxsim.simplify(skipped_optimizers=[...])` -- worth 69-71% of the nodes.
+5. `pulsar2 build` with `layer_configs` promoting the backward ops to `U16`.
+6. A resident runner keeps the model loaded and streams frames.
+
+## The ceiling: the gradient dies
+
+The gradient is an **output tensor**, quantised at a range fixed when the model
+was built. As training converges the true gradient shrinks below half a
+quantisation step and rounds to zero -- every entry, eventually.
+
+| gradient tensor | dies at | best SNR reached |
+| --- | --- | --- |
+| U8 | step ~1,000 | 30.88 dB |
+| U16 | step ~5,000 | 34.02 dB |
+
+Widening buys a factor of five in steps and 3 dB. It does not remove the
+mechanism. 34.02 dB is within 1.3 dB of that shape's INT8 *forward* floor, so
+for fine-tuning there is little left to win; for anything longer, this is the
+wall.
+
+**Loss scaling cannot fix it here.** The seed must reach the graph as a tensor,
+and a tensor is quantised to a fixed range with linear levels: over
+`[1, 2**21]` a U8 seed has 255 evenly spaced levels, so a seed of 1.0 rounds to
+**zero**; calibrated narrowly it pins to a constant. A probe sweeping the seed
+from 1 to 2**24 returned **bit-identical gradients at every value**. A
+multiplicative scale meant to span decades cannot live in a linear fixed-point
+tensor. `finetune.LossScaler` therefore detects that it is having no effect and
+stands down.
+
+The untried way out: `layer_configs` accepts `data_type: "FP32"` for
+elementwise ops, and the seed feeds a `Mul`. If the seed and its consumer stay
+float, scaling should work. **Not tested.**
+
+A second obstacle waits behind it: fixed-point clipping is **silent and local**.
+It happens to intermediates that never reach an output, so a controller reading
+the returned gradient sees a healthy tensor while the computation upstream is
+destroyed -- unlike fp16, where overflow makes an inf that propagates. Reliable
+back-off needs the graph to export `ReduceMax(|t|)` on those tensors.
+
+## Speed
+
+`axcl_run_model` costs ~580 ms per invocation (process start, device open,
+model load) plus ~3 ms per inference, and the LXD plumbing adds ~800 ms more in
+`lxc exec` calls and file copies. AXCL exposes load-once/run-many
+(`axclrtEngineLoadFromFile`/`CreateContext`/`CreateIO`/`Execute`), so a
+~120-line resident runner does the fixed work once:
+
+| | per step |
+| --- | --- |
+| `axcl_run_model` | ~1400 ms |
+| resident runner, 16-channel step | **1.70 ms** |
+| resident runner, resnet18 step | 200.6 ms (42.9 MB moved) |
+
+**820x** on the small step: 20,000 training steps in 30 seconds instead of
+eight hours. Past that the cost is transfer, not overhead, and residency is the
+lever:
+
+| 1024x1024 step | ms | moved |
+| --- | --- | --- |
+| send every input, read every output | 63.13 | 12.583 MB |
+| weight resident on the card | 41.03 | 8.389 MB |
+| weight resident, gradient not read back | **29.79** | 4.194 MB |
+
+**Double buffering is not worth it.** Feeding an updated weight back by
+device-to-device copy (27.57 ms) and by swapping the two device pointers
+(28.97 ms) are indistinguishable from no feedback edge (27.64 ms). A 4 MB copy
+inside the card's own DRAM is free; the two `Set*BufferByIndex` calls a swap
+needs cost more than the copy it avoids. The card has 7040 MiB of CMM with 12
+in use.
+
+Batch size is nearly free until it is not: batch 1 to 16 costs 0.38 ms
+(1.40 -> 1.78) for **12.6x** the throughput; batch 64 is worse *per sample*
+than 16.
+
+## Two vendor bugs, both silent
+
+**`ReduceMean` with no `axes` reduces only the last axis.** ONNX reduces all of
+them. Confirmed on the card: a `(1,16,32)` input returned 16 values where
+onnxruntime returned 1, with no warning and ignoring the declared output shape.
+Any model with a bare `ReduceMean` -- mean pooling, layer-norm statistics, most
+loss reductions -- gets a wrong answer on this hardware. Every rule in
+`legalize.py` names its axes explicitly.
+
+**A constant bias lets the backend rebuild a `Gemm` we removed.**
+`MatMul(live) + Add(constant 1-D)` is what `fuse_matmul_add_bias_into_gemm`
+matches. Skipping that pass in onnxsim (as onnxsim#1332 does upstream) is
+necessary but **not sufficient**: Pulsar2 runs its own optimizer and fuses it
+back, into a `Gemm` whose weight is live -- the node it cannot lower. It does
+not say so. The build dies inside PPQ's calibrator with
+`ValueError('The truth value of an array with more than one element is
+ambiguous')`, naming no node and nothing about `Gemm`.
+
+Bisecting 58 nodes to 4 by recompiling ranges found it; then four spellings of
+the same arithmetic separated cause from coincidence:
+
+| bias spelling | result |
+| --- | --- |
+| 1-D initializer | FAILED |
+| `Constant` node instead of initializer | FAILED |
+| operand order swapped | FAILED |
+| **shaped `[1, N]`** | **BUILT** |
+| `Identity` between `MatMul` and `Add` | BUILT |
+
+`_unfusable_bias` takes the reshape. The `Identity` also works and is the wrong
+fix -- it is exactly what a later dead-code pass would delete, putting the bug
+back.
+
+**The general lesson:** a graph that needs an op *gone* must be shaped so
+nothing can put it back. Suppressing your own optimizer is half the job.
+
+## The rules
+
+`legalize.TRAINING_RULES`, in an order that matters --
+`inline_local_functions` first, because every later rule inspects op types and
+would look straight past a function call.
+
+| rule | the failure it answers |
+| --- | --- |
+| `inline_local_functions` | `KeyError('dont support GradAdd opr')` -- a local `FunctionProto`, not an op type; one per residual connection |
+| `act_weight_conv_to_matmul` | `AxQuantizedActWeightConv, shapefn failed` -- the weight stays FP32 while the activation is U8 |
+| `gemm_to_matmul` | `NotImplementedError('Should fuse Gemm (two non-parameter inputs) to MatMul.')` |
+| `rank0_to_rank1` | `RuntimeError: zero-dimensional tensor ... cannot be concatenated` |
+| `neg_to_mul` | `Neg` is the one backward-pass op off the AX650 list |
+| `avgpool_ceil_to_floor` | `graph_grad` declines `ceil_mode=1`; cleared only where provably a no-op |
+| `flatten_to_reshape`, `global_pool_to_reduce` | no gradient rule, and none needed |
+
+`act_weight_conv_to_matmul` is the substantial one. With the activation
+transposed to `[N, spatial..., Cin]`, each tap is one `MatMul` against
+`w[..., k]` reshaped to `[Cin, Cout]`; stride becomes the tap slice's `step`.
+1-D and 2-D, any stride, with or without bias; dilation and groups are declined
+rather than approximated. `fuse=True` concatenates the taps into **one** matmul
+`K**2` times deeper -- exact, since the taps share an output and differ only
+along the reduction axis -- which is what the matrix unit rewards.
+
+## Simplify the gradient graph
+
+Nobody was, and it is worth a great deal:
+
+| graph | before | after |
+| --- | --- | --- |
+| resnet18 training step | 731 | **210** (-71%) |
+| earlier variant | 759 | 236 (-69%) |
+
+`graph_grad` spells the chain rule out literally and the tap rewrite multiplies
+it, so consecutive taps slicing the same tensors collapse under
+common-subexpression elimination -- simplification is worth *more* after
+legalization than before. onnxsim#1332 now does this inside
+`qat_graph.make_step_graph()`; the Axera path assembles its `ModelProto` by
+hand and so calls `simplify()` itself, with the same skip list.
+
+## What to do next
+
+1. **The FP32 gradient seed.** The one untried route past the dying gradient,
+   and the difference between a 5,000-step horizon and an open-ended one.
+2. **Weights resident with in-graph updates.** resnet18 moves 42.9 MB per step
+   purely because weights cross the wire. Put `w_next = w - lr*grad` in the
+   graph and bind it back device-to-device (the runner's `-b` already does
+   this) and only the batch crosses -- roughly 10x on step time.
+3. **All 23 tensors, and 224x224.** Only the last four layers and a 64x64 input
+   have been built.
+4. **An optimiser beyond SGD.** `qat_graph.adam_update` exists and has never
+   been put through this path.
+5. **Does QAT through the card beat training in float and quantising?** On a
+   single linear layer it bought +0.22 dB, which is a question the experiment
+   could not answer -- a single layer has nothing to route around. The depth
+   case is untested and is the one that matters.
+
+## Where the time went
+
+Of the blockers that cost real time, **most were self-inflicted**: a stale
+artifact that made a working fix look broken, an over-strict assertion, a probe
+file named `bisect.py` that shadowed the stdlib module `random` imports, a
+calibration range that pinned a seed to a constant, and a `GraphBuilder` whose
+functions were never attached to the model. The two genuine vendor bugs both
+hid behind errors that named nothing -- which is the argument for the bisector
+in `scripts/axera`: recompiling node ranges took 58 nodes to 4 in eight builds
+and found in twenty minutes what four hypotheses had failed to guess.

--- a/scripts/axera/legalize.py
+++ b/scripts/axera/legalize.py
@@ -622,6 +622,37 @@ def global_pool_to_reduce(model):
     return changed
 
 
+def _unfusable_bias(model, name, width):
+    """A copy of bias `name` shaped `[1, width]` instead of `[width]`.
+
+    `MatMul(live) + Add(constant 1-D)` is exactly what
+    `fuse_matmul_add_bias_into_gemm` matches, and skipping that pass in
+    onnxsim is not enough -- **Pulsar2 runs its own optimizer and fuses it
+    back**, into a `Gemm` whose weight is live, which it then cannot lower.
+    It does not say so: the build dies inside PPQ's calibrator with
+    `ValueError('The truth value of an array with more than one element is
+    ambiguous')`, naming no node.
+
+    Measured on the four-node repro this was bisected down to: a 1-D constant
+    bias fails, the same values shaped `[1, N]` build, and so does an
+    `Identity` wedged between the `MatMul` and the `Add`. The reshape is the
+    better of the two -- it adds no node, and an `Identity` is exactly what a
+    later dead-code pass would remove, putting the bug back.
+    """
+    for init in model.graph.initializer:
+        if init.name != name:
+            continue
+        values = numpy_helper.to_array(init)
+        if values.ndim != 1:
+            return name
+        wide = _unique_name(model, f"{name}_rank2")
+        model.graph.initializer.append(
+            numpy_helper.from_array(values.reshape(1, -1), wide)
+        )
+        return wide
+    return name
+
+
 def gemm_to_matmul(model):
     """A `Gemm` whose `B` is a live tensor becomes `MatMul` (plus what it drops).
 
@@ -697,7 +728,7 @@ def gemm_to_matmul(model):
             )
             cur = nxt
         if len(node.input) >= 3:
-            c = node.input[2]
+            c = _unfusable_bias(model, node.input[2], 0)
             if beta != 1.0:
                 k = _unique_name(model, f"{stem}_beta")
                 model.graph.initializer.append(
@@ -723,7 +754,7 @@ def gemm_to_matmul(model):
     return changed
 
 
-def act_weight_conv_to_matmul(model):
+def act_weight_conv_to_matmul(model, fuse=True):
     """A `Conv` whose weight is a live tensor becomes one `MatMul` per tap.
 
     Pulsar2 has an op for a runtime weight -- the error names
@@ -822,6 +853,7 @@ def act_weight_conv_to_matmul(model):
         )
 
         acc = None
+        tap_x, tap_w = [], []
         taps = [()]
         for j in range(nd):
             taps = [t + (k,) for t in taps for k in range(ksize[j])]
@@ -857,28 +889,71 @@ def act_weight_conv_to_matmul(model):
                     name=_unique_name(model, f"{stem}_WR{label}"),
                 )
             )
-            prod = _unique_name(model, f"{stem}_m{label}")
+            tap_x.append(cur_x)
+            tap_w.append(flat)
+
+        # sum_k X_k @ W_k is one matmul over the concatenation:
+        #   [X_0 | ... | X_{K-1}] @ [W_0 ; ... ; W_{K-1}]
+        # exactly, because the taps share an output and differ only along the
+        # reduction axis. For a 3x3 that is 9 MatMuls and 8 Adds replaced by
+        # two Concats and one MatMul nine times deeper -- fewer nodes to
+        # schedule, and an arithmetic intensity the matrix unit can actually
+        # use. `fuse` exists so the unfused form stays reachable for
+        # bisecting a compiler that dislikes one of them.
+        if fuse and len(tap_x) > 1:
+            xcat = _unique_name(model, f"{stem}_xcat")
+            wcat = _unique_name(model, f"{stem}_wcat")
+            made.append(
+                helper.make_node(
+                    "Concat",
+                    tap_x,
+                    [xcat],
+                    axis=-1,
+                    name=_unique_name(model, f"{stem}_XC"),
+                )
+            )
+            made.append(
+                helper.make_node(
+                    "Concat",
+                    tap_w,
+                    [wcat],
+                    axis=0,
+                    name=_unique_name(model, f"{stem}_WC"),
+                )
+            )
+            acc = _unique_name(model, f"{stem}_mm")
             made.append(
                 helper.make_node(
                     "MatMul",
-                    [cur_x, flat],
-                    [prod],
-                    name=_unique_name(model, f"{stem}_MM{label}"),
+                    [xcat, wcat],
+                    [acc],
+                    name=_unique_name(model, f"{stem}_MM"),
                 )
             )
-            if acc is None:
-                acc = prod
-            else:
-                nxt = _unique_name(model, f"{stem}_a{label}")
+        else:
+            for i, (xk, wk) in enumerate(zip(tap_x, tap_w)):
+                prod = _unique_name(model, f"{stem}_m{i}")
                 made.append(
                     helper.make_node(
-                        "Add",
-                        [acc, prod],
-                        [nxt],
-                        name=_unique_name(model, f"{stem}_AD{label}"),
+                        "MatMul",
+                        [xk, wk],
+                        [prod],
+                        name=_unique_name(model, f"{stem}_MM{i}"),
                     )
                 )
-                acc = nxt
+                if acc is None:
+                    acc = prod
+                else:
+                    nxt = _unique_name(model, f"{stem}_a{i}")
+                    made.append(
+                        helper.make_node(
+                            "Add",
+                            [acc, prod],
+                            [nxt],
+                            name=_unique_name(model, f"{stem}_AD{i}"),
+                        )
+                    )
+                    acc = nxt
         # A bias is [Cout], which broadcasts onto the trailing axis exactly
         # where the taps land -- before the output is transposed back. The
         # 1x1 downsample convolutions in resnet18 carry one, and skipping
@@ -889,7 +964,7 @@ def act_weight_conv_to_matmul(model):
             made.append(
                 helper.make_node(
                     "Add",
-                    [acc, node.input[2]],
+                    [acc, _unfusable_bias(model, node.input[2], cout)],
                     [biased],
                     name=_unique_name(model, f"{stem}_B"),
                 )

--- a/tests/test_axera_training_legalize.py
+++ b/tests/test_axera_training_legalize.py
@@ -108,6 +108,7 @@ def test_a_live_weight_convolution_becomes_matmuls_in_1d_and_2d():
         got = _run(after, feeds)[0]
         assert got.shape == ref.shape
         assert _snr(ref, got) > 100, (nd, k, stride, _snr(ref, got))
+        # `Concat` joins the taps into one wide MatMul; see `fuse` in the rule
         assert {n.op_type for n in after.graph.node} <= {
             "Pad",
             "Transpose",
@@ -115,6 +116,7 @@ def test_a_live_weight_convolution_becomes_matmuls_in_1d_and_2d():
             "Reshape",
             "MatMul",
             "Add",
+            "Concat",
         }
 
 
@@ -334,3 +336,92 @@ def test_training_rules_run_in_an_order_that_works():
     assert legalize.TRAINING_RULES[0] == "inline_local_functions"
     for name in legalize.TRAINING_RULES:
         assert name in legalize.RULES
+
+
+def test_a_constant_bias_is_reshaped_so_nothing_can_refuse_it():
+    """`MatMul(live) + Add(constant 1-D)` is what
+    `fuse_matmul_add_bias_into_gemm` matches, and skipping that pass in
+    onnxsim is not enough: Pulsar2 runs its own optimizer and fuses it back
+    into a `Gemm` whose weight is live, then dies in its calibrator naming no
+    node. Bisected to four nodes on real hardware; a 1-D constant bias fails
+    and the same values shaped `[1, N]` build."""
+    rng = np.random.default_rng(7)
+    bias = numpy_helper.from_array(rng.standard_normal(6).astype(np.float32), "c")
+    model = _model(
+        [helper.make_node("Gemm", ["a", "b", "c"], ["y"], transB=1, name="g")],
+        {"a": [5, 4], "b": [6, 4]},
+        {"y": [5, 6]},
+        [bias],
+    )
+    feeds = {
+        "a": rng.standard_normal((5, 4)).astype(np.float32),
+        "b": rng.standard_normal((6, 4)).astype(np.float32),
+    }
+    ref = _run(model, feeds)[0]
+    assert legalize.gemm_to_matmul(model) == 1
+    onnx.checker.check_model(model)
+    assert _snr(ref, _run(model, feeds)[0]) > 100
+
+    add = next(n for n in model.graph.node if n.op_type == "Add")
+    emitted = next(i for i in model.graph.initializer if i.name == add.input[1])
+    assert list(emitted.dims) == [1, 6], list(emitted.dims)
+    # the original is left alone -- other consumers may still want it
+    assert any(i.name == "c" and list(i.dims) == [6] for i in model.graph.initializer)
+
+
+def test_a_convolution_bias_gets_the_same_treatment():
+    rng = np.random.default_rng(8)
+    bias = numpy_helper.from_array(rng.standard_normal(6).astype(np.float32), "bb")
+    model = _model(
+        [
+            helper.make_node(
+                "Conv",
+                ["x", "w", "bb"],
+                ["y"],
+                kernel_shape=[3, 3],
+                pads=[1, 1, 1, 1],
+                name="c",
+            )
+        ],
+        {"x": [1, 8, 16, 16], "w": [6, 8, 3, 3]},
+        {"y": [1, 6, 16, 16]},
+        [bias],
+    )
+    feeds = {
+        "x": rng.standard_normal((1, 8, 16, 16)).astype(np.float32),
+        "w": (rng.standard_normal((6, 8, 3, 3)) * 0.2).astype(np.float32),
+    }
+    ref = _run(model, feeds)[0]
+    assert legalize.act_weight_conv_to_matmul(model) == 1
+    onnx.checker.check_model(model)
+    assert _snr(ref, _run(model, feeds)[0]) > 100
+    add = next(n for n in model.graph.node if n.op_type == "Add")
+    emitted = next(i for i in model.graph.initializer if i.name == add.input[1])
+    assert list(emitted.dims) == [1, 6]
+
+
+def test_the_taps_fuse_into_one_wide_matmul():
+    """`sum_k X_k @ W_k` is one matmul over the concatenation, exactly -- the
+    taps share an output and differ only along the reduction axis. Nine small
+    matmuls become one nine times deeper, which is what the matrix unit
+    rewards."""
+    rng = np.random.default_rng(9)
+    feeds = {
+        "x": rng.standard_normal((1, 8, 16, 16)).astype(np.float32),
+        "w": (rng.standard_normal((6, 8, 3, 3)) * 0.2).astype(np.float32),
+    }
+    counts = {}
+    for fuse in (False, True):
+        model = _conv(8, 6, 3, 16, 1, 1, 2)
+        ref = _run(model, feeds)[0]
+        assert legalize.act_weight_conv_to_matmul(model, fuse=fuse) == 1
+        onnx.checker.check_model(model)
+        got = _run(model, feeds)[0]
+        assert _snr(ref, got) > 100
+        counts[fuse] = (
+            len(model.graph.node),
+            sum(1 for n in model.graph.node if n.op_type == "MatMul"),
+        )
+    assert counts[True][1] == 1, counts
+    assert counts[False][1] == 9, counts
+    assert counts[True][0] < counts[False][0]


### PR DESCRIPTION
Follows #1333, which merged at its first commit and left this one behind.

## resnet18 trains on the card

resnet18d, last four layers trainable, 64×64 input, gradients computed on the NPU:

| output | cosine vs onnxruntime | SNR |
| --- | --- | --- |
| `layer4.0.downsample` weight gradient | 0.97676 | 13.35 dB |
| `layer4.1.conv2` weight gradient | 0.97272 | 12.60 dB |
| `layer4.1.conv1` weight gradient | 0.98140 | 14.23 dB |
| classifier weight gradient | 0.99710 | 22.14 dB |
| loss | 1.00000 | 37.23 dB |

5,361,664 trainable parameters, 731 nodes simplified to 210, 97 s to build,
**200.6 ms per step**. The convolution gradients are directionally right but not
precise — 12–14 dB — which is the INT8 backward pass, not a bug.

## The blocker was ours, and it extends #1332

`MatMul(live) + Add(constant 1-D)` is exactly what `fuse_matmul_add_bias_into_gemm`
matches. Skipping that pass in onnxsim — as #1332 does upstream — is **necessary
but not sufficient**: Pulsar2 runs its own optimizer and fuses it back, into a
`Gemm` whose weight is live, which is the node it cannot lower.

It does not say so. The build dies inside PPQ's calibrator with
`ValueError('The truth value of an array with more than one element is
ambiguous')`, naming no node and nothing about `Gemm`.

Bisecting 58 nodes down to 4 by recompiling node ranges found it. Four spellings
of the same arithmetic then separated cause from coincidence:

| bias spelling | result |
| --- | --- |
| 1-D initializer | FAILED |
| `Constant` node instead of initializer | FAILED |
| operand order swapped | FAILED |
| **shaped `[1, N]`** | **BUILT** |
| `Identity` between `MatMul` and `Add` | BUILT |

`_unfusable_bias` takes the reshape. The `Identity` also works and is the wrong
fix — it is precisely what a later dead-code pass would delete, putting the bug
back. Applied to both rewrites, since `gemm_to_matmul`'s `C` and
`act_weight_conv_to_matmul`'s bias ride the same pattern.

**The general lesson:** a graph that needs an op *gone* must be shaped so nothing
can put it back. Suppressing your own optimizer is half the job.

## Also here

- **Tap fusion.** `sum_k X_k @ W_k` is one matmul over the concatenation, exactly
  — the taps share an output and differ only along the reduction axis. Nine small
  matmuls become one nine times deeper, which is what the matrix unit rewards
  (measured earlier: 11 → 198 → 594 → 1086 GOPS as matmul size grows). `fuse=False`
  stays reachable, because with a compiler that dies naming no node, being able to
  change a rewrite's shape is worth more than tidier code.
- **`docs/axera-on-device-training-handoff.md`** — following the pattern of
  `docs/ozaki-scheme-axera-handoff.md`, whose conclusion this work overturned.
  Records the ceiling (the gradient rounds to zero by step ~1,000 at U8 and
  ~5,000 at U16; loss scaling cannot fix it because a multiplicative seed cannot
  live in a linear fixed-point tensor), both silent vendor bugs, the performance
  numbers, five concrete next steps, and which blockers were self-inflicted.

## Test plan

- [x] `pytest tests/test_axera_training_legalize.py` — 15 passed, 3 new
      (rank-2 bias on both rewrites, tap fusion emitting exactly one `MatMul`)
- [x] Hardware numbers measured on a real AX650N
- [x] `ruff check` / `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SURqECCQ8uE9QUoJmdSNfS