### PR TITLE
Add a Voyager (Axelera Metis AIPU) legalizer: op coverage + equivalent rewrites

### DIFF
--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -26,6 +26,7 @@
 #include "passes/eliminate_reshape_family_on_constant.h"
 #include "passes/eliminate_sequence_at_construct.h"
 #include "passes/eliminate_sequence_length_construct.h"
+#include "passes/explicit_auto_pad.h"
 #include "passes/fp6_llm.h"
 #include "passes/fuse_add_bias_into_conv.h"
 #include "passes/fuse_attention.h"
@@ -48,11 +49,13 @@
 #include "passes/fuse_rms_norm.h"
 #include "passes/fuse_rope.h"
 #include "passes/fuse_split_gather_concat.h"
+#include "passes/gemm_transa_to_transpose.h"
 #include "passes/gguf_legacy_quant.h"
 #include "passes/gguf_q6_k.h"
 #include "passes/gguf_ternary_quant.h"
 #include "passes/iq4_nl.h"
 #include "passes/magnitude_pruning.h"
+#include "passes/maxpool_rowmajor_when_indices_unused.h"
 #include "passes/qoperator_quantize_activation.h"
 #include "passes/qoperator_quantize_concat.h"
 #include "passes/qoperator_quantize_conv.h"
@@ -142,6 +145,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::EliminateReshapeFamilyOnConstant>(registry);
     RegisterOrReplace<p::EliminateSequenceAtConstruct>(registry);
     RegisterOrReplace<p::EliminateSequenceLengthConstruct>(registry);
+    RegisterOrReplace<p::ExplicitAutoPad>(registry);
     RegisterOrReplace<p::Fp6Llm>(registry);
     RegisterOrReplace<p::FuseAttention>(registry);
     RegisterOrReplace<p::FuseConsecutiveMul>(registry);
@@ -158,6 +162,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::FuseRMSNorm>(registry);
     RegisterOrReplace<p::FuseRope>(registry);
     RegisterOrReplace<p::FuseSplitGatherConcat>(registry);
+    RegisterOrReplace<p::GemmTransAToTranspose>(registry);
     RegisterOrReplace<p::GgufQ4_0>(registry);
     RegisterOrReplace<p::GgufQ4_1>(registry);
     RegisterOrReplace<p::GgufQ6K>(registry);
@@ -167,6 +172,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::MagnitudePruningConv>(registry);
     RegisterOrReplace<p::MagnitudePruningGlobal>(registry);
     RegisterOrReplace<p::MagnitudePruningMatMul>(registry);
+    RegisterOrReplace<p::MaxPoolRowMajorWhenIndicesUnused>(registry);
     RegisterOrReplace<p::QOperatorQuantizeActivation>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConcat>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConv>(registry);

--- a/onnxsim/passes/explicit_auto_pad.h
+++ b/onnxsim/passes/explicit_auto_pad.h
@@ -1,0 +1,178 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// `Conv`/`AveragePool`/`MaxPool` with `auto_pad` in `SAME_UPPER`,
+// `SAME_LOWER` or `VALID` get `auto_pad = "NOTSET"` and the equivalent
+// explicit `pads`, computed from the ONNX operator spec's own `auto_pad`
+// formula: `VALID` is zero padding by definition; `SAME_UPPER`/`SAME_LOWER`
+// split the padding the output needs to reach `ceil(input / stride)`, the
+// extra pixel (if any) going to the end (`SAME_UPPER`) or the start
+// (`SAME_LOWER`). The two forms are defined to agree, so this changes
+// nothing about what the op computes, only how the padding amount is
+// spelled.
+//
+// Needs the input's spatial shape to be statically known -- the formula is
+// defined in terms of it -- so a node whose input shape isn't resolved (a
+// dynamic axis) is left alone rather than guessed at. `Conv`'s
+// `kernel_shape` attribute is optional (inferrable from the weight tensor
+// `W`, which exporters routinely omit it in favor of), so this reads the
+// kernel from `W`'s shape when the attribute is absent, matching how
+// `AIPU`/NPU compilers that publish this same `auto_pad == "NOTSET"`
+// requirement (e.g. Axelera Voyager SDK's Metis compiler -- see
+// `scripts/axelera/legalize.py`'s Python counterpart of this rule) read it.
+//
+// This is a pure graph-shape rewrite -- not a node-count reduction -- so it
+// is `PassType::Other` and never runs by default. Opt in with
+// `extra_optimizers=["explicit_auto_pad"]` (Python) or
+// `--enable-optimization explicit_auto_pad` (CLI).
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+namespace explicit_auto_pad_detail {
+
+// The statically-known spatial (i.e. all but the leading N, C) dims of a
+// rank `nd + 2` tensor, or false if the rank doesn't match or any spatial
+// dim is symbolic/unknown.
+inline bool StaticSpatialShape(const Value* v, size_t nd,
+                               std::vector<int64_t>& out) {
+  if (!v->has_sizes() || v->sizes().size() != nd + 2) {
+    return false;
+  }
+  out.clear();
+  out.reserve(nd);
+  for (size_t i = 2; i < nd + 2; ++i) {
+    const Dimension& d = v->sizes()[i];
+    if (!d.is_int) {
+      return false;
+    }
+    out.push_back(d.dim);
+  }
+  return true;
+}
+
+// ONNX's own `auto_pad` formula (see the `Conv` operator spec), as explicit
+// `(begin, end)` pads per spatial axis.
+inline void SamePads(const std::string& auto_pad,
+                     const std::vector<int64_t>& spatial_in,
+                     const std::vector<int64_t>& kernel,
+                     const std::vector<int64_t>& strides,
+                     const std::vector<int64_t>& dilations,
+                     std::vector<int64_t>& begin, std::vector<int64_t>& end) {
+  const size_t nd = kernel.size();
+  begin.assign(nd, 0);
+  end.assign(nd, 0);
+  if (auto_pad == "VALID") {
+    return;
+  }
+  for (size_t i = 0; i < nd; ++i) {
+    const int64_t out_size =
+        (spatial_in[i] + strides[i] - 1) / strides[i];  // ceil division
+    int64_t needed = (out_size - 1) * strides[i] +
+                     ((kernel[i] - 1) * dilations[i] + 1) - spatial_in[i];
+    if (needed < 0) {
+      needed = 0;
+    }
+    if (auto_pad == "SAME_UPPER") {
+      begin[i] = needed / 2;
+      end[i] = needed - begin[i];
+    } else {  // SAME_LOWER
+      end[i] = needed / 2;
+      begin[i] = needed - end[i];
+    }
+  }
+}
+
+}  // namespace explicit_auto_pad_detail
+
+struct ExplicitAutoPad final : public PredicateBasedPass {
+  explicit ExplicitAutoPad()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override { return "explicit_auto_pad"; }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (node->kind() != kConv && node->kind() != Symbol("AveragePool") &&
+        node->kind() != Symbol("MaxPool")) {
+      return false;
+    }
+    const std::string auto_pad = GetValueFromAttrWithDefault<std::string>(
+        node, Symbol("auto_pad"), std::string("NOTSET"));
+    return auto_pad != "NOTSET";
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    using explicit_auto_pad_detail::SamePads;
+    using explicit_auto_pad_detail::StaticSpatialShape;
+
+    const std::string auto_pad = GetValueFromAttrWithDefault<std::string>(
+        node, Symbol("auto_pad"), std::string("NOTSET"));
+
+    std::vector<int64_t> kernel;
+    if (node->hasAttribute(kkernel_shape)) {
+      kernel = node->is(kkernel_shape);
+    } else if (node->kind() == kConv && node->inputs().size() > 1) {
+      const Value* w = node->input(1);
+      if (!w->has_sizes()) {
+        return false;
+      }
+      for (size_t i = 2; i < w->sizes().size(); ++i) {
+        const Dimension& d = w->sizes()[i];
+        if (!d.is_int) {
+          return false;
+        }
+        kernel.push_back(d.dim);
+      }
+    }
+    if (kernel.empty()) {
+      return false;
+    }
+
+    std::vector<int64_t> spatial_in;
+    if (!StaticSpatialShape(node->input(0), kernel.size(), spatial_in)) {
+      return false;
+    }
+
+    std::vector<int64_t> strides(kernel.size(), 1);
+    if (node->hasAttribute(kstrides)) {
+      strides = node->is(kstrides);
+    }
+    std::vector<int64_t> dilations(kernel.size(), 1);
+    if (node->hasAttribute(kdilations)) {
+      dilations = node->is(kdilations);
+    }
+    if (strides.size() != kernel.size() || dilations.size() != kernel.size()) {
+      return false;
+    }
+
+    std::vector<int64_t> begin, end;
+    SamePads(auto_pad, spatial_in, kernel, strides, dilations, begin, end);
+
+    node->s_(Symbol("auto_pad"), std::string("NOTSET"));
+    std::vector<int64_t> pads(begin);
+    pads.insert(pads.end(), end.begin(), end.end());
+    node->is_(kpads, std::move(pads));
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/gemm_transa_to_transpose.h
+++ b/onnxsim/passes/gemm_transa_to_transpose.h
@@ -45,8 +45,7 @@ struct GemmTransAToTranspose final : public PredicateBasedPass {
     if (node->kind() != kGemm || node->inputs().empty()) {
       return false;
     }
-    return GetValueFromAttrWithDefault<int64_t>(node, ktransA, int64_t(0)) !=
-           0;
+    return GetValueFromAttrWithDefault<int64_t>(node, ktransA, int64_t(0)) != 0;
   }
 
   bool runTransform(Node* node, Graph& graph,

--- a/onnxsim/passes/gemm_transa_to_transpose.h
+++ b/onnxsim/passes/gemm_transa_to_transpose.h
@@ -1,0 +1,76 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// A `Gemm` with `transA = 1` gets an explicit `Transpose` on `A` instead,
+// with `transA` cleared. `A` is required to be rank 2 by the `Gemm` spec, so
+// `perm=[1, 0]` is always the right transpose -- `transA = 1` means
+// "transpose A before the matmul", and inserting the `Transpose` node ahead
+// of the `Gemm` is the same operation, spelled as two nodes instead of one
+// attribute. Some backends document `transA == 0` as a hard requirement
+// (e.g. Axelera Voyager SDK's Metis compiler -- see
+// `scripts/axelera/legalize.py`'s Python counterpart of this rule).
+//
+// This is a pure graph-shape rewrite -- not a node-count reduction -- so it
+// is `PassType::Other` and never runs by default. Opt in with
+// `extra_optimizers=["gemm_transA_to_transpose"]` (Python) or
+// `--enable-optimization gemm_transA_to_transpose` (CLI).
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct GemmTransAToTranspose final : public PredicateBasedPass {
+  explicit GemmTransAToTranspose()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "gemm_transA_to_transpose";
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (node->kind() != kGemm || node->inputs().empty()) {
+      return false;
+    }
+    return GetValueFromAttrWithDefault<int64_t>(node, ktransA, int64_t(0)) !=
+           0;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+
+    Value* a = node->input(0);
+
+    Node* transpose = graph.create(kTranspose, 1);
+    transpose->addInput(a);
+    transpose->is_(kperm, std::vector<int64_t>{1, 0});
+    transpose->insertBefore(node);
+    transpose->output()->setElemType(a->elemType());
+    if (a->has_sizes() && a->sizes().size() == 2) {
+      std::vector<Dimension> swapped{a->sizes()[1], a->sizes()[0]};
+      transpose->output()->setSizes(std::move(swapped));
+    }
+
+    node->replaceInput(0, transpose->output());
+    node->i_(ktransA, int64_t(0));
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/maxpool_rowmajor_when_indices_unused.h
+++ b/onnxsim/passes/maxpool_rowmajor_when_indices_unused.h
@@ -1,0 +1,67 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// A `MaxPool` with `storage_order = 1` (column-major) gets it cleared to 0
+// (row-major) whenever the optional `Indices` output isn't actually
+// consumed -- the attribute only orders that output (whether it's read out
+// row-major or column-major), so with no `Indices` consumer the two
+// settings compute the identical `Y`. Some backends document
+// `storage_order == 0` as a hard requirement (e.g. Axelera Voyager SDK's
+// Metis compiler -- see `scripts/axelera/legalize.py`'s Python counterpart
+// of this rule).
+//
+// This is a pure graph-shape rewrite -- so it is `PassType::Other` and
+// never runs by default. Opt in with
+// `extra_optimizers=["maxpool_rowmajor_when_indices_unused"]` (Python) or
+// `--enable-optimization maxpool_rowmajor_when_indices_unused` (CLI).
+
+#include <cstdint>
+#include <string>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct MaxPoolRowMajorWhenIndicesUnused final : public PredicateBasedPass {
+  explicit MaxPoolRowMajorWhenIndicesUnused()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "maxpool_rowmajor_when_indices_unused";
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (node->kind() != Symbol("MaxPool")) {
+      return false;
+    }
+    if (GetValueFromAttrWithDefault<int64_t>(node, kstorage_order,
+                                             int64_t(0)) == 0) {
+      return false;
+    }
+    // Indices is produced (a second output was declared) and consumed;
+    // its ordering is observable, so leave storage_order alone.
+    return !(node->outputs().size() > 1 &&
+            !node->outputs()[1]->uses().empty());
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    node->i_(kstorage_order, int64_t(0));
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/maxpool_rowmajor_when_indices_unused.h
+++ b/onnxsim/passes/maxpool_rowmajor_when_indices_unused.h
@@ -50,8 +50,7 @@ struct MaxPoolRowMajorWhenIndicesUnused final : public PredicateBasedPass {
     }
     // Indices is produced (a second output was declared) and consumed;
     // its ordering is observable, so leave storage_order alone.
-    return !(node->outputs().size() > 1 &&
-            !node->outputs()[1]->uses().empty());
+    return !(node->outputs().size() > 1 && !node->outputs()[1]->uses().empty());
   }
 
   bool runTransform(Node* node, Graph& graph,

--- a/scripts/axelera/README.md
+++ b/scripts/axelera/README.md
@@ -99,6 +99,34 @@ if backend.has_axelera_compiler():
     print(result["bit_identical"], result["max_abs_diff"])
 ```
 
+## Legalizing: fixing what `evaluate_constraints()` finds
+
+`legalize.py` holds semantics-preserving rewrites for three of the scraped
+constraints -- the ones with a fix that's an exact rewrite, not just
+"avoid this op": `Conv`/`AveragePool`/`MaxPool`'s `auto_pad == "NOTSET"`
+requirement (this is the same rule the real compiler's own warning quoted
+back, above), `Gemm`'s `transA == 0`, and `MaxPool`'s `storage_order == 0`
+when the `Indices` output goes unused. See `legalize.py`'s module docstring
+for exactly what backs each rule and its real caveats (in particular:
+`gemm_transA_to_transpose`'s inserted `Transpose` is itself outside what
+the scraped `Transpose` rule covers for a rank-2 tensor).
+
+```python
+import legalize
+
+model = onnx.load("model.onnx")
+applied = legalize.legalize(model)  # {rule_name: sites changed}
+onnx.save(model, "model.legalized.onnx")
+```
+
+Or from the command line: `legalize.py in.onnx out.onnx`. `tests/
+test_axelera_legalize.py` checks each rule both structurally (against the
+ONNX operator spec's own `auto_pad` formula) and numerically (`onnx.
+reference.ReferenceEvaluator`, before vs. after), and cross-checks the
+`evaluate_constraints()` verdict flips from `"violated"` to `"ok"` where the
+rewrite is supposed to fully resolve a node -- none of that needs Docker,
+a device, or the optional `axelera-rt`/`axelera-devkit` install.
+
 ## Regenerating `voyager_op_support_data.py`
 
 The scraped data snapshot tracks whatever Voyager SDK checkout it was last

--- a/scripts/axelera/README.md
+++ b/scripts/axelera/README.md
@@ -111,15 +111,29 @@ for exactly what backs each rule and its real caveats (in particular:
 `gemm_transA_to_transpose`'s inserted `Transpose` is itself outside what
 the scraped `Transpose` rule covers for a rank-2 tensor).
 
+Run it **after** onnxsim's own simplify loop, not instead of it -- the same
+order `scripts/axera/README.md` found necessary (its Audio8 decoder walk-
+through gets the graph to float32 with fixed shapes via `onnxsim.simplify()`
+*before* any legalize rule runs). `explicit_auto_pad` in particular needs the
+input's spatial shape statically known, which is exactly what shape
+inference/constant folding inside `simplify()` resolves; handing it a graph
+`simplify()` hasn't already cleaned up just means more nodes it has to
+decline for a shape it can't yet see.
+
 ```python
+import onnx
+import onnxsim
 import legalize
 
 model = onnx.load("model.onnx")
-applied = legalize.legalize(model)  # {rule_name: sites changed}
+model, ok = onnxsim.simplify(model)  # the simplify loop, run to a fixed point
+assert ok
+applied = legalize.legalize(model)  # ... then legalize what it left explicit
 onnx.save(model, "model.legalized.onnx")
 ```
 
-Or from the command line: `legalize.py in.onnx out.onnx`. `tests/
+Or from the command line: `python3 -m onnxsim in.onnx simplified.onnx` then
+`legalize.py simplified.onnx out.onnx`. `tests/
 test_axelera_legalize.py` checks each rule both structurally (against the
 ONNX operator spec's own `auto_pad` formula) and numerically (`onnx.
 reference.ReferenceEvaluator`, before vs. after), and cross-checks the

--- a/scripts/axelera/README.md
+++ b/scripts/axelera/README.md
@@ -141,6 +141,36 @@ reference.ReferenceEvaluator`, before vs. after), and cross-checks the
 rewrite is supposed to fully resolve a node -- none of that needs Docker,
 a device, or the optional `axelera-rt`/`axelera-devkit` install.
 
+### The same three rules, natively in onnxsim's own C++ core
+
+`legalize.py` is a standalone script over a bare `onnx.ModelProto` -- useful
+on its own, but Python-only and a separate pass over the graph. The same
+three rewrites also exist as onnxsim C++ passes
+(`onnxsim/passes/explicit_auto_pad.h`, `gemm_transa_to_transpose.h`,
+`maxpool_rowmajor_when_indices_unused.h`), registered as opt-in
+`PassType::Other` optimizers -- so any onnxsim binding (Python, C, Rust,
+npm/WASM), not just this script, can run them, and they run *inside*
+`simplify()`'s own fixed point rather than as a second pass after it:
+
+```python
+model, ok = onnxsim.simplify(
+    model,
+    extra_optimizers=[
+        "explicit_auto_pad",
+        "gemm_transA_to_transpose",
+        "maxpool_rowmajor_when_indices_unused",
+    ],
+)
+```
+
+or `onnxsim in.onnx out.onnx --enable-optimization explicit_auto_pad
+--enable-optimization gemm_transA_to_transpose --enable-optimization
+maxpool_rowmajor_when_indices_unused` from the CLI. See
+`tests/test_explicit_auto_pad.py`, `tests/test_gemm_transa_to_transpose.py`
+and `tests/test_maxpool_rowmajor_when_indices_unused.py` for their tests
+(same rules, `onnxsim.simplify`'s own `check_n` doing the numeric-
+equivalence check instead of a standalone `ReferenceEvaluator` round-trip).
+
 ## Regenerating `voyager_op_support_data.py`
 
 The scraped data snapshot tracks whatever Voyager SDK checkout it was last

--- a/scripts/axelera/README.md
+++ b/scripts/axelera/README.md
@@ -171,6 +171,37 @@ and `tests/test_maxpool_rowmajor_when_indices_unused.py` for their tests
 (same rules, `onnxsim.simplify`'s own `check_n` doing the numeric-
 equivalence check instead of a standalone `ReferenceEvaluator` round-trip).
 
+This needs the pass actually compiled into the `onnxsim` in use -- true
+from whatever release first ships it onward, or a local build off this
+repo's own source (see the top-level `README.md`/`CMakeLists.txt`; it is
+not a quick rebuild -- protobuf, ONNX and onnx-optimizer all compile from
+scratch). When that isn't available, or a rebuild is simply unwanted, the
+next section gets the same rules running inside `simplify()`'s fixed point
+without one.
+
+### Same rules, no rebuild: `custom_rewriter`
+
+`onnxsim.simplify` already takes a `custom_rewriter` callable, run as an
+extra stage inside its own simplification fixed point (interleaved with
+shape inference/constant folding, same as a compiled-in pass). `legalize.
+as_custom_rewriter()` adapts `legalize()` to that contract, so any
+already-installed `onnxsim` -- a plain `pip install onnxsim`, nothing built
+locally -- can run these three rules today:
+
+```python
+model, ok = onnxsim.simplify(
+    model, custom_rewriter=legalize.as_custom_rewriter()
+)
+```
+
+The tradeoff is per-round Python instead of a one-time-compiled C++ pass --
+immaterial next to the cost of shape inference/constant folding on most
+graphs, but worth knowing about. `custom_rewriter` and
+`extra_optimizers`/`function_rewrite_rules` are not mutually exclusive with
+each other in general, but passing this adapter *and* the native passes'
+names in the same `simplify()` call would just run each rule twice for no
+benefit -- pick one path per call.
+
 ## Regenerating `voyager_op_support_data.py`
 
 The scraped data snapshot tracks whatever Voyager SDK checkout it was last

--- a/scripts/axelera/legalize.py
+++ b/scripts/axelera/legalize.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Rewrites that make a graph's use of `auto_pad`/`transA`/`storage_order`
+explicit, matching Voyager SDK's own opset-17 AIPU acceleration constraints
+(`voyager_ops.py`, scraped from its docs by `scrape_onnx_support_docs.py`).
+
+`voyager_simulator.evaluate_constraints()` is a docs-derived, no-hardware
+estimate of those constraints (see its docstring for exactly what it does
+and does not claim) -- op *coverage* the same way `pulsar2_ops.py` is for
+Axera. For three of its documented rules, the fix is not "avoid this op",
+it is a rewrite that is exact, not an approximation:
+
+- **`Conv`/`AveragePool`/`MaxPool` need `auto_pad == "NOTSET"`.** ONNX
+  defines each `auto_pad` mode (`SAME_UPPER`, `SAME_LOWER`, `VALID`) as a
+  formula over the input's spatial shape (see the ONNX operator spec for
+  `Conv`). Computing that formula once and writing the result out as
+  explicit `pads` with `auto_pad = "NOTSET"` changes nothing about what the
+  op computes, only how the padding amount is spelled -- the two forms are
+  defined to agree.
+- **`Gemm` needs `transA == 0`.** `transA = 1` means "transpose A before the
+  matmul"; inserting an explicit `Transpose` node ahead of the `Gemm` and
+  clearing the flag is the same operation, spelled as two nodes instead of
+  one attribute.
+- **`MaxPool` needs `storage_order == 0`.** The attribute only orders the
+  *second*, optional `Indices` output; a graph that never produces that
+  output computes an identical first output (`Y`) whichever way
+  `storage_order` is set, so forcing it to 0 there is a free rewrite rather
+  than a behavior change.
+
+Unlike `scripts/axera/legalize.py`'s rules -- each bisected against a real
+`pulsar2 build` failure on real hardware -- nothing here has been checked
+against an actual Voyager SDK compile. `axelera-rt`/`axelera-devkit`
+(`voyager_backend.py`) do install from a public index per Voyager SDK's own
+docs, but it's a large, optional pull (torch, CUDA toolkit packages, TVM)
+not exercised for this file. What backs these three rules instead is
+`voyager_ops.py`'s own scraped constraint text and
+`voyager_simulator.evaluate_constraints()`, derived from the same docs and
+itself partially cross-checked against the real compiler (see
+`voyager_backend.py`'s docstring) -- each rule's test checks that the
+target node's verdict against that checker moves from `"violated"` to
+`"ok"`, and separately that `onnx.reference.ReferenceEvaluator` gives the
+same output before and after. That is real, mechanical verification that
+the graph now reads as compliant and still computes the same thing; it is
+not a substitute for an actual `axelera.compiler` run.
+
+Usage::
+
+    legalize.py in.onnx out.onnx
+    legalize.py --rules gemm_transA_to_transpose in.onnx out.onnx
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+
+import onnx
+import onnx.shape_inference
+from onnx import helper
+
+
+def _attr(node, name):
+    for a in node.attribute:
+        if a.name == name:
+            return a
+    return None
+
+
+def _attr_int(node, name, default):
+    a = _attr(node, name)
+    return a.i if a is not None else default
+
+
+def _attr_ints(node, name, default=None):
+    a = _attr(node, name)
+    return list(a.ints) if a is not None else default
+
+
+def _attr_str(node, name, default):
+    a = _attr(node, name)
+    return a.s.decode("utf-8") if a is not None else default
+
+
+def _set_attr(node, name, value):
+    """Replace (or add) one attribute, inferring its kind from `value`."""
+    existing = _attr(node, name)
+    if existing is not None:
+        node.attribute.remove(existing)
+    node.attribute.append(helper.make_attribute(name, value))
+
+
+def _unique_name(model, stem):
+    taken = (
+        {i.name for i in model.graph.initializer}
+        | {n.name for n in model.graph.node if n.name}
+        | {o for n in model.graph.node for o in n.output}
+    )
+    name, k = stem, 0
+    while name in taken:
+        k += 1
+        name = f"{stem}_{k}"
+    return name
+
+
+def _value_shapes(model):
+    """{tensor name: [dims]} for every value whose shape is fully static --
+    graph inputs/outputs/value_info with every dim resolved, plus
+    initializers. Runs shape inference itself so this works even on a graph
+    fragment that carries no `value_info` of its own.
+    """
+    inferred = model
+    try:
+        inferred = onnx.shape_inference.infer_shapes(model, strict_mode=False)
+    except Exception:
+        pass
+    shapes = {}
+    for value in (
+        list(inferred.graph.input)
+        + list(inferred.graph.value_info)
+        + list(inferred.graph.output)
+    ):
+        dims = value.type.tensor_type.shape.dim
+        if all(d.HasField("dim_value") for d in dims):
+            shapes[value.name] = [d.dim_value for d in dims]
+    for init in model.graph.initializer:
+        shapes[init.name] = list(init.dims)
+    return shapes
+
+
+def _same_pads(auto_pad, spatial_in, kernel, strides, dilations):
+    """ONNX's own `auto_pad` formula (see the `Conv` operator spec), as
+    explicit `(begin, end)` pads per spatial axis. `VALID` is zero padding
+    by definition; `SAME_UPPER`/`SAME_LOWER` split the padding the output
+    needs to reach `ceil(input / stride)`, the extra pixel (if any) going to
+    the end (`SAME_UPPER`) or the start (`SAME_LOWER`).
+    """
+    nd = len(kernel)
+    if auto_pad == "VALID":
+        return [0] * nd, [0] * nd
+    begin, end = [0] * nd, [0] * nd
+    for i in range(nd):
+        out = -(-spatial_in[i] // strides[i])  # ceil division
+        needed = max(
+            0,
+            (out - 1) * strides[i]
+            + ((kernel[i] - 1) * dilations[i] + 1)
+            - spatial_in[i],
+        )
+        if auto_pad == "SAME_UPPER":
+            begin[i] = needed // 2
+            end[i] = needed - begin[i]
+        else:  # SAME_LOWER
+            end[i] = needed // 2
+            begin[i] = needed - end[i]
+    return begin, end
+
+
+def explicit_auto_pad(model):
+    """`Conv`/`AveragePool`/`MaxPool` with `auto_pad` in `SAME_UPPER`,
+    `SAME_LOWER` or `VALID` get `auto_pad = "NOTSET"` and the equivalent
+    explicit `pads`, computed from the ONNX spec's own formula.
+
+    Needs the input's spatial shape to be statically known -- the formula
+    is defined in terms of it -- so a node whose input shape isn't resolved
+    (a dynamic axis, or a graph fragment with no shape info at all) is left
+    alone rather than guessed at.
+    """
+    shapes = _value_shapes(model)
+    changed = 0
+    for node in model.graph.node:
+        if node.op_type not in ("Conv", "AveragePool", "MaxPool"):
+            continue
+        auto_pad = _attr_str(node, "auto_pad", "NOTSET")
+        if auto_pad == "NOTSET":
+            continue
+        kernel = _attr_ints(node, "kernel_shape")
+        if kernel is None and node.op_type == "Conv" and len(node.input) > 1:
+            # Conv's kernel_shape is optional -- inferrable from W -- and
+            # Voyager's own Conv rule reads it from W for the same reason.
+            wshape = shapes.get(node.input[1])
+            kernel = wshape[2:] if wshape else None
+        xshape = shapes.get(node.input[0])
+        if kernel is None or xshape is None or len(xshape) != len(kernel) + 2:
+            continue
+        nd = len(kernel)
+        strides = _attr_ints(node, "strides", [1] * nd)
+        dilations = _attr_ints(node, "dilations", [1] * nd)
+        begin, end = _same_pads(auto_pad, xshape[2:], kernel, strides, dilations)
+        _set_attr(node, "auto_pad", "NOTSET")
+        _set_attr(node, "pads", begin + end)
+        changed += 1
+    return changed
+
+
+def gemm_transA_to_transpose(model):
+    """A `Gemm` with `transA = 1` gets an explicit `Transpose` on `A`
+    instead, with `transA` cleared. `A` is required to be rank 2 by the
+    `Gemm` spec, so `perm=[1, 0]` is always the right transpose.
+
+    This satisfies Gemm's own documented rule, but does not by itself make
+    the rewritten graph fully Voyager-legal: `voyager_ops.py`'s scraped
+    `Transpose` rule (`perm == [0, 1, 2, 3]`) is written for 4D feature
+    maps and has no rank-2 case, so the inserted `Transpose` reads as its
+    own violation under `evaluate_constraints()` -- a real gap in what the
+    docs (and this transcription of them) cover for a bare `Gemm`, not a
+    correctness problem with the rewrite, which is exact either way.
+    """
+    out, changed = [], 0
+    for node in model.graph.node:
+        if node.op_type != "Gemm" or _attr_int(node, "transA", 0) == 0:
+            out.append(node)
+            continue
+        stem = node.name or node.output[0]
+        transposed = _unique_name(model, f"{stem}_A_T")
+        out.append(
+            helper.make_node(
+                "Transpose",
+                [node.input[0]],
+                [transposed],
+                perm=[1, 0],
+                name=_unique_name(model, f"{stem}_transA"),
+            )
+        )
+        node.input[0] = transposed
+        _set_attr(node, "transA", 0)
+        out.append(node)
+        changed += 1
+    if changed:
+        del model.graph.node[:]
+        model.graph.node.extend(out)
+    return changed
+
+
+def maxpool_rowmajor_when_indices_unused(model):
+    """A `MaxPool` with `storage_order = 1` (column-major) gets it cleared
+    to 0 (row-major) whenever the optional `Indices` output isn't actually
+    produced -- the attribute only orders that output, so with no `Indices`
+    consumer the two settings compute the identical `Y`.
+    """
+    changed = 0
+    for node in model.graph.node:
+        if node.op_type != "MaxPool" or _attr_int(node, "storage_order", 0) == 0:
+            continue
+        if len(node.output) > 1 and node.output[1]:
+            continue  # Indices is produced; its ordering is observable
+        _set_attr(node, "storage_order", 0)
+        changed += 1
+    return changed
+
+
+#: Order doesn't matter between these three -- each only touches its own
+#: op_type's attributes/inputs, and none produces a node another consumes.
+RULES = {
+    "explicit_auto_pad": explicit_auto_pad,
+    "gemm_transA_to_transpose": gemm_transA_to_transpose,
+    "maxpool_rowmajor_when_indices_unused": maxpool_rowmajor_when_indices_unused,
+}
+
+
+def legalize(model, rules=None):
+    """Apply the named rules in order; returns `{rule: sites changed}`."""
+    applied = collections.OrderedDict()
+    for name in rules or RULES:
+        applied[name] = RULES[name](model)
+    return applied
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input")
+    parser.add_argument("output")
+    parser.add_argument("--rules", nargs="*", choices=sorted(RULES))
+    args = parser.parse_args(argv)
+
+    model = onnx.load(args.input)
+    for name, n in legalize(model, args.rules).items():
+        print(f"  {name}: {n} sites")
+    onnx.save(
+        model,
+        args.output,
+        save_as_external_data=True,
+        location=args.output.rsplit("/", 1)[-1] + ".data",
+        size_threshold=1024,
+    )
+    print("wrote", args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/axelera/legalize.py
+++ b/scripts/axelera/legalize.py
@@ -58,6 +58,14 @@ scripting. See `tests/test_explicit_auto_pad.py`,
 `tests/test_maxpool_rowmajor_when_indices_unused.py` for the C++ passes'
 own tests.
 
+A third option needs neither a rebuild nor a standalone script step:
+`as_custom_rewriter()` adapts `legalize()` to `onnxsim.simplify`'s existing
+`custom_rewriter` parameter, so these rules run *inside* the same
+simplification fixed point from any already-installed `onnxsim` --
+`onnxsim.simplify(model, custom_rewriter=legalize.as_custom_rewriter())`.
+See that function's docstring for when to reach for it over
+`extra_optimizers`.
+
 Usage::
 
     legalize.py in.onnx out.onnx
@@ -278,6 +286,41 @@ def legalize(model, rules=None):
     for name in rules or RULES:
         applied[name] = RULES[name](model)
     return applied
+
+
+def as_custom_rewriter(rules=None):
+    """A callable usable as ``onnxsim.simplify(model, custom_rewriter=...)``.
+
+    `onnxsim.simplify` already accepts a `custom_rewriter`: "An optional
+    callable `ModelProto -> Optional[ModelProto]` run as an extra stage
+    inside onnxsim's simplification fixed point ... The callable may return
+    a new `ModelProto`, mutate and return `None`, or return `False` to
+    report that it rewrote nothing." This wraps `legalize()` to match that
+    contract exactly.
+
+    Why this exists alongside the native C++ passes
+    (`onnxsim/passes/explicit_auto_pad.h` and friends, opted into via
+    `extra_optimizers=[...]`): those need the *matching build* of `onnxsim`
+    -- the pass has to actually be compiled in, which is only true from
+    whatever release first ships it onward, or a local build off this
+    repo's own source tree. `custom_rewriter` needs neither: any
+    already-installed `onnxsim` (a plain `pip install onnxsim`, no rebuild)
+    can run these same three rules *today*, interleaved with onnxsim's own
+    shape inference/constant-folding fixed point exactly like a compiled-in
+    pass would be -- just executed in Python on each round instead of once
+    in C++. Prefer the native passes when the `onnxsim` in use already has
+    them (no per-round Python round-trip); reach for this adapter when it
+    doesn't and a rebuild isn't an option.
+
+    ``rules`` is the same optional list `legalize()` takes -- omit it to
+    apply every rule in `RULES`.
+    """
+
+    def rewriter(model):
+        applied = legalize(model, rules)
+        return None if any(applied.values()) else False
+
+    return rewriter
 
 
 def main(argv=None):

--- a/scripts/axelera/legalize.py
+++ b/scripts/axelera/legalize.py
@@ -42,6 +42,22 @@ same output before and after. That is real, mechanical verification that
 the graph now reads as compliant and still computes the same thing; it is
 not a substitute for an actual `axelera.compiler` run.
 
+Each of these three rules also has a C++ counterpart in onnxsim's own core
+(`onnxsim/passes/explicit_auto_pad.h`, `gemm_transa_to_transpose.h`,
+`maxpool_rowmajor_when_indices_unused.h`), registered as opt-in
+`PassType::Other` optimizers -- `onnxsim.simplify(model,
+extra_optimizers=["explicit_auto_pad", "gemm_transA_to_transpose",
+"maxpool_rowmajor_when_indices_unused"])`, or `--enable-optimization
+<name>` from the CLI -- so the same rewrites are available from every
+onnxsim binding (Python, C, Rust, npm/WASM), not only as a script run
+against a standalone `onnx.ModelProto`. This file stays useful on its own:
+it needs nothing beyond the `onnx` package (no onnxsim build), and its
+module-level functions compose freely with `legalize()`/`RULES` for
+scripting. See `tests/test_explicit_auto_pad.py`,
+`tests/test_gemm_transa_to_transpose.py` and
+`tests/test_maxpool_rowmajor_when_indices_unused.py` for the C++ passes'
+own tests.
+
 Usage::
 
     legalize.py in.onnx out.onnx

--- a/tests/test_axelera_legalize.py
+++ b/tests/test_axelera_legalize.py
@@ -18,6 +18,7 @@ Neither needs Docker, a device, or the (large, optional) `axelera-rt`/
 `axelera-devkit` install `voyager_backend.py` wraps.
 """
 
+import importlib.util
 import os
 import sys
 
@@ -33,7 +34,20 @@ _AXELERA_DIR = os.path.join(
 if _AXELERA_DIR not in sys.path:
     sys.path.insert(0, _AXELERA_DIR)
 
-import legalize  # noqa: E402
+# scripts/axera/legalize.py and scripts/axelera/legalize.py are two different,
+# same-named modules -- a plain `import legalize` here would share one
+# `sys.modules["legalize"]` entry with tests/test_axera_legalize.py's own
+# `import legalize` (whichever of the two collects first "wins", silently
+# handing the other test file the wrong module). Load this one under a
+# private key instead, so the two never collide regardless of collection
+# order.
+_spec = importlib.util.spec_from_file_location(
+    "axelera_legalize", os.path.join(_AXELERA_DIR, "legalize.py")
+)
+legalize = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = legalize
+_spec.loader.exec_module(legalize)
+
 import voyager_simulator as sim  # noqa: E402
 
 

--- a/tests/test_axelera_legalize.py
+++ b/tests/test_axelera_legalize.py
@@ -23,6 +23,7 @@ import sys
 
 import numpy as np
 import onnx
+import pytest
 from onnx import numpy_helper, parser
 from onnx.reference import ReferenceEvaluator
 
@@ -396,3 +397,81 @@ def test_legalize_reports_what_each_rule_changed():
     assert applied["explicit_auto_pad"] == 1
     assert applied["gemm_transA_to_transpose"] == 0
     assert applied["maxpool_rowmajor_when_indices_unused"] == 0
+
+
+# --- as_custom_rewriter() ---
+
+
+def _same_upper_conv_model():
+    w = numpy_helper.from_array(np.zeros((4, 4, 3, 3), np.float32), "w")
+    return _model(
+        """
+        g (float[1,4,10,10] x) => (float[1,4,?,?] y)
+        { y = Conv<kernel_shape = [3, 3], auto_pad = "SAME_UPPER">(x, w) }
+        """,
+        initializer=[w],
+    )
+
+
+def test_as_custom_rewriter_mutates_in_place_and_returns_none_when_changed():
+    """Matches `onnxsim.simplify`'s `custom_rewriter` contract: mutate
+    `model` and return `None` when something changed (as opposed to
+    returning a new `ModelProto`, the contract's other allowed form)."""
+    model = _same_upper_conv_model()
+    rewriter = legalize.as_custom_rewriter()
+    result = rewriter(model)
+    assert result is None
+    conv = model.graph.node[0]
+    assert any(a.name == "pads" for a in conv.attribute)
+
+
+def test_as_custom_rewriter_returns_false_when_nothing_changed():
+    """`custom_rewriter` returning `False` tells onnxsim's fixed point
+    nothing changed this round, so it can skip re-processing the model --
+    this is what lets `as_custom_rewriter()` be called repeatedly (as the
+    fixed point does) without looping forever re-declaring "changed"."""
+    model = _model(
+        """
+        g (float[4,8] a) => (float[4,4] y)
+        { y = Gemm(a, b) }
+        """,
+        initializer=[numpy_helper.from_array(np.zeros((8, 4), np.float32), "b")],
+    )
+    rewriter = legalize.as_custom_rewriter()
+    assert rewriter(model) is False
+    # Idempotent: a second call against an already-legalized model also
+    # reports no change, exactly like the fixed point's steady state.
+    changed_model = _same_upper_conv_model()
+    rewriter(changed_model)
+    assert rewriter(changed_model) is False
+
+
+def test_as_custom_rewriter_honors_an_explicit_rule_subset():
+    model = _same_upper_conv_model()
+    rewriter = legalize.as_custom_rewriter(rules=["gemm_transA_to_transpose"])
+    # SAME_UPPER only affects explicit_auto_pad, which wasn't asked for.
+    assert rewriter(model) is False
+    conv = model.graph.node[0]
+    assert not any(a.name == "pads" for a in conv.attribute)
+
+
+def test_as_custom_rewriter_used_by_onnxsim_simplify():
+    """End-to-end: the adapter actually works as `onnxsim.simplify`'s
+    `custom_rewriter`, with no `onnxsim` rebuild needed -- unlike the native
+    C++ passes (`tests/test_explicit_auto_pad.py` and friends), which need
+    the matching pass compiled into the `onnxsim` in use."""
+    onnxsim = pytest.importorskip("onnxsim")
+
+    model = _same_upper_conv_model()
+    x = np.zeros((1, 4, 10, 10), np.float32)
+    sim_model, ok = onnxsim.simplify(
+        model,
+        check_n=1,
+        input_data={"x": x},
+        custom_rewriter=legalize.as_custom_rewriter(),
+    )
+    assert ok
+    conv = next(n for n in sim_model.graph.node if n.op_type == "Conv")
+    assert not any(
+        a.name == "auto_pad" and a.s == b"SAME_UPPER" for a in conv.attribute
+    )

--- a/tests/test_axelera_legalize.py
+++ b/tests/test_axelera_legalize.py
@@ -1,0 +1,398 @@
+"""Voyager SDK (Axelera Metis AIPU) legalization rewrites, checked offline.
+
+`scripts/axelera/legalize.py` holds rewrites for three of the AIPU
+acceleration constraints `voyager_ops.py`/`voyager_simulator.py` scrape from
+Voyager SDK's own docs and check statically. Each test here checks the two
+properties that matter: the rewrite fires where it should and nowhere else,
+and it does not change what the graph computes. Where the target constraint
+is one `voyager_simulator.evaluate_constraints()` can check, the test also
+confirms the rewrite actually flips its verdict from `"violated"` to `"ok"`
+-- real (if docs-derived, not hardware-verified) evidence the rewrite did
+what it claims, not just that it ran.
+
+Numeric equivalence is checked with `onnx.reference.ReferenceEvaluator`
+rather than onnxruntime, since nothing here needs a real accelerator or even
+a real ONNX Runtime install.
+
+Neither needs Docker, a device, or the (large, optional) `axelera-rt`/
+`axelera-devkit` install `voyager_backend.py` wraps.
+"""
+
+import os
+import sys
+
+import numpy as np
+import onnx
+from onnx import numpy_helper, parser
+from onnx.reference import ReferenceEvaluator
+
+_AXELERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axelera"
+)
+if _AXELERA_DIR not in sys.path:
+    sys.path.insert(0, _AXELERA_DIR)
+
+import legalize  # noqa: E402
+import voyager_simulator as sim  # noqa: E402
+
+
+def _model(body, initializer=(), opset=17, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    onnx.checker.check_model(model)
+    return model
+
+
+def _verdicts(model):
+    cache = sim._ShapeCache(model)
+    return [sim.evaluate_constraints(n, cache).verdict for n in model.graph.node]
+
+
+def _assert_same_output(before, after, feeds):
+    onnx.checker.check_model(after)
+    before_out = ReferenceEvaluator(before).run(None, feeds)
+    after_out = ReferenceEvaluator(after).run(None, feeds)
+    for b, a in zip(before_out, after_out):
+        assert np.allclose(b, a, atol=1e-5), np.abs(np.asarray(b) - np.asarray(a)).max()
+
+
+# --- explicit_auto_pad ---
+
+
+def _conv_model(auto_pad, C=4, H=10, W=10, k=3):
+    w = numpy_helper.from_array(
+        np.random.RandomState(0).randn(C, C, k, k).astype(np.float32), "w"
+    )
+    return _model(
+        f"""
+        g (float[1,{C},{H},{W}] x) => (float[1,{C},?,?] y)
+        {{ y = Conv<kernel_shape = [{k}, {k}], auto_pad = "{auto_pad}">(x, w) }}
+        """,
+        initializer=[w],
+    )
+
+
+def test_conv_same_upper_gets_explicit_pads_and_computes_the_same_thing():
+    before = _conv_model("SAME_UPPER")
+    after = _conv_model("SAME_UPPER")
+    assert _verdicts(before) == ["violated"]
+
+    assert legalize.explicit_auto_pad(after) == 1
+    conv = after.graph.node[0]
+    assert (
+        onnx.helper.get_attribute_value(
+            next(a for a in conv.attribute if a.name == "auto_pad")
+        )
+        == b"NOTSET"
+    )
+    pads = list(next(a for a in conv.attribute if a.name == "pads").ints)
+    # 10x10 input, 3x3 kernel, stride 1 -> SAME needs 2 total, 1 on each side.
+    assert pads == [1, 1, 1, 1]
+    assert _verdicts(after) == ["ok"]
+
+    x = np.random.RandomState(1).randn(1, 4, 10, 10).astype(np.float32)
+    _assert_same_output(before, after, {"x": x})
+
+
+def test_conv_same_lower_splits_the_odd_pixel_the_other_way():
+    w = numpy_helper.from_array(
+        np.random.RandomState(0).randn(4, 4, 4, 4).astype(np.float32), "w"
+    )
+    before = _model(
+        """
+        g (float[1,4,9,9] x) => (float[1,4,?,?] y)
+        { y = Conv<kernel_shape = [4, 4], auto_pad = "SAME_LOWER", strides = [1, 1]>(x, w) }
+        """,
+        initializer=[w],
+    )
+    after = _model(
+        """
+        g (float[1,4,9,9] x) => (float[1,4,?,?] y)
+        { y = Conv<kernel_shape = [4, 4], auto_pad = "SAME_LOWER", strides = [1, 1]>(x, w) }
+        """,
+        initializer=[w],
+    )
+    assert legalize.explicit_auto_pad(after) == 1
+    pads = list(next(a for a in after.graph.node[0].attribute if a.name == "pads").ints)
+    # needed = 3 total; SAME_LOWER puts the extra pixel at the start.
+    assert pads == [2, 2, 1, 1]
+
+    x = np.random.RandomState(2).randn(1, 4, 9, 9).astype(np.float32)
+    _assert_same_output(before, after, {"x": x})
+
+
+def test_conv_valid_becomes_zero_pads():
+    # No numeric round-trip against the un-rewritten model here: the ONNX
+    # spec defines VALID as zero padding, but the installed onnx package's
+    # own ReferenceEvaluator has a real bug where Conv's auto_pad=="VALID"
+    # branch reuses the SAME_UPPER pad formula instead of padding with zero
+    # (onnx/reference/ops/op_conv.py, the `if auto_pad in {"SAME_LOWER",
+    # "SAME_UPPER", "VALID"}:` branch does not special-case VALID) --
+    # verified directly: a VALID Conv over this test's 10x10/3x3/stride-1
+    # shape comes back from ReferenceEvaluator as 10x10, not the spec's 8x8.
+    # The rewrite's own correctness is checked structurally against the
+    # spec text instead, and numerically against the *correct* zero-pad
+    # reading of VALID.
+    after = _conv_model("VALID")
+    assert legalize.explicit_auto_pad(after) == 1
+    conv = after.graph.node[0]
+    pads = list(next(a for a in conv.attribute if a.name == "pads").ints)
+    assert pads == [0, 0, 0, 0]
+    assert (
+        onnx.helper.get_attribute_value(
+            next(a for a in conv.attribute if a.name == "auto_pad")
+        )
+        == b"NOTSET"
+    )
+
+    reference = _conv_model("NOTSET")  # explicit zero pads, spec-correct VALID
+    x = np.random.RandomState(3).randn(1, 4, 10, 10).astype(np.float32)
+    _assert_same_output(reference, after, {"x": x})
+
+
+def test_conv_notset_is_left_alone():
+    model = _conv_model("NOTSET")
+    assert legalize.explicit_auto_pad(model) == 0
+
+
+def test_conv_kernel_shape_is_read_from_weight_when_attribute_is_absent():
+    """Voyager's own Conv rule reads the kernel from `W`'s shape, since
+    exporters routinely omit the `kernel_shape` attribute -- this rewrite
+    has to do the same or it silently skips exactly those graphs."""
+    w = numpy_helper.from_array(
+        np.random.RandomState(0).randn(4, 4, 3, 3).astype(np.float32), "w"
+    )
+    before = _model(
+        """
+        g (float[1,4,10,10] x) => (float[1,4,?,?] y)
+        { y = Conv<auto_pad = "SAME_UPPER">(x, w) }
+        """,
+        initializer=[w],
+    )
+    after = _model(
+        """
+        g (float[1,4,10,10] x) => (float[1,4,?,?] y)
+        { y = Conv<auto_pad = "SAME_UPPER">(x, w) }
+        """,
+        initializer=[w],
+    )
+    assert legalize.explicit_auto_pad(after) == 1
+    x = np.random.RandomState(4).randn(1, 4, 10, 10).astype(np.float32)
+    _assert_same_output(before, after, {"x": x})
+
+
+def test_conv_with_dynamic_input_shape_is_left_alone():
+    """The `auto_pad` formula needs the input's spatial shape; a dynamic
+    axis means it can't be computed, so the rule has to decline rather than
+    guess and risk changing the output shape."""
+    w = numpy_helper.from_array(np.zeros((4, 4, 3, 3), np.float32), "w")
+    model = _model(
+        """
+        g (float[1,4,H,W] x) => (float[1,4,?,?] y)
+        { y = Conv<kernel_shape = [3, 3], auto_pad = "SAME_UPPER">(x, w) }
+        """,
+        initializer=[w],
+    )
+    assert legalize.explicit_auto_pad(model) == 0
+    assert _verdicts(model) == ["violated"]
+
+
+def test_maxpool_same_upper_is_rewritten_and_becomes_fully_ok():
+    """MaxPool's only two documented rules are `auto_pad == "NOTSET"` and
+    `storage_order == 0`; with no `count_include_pad`-style wrinkle, this
+    rewrite alone is enough to flip the whole verdict."""
+    before = _model(
+        """
+        g (float[1,4,10,10] x) => (float[1,4,?,?] y)
+        { y = MaxPool<kernel_shape = [3, 3], auto_pad = "SAME_UPPER">(x) }
+        """
+    )
+    after = _model(
+        """
+        g (float[1,4,10,10] x) => (float[1,4,?,?] y)
+        { y = MaxPool<kernel_shape = [3, 3], auto_pad = "SAME_UPPER">(x) }
+        """
+    )
+    assert legalize.explicit_auto_pad(after) == 1
+    assert _verdicts(before) == ["violated"]
+    assert _verdicts(after) == ["ok"]
+
+    x = np.random.RandomState(5).randn(1, 4, 10, 10).astype(np.float32)
+    _assert_same_output(before, after, {"x": x})
+
+
+def test_averagepool_same_upper_is_rewritten_and_preserves_semantics():
+    """AveragePool's rules also require `count_include_pad == 1` once the
+    padding is non-zero -- and that attribute changes the *result* at the
+    padded edge (whether the implicit zeros count toward the divisor), so
+    this rewrite correctly leaves it alone rather than flipping it to chase
+    a clean verdict. What it does guarantee: the `auto_pad` rule specifically
+    is satisfied, and the graph still computes the same thing.
+    """
+    before = _model(
+        """
+        g (float[1,4,10,10] x) => (float[1,4,?,?] y)
+        { y = AveragePool<kernel_shape = [3, 3], auto_pad = "SAME_UPPER">(x) }
+        """
+    )
+    after = _model(
+        """
+        g (float[1,4,10,10] x) => (float[1,4,?,?] y)
+        { y = AveragePool<kernel_shape = [3, 3], auto_pad = "SAME_UPPER">(x) }
+        """
+    )
+    assert legalize.explicit_auto_pad(after) == 1
+    before_verdict = _verdicts(before)[0]
+    assert before_verdict == "violated"
+
+    cache = sim._ShapeCache(after)
+    result = sim.evaluate_constraints(after.graph.node[0], cache)
+    assert not any("auto_pad" in rule for rule in result.detail)
+
+    x = np.random.RandomState(5).randn(1, 4, 10, 10).astype(np.float32)
+    _assert_same_output(before, after, {"x": x})
+
+
+# --- gemm_transA_to_transpose ---
+
+
+def test_gemm_transA_becomes_an_explicit_transpose_and_computes_the_same_thing():
+    b = numpy_helper.from_array(
+        np.random.RandomState(0).randn(4, 8).astype(np.float32), "b"
+    )
+    c = numpy_helper.from_array(
+        np.random.RandomState(1).randn(8).astype(np.float32), "c"
+    )
+    before = _model(
+        """
+        g (float[4,10] a) => (float[10,8] y)
+        { y = Gemm<transA = 1>(a, b, c) }
+        """,
+        initializer=[b, c],
+    )
+    after = _model(
+        """
+        g (float[4,10] a) => (float[10,8] y)
+        { y = Gemm<transA = 1>(a, b, c) }
+        """,
+        initializer=[b, c],
+    )
+    assert _verdicts(before) == ["violated"]
+
+    assert legalize.gemm_transA_to_transpose(after) == 1
+    kinds = [n.op_type for n in after.graph.node]
+    assert kinds == ["Transpose", "Gemm"]
+    gemm = after.graph.node[1]
+    assert (
+        onnx.helper.get_attribute_value(
+            next(a for a in gemm.attribute if a.name == "transA")
+        )
+        == 0
+    )
+    # The Gemm's own rule is now satisfied...
+    assert (
+        sim.evaluate_constraints(after.graph.node[1], sim._ShapeCache(after)).verdict
+        == "ok"
+    )
+    # ...but the inserted Transpose trades one documented violation for
+    # another: Voyager's scraped `Transpose` rule (`perm == [0, 1, 2, 3]`)
+    # is written for 4D feature maps, and a rank-2 `perm=[1, 0]` never
+    # matches it -- the docs simply have no rank-2 case. That is a real gap
+    # in what this checker (and, per its docstring, possibly Voyager's own
+    # docs) can bless here, not a bug in the rewrite: it is still exact.
+    assert (
+        sim.evaluate_constraints(after.graph.node[0], sim._ShapeCache(after)).verdict
+        == "violated"
+    )
+
+    a = np.random.RandomState(2).randn(4, 10).astype(np.float32)
+    _assert_same_output(before, after, {"a": a})
+
+
+def test_gemm_without_transA_is_left_alone():
+    b = numpy_helper.from_array(np.zeros((8, 4), np.float32), "b")
+    model = _model(
+        """
+        g (float[4,8] a) => (float[4,4] y)
+        { y = Gemm(a, b) }
+        """,
+        initializer=[b],
+    )
+    assert legalize.gemm_transA_to_transpose(model) == 0
+    assert [n.op_type for n in model.graph.node] == ["Gemm"]
+
+
+# --- maxpool_rowmajor_when_indices_unused ---
+
+
+def test_maxpool_storage_order_cleared_when_indices_output_is_absent():
+    before = _model(
+        """
+        g (float[1,4,8,8] x) => (float[1,4,7,7] y)
+        { y = MaxPool<kernel_shape = [2, 2], storage_order = 1>(x) }
+        """
+    )
+    after = _model(
+        """
+        g (float[1,4,8,8] x) => (float[1,4,7,7] y)
+        { y = MaxPool<kernel_shape = [2, 2], storage_order = 1>(x) }
+        """
+    )
+    assert legalize.maxpool_rowmajor_when_indices_unused(after) == 1
+    node = after.graph.node[0]
+    assert (
+        onnx.helper.get_attribute_value(
+            next(a for a in node.attribute if a.name == "storage_order")
+        )
+        == 0
+    )
+
+    x = np.random.RandomState(6).randn(1, 4, 8, 8).astype(np.float32)
+    _assert_same_output(before, after, {"x": x})
+
+
+def test_maxpool_storage_order_is_left_alone_when_indices_output_is_used():
+    model = _model(
+        """
+        g (float[1,4,8,8] x) => (float[1,4,7,7] y, int64[1,4,7,7] idx)
+        { y, idx = MaxPool<kernel_shape = [2, 2], storage_order = 1>(x) }
+        """
+    )
+    assert legalize.maxpool_rowmajor_when_indices_unused(model) == 0
+
+
+def test_maxpool_default_storage_order_is_left_alone():
+    model = _model(
+        """
+        g (float[1,4,8,8] x) => (float[1,4,7,7] y)
+        { y = MaxPool<kernel_shape = [2, 2]>(x) }
+        """
+    )
+    assert legalize.maxpool_rowmajor_when_indices_unused(model) == 0
+
+
+# --- legalize() driver ---
+
+
+def test_legalize_reports_what_each_rule_changed():
+    w = numpy_helper.from_array(np.zeros((4, 4, 3, 3), np.float32), "w")
+    model = _model(
+        """
+        g (float[1,4,10,10] x) => (float[1,4,?,?] y)
+        { y = Conv<kernel_shape = [3, 3], auto_pad = "SAME_UPPER">(x, w) }
+        """,
+        initializer=[w],
+    )
+    applied = legalize.legalize(model)
+    assert set(applied) == set(legalize.RULES)
+    assert applied["explicit_auto_pad"] == 1
+    assert applied["gemm_transA_to_transpose"] == 0
+    assert applied["maxpool_rowmajor_when_indices_unused"] == 0

--- a/tests/test_explicit_auto_pad.py
+++ b/tests/test_explicit_auto_pad.py
@@ -1,0 +1,205 @@
+"""Tests for the ``explicit_auto_pad`` C++ pass
+(onnxsim/passes/explicit_auto_pad.h).
+
+``Conv``/``AveragePool``/``MaxPool`` with ``auto_pad`` in ``SAME_UPPER``,
+``SAME_LOWER`` or ``VALID`` get ``auto_pad = "NOTSET"`` and the equivalent
+explicit ``pads``, computed from the ONNX operator spec's own ``auto_pad``
+formula -- the same rewrite ``scripts/axelera/legalize.py``'s
+``explicit_auto_pad`` does at the Python/script level (that file's docstring
+records this as one of the rules a real Voyager SDK compiler build enforces,
+under the vendor's own ``auto_pad == "NOTSET"`` requirement); this is its
+onnxsim-core counterpart, usable from any binding (Python, C, Rust, npm) via
+``extra_optimizers=["explicit_auto_pad"]`` rather than only as a standalone
+script.
+
+Every model is built with the ONNX text format parser (``onnx.parser``) per
+CLAUDE.md's convention for this repo's tests. ``onnxsim.simplify``'s own
+``check_n`` machinery gives the numeric-equivalence check (onnxruntime, or
+the onnx reference evaluator when onnxruntime is not installed) -- except
+for ``VALID``, where the installed ``onnx`` package's own
+``ReferenceEvaluator`` has a real bug (``onnx/reference/ops/op_conv.py``
+reuses the ``SAME_UPPER`` pad formula for ``auto_pad == "VALID"`` instead of
+padding with zero), so that case is checked structurally against the ONNX
+spec's own definition of ``VALID`` instead of round-tripped through
+``check_n``.
+"""
+
+import numpy as np
+import onnx
+import pytest
+from onnx import numpy_helper, parser
+
+import onnxsim
+
+
+def _model(body, initializer=(), opset=17, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    onnx.checker.check_model(model)
+    return model
+
+
+def _find(model, op_type):
+    return next(n for n in model.graph.node if n.op_type == op_type)
+
+
+def _attr(node, name):
+    return next((a for a in node.attribute if a.name == name), None)
+
+
+def _auto_pad(node):
+    a = _attr(node, "auto_pad")
+    return a.s.decode("utf-8") if a is not None else "NOTSET"
+
+
+def _pads(node):
+    a = _attr(node, "pads")
+    return list(a.ints) if a is not None else None
+
+
+def _conv_model(auto_pad, C=4, H=10, W=10, k=3, include_kernel_shape=True):
+    w = numpy_helper.from_array(
+        np.random.RandomState(0).randn(C, C, k, k).astype(np.float32), "w"
+    )
+    kernel_attr = f"kernel_shape=[{k}, {k}], " if include_kernel_shape else ""
+    return _model(
+        f"""
+        g (float[1,{C},{H},{W}] x) => (float[1,{C},?,?] y)
+        {{ y = Conv<{kernel_attr}auto_pad = "{auto_pad}">(x, w) }}
+        """,
+        initializer=[w],
+    )
+
+
+def _simplify(model, x, check_n=1):
+    return onnxsim.simplify(
+        model,
+        check_n=check_n,
+        input_data={"x": x},
+        extra_optimizers=["explicit_auto_pad"],
+    )
+
+
+def test_conv_same_upper_gets_explicit_pads_and_computes_the_same_thing():
+    model = _conv_model("SAME_UPPER")
+    x = np.random.RandomState(1).randn(1, 4, 10, 10).astype(np.float32)
+    sim_model, ok = _simplify(model, x)
+    assert ok
+
+    conv = _find(sim_model, "Conv")
+    assert _auto_pad(conv) == "NOTSET"
+    # 10x10 input, 3x3 kernel, stride 1 -> SAME needs 2 total, 1 on each side.
+    assert _pads(conv) == [1, 1, 1, 1]
+
+
+def test_conv_same_lower_splits_the_odd_pixel_the_other_way():
+    w = numpy_helper.from_array(
+        np.random.RandomState(0).randn(4, 4, 4, 4).astype(np.float32), "w"
+    )
+    model = _model(
+        """
+        g (float[1,4,9,9] x) => (float[1,4,?,?] y)
+        { y = Conv<kernel_shape=[4, 4], auto_pad="SAME_LOWER", strides=[1, 1]>(x, w) }
+        """,
+        initializer=[w],
+    )
+    x = np.random.RandomState(2).randn(1, 4, 9, 9).astype(np.float32)
+    sim_model, ok = _simplify(model, x)
+    assert ok
+
+    conv = _find(sim_model, "Conv")
+    # needed = 3 total; SAME_LOWER puts the extra pixel at the start.
+    assert _pads(conv) == [2, 2, 1, 1]
+
+
+def test_conv_valid_becomes_zero_pads():
+    # No check_n round-trip here -- see this file's module docstring for the
+    # ReferenceEvaluator VALID bug this sidesteps. Structural correctness
+    # follows directly from the ONNX spec's own definition of VALID (zero
+    # padding), which needs no numeric check to confirm.
+    model = _conv_model("VALID")
+    x = np.random.RandomState(3).randn(1, 4, 10, 10).astype(np.float32)
+    sim_model, ok = _simplify(model, x, check_n=0)
+    assert ok
+
+    conv = _find(sim_model, "Conv")
+    assert _auto_pad(conv) == "NOTSET"
+    assert _pads(conv) == [0, 0, 0, 0]
+
+
+def test_conv_notset_is_left_alone():
+    model = _conv_model("NOTSET")
+    x = np.random.RandomState(4).randn(1, 4, 10, 10).astype(np.float32)
+    sim_model, ok = _simplify(model, x)
+    assert ok
+    conv = _find(sim_model, "Conv")
+    assert _pads(conv) is None
+
+
+def test_conv_kernel_shape_is_read_from_weight_when_attribute_is_absent():
+    """Conv's own kernel_shape attribute is optional (inferrable from `W`),
+    and exporters routinely omit it -- this rewrite has to do the same or it
+    silently skips exactly those graphs."""
+    model = _conv_model("SAME_UPPER", include_kernel_shape=False)
+    x = np.random.RandomState(5).randn(1, 4, 10, 10).astype(np.float32)
+    sim_model, ok = _simplify(model, x)
+    assert ok
+    conv = _find(sim_model, "Conv")
+    assert _auto_pad(conv) == "NOTSET"
+    assert _pads(conv) == [1, 1, 1, 1]
+
+
+def test_conv_with_dynamic_input_shape_is_left_alone():
+    """The `auto_pad` formula needs the input's spatial shape; a dynamic
+    axis means it can't be computed, so the rule declines rather than guess
+    and risk changing the output shape."""
+    w = numpy_helper.from_array(np.zeros((4, 4, 3, 3), np.float32), "w")
+    model = _model(
+        """
+        g (float[1,4,H,W] x) => (float[1,4,?,?] y)
+        { y = Conv<kernel_shape=[3, 3], auto_pad="SAME_UPPER">(x, w) }
+        """,
+        initializer=[w],
+    )
+    sim_model, ok = onnxsim.simplify(
+        model, check_n=0, extra_optimizers=["explicit_auto_pad"]
+    )
+    assert ok
+    conv = _find(sim_model, "Conv")
+    assert _auto_pad(conv) == "SAME_UPPER"
+
+
+@pytest.mark.parametrize("op_type", ["AveragePool", "MaxPool"])
+def test_averagepool_and_maxpool_same_upper_are_also_rewritten(op_type):
+    model = _model(
+        f"""
+        g (float[1,4,10,10] x) => (float[1,4,?,?] y)
+        {{ y = {op_type}<kernel_shape=[3, 3], auto_pad="SAME_UPPER">(x) }}
+        """
+    )
+    x = np.random.RandomState(6).randn(1, 4, 10, 10).astype(np.float32)
+    sim_model, ok = _simplify(model, x)
+    assert ok
+
+    node = _find(sim_model, op_type)
+    assert _auto_pad(node) == "NOTSET"
+    assert _pads(node) == [1, 1, 1, 1]
+
+
+def test_disabled_by_default():
+    """`explicit_auto_pad` is `PassType::Other`, so a plain `simplify()` call
+    (no `extra_optimizers`) must leave a SAME-padded Conv untouched."""
+    model = _conv_model("SAME_UPPER")
+    x = np.random.RandomState(7).randn(1, 4, 10, 10).astype(np.float32)
+    sim_model, ok = onnxsim.simplify(model, check_n=1, input_data={"x": x})
+    assert ok
+    conv = _find(sim_model, "Conv")
+    assert _auto_pad(conv) == "SAME_UPPER"

--- a/tests/test_gemm_transa_to_transpose.py
+++ b/tests/test_gemm_transa_to_transpose.py
@@ -1,0 +1,113 @@
+"""Tests for the ``gemm_transA_to_transpose`` C++ pass
+(onnxsim/passes/gemm_transa_to_transpose.h).
+
+A `Gemm` with `transA = 1` gets an explicit `Transpose` on `A` instead, with
+`transA` cleared -- the onnxsim-core counterpart of
+``scripts/axelera/legalize.py``'s ``gemm_transA_to_transpose`` rule (that
+file's docstring records ``transA == 0`` as a real vendor compiler
+requirement). Usable from any binding via
+``extra_optimizers=["gemm_transA_to_transpose"]``.
+
+Models are built with ``onnx.parser`` per CLAUDE.md's convention.
+Numeric equivalence comes from ``onnxsim.simplify``'s own ``check_n``.
+"""
+
+import numpy as np
+import onnx
+from onnx import numpy_helper, parser
+
+import onnxsim
+
+
+def _model(body, initializer=(), opset=17, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    onnx.checker.check_model(model)
+    return model
+
+
+def _find(model, op_type):
+    return next(n for n in model.graph.node if n.op_type == op_type)
+
+
+def _attr_int(node, name, default=0):
+    a = next((a for a in node.attribute if a.name == name), None)
+    return a.i if a is not None else default
+
+
+def test_gemm_transA_becomes_an_explicit_transpose_and_computes_the_same_thing():
+    b = numpy_helper.from_array(
+        np.random.RandomState(0).randn(4, 8).astype(np.float32), "b"
+    )
+    c = numpy_helper.from_array(
+        np.random.RandomState(1).randn(8).astype(np.float32), "c"
+    )
+    model = _model(
+        """
+        g (float[4,10] a) => (float[10,8] y)
+        { y = Gemm<transA=1>(a, b, c) }
+        """,
+        initializer=[b, c],
+    )
+    a = np.random.RandomState(2).randn(4, 10).astype(np.float32)
+    sim_model, ok = onnxsim.simplify(
+        model,
+        check_n=1,
+        input_data={"a": a},
+        extra_optimizers=["gemm_transA_to_transpose"],
+    )
+    assert ok
+
+    gemm = _find(sim_model, "Gemm")
+    assert _attr_int(gemm, "transA") == 0
+    transpose = _find(sim_model, "Transpose")
+    perm = next(a for a in transpose.attribute if a.name == "perm")
+    assert list(perm.ints) == [1, 0]
+    assert transpose.output[0] == gemm.input[0]
+
+
+def test_gemm_without_transA_is_left_alone():
+    b = numpy_helper.from_array(np.zeros((8, 4), np.float32), "b")
+    model = _model(
+        """
+        g (float[4,8] a) => (float[4,4] y)
+        { y = Gemm(a, b) }
+        """,
+        initializer=[b],
+    )
+    a = np.zeros((4, 8), np.float32)
+    sim_model, ok = onnxsim.simplify(
+        model,
+        check_n=1,
+        input_data={"a": a},
+        extra_optimizers=["gemm_transA_to_transpose"],
+    )
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert "Transpose" not in op_types
+
+
+def test_disabled_by_default():
+    """`gemm_transA_to_transpose` is `PassType::Other`, so a plain
+    `simplify()` call (no `extra_optimizers`) must leave `transA` alone."""
+    b = numpy_helper.from_array(np.zeros((4, 8), np.float32), "b")
+    model = _model(
+        """
+        g (float[4,10] a) => (float[10,8] y)
+        { y = Gemm<transA=1>(a, b) }
+        """,
+        initializer=[b],
+    )
+    a = np.zeros((4, 10), np.float32)
+    sim_model, ok = onnxsim.simplify(model, check_n=1, input_data={"a": a})
+    assert ok
+    gemm = _find(sim_model, "Gemm")
+    assert _attr_int(gemm, "transA") == 1

--- a/tests/test_maxpool_rowmajor_when_indices_unused.py
+++ b/tests/test_maxpool_rowmajor_when_indices_unused.py
@@ -1,0 +1,130 @@
+"""Tests for the ``maxpool_rowmajor_when_indices_unused`` C++ pass
+(onnxsim/passes/maxpool_rowmajor_when_indices_unused.h).
+
+A `MaxPool` with `storage_order = 1` (column-major) gets it cleared to 0
+(row-major) whenever the optional `Indices` output isn't actually consumed
+-- the attribute only orders that output, so with no consumer the two
+settings compute the identical `Y`. The onnxsim-core counterpart of
+``scripts/axelera/legalize.py``'s ``maxpool_rowmajor_when_indices_unused``
+rule (that file's docstring records ``storage_order == 0`` as a real vendor
+compiler requirement). This version is a little more thorough than the
+Python script: it declines based on whether `Indices` actually has a
+consumer (tracked by the in-memory graph IR), not merely whether a second
+output name is declared, so a *declared-but-dead* `Indices` output is still
+safely rewritten.
+
+Models are built with ``onnx.parser`` per CLAUDE.md's convention. Numeric
+equivalence comes from ``onnxsim.simplify``'s own ``check_n``.
+"""
+
+import numpy as np
+import onnx
+from onnx import parser
+
+import onnxsim
+
+
+def _model(body, initializer=(), opset=17, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    onnx.checker.check_model(model)
+    return model
+
+
+def _find(model, op_type):
+    return next(n for n in model.graph.node if n.op_type == op_type)
+
+
+def _attr_int(node, name, default=0):
+    a = next((a for a in node.attribute if a.name == name), None)
+    return a.i if a is not None else default
+
+
+def _simplify(model, x, check_n=1):
+    return onnxsim.simplify(
+        model,
+        check_n=check_n,
+        input_data={"x": x},
+        extra_optimizers=["maxpool_rowmajor_when_indices_unused"],
+    )
+
+
+def test_storage_order_cleared_when_no_indices_output_is_declared():
+    model = _model(
+        """
+        g (float[1,4,8,8] x) => (float[1,4,7,7] y)
+        { y = MaxPool<kernel_shape=[2, 2], storage_order=1>(x) }
+        """
+    )
+    x = np.random.RandomState(0).randn(1, 4, 8, 8).astype(np.float32)
+    sim_model, ok = _simplify(model, x)
+    assert ok
+    node = _find(sim_model, "MaxPool")
+    assert _attr_int(node, "storage_order") == 0
+
+
+def test_storage_order_cleared_when_indices_output_is_declared_but_dead():
+    model = _model(
+        """
+        g (float[1,4,8,8] x) => (float[1,4,7,7] y)
+        { y, idx = MaxPool<kernel_shape=[2, 2], storage_order=1>(x) }
+        """
+    )
+    x = np.random.RandomState(1).randn(1, 4, 8, 8).astype(np.float32)
+    sim_model, ok = _simplify(model, x)
+    assert ok
+    node = _find(sim_model, "MaxPool")
+    assert _attr_int(node, "storage_order") == 0
+
+
+def test_storage_order_is_left_alone_when_indices_output_is_used():
+    model = _model(
+        """
+        g (float[1,4,8,8] x) => (float[1,4,7,7] y, int64[1,4,7,7] idx)
+        { y, idx = MaxPool<kernel_shape=[2, 2], storage_order=1>(x) }
+        """
+    )
+    x = np.random.RandomState(2).randn(1, 4, 8, 8).astype(np.float32)
+    sim_model, ok = _simplify(model, x)
+    assert ok
+    node = _find(sim_model, "MaxPool")
+    assert _attr_int(node, "storage_order") == 1
+
+
+def test_default_storage_order_is_left_alone():
+    model = _model(
+        """
+        g (float[1,4,8,8] x) => (float[1,4,7,7] y)
+        { y = MaxPool<kernel_shape=[2, 2]>(x) }
+        """
+    )
+    x = np.random.RandomState(3).randn(1, 4, 8, 8).astype(np.float32)
+    sim_model, ok = _simplify(model, x)
+    assert ok
+    node = _find(sim_model, "MaxPool")
+    assert _attr_int(node, "storage_order") == 0
+
+
+def test_disabled_by_default():
+    """`maxpool_rowmajor_when_indices_unused` is `PassType::Other`, so a
+    plain `simplify()` call (no `extra_optimizers`) must leave
+    `storage_order` alone."""
+    model = _model(
+        """
+        g (float[1,4,8,8] x) => (float[1,4,7,7] y)
+        { y = MaxPool<kernel_shape=[2, 2], storage_order=1>(x) }
+        """
+    )
+    x = np.random.RandomState(4).randn(1, 4, 8, 8).astype(np.float32)
+    sim_model, ok = onnxsim.simplify(model, check_n=1, input_data={"x": x})
+    assert ok
+    node = _find(sim_model, "MaxPool")
+    assert _attr_int(node, "storage_order") == 1


### PR DESCRIPTION
scripts/axelera already scrapes Voyager SDK's real per-op AIPU support data
(voyager_op_support_data.py) and checks it statically (voyager_simulator.
evaluate_constraints()), the same "op coverage" role pulsar2_ops.py plays
for Axera -- but had no legalizer to act on what that coverage check finds,
unlike scripts/axera/legalize.py.

Add scripts/axelera/legalize.py with three semantics-preserving rewrites
for documented Voyager constraints that have an exact fix rather than just
"avoid this op":

- explicit_auto_pad: Conv/AveragePool/MaxPool's `auto_pad` (SAME_UPPER/
  SAME_LOWER/VALID) becomes NOTSET with explicit `pads`, computed from the
  ONNX spec's own auto_pad formula -- the same `auto_pad == "NOTSET"` rule
  scripts/axelera/README.md already records the real compiler enforcing.
- gemm_transA_to_transpose: Gemm(transA=1) becomes an explicit Transpose
  feeding a Gemm with transA cleared.
- maxpool_rowmajor_when_indices_unused: MaxPool's storage_order is cleared
  to row-major when the optional Indices output isn't produced (the
  attribute only orders that output).

Unlike scripts/axera/legalize.py's rules, none of this has been checked
against a real Voyager SDK compile -- that needs a large optional install
not exercised here. Each rule's docstring says so plainly. What backs them
instead: voyager_ops.py's scraped constraint text, and
voyager_simulator.evaluate_constraints() as a real (docs-derived) check
that a rewrite actually flips a node's verdict from "violated" to "ok".
tests/test_axelera_legalize.py checks that, plus numeric equivalence via
onnx.reference.ReferenceEvaluator (no onnxruntime/device/Docker needed) --
including an honest miss for AveragePool (count_include_pad is a separate,
non-spelling constraint this rewrite correctly leaves alone) and for
Gemm's inserted Transpose (Voyager's scraped Transpose rule has no rank-2
case, so it reads as its own violation despite being exact).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0159ScU6rWSuZPXmP21r4CSu