### PR TITLE
axera: quantize-tax negative finding, then the transpose fix that landed

### DIFF
--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -158,9 +158,62 @@ transpose/slice glue, not arithmetic** -- the tax `act_weight_conv_to_matmul`
 pays for turning a live-weight `Conv` into per-tap `MatMul`s (each tap needs
 its own `Slice` and `Transpose`, and apparently its own quantization
 boundary). Residency removed the *transfer* bottleneck; this is what is left,
-and it is now the bigger one. Untried: whether `fuse=True`'s single wide
-matmul-per-conv (already default) can be pushed further, or whether the
-per-tap quantize/dequantize pairs can be coalesced.
+and it is now the bigger one.
+
+### The quantize redundancy is real, and not fixable from the ONNX side
+
+Each trainable weight is read directly by **three** nodes -- the forward
+conv-as-matmul's weight-transpose, its own gradient's reshape, and the
+in-graph SGD `Sub` -- and Pulsar2 inserts a **separate `AxQuantizeLinear` per
+edge** rather than sharing one quantized copy: confirmed on the compiled
+graph, `fc.weight` and all three `layer4` weights are each quantized 2-3
+times, while **no ordinary multi-consumer activation in the same graph is
+ever requantized more than once**. Checking the quantize nodes' own
+parameters found the redundancy is partly real: two of the three edges for
+`layer4.1.conv1`'s weight (the forward-matmul path and the gradient-reshape
+path) quantize to the *identical* domain (`S8`, `scale=0.00209808`,
+`zeropoint=0`) -- genuinely the same computation, done twice. The third (the
+SGD-update `Sub`) quantizes to a different domain entirely (`U8`,
+`scale=0.00209251`, `zeropoint=128`), so that one is not redundant: the
+update path legitimately needs its own quantization range.
+
+**Tried and failed: routing all three edges through one shared node.** Two
+spellings, both mathematically identity and both checked bit-exact against
+the un-rewritten graph on host (`onnxruntime`, max abs diff `0.0`):
+
+| shared-node spelling | result |
+| --- | --- |
+| `Reshape(w, same_shape)` | no change |
+| `Mul(w, ones_like(w))` | no change |
+
+Both compiled to the **exact same 213-node optimized/quantized graph**
+(`frontend/optimized_quant_axmodel.onnx`) and the **exact same
+`max_cycle`** (31,369,216) as the unmodified graph -- Pulsar2's own frontend
+optimizer canonicalizes a same-shape `Reshape` and a multiply-by-a-literal-
+all-ones-constant as identities and removes them **before** its
+quantization-boundary insertion pass runs, independent of anything onnxsim
+did upstream (both variants only needed `onnxsim.simplify()`'s
+`eliminate_nop_reshape` to *not* run, which it didn't here since these were
+inserted after the last `simplify()` call -- and it made no difference,
+because Pulsar2 does the same collapse internally regardless). This is a
+different failure shape than the `Gemm`-reconstruction bug elsewhere in this
+document: that fix worked by changing *which pattern matches* (a 1-D bias
+vs. a `[1, N]` one); there is no equivalent lever here, because the thing
+being matched is generic identity-elimination, not a specific fusion
+pattern with a shape precondition to dodge.
+
+**So this one op-type share is confirmed structural, not an oversight
+onnxsim's graph shape controls.** Whatever decides Pulsar2 requantizes a
+live-weight input per direct consumer instead of per distinct
+(source, quantization-domain) pair is internal to Pulsar2's own frontend
+compiler; there is no ONNX-graph-level lever this project has access to that
+moves it. Not investigated: whether Pulsar2's `layer_configs` can pin one
+named intermediate's quantization domain such that two edges are *forced*
+into the same domain by construction rather than merely happening to match
+-- worth trying if this is revisited, but it wasn't tried here since the two
+redundant edges already match by calibration coincidence, not by any config
+this project controls, so forcing it would need to survive the same
+collapse just demonstrated.
 
 Correctness was checked the same way as the rest of this document -- a
 directional-derivative check against `onnxruntime` on host (not the on-device
@@ -255,8 +308,20 @@ hand and so calls `simplify()` itself, with the same skip list.
    38.3 ms/step) -- see "Weights resident with in-graph updates" above.
    What's left in this direction: the quantize/dequantize + transpose/slice
    glue around `act_weight_conv_to_matmul`'s per-tap decomposition is now
-   *the* cost (75% of NPU cycles, per the profile above) -- worth another
-   pass on its own before reaching for anything else here.
+   *the* cost (75% of NPU cycles, per the profile above). The
+   quantize/dequantize half (48.8%) was tried and is **confirmed structural**
+   -- see "The quantize redundancy is real, and not fixable from the ONNX
+   side" above, two independent fixes both silently collapsed by Pulsar2's
+   own optimizer. **Untried and the more promising remaining half: the
+   `AxTranspose`/`AxSlice` 26.3%.** `act_weight_conv_to_matmul` transposes
+   the activation to `[N, spatial..., Cin]` and slices out each of the K**2
+   taps -- worth checking whether the transpose is being redone once per tap
+   (K**2 transposes of overlapping data) when it could be hoisted to run
+   once per convolution, with every tap's `Slice` reading from that single
+   transposed tensor. Unlike the quantize case, this is squarely onnxsim's
+   own graph shape (the rule's own emission order), not something Pulsar2's
+   optimizer stands between -- a materially different kind of lever than the
+   one that just failed.
 3. **All 23 tensors, and 224x224.** Only the last four layers and a 64x64 input
    have been built.
 4. **An optimiser beyond SGD.** `qat_graph.adam_update` exists and has never

--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -113,7 +113,7 @@ Batch size is nearly free until it is not: batch 1 to 16 costs 0.38 ms
 (1.40 -> 1.78) for **12.6x** the throughput; batch 64 is worse *per sample*
 than 16.
 
-### Weights resident with in-graph updates: 5.2x, measured
+### Weights resident with in-graph updates: 7.0x, measured
 
 The 42.9 MB the resnet18 step moves is every trainable weight crossing the
 host boundary twice -- once in as a graph input, once back out as the
@@ -133,13 +133,16 @@ Same four tensors, same `resnet18d` shape, real AX650N, 30 timed steps after
 | --- | --- | --- |
 | baseline (host applies `w -= lr*grad`, 42.9 MB/step) | 200.6 ms | -- |
 | in-graph update, **non-resident** (`-n`: state round-tripped through host) | 114.8 ms | 110.6 ms |
-| in-graph update, **resident** (state copied device-to-device) | **38.3 ms** | 36.0 ms |
+| in-graph update, **resident** (state copied device-to-device) | 38.3 ms | 36.0 ms |
+| resident + `_linearize_trainable_convs` (no weight transpose) | **28.6 ms** | 26.3 ms |
 
-**5.2x**, not quite the "roughly 10x" estimated -- real, and short of the
-estimate for a real reason (below), not a measurement artifact: the
-non-resident row isolates that some of the win is just the in-graph update
-itself (fewer distinct tensors cross the wire even before residency helps),
-and the resident row is the full effect.
+**5.2x** from residency alone, not quite the "roughly 10x" estimated -- real,
+and short of the estimate for a real reason (below), not a measurement
+artifact: the non-resident row isolates that some of the win is just the
+in-graph update itself (fewer distinct tensors cross the wire even before
+residency helps), and the resident row is the full effect. Removing the
+weight-transpose tax (last row, see below) pushes the total to **7.0x**
+(200.6 ms -> 28.6 ms).
 
 A `--compiler.npu_perf` profile of the resident graph (`pulsar2_docker.
 build(profile=True)`, see `scripts/axera/README.md`'s "Real NPU profiling"
@@ -224,6 +227,90 @@ near-zero dummy batch's loss landed at 0.1416 on the card against 0.0972 from
 the fp32 host reference, the right order of magnitude for INT8 quantization
 noise on an untuned calibration set, not a wiring bug.
 
+### The transpose/slice half was fixable, from the ONNX side -- 28% more
+
+Unlike the quantize half, the `AxTranspose`/`AxSlice` 26.3% *was* squarely
+onnxsim's own graph shape, and a real fix landed. The suspect going in was
+per-tap transpose duplication (`act_weight_conv_to_matmul` redoing the
+activation transpose once per tap instead of once per convolution) -- reading
+the rule directly showed that hypothesis was **wrong**: the transpose is
+already hoisted once per convolution, both for the activation and the weight.
+The actual cost was almost entirely (89.6% of the whole step's `AxTranspose`
+cycles) the **weight** transpose alone, `[Cout, Cin, k...] -> [k..., Cin,
+Cout]`, on exactly the two 512-channel trainable convs -- large enough
+(2.36 MB) that Pulsar2 shards it into 16 hardware sub-instructions per
+occurrence, each costing the same ~184K cycles, and it is recomputed from
+scratch on every `Execute()` even though the weight it operates on is now
+resident state that barely changes step to step.
+
+**Why not just pre-transpose the state once and keep it in that layout.**
+That was the first attempt, and it numerically works (a finite-difference
+check confirmed it) but is not what shipped: `act_weight_conv_to_matmul`'s
+own construction needs `Pad`/`Slice`/`Concat`, and `onnxsim.graph_grad` has
+no gradient rule for any of the three -- built-in or registerable without
+hand-writing three new ones (`graph_grad.register_gradient`/`custom_gradient`
+exist for exactly this, but three new rules is a materially bigger, riskier
+change than what actually fixed this).
+
+**What shipped instead: avoid needing a weight transpose at all.**
+`onnxsim.graph_grad._grad_conv` already differentiates a live-weight `Conv`
+without emitting a convolution, by the same im2col identity its own
+docstring spells out:
+
+```
+col[c, t, o] = X[c, position(o, t)]      (im2col: one Gather)
+Y[m, o]      = sum_{c, t} W[m, c, t] * col[c, t, o]
+```
+
+-- where `W` reshaped to `[M, C*K]` is `w.reshape(Cout, -1)`, a **free**
+C-order reshape of the weight's original `[Cout, Cin, k...]` layout (`Cin`
+is already the second axis, `k...` already trailing), unlike
+`act_weight_conv_to_matmul`'s `[k..., Cin, Cout]`, which moves `Cout` from
+first to last and is what actually costs. `build_resident_train_step.py`'s
+`_linearize_trainable_convs` now builds the **forward** pass this same way
+-- reusing `graph_grad`'s own `_conv_geometry`/`_im2col_indices` so the
+index/mask tables are exactly the ones `_grad_conv` would derive for the
+same node -- for every trainable `Conv`, *before* `build_backward` ever
+runs. Since `Gather`/`Mul`/`MatMul`/`Reshape` are all builtin-differentiable,
+`build_backward` needs no custom gradient registration at all, and the
+gradient comes out in `w`'s original, unchanged shape -- state stays exactly
+the shape it always was, `params`/`state`/`shapes[p]` unaffected.
+
+Verified on host first (`tests/test_build_resident_train_step.py`'s new
+`test_linearize_trainable_convs_matches_conv_and_drops_the_weight_transpose`:
+the two resnet18 geometries this actually has to handle -- a strided, biased
+1x1 downsample and a padded, stride-1, biased 3x3, with and without bias --
+matched plain `Conv` on `onnxruntime` to `1e-4`, and no `Transpose` reads the
+weight), then on real hardware, same calibration/build methodology as the
+quantize-half check above:
+
+| | max_cycle | step time (avg / min) |
+| --- | --- | --- |
+| before (weight-transpose per step) | 31,369,216 | 37.5 ms / 35.4 ms |
+| after (`_linearize_trainable_convs`) | 22,625,104 | **28.6 ms / 26.3 ms** |
+
+**-27.9% max_cycle, -23.6% step time** (28.07M vs the naive 45.56M cycle-sum
+this section's profile table was built from -- **-38.4%** by that metric).
+Fresh profile of the "after" graph: `AxTranspose` fell from 6,762,810 cycles
+(14.8% of the old total) to 228,012 (0.8% of the new, smaller total) --
+essentially gone, and better than the design aimed for: Pulsar2's own
+lowering turned the `Gather`s this rule emits into native `AxSlice`
+instructions wherever the index pattern was regular enough to allow it (no
+`AxGather` appears in the new profile at all), cheaper than asking for a
+`Gather` outright. `AxSlice` itself dropped too, 5,239,500 -> 3,550,346
+cycles. `AxQuantizeLinear`/`AxDequantizeLinear` are now the dominant cost by
+a wide margin (56.7% combined of the new, smaller total) -- `AxDequantizeLinear`
+is unchanged in absolute cycles (6,553,923, exactly the old number), which is
+the same structural quantize-per-consumer tax the previous section already
+found and closed; not reinvestigated here.
+
+Committed as `scripts/axera/build_resident_train_step.py`'s
+`_linearize_trainable_convs`, exercised by the new test above plus the
+existing `test_state_output_is_sgd_update_of_the_input`/
+`test_in_graph_gradient_matches_finite_differences` (unchanged, still
+passing -- this function changes nothing any test outside it observes,
+by design).
+
 ## Two vendor bugs, both silent
 
 **`ReduceMean` with no `axes` reduces only the last axis.** ONNX reduces all of
@@ -304,24 +391,28 @@ hand and so calls `simplify()` itself, with the same skip list.
 
 1. **The FP32 gradient seed.** The one untried route past the dying gradient,
    and the difference between a 5,000-step horizon and an open-ended one.
-2. ~~Weights resident with in-graph updates.~~ **Done: 5.2x** (200.6 ms ->
-   38.3 ms/step) -- see "Weights resident with in-graph updates" above.
-   What's left in this direction: the quantize/dequantize + transpose/slice
-   glue around `act_weight_conv_to_matmul`'s per-tap decomposition is now
-   *the* cost (75% of NPU cycles, per the profile above). The
-   quantize/dequantize half (48.8%) was tried and is **confirmed structural**
-   -- see "The quantize redundancy is real, and not fixable from the ONNX
-   side" above, two independent fixes both silently collapsed by Pulsar2's
-   own optimizer. **Untried and the more promising remaining half: the
-   `AxTranspose`/`AxSlice` 26.3%.** `act_weight_conv_to_matmul` transposes
-   the activation to `[N, spatial..., Cin]` and slices out each of the K**2
-   taps -- worth checking whether the transpose is being redone once per tap
-   (K**2 transposes of overlapping data) when it could be hoisted to run
-   once per convolution, with every tap's `Slice` reading from that single
-   transposed tensor. Unlike the quantize case, this is squarely onnxsim's
-   own graph shape (the rule's own emission order), not something Pulsar2's
-   optimizer stands between -- a materially different kind of lever than the
-   one that just failed.
+2. ~~Weights resident with in-graph updates.~~ **Done: 7.0x** (200.6 ms ->
+   28.6 ms/step) -- see "Weights resident with in-graph updates" above.
+   Residency alone was 5.2x; `_linearize_trainable_convs` (avoiding the
+   per-step weight transpose `act_weight_conv_to_matmul` was paying,
+   confirmed 89.6% of the whole step's `AxTranspose` cost) pushed it the
+   rest of the way. Both sub-bottlenecks the profile originally flagged are
+   now resolved one way or another: quantize/dequantize (48.8%) is
+   **confirmed structural** (Pulsar2's own optimizer, not onnxsim's graph
+   shape -- see "The quantize redundancy is real, and not fixable from the
+   ONNX side"); transpose/slice (26.3%) is **fixed** (see "The
+   transpose/slice half was fixable, from the ONNX side -- 28% more").
+   What's left in this direction: `AxQuantizeLinear`/`AxDequantizeLinear` are
+   now 56.7% of the (smaller) remaining total on a fresh profile of the fixed
+   graph -- `AxDequantizeLinear`'s absolute cycle count is unchanged from
+   before this fix (6,553,923, exactly), so it is very likely the same
+   structural tax already investigated and not a new lead; not
+   reinvestigated. No further concrete, well-scoped lever was found in the
+   op-type profile this iteration -- the next win in this direction, if
+   there is one, likely needs a different angle than "which op type costs
+   the most cycles" (e.g. batching more than one training step's worth of
+   work per `Execute()` call, amortizing whatever fixed per-call overhead
+   remains).
 3. **All 23 tensors, and 224x224.** Only the last four layers and a 64x64 input
    have been built.
 4. **An optimiser beyond SGD.** `qat_graph.adam_update` exists and has never

--- a/scripts/axera/build_resident_train_step.py
+++ b/scripts/axera/build_resident_train_step.py
@@ -82,7 +82,7 @@ from typing import Dict, Sequence, Tuple
 
 import numpy as np
 import onnx
-from onnx import TensorProto, helper
+from onnx import TensorProto, helper, numpy_helper
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 if HERE not in sys.path:
@@ -106,6 +106,182 @@ _POST_BACKWARD_RULES = (
     "gemm_to_matmul",
     "act_weight_conv_to_matmul",
 )
+
+
+def _linearize_trainable_convs(
+    model: onnx.ModelProto, params: Sequence[str]
+) -> onnx.ModelProto:
+    """Rewrites each `Conv` node whose weight is in `params` from `Conv(x,
+    w)` into the *same* im2col-as-gather identity `onnxsim.graph_grad`'s own
+    `_grad_conv` already uses internally for this op's backward -- one
+    `Gather`/`Mul`(mask)/`MatMul`, no `Transpose` of the weight at all.
+
+    Why this exists, and why `legalize.act_weight_conv_to_matmul` is not
+    enough: this weight is about to become **state** -- an input *and* an
+    output of a graph run repeatedly by a resident runner that keeps state
+    device-side between calls (see this module's docstring). Left as a plain
+    `Conv(x, w)`, `act_weight_conv_to_matmul` legalizes it by transposing `w`
+    from `[Cout, Cin, k...]` into `[k..., Cin, Cout]` *inside the compiled
+    graph* -- correct for a one-shot inference graph, but on a real AX650N
+    that transpose is recomputed from scratch on every `Execute()` call even
+    though the weight barely changes step to step: measured (real hardware,
+    `pulsar2 build --compiler.npu_perf`) at 89.6% of the whole step's
+    `AxTranspose` cost and 13.3% of total NPU cycles, entirely from the two
+    512-channel trainable convs (`docs/axera-on-device-training-
+    handoff.md`'s "AxTranspose/AxSlice glue" section).
+
+    The fix is not to *move* that transpose to build time (an earlier
+    version of this function tried exactly that, pre-transposing the weight
+    once in host numpy and keeping state in the transposed layout -- it
+    numerically works, but `graph_grad.build_backward` cannot differentiate
+    the `Pad`/`Slice`/`Concat` nodes `act_weight_conv_to_matmul`'s own
+    construction needs, none of which have a gradient rule, built-in or
+    registerable without hand-writing three new ones). The fix is to **avoid
+    needing a weight transpose in the first place**: `_grad_conv`'s own
+    docstring spells out the identity --
+
+        col[c, t, o] = X[c, position(o, t)]      (im2col: one gather)
+        Y[m, o]      = sum_{c, t} W[m, c, t] * col[c, t, o]
+
+    -- where "W reshaped to `[M, C*K]`" is `w.reshape(Cout, -1)`, a plain
+    C-order reshape of the *original* `[Cout, Cin, k...]` layout with no
+    data movement at all, because `Cin` is already `W`'s second axis and
+    `k...` are already trailing -- unlike `act_weight_conv_to_matmul`'s
+    `[k..., Cin, Cout]`, which moves `Cout` from first to last. Building the
+    forward pass with this identity (reusing `graph_grad`'s own
+    `_conv_geometry`/`_im2col_indices` so the index/mask tables are exactly
+    the ones `_grad_conv` would derive for the same node) means: no weight
+    transpose ever appears, `Gather`/`Mul`/`MatMul`/`Reshape` are all
+    builtin-differentiable so `build_backward` needs no custom gradient
+    registration either, and the gradient it produces is already in `w`'s
+    original, unchanged shape -- so **state stays exactly the shape it
+    always was**, nothing above this function (`params`, `state`,
+    `shapes[p]`) changes at all.
+
+    A `Conv` this function declines (see `_conv_geometry`'s own refusals:
+    not 1-D/2-D, `auto_pad`, a geometry that does not reproduce its declared
+    output shape, ...; grouped convs are declined here directly, since the
+    identity above assumes `group=1`) is left untouched and still caught by
+    `act_weight_conv_to_matmul` later in `_POST_BACKWARD_RULES` -- this
+    function is an optimization for the common case (an ungrouped 1-D/2-D
+    conv, which is every trainable conv resnet18 has), not a superset of
+    that rule's coverage.
+    """
+    shapes = legalize._value_shapes(model)
+    initializers = {t.name: t for t in model.graph.initializer}
+    trained = set(params)
+    out_nodes = []
+    linearized = set()
+
+    for node in model.graph.node:
+        w = node.input[1] if node.op_type == "Conv" and len(node.input) > 1 else None
+        if w is None or w not in trained or not legalize._is_initializer(model, w):
+            out_nodes.append(node)
+            continue
+
+        w_array = numpy_helper.to_array(initializers[w])
+        x_shape, y_shape = shapes.get(node.input[0]), shapes.get(node.output[0])
+        if not x_shape or not y_shape:
+            out_nodes.append(node)
+            continue
+        try:
+            group, kernel, strides, dilations, pads_begin = graph_grad._conv_geometry(
+                node, tuple(x_shape), tuple(w_array.shape), tuple(y_shape)
+            )
+        except graph_grad.UnsupportedOpError:
+            out_nodes.append(node)
+            continue
+        if group != 1:
+            out_nodes.append(node)  # the reshape identity below assumes group=1
+            continue
+
+        cout, cin = int(w_array.shape[0]), int(w_array.shape[1])
+        in_dims, out_dims = [int(d) for d in x_shape[2:]], [int(d) for d in y_shape[2:]]
+        taps = graph_grad._prod(kernel)
+        in_count, out_count = graph_grad._prod(in_dims), graph_grad._prod(out_dims)
+        index, mask = graph_grad._im2col_indices(
+            in_dims, out_dims, kernel, strides, dilations, pads_begin
+        )
+
+        stem = node.name or node.output[0]
+        made = []
+
+        def const(array, hint):
+            name = legalize._unique_name(model, f"{stem}_{hint}")
+            model.graph.initializer.append(numpy_helper.from_array(array, name))
+            return name
+
+        def op(op_type, inputs, hint, **attrs):
+            out = legalize._unique_name(model, f"{stem}_{hint}")
+            made.append(
+                helper.make_node(
+                    op_type,
+                    inputs,
+                    [out],
+                    name=legalize._unique_name(model, f"{stem}_{hint.upper()}"),
+                    **attrs,
+                )
+            )
+            return out
+
+        batch = int(x_shape[0])
+        x3 = op(
+            "Reshape",
+            [node.input[0], const(np.array([batch, cin, in_count], np.int64), "x3s")],
+            "x3",
+        )
+        gathered = op(
+            "Gather",
+            [x3, const(np.array(index, np.int64), "idx")],
+            "gathered",
+            axis=2,
+        )
+        masked = op(
+            "Mul",
+            [
+                gathered,
+                const(mask.reshape(1, 1, taps * out_count).astype(np.float32), "mask"),
+            ],
+            "masked",
+        )
+        col = op(
+            "Reshape",
+            [masked, const(np.array([batch, cin * taps, out_count], np.int64), "cols")],
+            "col",
+        )
+        w2 = op(
+            "Reshape",
+            [w, const(np.array([cout, cin * taps], np.int64), "w2s")],
+            "w2",
+        )
+        y3 = op(
+            "MatMul", [w2, col], "mm"
+        )  # [Cout,C*K] x [batch,C*K,out] -> [batch,Cout,out]
+        if len(node.input) > 2 and node.input[2]:
+            bias4 = op(
+                "Reshape",
+                [node.input[2], const(np.array([1, cout, 1], np.int64), "bs")],
+                "bias3",
+            )
+            y3 = op("Add", [y3, bias4], "biased")
+        # [batch, Cout, out_count] -> [batch, Cout, *out_dims], the original
+        # Conv's own declared output shape/name.
+        made.append(
+            helper.make_node(
+                "Reshape",
+                [y3, const(np.array([batch, cout] + out_dims, np.int64), "ys")],
+                [node.output[0]],
+                name=legalize._unique_name(model, f"{stem}_Y"),
+            )
+        )
+
+        out_nodes.extend(made)
+        linearized.add(w)
+
+    if linearized:
+        del model.graph.node[:]
+        model.graph.node.extend(out_nodes)
+    return model
 
 
 def add_mse_loss(
@@ -170,6 +346,15 @@ def build_resident_step(
     legalize.avgpool_ceil_to_floor(model)
     legalize.flatten_to_reshape(model)
     legalize.global_pool_to_reduce(model)
+    onnx.checker.check_model(model)
+
+    # Pre-transpose any trainable Conv's weight into matmul layout now, in
+    # host numpy, once -- instead of leaving `act_weight_conv_to_matmul` to
+    # rebuild that transpose on the device every step. See
+    # `_linearize_trainable_convs`'s own docstring for the measured cost
+    # this removes; `params`'/`state`'s names are unaffected, only the
+    # linearized weights' shapes change.
+    model = _linearize_trainable_convs(model, params)
     onnx.checker.check_model(model)
 
     shapes, elem_types = _static_shapes_and_types(model)

--- a/tests/test_build_resident_train_step.py
+++ b/tests/test_build_resident_train_step.py
@@ -161,3 +161,58 @@ def test_in_graph_gradient_matches_finite_differences():
         fd = (loss_at(w_plus) - loss_at(w_minus)) / (2 * eps)
         predicted = float((grads[p] * d).sum())
         assert predicted == pytest.approx(fd, rel=0.05, abs=1e-6), p
+
+
+def test_linearize_trainable_convs_matches_conv_and_drops_the_weight_transpose():
+    """`_linearize_trainable_convs`'s whole reason to exist:
+    `legalize.act_weight_conv_to_matmul` (run later, on the *step* graph)
+    legalizes a live-weight `Conv` by transposing its weight into matmul
+    layout -- measured on real AX650N hardware at 89.6% of the step's
+    `AxTranspose` cost, recomputed from scratch every step for a weight that
+    is now resident state and barely changes step to step
+    (`docs/axera-on-device-training-handoff.md`). This checks the
+    replacement directly: same numbers as `Conv` (including the two
+    resnet18 geometries this actually has to handle -- a strided, biased 1x1
+    downsample and a padded, stride-1, biased 3x3), and no `Transpose` node
+    reads the weight at all.
+    """
+    rng = np.random.default_rng(4)
+    for cin, cout, k, size, stride, pad, has_bias in (
+        (16, 32, 1, 8, 2, 0, True),  # resnet18's downsample conv
+        (16, 16, 3, 8, 1, 1, True),  # resnet18's 3x3 conv, post-BN-fold bias
+        (16, 16, 3, 8, 1, 1, False),  # no bias, the pre-fold shape
+    ):
+        out = (size + 2 * pad - k) // stride + 1
+        cw = (rng.standard_normal((cout, cin, k, k)) * 0.2).astype(np.float32)
+        cb = (rng.standard_normal(cout) * 0.1).astype(np.float32) if has_bias else None
+        model = parser.parse_model(
+            f"""
+            <
+              ir_version: 10,
+              opset_import: ["": 17]
+            >
+            g (float[1,{cin},{size},{size}] x) => (float[1,{cout},{out},{out}] y)
+            {{
+              y = Conv<kernel_shape=[{k},{k}], strides=[{stride},{stride}],
+                       pads=[{pad},{pad},{pad},{pad}]>(x, cw{", cb" if has_bias else ""})
+            }}
+            """
+        )
+        inits = [_f32(cw, "cw")]
+        if has_bias:
+            inits.append(_f32(cb, "cb"))
+        model.graph.initializer.extend(inits)
+
+        x = rng.standard_normal((1, cin, size, size)).astype(np.float32)
+        (ref,) = _run(model, {"x": x}, ["y"])
+
+        linearized = brts._linearize_trainable_convs(
+            onnx.shape_inference.infer_shapes(model), ["cw"]
+        )
+        onnx.checker.check_model(linearized)
+        assert not any(
+            n.op_type == "Transpose" and "cw" in n.input for n in linearized.graph.node
+        )
+        (got,) = _run(linearized, {"x": x}, ["y"])
+        assert got.shape == ref.shape
+        assert np.allclose(got, ref, atol=1e-4), (cin, cout, k, stride, pad, has_bias)


### PR DESCRIPTION
## Summary
- Continues #1335's resident-training-step speedup. Its NPU profile found 75% of cycles going to quantize/dequantize + transpose/slice glue; this PR chases both halves.
- **Quantize/dequantize half (48.8%): confirmed structural, no code change.** Each trainable weight is read by three nodes (forward conv-as-matmul, its own gradient, the in-graph SGD update); Pulsar2 inserts a separate `AxQuantizeLinear` per edge instead of sharing one. Two of the three edges genuinely match in quantization domain and are true redundancy. Tried forcing them to share one node two ways (`Reshape` to the same shape, `Mul` by an all-ones constant), both bit-exact on host. Both compiled to the exact same 213-node optimized graph and exact same `max_cycle` as doing nothing -- Pulsar2's own frontend optimizer canonicalizes both as identities before its quantization-boundary pass runs, independent of onnxsim.
- **Transpose/slice half (26.3%): fixed.** The suspect (per-tap transpose duplication) was wrong -- `act_weight_conv_to_matmul` already hoists the transpose once per conv. The real cost (89.6% of `AxTranspose`) was the *weight* transpose alone on the two 512-channel trainable convs, recomputed from scratch every step on now-resident state. Pre-transposing the state doesn't work (needs `Pad`/`Slice`/`Concat`, none of which `graph_grad` has a gradient rule for). The fix: build the forward pass the same im2col-as-gather way `graph_grad._grad_conv` already differentiates it internally -- `w.reshape(Cout, -1)` is a *free* reshape of the original layout, so the whole conv becomes `Gather`/`Mul`(mask)/`MatMul`, all builtin-differentiable, no weight transpose at all.
- Measured on real AX650N hardware, same before/after methodology both times: quantize attempt made no change (31,369,216 max_cycle before and after); transpose fix took it to 22,625,104 (-27.9%), and step time from 37.5ms to 28.6ms (-23.6%) with the resident runner. Combined with #1335's residency win: **200.6ms -> 28.6ms, 7.0x total** (up from 5.2x).

## Test plan
- [x] `python3 -m pytest tests/test_build_resident_train_step.py tests/test_axera_training_legalize.py -q` -- 8 passed, including a new test verifying the linearized conv matches `onnxruntime`'s native `Conv` (1x1 strided+biased, 3x3 padded+biased, 3x3 unbiased) and that no `Transpose` reads the weight
- [x] Both quantize-dedupe attempts verified bit-exact against the unmodified graph on host before compiling
- [x] The transpose fix compiled and ran on the real AX650N (via this environment's `axcl-vm` LXD VM), fresh `--compiler.npu_perf` profile confirms `AxTranspose` dropped from 6.76M to 0.23M cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W