### PR TITLE
Make the three legalization passes target-agnostic in onnxsim's core

### DIFF
--- a/onnxsim/passes/explicit_auto_pad.h
+++ b/onnxsim/passes/explicit_auto_pad.h
@@ -22,10 +22,17 @@
 // dynamic axis) is left alone rather than guessed at. `Conv`'s
 // `kernel_shape` attribute is optional (inferrable from the weight tensor
 // `W`, which exporters routinely omit it in favor of), so this reads the
-// kernel from `W`'s shape when the attribute is absent, matching how
-// `AIPU`/NPU compilers that publish this same `auto_pad == "NOTSET"`
-// requirement (e.g. Axelera Voyager SDK's Metis compiler -- see
-// `scripts/axelera/legalize.py`'s Python counterpart of this rule) read it.
+// kernel from `W`'s shape when the attribute is absent -- the same place a
+// compiler that itself requires `auto_pad == "NOTSET"` would have to read
+// it from.
+//
+// A generic, target-agnostic legalization: many inference backends accept
+// only explicit padding and refuse (or silently mishandle) `SAME_*`/`VALID`
+// `auto_pad`. This pass carries no knowledge of any particular target; a
+// target-specific legalizer decides whether it needs this rewrite and opts
+// into it (see e.g. `scripts/axelera/legalize.py`, whose own docstring
+// records a real compiler that documents `auto_pad == "NOTSET"` as a hard
+// requirement).
 //
 // This is a pure graph-shape rewrite -- not a node-count reduction -- so it
 // is `PassType::Other` and never runs by default. Opt in with

--- a/onnxsim/passes/gemm_transa_to_transpose.h
+++ b/onnxsim/passes/gemm_transa_to_transpose.h
@@ -12,9 +12,15 @@
 // `perm=[1, 0]` is always the right transpose -- `transA = 1` means
 // "transpose A before the matmul", and inserting the `Transpose` node ahead
 // of the `Gemm` is the same operation, spelled as two nodes instead of one
-// attribute. Some backends document `transA == 0` as a hard requirement
-// (e.g. Axelera Voyager SDK's Metis compiler -- see
-// `scripts/axelera/legalize.py`'s Python counterpart of this rule).
+// attribute.
+//
+// A generic, target-agnostic legalization: some inference backends only
+// implement (or only accelerate) `Gemm` with `transA == 0`, requiring any
+// transposition to already be a separate op. This pass carries no
+// knowledge of any particular target; a target-specific legalizer decides
+// whether it needs this rewrite and opts into it (see e.g.
+// `scripts/axelera/legalize.py`, whose own docstring records a real
+// compiler that documents `transA == 0` as a hard requirement).
 //
 // This is a pure graph-shape rewrite -- not a node-count reduction -- so it
 // is `PassType::Other` and never runs by default. Opt in with

--- a/onnxsim/passes/maxpool_rowmajor_when_indices_unused.h
+++ b/onnxsim/passes/maxpool_rowmajor_when_indices_unused.h
@@ -11,10 +11,14 @@
 // (row-major) whenever the optional `Indices` output isn't actually
 // consumed -- the attribute only orders that output (whether it's read out
 // row-major or column-major), so with no `Indices` consumer the two
-// settings compute the identical `Y`. Some backends document
-// `storage_order == 0` as a hard requirement (e.g. Axelera Voyager SDK's
-// Metis compiler -- see `scripts/axelera/legalize.py`'s Python counterpart
-// of this rule).
+// settings compute the identical `Y`.
+//
+// A generic, target-agnostic legalization: some inference backends only
+// implement (or only accelerate) `MaxPool` with `storage_order == 0`. This
+// pass carries no knowledge of any particular target; a target-specific
+// legalizer decides whether it needs this rewrite and opts into it (see
+// e.g. `scripts/axelera/legalize.py`, whose own docstring records a real
+// compiler that documents `storage_order == 0` as a hard requirement).
 //
 // This is a pure graph-shape rewrite -- so it is `PassType::Other` and
 // never runs by default. Opt in with

--- a/scripts/axelera/README.md
+++ b/scripts/axelera/README.md
@@ -150,7 +150,11 @@ three rewrites also exist as onnxsim C++ passes
 `maxpool_rowmajor_when_indices_unused.h`), registered as opt-in
 `PassType::Other` optimizers -- so any onnxsim binding (Python, C, Rust,
 npm/WASM), not just this script, can run them, and they run *inside*
-`simplify()`'s own fixed point rather than as a second pass after it:
+`simplify()`'s own fixed point rather than as a second pass after it. Those
+core passes carry no Voyager/Axelera-specific knowledge at all -- they're
+generic ONNX-legal rewrites for a *kind* of backend limitation
+(explicit-padding-only, no `transA`, row-major-only `storage_order`); this
+directory is the legalizer that knows Voyager needs all three, and why:
 
 ```python
 model, ok = onnxsim.simplify(

--- a/scripts/axelera/legalize.py
+++ b/scripts/axelera/legalize.py
@@ -44,7 +44,13 @@ not a substitute for an actual `axelera.compiler` run.
 
 Each of these three rules also has a C++ counterpart in onnxsim's own core
 (`onnxsim/passes/explicit_auto_pad.h`, `gemm_transa_to_transpose.h`,
-`maxpool_rowmajor_when_indices_unused.h`), registered as opt-in
+`maxpool_rowmajor_when_indices_unused.h`). Those core passes are
+deliberately generic and target-agnostic -- they carry no mention of
+Voyager SDK or Axelera at all, only the ONNX-legal rewrite itself and the
+*kind* of backend limitation it answers (explicit-padding-only, `transA`-
+unsupported, row-major-only). This file is the legalizer: the place that
+knows *this* target needs all three, and why (the constraint text and
+evaluator above). Registered as opt-in
 `PassType::Other` optimizers -- `onnxsim.simplify(model,
 extra_optimizers=["explicit_auto_pad", "gemm_transA_to_transpose",
 "maxpool_rowmajor_when_indices_unused"])`, or `--enable-optimization


### PR DESCRIPTION
Follow-up to #1338: `onnxsim/passes/explicit_auto_pad.h`, `gemm_transa_to_transpose.h` and `maxpool_rowmajor_when_indices_unused.h` named "Axelera Voyager SDK's Metis compiler" directly as the reason each rule exists — tying an otherwise generic, reusable ONNX legalization pass to one target inside code meant to be usable by any target's own legalizer.

This PR reframes each pass's docstring in purely generic terms (the *kind* of backend limitation it answers — explicit-padding-only, `transA`-unsupported, row-major-only `storage_order` — not which vendor happens to need it), and moves the target-specific "why" back to `scripts/axelera/legalize.py` and its README, which is where a target's own rationale belongs: that file is the *legalizer* — the place that knows Voyager needs all three passes, and why.

No code changes — this is comments/docs only:
- `onnxsim/passes/{explicit_auto_pad,gemm_transa_to_transpose,maxpool_rowmajor_when_indices_unused}.h`: drop the Axelera-specific parenthetical, replace with generic "some backends require X" framing plus a neutral pointer to `scripts/axelera/legalize.py` as one example consumer.
- `scripts/axelera/legalize.py` / `scripts/axelera/README.md`: add a sentence making explicit that the core passes carry no target-specific knowledge and that this directory is the legalizer that supplies it.

Verified with `clang-format --style=file:onnxsim/.clang-format --dry-run --Werror` (clean), a full incremental rebuild, and the complete legalize/pass test suite (`test_explicit_auto_pad.py`, `test_gemm_transa_to_transpose.py`, `test_maxpool_rowmajor_when_indices_unused.py`, `test_axelera_legalize.py`, `test_axera_legalize.py`, `test_axera_training_legalize.py`, `test_build_resident_train_step.py` — 65 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159ScU6rWSuZPXmP21r4CSu

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ScU6rWSuZPXmP21r4CSu)_