### PR TITLE
axera: put the training-step weight update in-graph -- 5.2x on step time

### DIFF
--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -113,6 +113,64 @@ Batch size is nearly free until it is not: batch 1 to 16 costs 0.38 ms
 (1.40 -> 1.78) for **12.6x** the throughput; batch 64 is worse *per sample*
 than 16.
 
+### Weights resident with in-graph updates: 5.2x, measured
+
+The 42.9 MB the resnet18 step moves is every trainable weight crossing the
+host boundary twice -- once in as a graph input, once back out as the
+gradient the host then applies. `scripts/axera/build_resident_train_step.py`
+puts the update itself in the graph instead: each trained weight is a
+`qat_graph.StepGraph`-style *state* tensor (both input and output, `w_next =
+w - lr * grad` computed by ordinary `Mul`/`Sub` nodes), so
+`scripts/axera/tools/resident_runner.c` can copy each step's output buffer
+straight back into its own input buffer device-to-device and never send the
+weight across the host boundary at all -- only the batch (`x`, `y`) goes in
+and the scalar loss comes out.
+
+Same four tensors, same `resnet18d` shape, real AX650N, 30 timed steps after
+5 warmup:
+
+| | avg | min |
+| --- | --- | --- |
+| baseline (host applies `w -= lr*grad`, 42.9 MB/step) | 200.6 ms | -- |
+| in-graph update, **non-resident** (`-n`: state round-tripped through host) | 114.8 ms | 110.6 ms |
+| in-graph update, **resident** (state copied device-to-device) | **38.3 ms** | 36.0 ms |
+
+**5.2x**, not quite the "roughly 10x" estimated -- real, and short of the
+estimate for a real reason (below), not a measurement artifact: the
+non-resident row isolates that some of the win is just the in-graph update
+itself (fewer distinct tensors cross the wire even before residency helps),
+and the resident row is the full effect.
+
+A `--compiler.npu_perf` profile of the resident graph (`pulsar2_docker.
+build(profile=True)`, see `scripts/axera/README.md`'s "Real NPU profiling"
+section) explains the gap from 10x: op-type cycle share for this step is
+
+| op type | share of cycles |
+| --- | --- |
+| `AxQuantizeLinear` + `AxDequantizeLinear` | 48.8% |
+| `AxTranspose` + `AxSlice` | 26.3% |
+| `assign` (state write-back) | 6.7% |
+| `AxQuantizedMul`/`Sub`/`MatMul`/`ReduceSum` (the actual backward arithmetic + SGD update) | 16.2% |
+| `AxQuantizedConv` (the untouched forward convs) | 0.9% |
+
+**Three quarters of the NPU's own cycles are quantize/dequantize and
+transpose/slice glue, not arithmetic** -- the tax `act_weight_conv_to_matmul`
+pays for turning a live-weight `Conv` into per-tap `MatMul`s (each tap needs
+its own `Slice` and `Transpose`, and apparently its own quantization
+boundary). Residency removed the *transfer* bottleneck; this is what is left,
+and it is now the bigger one. Untried: whether `fuse=True`'s single wide
+matmul-per-conv (already default) can be pushed further, or whether the
+per-tap quantize/dequantize pairs can be coalesced.
+
+Correctness was checked the same way as the rest of this document -- a
+directional-derivative check against `onnxruntime` on host (not the on-device
+number itself, which was not re-measured to gradient precision this time;
+see `tests/test_build_resident_train_step.py` for the from-scratch,
+no-hardware version of that check) -- and a coarse on-device sanity check: a
+near-zero dummy batch's loss landed at 0.1416 on the card against 0.0972 from
+the fp32 host reference, the right order of magnitude for INT8 quantization
+noise on an untuned calibration set, not a wiring bug.
+
 ## Two vendor bugs, both silent
 
 **`ReduceMean` with no `axes` reduces only the last axis.** ONNX reduces all of
@@ -193,14 +251,21 @@ hand and so calls `simplify()` itself, with the same skip list.
 
 1. **The FP32 gradient seed.** The one untried route past the dying gradient,
    and the difference between a 5,000-step horizon and an open-ended one.
-2. **Weights resident with in-graph updates.** resnet18 moves 42.9 MB per step
-   purely because weights cross the wire. Put `w_next = w - lr*grad` in the
-   graph and bind it back device-to-device (the runner's `-b` already does
-   this) and only the batch crosses -- roughly 10x on step time.
+2. ~~Weights resident with in-graph updates.~~ **Done: 5.2x** (200.6 ms ->
+   38.3 ms/step) -- see "Weights resident with in-graph updates" above.
+   What's left in this direction: the quantize/dequantize + transpose/slice
+   glue around `act_weight_conv_to_matmul`'s per-tap decomposition is now
+   *the* cost (75% of NPU cycles, per the profile above) -- worth another
+   pass on its own before reaching for anything else here.
 3. **All 23 tensors, and 224x224.** Only the last four layers and a 64x64 input
    have been built.
 4. **An optimiser beyond SGD.** `qat_graph.adam_update` exists and has never
-   been put through this path.
+   been put through this path -- and now has a real in-graph-update precedent
+   to extend (`build_resident_step` currently hand-rolls plain SGD rather
+   than calling `qat_graph.sgd_momentum_update`/`adam_update`, specifically
+   to match `finetune.py`'s zero-momentum host loop; either builtin optimizer
+   would carry its own extra state tensor(s), which residency handles the
+   same way).
 5. **Does QAT through the card beat training in float and quantising?** On a
    single linear layer it bought +0.22 dB, which is a question the experiment
    could not answer -- a single layer has nothing to route around. The depth

--- a/scripts/axera/build_resident_train_step.py
+++ b/scripts/axera/build_resident_train_step.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Build a resnet18-shaped training-step graph with the weight update *in
+the graph*, for a resident runner to keep entirely device-side.
+
+`finetune.py`'s loop treats a compiled training step as a pure function:
+feed weights and a batch, get back a gradient, and do `w -= lr * grad` in
+host numpy. That means every trainable weight crosses the host<->device
+boundary twice a step (once as input, once as the returned gradient) for no
+reason but that the update lives off-device -- 42.9 MB of the resnet18
+step's 42.9 MB moved is exactly this, measured in
+`docs/axera-on-device-training-handoff.md`.
+
+This module builds a different graph for the same step: each trainable
+weight is a **state** tensor (`onnxsim.qat_graph.StepGraph`'s sense) that is
+both an input and an output, with `w_next = w - lr * grad` computed by
+ordinary `Mul`/`Sub` nodes inside the graph itself (plain SGD, no momentum --
+matching `finetune.train()`'s own host update exactly, so the two are
+directly comparable). A resident runner
+(`scripts/axera/tools/resident_runner.c`) can then bind each state output
+back to its own input's device buffer between `Execute()` calls and never
+send the weight across the host boundary at all; only the batch (`x`, `y`)
+goes in and the scalar loss comes out.
+
+Pipeline, and why the order matters:
+
+1. Append a scalar loss to the forward model (`Sub`/`Mul`/`ReduceMean`, with
+   explicit `axes` -- see `legalize.avgpool_ceil_to_floor`'s and
+   `global_pool_to_reduce`'s own docstrings for the vendor bug this dodges).
+2. Legalize *forward*-graph blockers that are differentiability blockers,
+   not just Pulsar2-compile-time ones: `avgpool_ceil_to_floor`,
+   `flatten_to_reshape`, `global_pool_to_reduce`. `onnxsim.graph_grad` has no
+   rule for `Flatten`/`GlobalAveragePool` and declines `ceil_mode=1`
+   outright, so these three must run *before* `build_backward`, not after
+   (unlike the rest of `legalize.TRAINING_RULES`, which only needs to run on
+   the finished step graph).
+3. `onnxsim.graph_grad.build_backward()` differentiates the (now legal)
+   forward+loss graph against the chosen trainable weights.
+4. Plain SGD, in-graph: `step = lr * grad; w_next = w - step` per weight,
+   via `onnxsim.qat_graph.GraphBuilder.mul`/`.sub` directly -- not
+   `qat_graph.sgd_momentum_update`, which always carries a momentum buffer
+   as extra state; this is the zero-momentum case `finetune.py`'s host loop
+   already implements, so there is nothing to gain from carrying one.
+5. `onnxsim.qat_graph.make_step_graph()` wraps it into a `StepGraph` and
+   simplifies with the same skip list `docs/axera-on-device-training-
+   handoff.md`'s "Simplify the gradient graph" section describes
+   (`fuse_matmul_add_bias_into_gemm`/`fuse_transpose_into_gemm` -- a training
+   graph's whole point is a *live* weight, and both fusions would rebuild
+   exactly the `Gemm`/transpose-into-`Gemm` shape this graph exists to
+   avoid).
+6. The remaining `legalize.TRAINING_RULES` (`inline_local_functions`,
+   `avgpool_ceil_to_floor` again for any pool the update graph itself
+   introduced, `neg_to_mul`, `rank0_to_rank1`, `gemm_to_matmul`,
+   `act_weight_conv_to_matmul`) make the *step* graph -- backward pass and
+   update included -- something `pulsar2 build` will actually lower.
+7. One more `onnxsim.simplify()` pass, same skip list: `act_weight_conv_to_
+   matmul`'s per-tap expansion multiplies node count, and consecutive taps
+   slicing the same tensors collapse under common-subexpression elimination
+   -- worth doing after legalization, not only before it (same finding the
+   handoff's own "Simplify the gradient graph" section records).
+
+One graph-construction quirk worth naming: `qat_graph.make_step_graph`
+declares every scalar input (here, just `lr`) at rank 0. Pulsar2's
+calibration step concatenates each input across calibration samples, and a
+rank-0 tensor cannot be concatenated -- the same failure
+`legalize.rank0_to_rank1` exists to fix for a rank-0 *output* (the loss).
+There is no equivalent rule for a rank-0 *input*, so this module reshapes
+`lr` to `[1]` directly after `make_step_graph` returns; broadcasting a `[1]`
+scalar against every weight's `Mul` is identical arithmetic.
+
+See `tests/test_build_resident_train_step.py` for a from-scratch synthetic
+model exercising this whole pipeline without resnet18 or real hardware, and
+`docs/axera-on-device-training-handoff.md` for the measured speed this
+bought on a real AX650N.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Dict, Sequence, Tuple
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import legalize  # noqa: E402
+
+from onnxsim import graph_grad, qat_graph  # noqa: E402
+from onnxsim.compile_training import _static_shapes_and_types  # noqa: E402
+
+#: Applied to the *step* graph (forward + loss + backward + in-graph
+#: update), after `make_step_graph`'s own simplify. Mirrors
+#: `legalize.TRAINING_RULES` minus the three rules that had to run on the
+#: forward graph earlier, before differentiation -- see this module's
+#: docstring.
+_POST_BACKWARD_RULES = (
+    "inline_local_functions",
+    "avgpool_ceil_to_floor",
+    "neg_to_mul",
+    "rank0_to_rank1",
+    "gemm_to_matmul",
+    "act_weight_conv_to_matmul",
+)
+
+
+def add_mse_loss(
+    model: onnx.ModelProto, logits: str, num_classes: int
+) -> onnx.ModelProto:
+    """Returns a copy of `model` with a `y` input and a scalar MSE `loss`
+    output appended: `loss = mean((logits - y) ** 2)`.
+
+    A plain elementwise MSE is the simplest loss `graph_grad` differentiates
+    exactly, and is all this module needs to demonstrate the in-graph
+    update -- swap in a different loss (cross-entropy, ...) by building one
+    yourself and skipping this helper.
+    """
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    g = out.graph
+    g.input.append(
+        helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, num_classes])
+    )
+    g.node.extend(
+        [
+            helper.make_node("Sub", [logits, "y"], ["loss_diff"], name="loss_diff"),
+            helper.make_node(
+                "Mul", ["loss_diff", "loss_diff"], ["loss_sq"], name="loss_sq"
+            ),
+            helper.make_node(
+                "ReduceMean",
+                ["loss_sq"],
+                ["loss"],
+                name="loss_mean",
+                axes=[0, 1],
+                keepdims=0,
+            ),
+        ]
+    )
+    g.output.append(helper.make_tensor_value_info("loss", TensorProto.FLOAT, []))
+    return out
+
+
+def build_resident_step(
+    forward_and_loss: onnx.ModelProto,
+    params: Sequence[str],
+    loss_output: str = "loss",
+) -> Tuple[onnx.ModelProto, Dict[str, str]]:
+    """The full pipeline (this module's docstring, steps 2-7) over a forward
+    model that already has its loss appended (`add_mse_loss`, or your own).
+
+    :param params: names of `forward_and_loss`'s own float32 initializers to
+            train -- promoted to state (input *and* output) rather than left
+            as fixed initializers.
+    :returns: `(step_model, state)`, where `state` maps each trainable
+            weight's name to the output name carrying its updated value --
+            exactly `qat_graph.StepGraph.state`, restricted to `params`
+            (the optimizer's own extra state, if any, is not exposed here
+            since plain SGD carries none).
+    """
+    model = onnx.ModelProto()
+    model.CopyFrom(forward_and_loss)
+
+    # Forward-graph blockers that must be fixed before build_backward can
+    # even walk the graph -- see this module's docstring, step 2.
+    legalize.avgpool_ceil_to_floor(model)
+    legalize.flatten_to_reshape(model)
+    legalize.global_pool_to_reduce(model)
+    onnx.checker.check_model(model)
+
+    shapes, elem_types = _static_shapes_and_types(model)
+    initializers = {t.name: t for t in model.graph.initializer}
+    missing = [p for p in params if p not in initializers]
+    if missing:
+        raise ValueError(f"{missing} are not initializers of the forward model")
+
+    b = qat_graph.GraphBuilder(prefix="resident_step__")
+    b.nodes = list(model.graph.node)
+    trained = set(params)
+    b.initializer = [t for t in model.graph.initializer if t.name not in trained]
+
+    seed = b.const(np.array(1.0, dtype=np.float32), "loss_seed")
+    grads = graph_grad.build_backward(
+        b,
+        nodes=list(model.graph.node),
+        shapes=shapes,
+        grad_outputs={loss_output: seed},
+        targets=list(params),
+    )
+
+    state: Dict[str, Tuple[Sequence[int], str]] = {}
+    for p in params:
+        w_shape = tuple(int(d) for d in shapes[p])
+        step = b.mul("lr", grads[p])
+        w_next = b.sub(p, step)
+        state[p] = (w_shape, w_next)
+
+    constants: Dict[str, Tuple[Sequence[int], int]] = {}
+    for inp in model.graph.input:
+        if inp.name in initializers:
+            continue
+        shape = shapes.get(inp.name)
+        if shape is None:
+            raise ValueError(f"no static shape for model input {inp.name!r}")
+        constants[inp.name] = (
+            tuple(int(d) for d in shape),
+            elem_types.get(inp.name, TensorProto.FLOAT),
+        )
+
+    step_graph = qat_graph.make_step_graph(
+        b,
+        constants=constants,
+        state=state,
+        scalars=["lr"],
+        loss=loss_output,
+        name="resident_train_step",
+    )
+    step_model = step_graph.model
+
+    # rank0_to_rank1 only fixes a scalar *output* (the loss); a scalar
+    # *input* hits the identical Pulsar2 calibration failure -- see this
+    # module's own docstring.
+    for inp in step_model.graph.input:
+        if inp.name == "lr":
+            del inp.type.tensor_type.shape.dim[:]
+            inp.type.tensor_type.shape.dim.add().dim_value = 1
+
+    legalize.legalize(step_model, _POST_BACKWARD_RULES)
+    onnx.checker.check_model(step_model)
+
+    from onnxsim import simplify as _simplify
+
+    step_model, ok = _simplify(
+        step_model,
+        skipped_optimizers=[
+            "fuse_matmul_add_bias_into_gemm",
+            "fuse_transpose_into_gemm",
+        ],
+    )
+    if not ok:
+        raise RuntimeError("post-legalize simplify() failed its own correctness check")
+
+    return step_model, step_graph.state
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "forward_onnx", help="forward model, already simplified/BN-folded"
+    )
+    parser.add_argument("output_onnx")
+    parser.add_argument(
+        "--logits", default="logits", help="forward model's output tensor"
+    )
+    parser.add_argument("--num-classes", type=int, required=True)
+    parser.add_argument(
+        "--param",
+        action="append",
+        required=True,
+        dest="params",
+        help="a trainable initializer's name; repeat for each",
+    )
+    args = parser.parse_args(argv)
+
+    forward = onnx.load(args.forward_onnx)
+    with_loss = add_mse_loss(forward, args.logits, args.num_classes)
+    step_model, state = build_resident_step(with_loss, args.params)
+
+    print(f"step graph: {len(step_model.graph.node)} nodes")
+    for p, out_name in state.items():
+        print(f"  state: {p} -> {out_name}")
+    onnx.save(step_model, args.output_onnx)
+    print("wrote", args.output_onnx)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/axera/tools/README.md
+++ b/scripts/axera/tools/README.md
@@ -1,6 +1,6 @@
 # AXCL runtime tools
 
-Two small C programs against the AXCL engine API (`/usr/include/axcl`), for
+Three small C programs against the AXCL engine API (`/usr/include/axcl`), for
 things `axcl_run_model` cannot do.
 
 `axcl_run_model` only ever runs a model's **first** shape group. An
@@ -13,6 +13,15 @@ prefill cannot be timed with the shipped CLI. These talk to
   `llm_build` layer to have two groups rather than the zero the CLI reports.
 - `bench_shape_group.c` -- allocate device buffers for one group, execute it
   `repeat` times and report min/avg latency.
+- `resident_runner.c` -- run a compiled `onnxsim.qat_graph.StepGraph`-shaped
+  training step (see `../build_resident_train_step.py`) in a loop with its
+  trainable-weight state kept **device-resident** between `Execute()` calls
+  (copied output-buffer -> input-buffer device-to-device, never through the
+  host), and only the batch crossing the host boundary each step. `-n` runs
+  the same loop but round-trips state through a host buffer instead, for a
+  direct before/after comparison against the same compiled model -- see
+  `docs/axera-on-device-training-handoff.md`'s "Weights resident with
+  in-graph updates" section for the numbers this produced on a real AX650N.
 
 Build and run them where the card is visible (inside the VM, if the device is
 passed through -- see `../vm/README.md`):
@@ -22,6 +31,11 @@ gcc -O2 -I/usr/include/axcl -o bench_shape_group bench_shape_group.c \
     -L/usr/lib/axcl -laxcl_rt -Wl,-rpath,/usr/lib/axcl
 ./probe_model_io  layer.axmodel
 ./bench_shape_group layer.axmodel 1 15      # group 1 = prefill
+
+gcc -O2 -std=c11 -I/usr/include/axcl -o resident_runner resident_runner.c \
+    -L/usr/lib/axcl -laxcl_rt -Wl,-rpath,/usr/lib/axcl
+./resident_runner train_step.axmodel 30       # resident (device-to-device)
+./resident_runner train_step.axmodel 30 -n    # non-resident (host round trip)
 ```
 
 Group 0's latency from `bench_shape_group` matches `axcl_run_model`'s to

--- a/scripts/axera/tools/resident_runner.c
+++ b/scripts/axera/tools/resident_runner.c
@@ -1,0 +1,176 @@
+/* Resident runner for a compiled onnxsim training-step .axmodel: loads the
+ * model once, keeps every trainable-weight state buffer device-resident
+ * between steps (bound in/out buffers are separate; after each Execute the
+ * output is copied device-to-device back into the input buffer), and only
+ * streams the batch (x, y) in and the loss out across the host boundary.
+ *
+ * Usage: resident_runner model.axmodel steps [warmup] [-n]
+ *
+ * -n: non-resident comparison mode. Instead of copying each step's updated
+ * weight straight back device-to-device, round-trip it through a host
+ * buffer (device -> host -> device) -- what a loop that treats the compiled
+ * step graph as a stateless function, the same way the pre-residency design
+ * did, would have to do. Isolates the residency win from the in-graph-update
+ * graph-structure change itself.
+ *
+ * The model's own I/O order is fixed here rather than discovered generically
+ * (see probe_io's dump): inputs x, y, _v_231, _v_233, _v_235, fc.weight, lr;
+ * outputs sub_950 (_v_231'), sub_952 (_v_233'), sub_954 (_v_235'),
+ * sub_956 (fc.weight'), loss. State pairing is positional: input i (for
+ * i in 2..5) pairs with output i-2.
+ */
+#define _POSIX_C_SOURCE 199309L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "axcl.h"
+
+#define CK(e) do { axclError _r = (e); if (_r != 0) { \
+    fprintf(stderr, "%s failed: 0x%x\n", #e, _r); return 1; } } while (0)
+
+#define N_STATE 4
+
+static double now_ms(void) {
+    struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1e6;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s model.axmodel steps [warmup]\n", argv[0]);
+        return 2;
+    }
+    int steps = atoi(argv[2]);
+    int warmup = argc > 3 && strcmp(argv[3], "-n") != 0 ? atoi(argv[3]) : 5;
+    int non_resident = 0;
+    for (int i = 3; i < argc; i++) if (strcmp(argv[i], "-n") == 0) non_resident = 1;
+    fprintf(stderr, "mode: %s\n", non_resident ? "non-resident (host round trip)" : "resident (device-to-device)");
+
+    CK(axclInit(NULL));
+    axclrtDeviceList devs; CK(axclrtGetDeviceList(&devs));
+    if (!devs.num) { fprintf(stderr, "no device\n"); return 1; }
+    CK(axclrtSetDevice(devs.devices[0]));
+    CK(axclrtEngineInit(AXCL_VNPU_DISABLE));
+
+    uint64_t modelId = 0, ctx = 0;
+    CK(axclrtEngineLoadFromFile(argv[1], &modelId));
+    CK(axclrtEngineCreateContext(modelId, &ctx));
+
+    axclrtEngineIOInfo info; CK(axclrtEngineGetIOInfo(modelId, &info));
+    uint32_t ni = axclrtEngineGetNumInputs(info), no = axclrtEngineGetNumOutputs(info);
+    fprintf(stderr, "inputs=%u outputs=%u\n", ni, no);
+
+    axclrtEngineIO io; CK(axclrtEngineCreateIO(info, &io));
+
+    /* input indices: 0=x 1=y 2.._v_231 3.._v_233 4.._v_235 5=fc.weight 6=lr
+     * output indices: 0.._v_231' 1.._v_233' 2.._v_235' 3=fc.weight' 4=loss */
+    const int state_in[N_STATE]  = {2, 3, 4, 5};
+    const int state_out[N_STATE] = {0, 1, 2, 3};
+    const int x_in = 0, y_in = 1, lr_in = 6, loss_out = 4;
+
+    void *in_bufs[7] = {0}, *out_bufs[5] = {0};
+    uint64_t in_sz[7], out_sz[5];
+
+    for (uint32_t i = 0; i < ni; i++) {
+        in_sz[i] = axclrtEngineGetInputSizeByIndex(info, 0, i);
+        CK(axclrtMalloc(&in_bufs[i], in_sz[i], AXCL_MEM_MALLOC_NORMAL_ONLY));
+        CK(axclrtEngineSetInputBufferByIndex(io, i, in_bufs[i], in_sz[i]));
+    }
+    for (uint32_t i = 0; i < no; i++) {
+        out_sz[i] = axclrtEngineGetOutputSizeByIndex(info, 0, i);
+        CK(axclrtMalloc(&out_bufs[i], out_sz[i], AXCL_MEM_MALLOC_NORMAL_ONLY));
+        CK(axclrtEngineSetOutputBufferByIndex(io, i, out_bufs[i], out_sz[i]));
+    }
+
+    /* seed the 4 trainable state inputs and lr from host files written
+     * alongside the model (see push_and_run.sh): <argv[1]>.state<k> and
+     * <argv[1]>.lr */
+    char path[1024];
+    for (int k = 0; k < N_STATE; k++) {
+        int i = state_in[k];
+        snprintf(path, sizeof(path), "%s.state%d", argv[1], k);
+        FILE *f = fopen(path, "rb");
+        if (!f) { fprintf(stderr, "missing %s\n", path); return 1; }
+        void *host = malloc(in_sz[i]);
+        size_t got = fread(host, 1, in_sz[i], f);
+        fclose(f);
+        if (got != in_sz[i]) { fprintf(stderr, "short read %s\n", path); return 1; }
+        CK(axclrtMemcpy(in_bufs[i], host, in_sz[i], AXCL_MEMCPY_HOST_TO_DEVICE));
+        free(host);
+    }
+    {
+        float lr = 1e-4f;
+        CK(axclrtMemcpy(in_bufs[lr_in], &lr, sizeof(lr), AXCL_MEMCPY_HOST_TO_DEVICE));
+    }
+
+    /* x/y: reused synthetic batch, re-uploaded every step exactly as a real
+     * loop would upload a fresh batch (the point being measured is that nothing
+     * ELSE crosses the bus, not that x/y are literally static). */
+    void *hx = malloc(in_sz[x_in]);
+    void *hy = malloc(in_sz[y_in]);
+    memset(hx, 0x11, in_sz[x_in]);
+    memset(hy, 0x22, in_sz[y_in]);
+
+    float loss_host;
+    void *state_host[N_STATE];
+    for (int k = 0; k < N_STATE; k++) state_host[k] = malloc(out_sz[state_out[k]]);
+
+    /* warmup */
+    for (int i = 0; i < warmup; i++) {
+        CK(axclrtMemcpy(in_bufs[x_in], hx, in_sz[x_in], AXCL_MEMCPY_HOST_TO_DEVICE));
+        CK(axclrtMemcpy(in_bufs[y_in], hy, in_sz[y_in], AXCL_MEMCPY_HOST_TO_DEVICE));
+        CK(axclrtEngineExecute(modelId, ctx, 0, io));
+        for (int k = 0; k < N_STATE; k++) {
+            if (non_resident) {
+                CK(axclrtMemcpy(state_host[k], out_bufs[state_out[k]],
+                                 out_sz[state_out[k]], AXCL_MEMCPY_DEVICE_TO_HOST));
+                CK(axclrtMemcpy(in_bufs[state_in[k]], state_host[k],
+                                 out_sz[state_out[k]], AXCL_MEMCPY_HOST_TO_DEVICE));
+            } else {
+                CK(axclrtMemcpy(in_bufs[state_in[k]], out_bufs[state_out[k]],
+                                 out_sz[state_out[k]], AXCL_MEMCPY_DEVICE_TO_DEVICE));
+            }
+        }
+        CK(axclrtMemcpy(&loss_host, out_bufs[loss_out], sizeof(loss_host),
+                         AXCL_MEMCPY_DEVICE_TO_HOST));
+    }
+
+    double best = 1e30, sum = 0, t_start = now_ms();
+    for (int i = 0; i < steps; i++) {
+        double t0 = now_ms();
+        CK(axclrtMemcpy(in_bufs[x_in], hx, in_sz[x_in], AXCL_MEMCPY_HOST_TO_DEVICE));
+        CK(axclrtMemcpy(in_bufs[y_in], hy, in_sz[y_in], AXCL_MEMCPY_HOST_TO_DEVICE));
+        CK(axclrtEngineExecute(modelId, ctx, 0, io));
+        for (int k = 0; k < N_STATE; k++) {
+            if (non_resident) {
+                CK(axclrtMemcpy(state_host[k], out_bufs[state_out[k]],
+                                 out_sz[state_out[k]], AXCL_MEMCPY_DEVICE_TO_HOST));
+                CK(axclrtMemcpy(in_bufs[state_in[k]], state_host[k],
+                                 out_sz[state_out[k]], AXCL_MEMCPY_HOST_TO_DEVICE));
+            } else {
+                CK(axclrtMemcpy(in_bufs[state_in[k]], out_bufs[state_out[k]],
+                                 out_sz[state_out[k]], AXCL_MEMCPY_DEVICE_TO_DEVICE));
+            }
+        }
+        CK(axclrtMemcpy(&loss_host, out_bufs[loss_out], sizeof(loss_host),
+                         AXCL_MEMCPY_DEVICE_TO_HOST));
+        double dt = now_ms() - t0;
+        if (dt < best) best = dt;
+        sum += dt;
+        if (i < 5 || i == steps - 1)
+            fprintf(stderr, "step %d: %.3f ms  loss=%g\n", i, dt, loss_host);
+    }
+    double total = now_ms() - t_start;
+    printf("steps=%d min=%.3fms avg=%.3fms total=%.3fms throughput=%.1f steps/s\n",
+           steps, best, sum / steps, total, 1000.0 * steps / total);
+
+    for (uint32_t i = 0; i < ni; i++) axclrtFree(in_bufs[i]);
+    for (uint32_t i = 0; i < no; i++) axclrtFree(out_bufs[i]);
+    axclrtEngineDestroyIO(io);
+    axclrtEngineDestroyIOInfo(info);
+    axclrtEngineUnload(modelId);
+    axclrtEngineFinalize();
+    axclFinalize();
+    return 0;
+}

--- a/tests/test_build_resident_train_step.py
+++ b/tests/test_build_resident_train_step.py
@@ -1,0 +1,163 @@
+"""Tests for ``scripts/axera/build_resident_train_step.py`` -- the in-graph
+SGD update that lets a resident runner keep a training step's trainable
+weights entirely device-side (see ``docs/axera-on-device-training-
+handoff.md``'s "Weights resident with in-graph updates" section, and
+``scripts/axera/tools/resident_runner.c``, which is what actually binds a
+state output back to its own input's device buffer between steps -- neither
+needs a real AX650N to check that the *graph* computes what it should).
+
+Everything here runs on the CPU reference/onnxruntime; no Docker, no device.
+"""
+
+import os
+import sys
+
+import numpy as np
+import onnx
+import pytest
+from onnx import parser
+
+ort = pytest.importorskip("onnxruntime")
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import build_resident_train_step as brts  # noqa: E402
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def _forward_model():
+    """`x -> Conv -> Relu -> Flatten -> Gemm -> logits`: small enough to run
+    instantly, but exercises both a trainable `Conv` weight and a trainable
+    `Gemm` weight, plus the `Flatten` this module's own docstring says must
+    be legalized to `Reshape` *before* `graph_grad.build_backward` ever sees
+    it (`onnxsim.graph_grad` has no gradient rule for `Flatten` itself).
+    """
+    rng = np.random.default_rng(0)
+    cw = rng.standard_normal((2, 1, 3, 3)).astype(np.float32) * 0.3
+    gw = rng.standard_normal((10, 32)).astype(np.float32) * 0.2
+    gb = rng.standard_normal((10,)).astype(np.float32) * 0.1
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 17]
+        >
+        g (float[1,1,4,4] x) => (float[1,10] logits)
+        {
+          h = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(x, cw)
+          r = Relu(h)
+          f = Flatten<axis=1>(r)
+          logits = Gemm<transB=1>(f, gw, gb)
+        }
+        """
+    )
+    model.graph.initializer.extend([_f32(cw, "cw"), _f32(gw, "gw"), _f32(gb, "gb")])
+    return model
+
+
+def _run(model, feeds, output_names=None):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(output_names, feeds)
+
+
+def test_add_mse_loss_matches_manual_computation():
+    forward = _forward_model()
+    with_loss = brts.add_mse_loss(forward, "logits", num_classes=10)
+    onnx.checker.check_model(with_loss)
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((1, 1, 4, 4)).astype(np.float32)
+    y = rng.standard_normal((1, 10)).astype(np.float32)
+
+    (logits,) = _run(forward, {"x": x}, ["logits"])
+    (loss,) = _run(with_loss, {"x": x, "y": y}, ["loss"])
+    assert loss.shape == ()
+    assert np.allclose(loss, np.mean((logits - y) ** 2), atol=1e-5)
+
+
+def test_state_output_is_sgd_update_of_the_input():
+    """`w_next` for each trained param must be exactly `w - lr * grad`, with
+    `lr=0` a pure pass-through -- the cheapest end-to-end check that the
+    in-graph `Mul`/`Sub` update is wired to the right tensors."""
+    forward = _forward_model()
+    with_loss = brts.add_mse_loss(forward, "logits", num_classes=10)
+    step_model, state = brts.build_resident_step(with_loss, params=["cw", "gw"])
+    onnx.checker.check_model(step_model)
+
+    assert set(state) == {"cw", "gw"}
+    # lr was reshaped from rank 0 to rank 1 -- see this module's docstring.
+    lr_input = next(i for i in step_model.graph.input if i.name == "lr")
+    assert [d.dim_value for d in lr_input.type.tensor_type.shape.dim] == [1]
+
+    initializers = {t.name: t for t in forward.graph.initializer}
+    cw0 = onnx.numpy_helper.to_array(initializers["cw"])
+    gw0 = onnx.numpy_helper.to_array(initializers["gw"])
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((1, 1, 4, 4)).astype(np.float32)
+    y = rng.standard_normal((1, 10)).astype(np.float32)
+
+    feeds = {"x": x, "y": y, "lr": np.array([0.0], np.float32), "cw": cw0, "gw": gw0}
+    out_names = [o.name for o in step_model.graph.output]
+    outs = dict(zip(out_names, _run(step_model, feeds, out_names)))
+    assert np.array_equal(outs[state["cw"]], cw0)
+    assert np.array_equal(outs[state["gw"]], gw0)
+
+
+def test_in_graph_gradient_matches_finite_differences():
+    """The gradient implied by the in-graph update (`grad = (w -
+    w_next) / lr`) must agree with a numeric directional derivative of the
+    *original* forward+loss graph -- the same kind of check
+    `tests/test_axera_training_legalize.py` runs for each legalization rule,
+    here covering the whole build_backward + in-graph-update pipeline at
+    once."""
+    forward = _forward_model()
+    with_loss = brts.add_mse_loss(forward, "logits", num_classes=10)
+    step_model, state = brts.build_resident_step(with_loss, params=["cw", "gw"])
+
+    initializers = {t.name: t for t in forward.graph.initializer}
+    w0 = {p: onnx.numpy_helper.to_array(initializers[p]) for p in state}
+
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal((1, 1, 4, 4)).astype(np.float32)
+    y = rng.standard_normal((1, 10)).astype(np.float32)
+
+    out_names = [o.name for o in step_model.graph.output]
+    feeds = {"x": x, "y": y, "lr": np.array([1.0], np.float32), **w0}
+    outs = dict(zip(out_names, _run(step_model, feeds, out_names)))
+    grads = {p: (w0[p] - outs[state[p]]).astype(np.float64) for p in state}
+
+    def loss_at(weights):
+        # `with_loss` still carries each trained weight as a plain
+        # initializer (only build_resident_step's own internal builder
+        # promotes them to graph inputs) -- so overriding one for this probe
+        # means replacing its initializer, not feeding it as a run() input.
+        probe = onnx.ModelProto()
+        probe.CopyFrom(with_loss)
+        for init in probe.graph.initializer:
+            if init.name in weights:
+                init.CopyFrom(
+                    onnx.numpy_helper.from_array(weights[init.name], init.name)
+                )
+        (loss,) = _run(probe, {"x": x, "y": y}, ["loss"])
+        return float(loss)
+
+    for p in state:
+        d = rng.standard_normal(w0[p].shape).astype(np.float64)
+        eps = 1e-2 / (np.linalg.norm(d) + 1e-12)
+        w_plus = dict(w0)
+        w_plus[p] = (w0[p].astype(np.float64) + eps * d).astype(np.float32)
+        w_minus = dict(w0)
+        w_minus[p] = (w0[p].astype(np.float64) - eps * d).astype(np.float32)
+        fd = (loss_at(w_plus) - loss_at(w_minus)) / (2 * eps)
+        predicted = float((grads[p] * d).sum())
+        assert predicted == pytest.approx(fd, rel=0.05, abs=1e-6), p


### PR DESCRIPTION
## Summary

Continues `docs/axera-on-device-training-handoff.md`'s "What to do next" item #2. The resnet18 training step moved 42.9 MB/step because every trainable weight crossed the host boundary twice (in as an input, out as the gradient the host then applied). This puts `w_next = w - lr*grad` **in the graph itself** (plain SGD, matching `finetune.py`'s own host update), turning each trained weight into a state tensor (both input and output) that a resident runner can copy straight back device-to-device between `Execute()` calls.

- `scripts/axera/build_resident_train_step.py`: forward+loss -> `graph_grad.build_backward()` -> in-graph SGD update -> `legalize.TRAINING_RULES` -> simplify, producing a step graph whose trained weights are state (`qat_graph.StepGraph` sense).
- `scripts/axera/tools/resident_runner.c`: loads the compiled `.axmodel` once, keeps state device-resident (`-n` switches to a host round-trip for direct comparison).
- `tests/test_build_resident_train_step.py`: checks the in-graph update against finite differences on a small synthetic model -- no hardware needed.

## Measured, real AX650N, same four resnet18 tensors as the existing handoff doc

| | avg | min |
| --- | --- | --- |
| baseline (host applies the update, 42.9 MB/step) | 200.6 ms | -- |
| in-graph update, non-resident (state round-tripped through host) | 114.8 ms | 110.6 ms |
| in-graph update, resident (state device-to-device) | **38.3 ms** | 36.0 ms |

**5.2x**, short of the ~10x the handoff estimated -- a `--compiler.npu_perf` profile of the resident graph shows why: quantize/dequantize + transpose/slice glue around the live-weight-conv-to-matmul-tap legalization is now 75% of NPU cycles, not the transfer this change removed. Recorded in the handoff doc along with what's left in that direction.

## Test plan

- [x] `pytest tests/test_build_resident_train_step.py tests/test_axera_training_legalize.py tests/test_axera_emitter.py` -- 36 passed
- [x] `ruff check` / `ruff format --check` on the new Python files
- [x] `scripts/axera/tools/resident_runner.c` built and ran against a real compiled `.axmodel` on a real AX650N (via the LXD VM this environment's card is passed through to); numbers above are from that run
- [x] In-graph gradient verified against `onnxruntime` finite differences on host, both for the synthetic test fixture and (ad hoc, during development) the full resnet18 step graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W