### PR TITLE
axera: close the audio-model depthwise-conv and Split gaps; confirm the Where one

### DIFF
--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -72,7 +72,7 @@ simple. `Erf` is GELU's decomposed form -- `transformers`' export already
 emits the Erf-based GELU here, not the fused `Gelu` op, so the Gelu gap above
 does not block this model in practice.
 
-### wav2vec2 -- mostly clean, one open question
+### wav2vec2 -- one gap, now confirmed real (not "maybe")
 
 `transformers.Wav2Vec2Model(...)`, 228 nodes:
 
@@ -82,55 +82,124 @@ does not block this model in practice.
 | `Where`, `IsNaN`, `GreaterOrEqual`, `Equal`, `Expand`, `Slice`, `Cast`, `ConstantOfShape`, `Shape`, `Unsqueeze` | **no** |
 | `Constant` | needs no gradient |
 
-The second row is real but, on inspection, looks like attention-mask/padding
-construction from the `attention_mask` input (`Where`/`IsNaN` guard against
-`-inf` propagating through softmax on fully-masked rows, `Equal`/`GreaterOrEqual`
-build the boolean mask itself) -- a subgraph that depends only on the
-(non-trainable) input mask, not on any trainable weight, and so should never
-need differentiating if the trainable region is a tail of encoder layers
-downstream of where the mask is already folded in as an additive bias.
-**This is not proven here** -- it is a static op-list argument, not a traced
-backward slice. The concrete follow-up: pick a trainable tail (e.g. the last
-1-2 transformer layers, same recipe as resnet18's last-four-layers), run
-`build_backward` over just that slice, and confirm it never needs to touch
-the `Where`/mask subgraph. If the trainable slice is chosen the same way the
-resnet18 work chose its trainable tail (downstream of everything
-mask-related), this is very likely fine, but "likely" is doing real work in
-that sentence until someone runs it.
+The first pass of this survey guessed the `Where`/`IsNaN` row was probably
+confined to attention-mask *construction* -- upstream of, and excludable
+from, any trainable tail chosen downstream of it -- and flagged that as
+unproven. **It is disproven.** Tracing the real export (`onnx.load` +
+following each `Where`/`IsNaN` node's producer/consumer edges, not just its
+op-type membership) shows each of the two encoder layers has its own,
+per-layer `attn_weights = Where(IsNaN(attn_weights), 0, attn_weights)`
+sitting **directly between that layer's own `Softmax` and its own
+`MatMul` with `V`** --
+`/encoder/layers.{i}/attention/IsNaN` -> `/encoder/layers.{i}/attention/Where_1`
+-> `MatMul`. This is numerical-stability cleanup (a fully-masked row's
+softmax is uniform, not `NaN`, until floating-point cancellation makes it one
+in practice -- HF's own attention implementations guard against exactly
+this), and it is baked into *every* layer's own forward computation, not
+shared or hoisted out. So there is no way to choose a trainable tail that
+excludes it: even "the last layer only" (`V`'s projection, the output
+projection) needs a gradient through its own layer's `Where`, because that
+`Where`'s input and output are both fresh intermediates computed inside that
+layer -- unlike an external bias tensor merely *added* to the scores, there
+is nothing outside the layer to treat as an opaque boundary input instead.
+**wav2vec2 (the plain, non-Conformer model) cannot train through any tail
+that includes attention output until `Where` has a backward rule.** That
+rule is not hard -- `Where`'s gradient is `dX = mask * g`, `dY = (1-mask) *
+g` with `mask = Cast(condition, FLOAT)`, i.e. the same "boolean condition
+becomes a float 0/1 multiplied in, never re-emitted as `Where` itself"
+convention `graph_grad`'s own module docstring already states as a rule for
+every hand-written gradient here -- but it is real, unimplemented work, not
+a design workaround. Left for the next person who wants wav2vec2 itself
+(Whisper, below, remains gap-free and is still the better first trial).
 
-### Wav2Vec2-Conformer -- two real, specific gaps
+### Wav2Vec2-Conformer -- both gaps closed; one different, unresolved question
 
-`transformers.Wav2Vec2ConformerModel(...)`, 231 nodes. Same `Where`-family
-caveat as wav2vec2 above, plus two new, concrete blockers:
+`transformers.Wav2Vec2ConformerModel(...)`, 231 nodes. Two concrete blockers
+found by the first pass, **both fixed and verified on host** (no hardware
+needed for either -- both are onnxruntime-checked numerically, the same bar
+every other rule in this codebase holds itself to):
 
-- **A real depthwise `Conv`.** The conformer block's `conv_module` has
-  `/encoder/layers.0/conv_module/depthwise_conv/Conv` with **`group=32`**
-  (fully depthwise: `groups == channels`) sitting right next to two ordinary
-  `group=1` pointwise convs. If this convolution's weight were made
-  trainable, **neither `act_weight_conv_to_matmul` nor
-  `_linearize_trainable_convs` has any path for it** -- both decline
-  `group != 1` outright and fall through unlegalized, which would fail at
-  Pulsar2 build time exactly the way an un-legalized live-weight `Conv` did
-  for resnet18 before that rule existed. See "The depthwise-conv gap" below.
-- **`Split`, with no backward rule.** The conv module's gating
-  (`Split` + `Sigmoid` + `Mul`, a GLU) uses an op type absent from `_RULES`.
-  `Sigmoid` and `Mul` are both covered; `Split` alone is the gap. Unlike the
-  depthwise conv, this would be a small addition -- `Split`'s gradient is
-  just the reverse operation, `Concat` of the incoming per-output gradients
-  back along the same axis, which is itself already an op Pulsar2's own
-  compiler emits from `act_weight_conv_to_matmul`'s tap-fusion (`fuse=True`),
-  so it is at least a known-compilable op type on this hardware, just not
-  yet a registered gradient rule.
+- **A real depthwise `Conv`, group-legalization now handled.** The conformer
+  block's `conv_module` has `/encoder/layers.0/conv_module/depthwise_conv/Conv`
+  with **`group=32`** (fully depthwise: `groups == channels`) beside two
+  ordinary `group=1` pointwise convs. `scripts/axera/legalize.py`'s
+  `act_weight_conv_to_matmul` now legalizes `group > 1` too: each group's
+  own channel slice of the (already-transposed-once) activation and weight
+  runs through the exact same per-tap-matmul path as `group=1`, and the
+  per-group outputs concatenate back onto the `Cout` axis before the shared
+  bias add -- no new op types (`Slice`/`Concat` are already used for
+  tap-fusion and were already in this rule's own output vocabulary), and
+  `group=1` (resnet18, and every model this rule ran on before) takes the
+  exact pre-existing node sequence, unchanged, so nothing already shipped
+  moves. Verified against onnxruntime at >100 dB SNR for a fully depthwise
+  1-D case (`group == cin == cout`, the literal Conformer shape, both plain
+  and strided) and a grouped-not-depthwise 2-D case
+  (`tests/test_axera_training_legalize.py::test_a_grouped_live_weight_convolution_becomes_per_group_matmuls`,
+  plus a biased-grouped-conv case checking the bias broadcasts correctly
+  over the concatenated output). `_linearize_trainable_convs`
+  (`scripts/axera/build_resident_train_step.py`, PR #1336 -- open at the
+  time of this fix, not yet merged) still declines `group != 1` on purpose
+  and falls through to `act_weight_conv_to_matmul` for those convs, so a
+  Conformer trial gets full grouped-conv coverage today even before that
+  optimization is extended to match; extending it the same way would be a
+  pure speed win on top, not a correctness gap.
+- **`Split`, backward rule added.** The conv module's gating (`Split` +
+  `Sigmoid` + `Mul`, a GLU) used an op type absent from `graph_grad._RULES`.
+  `Sigmoid` and `Mul` were already covered; `Split` alone was the gap. Its
+  gradient is now `onnxsim.graph_grad._grad_split`, registered in a new
+  `_MULTI_OUTPUT_RULES` table (`build_backward`'s per-node dispatch now
+  checks this table first) rather than `_RULES`, because a rule for an op
+  with more than one *output* genuinely needs more than one incoming
+  gradient -- a different argument shape from every other rule in this
+  module, not a variant of the existing single-output `Rule` contract.
+  Deliberately **not** `Concat` of the incoming gradients (the textbook
+  VJP): `Concat` is not in `graph_grad.BACKWARD_OPS` (this module's own
+  WebGPU/WebNN/NPU-portable allowlist), and `tests/test_graph_grad.py`'s own
+  harness asserts every emitted backward op stays inside it. Instead, each
+  output's gradient is right-multiplied by a constant 0/1 selection matrix
+  (`E_i = eye(N)[offset_i : offset_i + size_i, :]`) after moving the split
+  axis to the last position (`Transpose`, skipped when already there) --
+  `MatMul`/`Add`/`Transpose` only, all three already in `BACKWARD_OPS`, so
+  no allowlist change was needed at all. `Split` is consequently visible
+  through `graph_grad.supported_ops()` (what QAT/LoRA block discovery
+  already keys off) but deliberately **not** in the parity-pinned
+  `SUPPORTED_OPS` constant, since it has no C++/WASM mirror yet -- a real,
+  stated limitation (Python-only today), not an oversight. Verified against
+  finite differences for: both outputs consumed (equal sizes), one output
+  consumed with the other zero-contributing (uneven sizes, negative axis),
+  and a non-last split axis (`tests/test_graph_grad.py::test_rule_matches_finite_differences[split_*]`,
+  6 cases).
+
+**What's still open for Conformer, and it is a different situation from
+plain wav2vec2's confirmed block above, not the same one:** Conformer's
+encoder layers also each have a `Where` node
+(`/encoder/layers.{i}/self_attn/Where`), but tracing it shows a different
+shape than wav2vec2's -- no `IsNaN` anywhere in the whole 231-node Conformer
+export (confirmed by listing every `Where`/`IsNaN`/`Equal`/`GreaterOrEqual`
+node in the real export), and this `Where`'s *condition* operand comes from
+`/encoder/Expand_1`, computed once outside the per-layer loop and shared,
+not recomputed per layer. That is the shape of an additive attention-mask
+bias built once and added into each layer's own scores (`Where(shared_cond,
+per-layer-scaled-value, 0)` -> `Add` to that layer's scores) -- the pattern
+the original first-pass guess was about, and which a trainable tail chosen
+downstream of the shared mask-bias tensor (treating it as an opaque external
+input to the slice, the same way a `discover_qat_blocks`-style boundary
+would) can plausibly route around. **This was not traced end-to-end the way
+wav2vec2's was** (time-boxed: the wav2vec2 case already gave a definitive,
+generalizable answer -- "does a `Where` ever sit between two internally-
+computed tensors with no external tensor to treat as a boundary" -- and
+Conformer's shares HF's attention code enough that resolving it precisely
+needs its own trace, not an inference from wav2vec2's). Flagged, not closed.
 
 ## What actually blocks each family, ranked by cost to fix
 
-| gap | blocks | fix, roughly |
-| --- | --- | --- |
-| Raw `Gelu` has no backward rule | only an exporter that emits fused `Gelu` instead of decomposed Erf-GELU (neither Whisper's nor wav2vec2's `transformers` export does this) | cheapest: a `legalize.py` rule decomposing `Gelu` into `Mul`/`Add`/`Erf`/`Div`-by-constant, all already covered |
-| `Split` has no backward rule | Conformer's GLU gating only (not wav2vec2, not Whisper) | small: gradient of `Split` is `Concat` of the per-output gradients along the same axis |
-| Grouped/depthwise `Conv` has no forward-legalization path | Conformer's `conv_module` only (not wav2vec2, not Whisper -- neither uses a grouped conv anywhere) | real but bounded: `onnxsim.graph_grad._grad_conv`'s own docstring states groups "cost nothing extra" for the *backward* im2col-as-gather identity it already uses (the group axis splits out of the channel axis via reshape, and `MatMul` batches over it) -- the same generalization applied to `_linearize_trainable_convs`'s forward-side use of that identity (PR #1336) would very likely close this, since the underlying primitive already handles groups; it is un-extended, not fundamentally blocked |
-| `Where`/mask-construction ops have no backward rule | *maybe* wav2vec2 and Wav2Vec2-Conformer, if a trainable tail is chosen upstream of where the mask is folded in -- unconfirmed | not a fix, a design constraint: choose the trainable region downstream of all mask handling, the same way resnet18's trainable tail was chosen downstream of the frozen stem |
-| LSTM/GRU have no backward rule at all, and the real ONNX op is opaque (no legalization route around it) | any classic RNN-based ASR/TTS model, full stop | the largest lift here -- would need either a dedicated LSTM-cell backward rule (the four gates are themselves ordinary `MatMul`/`Sigmoid`/`Tanh` arithmetic once unrolled, so the primitives exist) or accepting only models that unroll their own recurrence in ONNX rather than emitting the fused `LSTM` op |
+| gap | status | blocks | fix |
+| --- | --- | --- | --- |
+| Grouped/depthwise `Conv` has no forward-legalization path | **fixed** (`scripts/axera/legalize.py`'s `act_weight_conv_to_matmul`) | was: Conformer's `conv_module` | per-group tap-matmul + `Concat` back onto `Cout`, `group=1` path untouched |
+| `Split` has no backward rule | **fixed** (`onnxsim/graph_grad.py`'s `_grad_split`, via the new `_MULTI_OUTPUT_RULES` table) | was: Conformer's GLU gating | `MatMul` against a constant 0/1 selection matrix per output, no `Concat`, stays inside `BACKWARD_OPS` |
+| `Where`/`IsNaN` numerical-stability cleanup has no backward rule | **confirmed blocking**, not a design workaround | plain wav2vec2, any tail touching attention output -- Conformer's own (differently-shaped) `Where` usage is still unresolved | `dX = Cast(cond, FLOAT) * g`, `dY = (1 - that) * g` -- same "float mask, not `Where` itself" convention this module already uses everywhere else; not yet implemented |
+| Raw `Gelu` has no backward rule | open, low priority | only an exporter emitting fused `Gelu` instead of decomposed Erf-GELU (neither Whisper's nor wav2vec2's `transformers` export does this) | a `legalize.py` rule decomposing `Gelu` into `Mul`/`Add`/`Erf`/`Div`-by-constant, all already covered |
+| LSTM/GRU have no backward rule at all, and the real ONNX op is opaque (no legalization route around it) | open, largest lift | any classic RNN-based ASR/TTS model, full stop | a dedicated LSTM-cell backward rule (the four gates are themselves ordinary `MatMul`/`Sigmoid`/`Tanh` arithmetic once unrolled) or accepting only models that unroll their own recurrence in ONNX |
 
 ## Do the two silent vendor bugs generalize?
 
@@ -161,15 +230,28 @@ enough that a new architecture should not need to rediscover them:
 ## Recommendation: smallest real next trial
 
 **Whisper's encoder**, trainable tail = last 1-2 transformer layers (same
-shape as resnet18's "last four layers," frozen stem + trainable tail). It is
-the cleanest of the three surveyed: full op coverage confirmed with zero open
-questions (no `Where`-family uncertainty to resolve, no depthwise conv, no
-`Split`), and a fixed-length input (no attention-mask handling at all) that
-avoids the one thing this survey could not settle statically. wav2vec2 is the
-second choice, gated on confirming the `Where`-family ops stay off the
-trainable slice's backward path -- worth trying once the Whisper trial is
-working, not before. Wav2Vec2-Conformer needs the depthwise-conv and `Split`
-gaps closed first and should wait.
+shape as resnet18's "last four layers," frozen stem + trainable tail), still
+stands as the best first trial and is now *more* clearly so than the first
+pass thought: full op coverage confirmed with zero open questions, and a
+fixed-length input (no attention-mask handling at all) that sidesteps every
+`Where`-shaped question this survey has now spent real effort on for the
+other two families.
+
+The ranking below it changed. Wav2Vec2-Conformer's conv-module gaps
+(depthwise `Conv`, `Split`) are now **closed** -- it is Conformer's
+still-open, differently-shaped `Where` question (see above) that gates it
+next, not the conv-module work this pass finished. Plain wav2vec2 dropped
+from "second choice, likely fine" to **blocked**: its `Where`/`IsNaN`
+numerical-stability cleanup is confirmed to sit inside every encoder layer's
+own attention computation with no external tensor to route a trainable
+tail's boundary around, so it needs `Where`'s backward rule implemented
+before any tail including attention output can train, not just a careful
+choice of trainable region. Concretely, after Whisper: either implement
+`Where`'s backward rule (unblocks wav2vec2 outright, and is the same
+"boolean condition, not the op, becomes a float mask" work either way) or
+trace Conformer's shared-condition `Where` end-to-end to confirm it is
+excludable by block boundary (cheaper if it pans out, but unproven, and
+resolves only Conformer -- `Where`'s backward rule resolves both).
 
 ## Reproducing the exports
 

--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -1,0 +1,193 @@
+# Op coverage for training audio/speech models on the AX650N: a survey
+
+Companion to `docs/axera-on-device-training-handoff.md`, which got a resnet18
+fine-tuning step running and fast on real hardware. This asks a narrower
+question before anyone spends a session on it: for a *speech* model, which
+architecture families does today's pipeline (`onnxsim.graph_grad.build_backward`
++ `scripts/axera/legalize.py`'s `TRAINING_RULES`) actually reach, and which
+have a real, specific gap? Nothing here touched the AX650N or Pulsar2 Docker
+-- it is a static code-coverage check plus real ONNX exports of three
+architecture families, cross-referenced against the two things that decide
+trainability on this hardware: `onnxsim.graph_grad._RULES` (what
+`build_backward` can differentiate) and `scripts/axera/pulsar2_ops.py`'s
+`AX650_SUPPORTED_OPS` (what the NPU can run at all).
+
+## Corrections to a first-pass guess
+
+Before this survey, the following was assumed from memory rather than the
+code. All four held up, with one real refinement:
+
+- **Conv1D is supported** by `act_weight_conv_to_matmul` -- confirmed by
+  reading the rule and by `tests/test_axera_training_legalize.py`'s existing
+  `test_a_live_weight_convolution_becomes_matmuls_in_1d_and_2d`, which already
+  exercises `nd=1` (kernel 3, stride 1, pad 1) and checks it against
+  onnxruntime at >100 dB SNR. **Refinement**: both this rule and the newer,
+  faster `_linearize_trainable_convs` (`scripts/axera/build_resident_train_step.py`,
+  landed in PR #1336) require `group=1, dilation=1` -- "1-D and 2-D, any
+  stride" was accurate but incomplete; grouped/dilated convolutions of any
+  rank are declined outright by both. See "The depthwise-conv gap" below --
+  this is the one place the first pass undersold a real limitation.
+- **Softmax and LayerNormalization are both differentiable** (`_grad_softmax`,
+  `_grad_layer_normalization` in `onnxsim/graph_grad.py`'s `_RULES` dispatch
+  table) **and NPU-executable** (both names are in `AX650_SUPPORTED_OPS`) --
+  confirmed by reading both tables directly.
+- **The raw ONNX `Gelu` op has no backward rule** -- confirmed: absent from
+  `_RULES`, and `legalize.py` has no decompose-to-`Erf` rule for it either
+  (`grep -rn "Gelu" scripts/axera/legalize.py onnxsim/graph_grad.py` -- no
+  hits). `Gelu` itself *is* in `AX650_SUPPORTED_OPS`, so it runs fine at
+  inference; it just cannot appear on a path back to a trainable weight
+  today. See "The Gelu gap" below for why this turned out not to matter for
+  the models actually inspected.
+- **LSTM has no backward rule**, confirmed two ways: `LSTM` is absent from
+  `_RULES`, and a real `torch.onnx.export` of a plain `torch.nn.LSTM` (opset
+  17) emits it as a single opaque `LSTM` node, not a decomposed
+  gate-by-gate graph -- so there is no way to route around the missing rule
+  by legalizing it into already-covered ops, the way `act_weight_conv_to_matmul`
+  routes a `Conv` into `MatMul`s. `LSTM` **is** in `AX650_SUPPORTED_OPS` (it
+  runs fine at inference); `GRU` is in neither table. Classic RNN-based
+  ASR/TTS models are not trainable through this pipeline today, full stop.
+
+## Three real architectures, real exports
+
+Random-initialized, opset-17 ONNX exports via `torch.onnx.export` (no
+pretrained weights needed or fetched -- only architecture shape matters
+here), built with tiny configs (`hidden_size`/`d_model` 32, 1-2 layers) purely
+to get a real op graph rather than reason from documentation. Every op type
+below is cross-checked against `onnxsim.graph_grad._RULES`'s 28 keys.
+
+### Whisper encoder -- clean, would build today
+
+`transformers.WhisperModel(...).get_encoder()`, 128 nodes:
+
+| op types present | in `_RULES`? |
+| --- | --- |
+| `Add`, `Identity`, `MatMul`, `Mul`, `Transpose`, `Reshape`, `LayerNormalization`, `Div`, `Erf`, `Conv`, `Softmax` | yes, all of them |
+| `Constant` | needs no gradient (a literal, not a function of any input) |
+
+**Every node type in a real Whisper-encoder export already has a backward
+rule.** No `Where`, no mask-construction ops at all -- Whisper's encoder has
+no variable-length attention masking (it always processes a fixed 30 s /
+3000-frame window, padded upstream), which is exactly what keeps this graph
+simple. `Erf` is GELU's decomposed form -- `transformers`' export already
+emits the Erf-based GELU here, not the fused `Gelu` op, so the Gelu gap above
+does not block this model in practice.
+
+### wav2vec2 -- mostly clean, one open question
+
+`transformers.Wav2Vec2Model(...)`, 228 nodes:
+
+| op types present | in `_RULES`? |
+| --- | --- |
+| `Add`, `Mul`, `Identity`, `MatMul`, `Transpose`, `Reshape`, `Div`, `Erf`, `Conv`, `LayerNormalization`, `Softmax`, `InstanceNormalization` | yes |
+| `Where`, `IsNaN`, `GreaterOrEqual`, `Equal`, `Expand`, `Slice`, `Cast`, `ConstantOfShape`, `Shape`, `Unsqueeze` | **no** |
+| `Constant` | needs no gradient |
+
+The second row is real but, on inspection, looks like attention-mask/padding
+construction from the `attention_mask` input (`Where`/`IsNaN` guard against
+`-inf` propagating through softmax on fully-masked rows, `Equal`/`GreaterOrEqual`
+build the boolean mask itself) -- a subgraph that depends only on the
+(non-trainable) input mask, not on any trainable weight, and so should never
+need differentiating if the trainable region is a tail of encoder layers
+downstream of where the mask is already folded in as an additive bias.
+**This is not proven here** -- it is a static op-list argument, not a traced
+backward slice. The concrete follow-up: pick a trainable tail (e.g. the last
+1-2 transformer layers, same recipe as resnet18's last-four-layers), run
+`build_backward` over just that slice, and confirm it never needs to touch
+the `Where`/mask subgraph. If the trainable slice is chosen the same way the
+resnet18 work chose its trainable tail (downstream of everything
+mask-related), this is very likely fine, but "likely" is doing real work in
+that sentence until someone runs it.
+
+### Wav2Vec2-Conformer -- two real, specific gaps
+
+`transformers.Wav2Vec2ConformerModel(...)`, 231 nodes. Same `Where`-family
+caveat as wav2vec2 above, plus two new, concrete blockers:
+
+- **A real depthwise `Conv`.** The conformer block's `conv_module` has
+  `/encoder/layers.0/conv_module/depthwise_conv/Conv` with **`group=32`**
+  (fully depthwise: `groups == channels`) sitting right next to two ordinary
+  `group=1` pointwise convs. If this convolution's weight were made
+  trainable, **neither `act_weight_conv_to_matmul` nor
+  `_linearize_trainable_convs` has any path for it** -- both decline
+  `group != 1` outright and fall through unlegalized, which would fail at
+  Pulsar2 build time exactly the way an un-legalized live-weight `Conv` did
+  for resnet18 before that rule existed. See "The depthwise-conv gap" below.
+- **`Split`, with no backward rule.** The conv module's gating
+  (`Split` + `Sigmoid` + `Mul`, a GLU) uses an op type absent from `_RULES`.
+  `Sigmoid` and `Mul` are both covered; `Split` alone is the gap. Unlike the
+  depthwise conv, this would be a small addition -- `Split`'s gradient is
+  just the reverse operation, `Concat` of the incoming per-output gradients
+  back along the same axis, which is itself already an op Pulsar2's own
+  compiler emits from `act_weight_conv_to_matmul`'s tap-fusion (`fuse=True`),
+  so it is at least a known-compilable op type on this hardware, just not
+  yet a registered gradient rule.
+
+## What actually blocks each family, ranked by cost to fix
+
+| gap | blocks | fix, roughly |
+| --- | --- | --- |
+| Raw `Gelu` has no backward rule | only an exporter that emits fused `Gelu` instead of decomposed Erf-GELU (neither Whisper's nor wav2vec2's `transformers` export does this) | cheapest: a `legalize.py` rule decomposing `Gelu` into `Mul`/`Add`/`Erf`/`Div`-by-constant, all already covered |
+| `Split` has no backward rule | Conformer's GLU gating only (not wav2vec2, not Whisper) | small: gradient of `Split` is `Concat` of the per-output gradients along the same axis |
+| Grouped/depthwise `Conv` has no forward-legalization path | Conformer's `conv_module` only (not wav2vec2, not Whisper -- neither uses a grouped conv anywhere) | real but bounded: `onnxsim.graph_grad._grad_conv`'s own docstring states groups "cost nothing extra" for the *backward* im2col-as-gather identity it already uses (the group axis splits out of the channel axis via reshape, and `MatMul` batches over it) -- the same generalization applied to `_linearize_trainable_convs`'s forward-side use of that identity (PR #1336) would very likely close this, since the underlying primitive already handles groups; it is un-extended, not fundamentally blocked |
+| `Where`/mask-construction ops have no backward rule | *maybe* wav2vec2 and Wav2Vec2-Conformer, if a trainable tail is chosen upstream of where the mask is folded in -- unconfirmed | not a fix, a design constraint: choose the trainable region downstream of all mask handling, the same way resnet18's trainable tail was chosen downstream of the frozen stem |
+| LSTM/GRU have no backward rule at all, and the real ONNX op is opaque (no legalization route around it) | any classic RNN-based ASR/TTS model, full stop | the largest lift here -- would need either a dedicated LSTM-cell backward rule (the four gates are themselves ordinary `MatMul`/`Sigmoid`/`Tanh` arithmetic once unrolled, so the primitives exist) or accepting only models that unroll their own recurrence in ONNX rather than emitting the fused `LSTM` op |
+
+## Do the two silent vendor bugs generalize?
+
+The resnet18 work found two silent Pulsar2 bugs and fixed both generically
+enough that a new architecture should not need to rediscover them:
+
+- **Bare `ReduceMean` only reduces the last axis on this hardware.**
+  `graph_grad`'s own `_grad_layer_normalization` and
+  `_grad_instance_normalization` always emit `ReduceMean` with an explicit
+  `axes=` attribute (confirmed: `grep -n "ReduceMean" onnxsim/graph_grad.py`
+  shows every occurrence passing `axes=...`) -- so anything `graph_grad`
+  itself emits for LayerNorm/InstanceNorm's backward is safe by
+  construction. This is a *coding discipline* the module follows, not an
+  automatic guard: a source model's own *forward* graph could still contain
+  a bare `ReduceMean` somewhere outside a fused norm op (an ad hoc pooling
+  head, say), which would need catching on a case-by-case basis the way the
+  resnet18 handoff caught it -- nothing here makes that check unnecessary
+  for a new model, it just confirms the tooling itself doesn't reintroduce
+  the bug.
+- **A constant bias lets Pulsar2 reconstruct a `Gemm` we removed.** The fix
+  (`legalize._unfusable_bias`, reshaping a bias to `[1, N]`) is already a
+  general helper used inside both `gemm_to_matmul` and
+  `act_weight_conv_to_matmul`, which any model runs through via
+  `TRAINING_RULES` regardless of architecture -- confirmed by reading both
+  call sites. Attention's `MatMul`+bias projections should already be
+  protected the same way resnet18's classifier head was, with no new work.
+
+## Recommendation: smallest real next trial
+
+**Whisper's encoder**, trainable tail = last 1-2 transformer layers (same
+shape as resnet18's "last four layers," frozen stem + trainable tail). It is
+the cleanest of the three surveyed: full op coverage confirmed with zero open
+questions (no `Where`-family uncertainty to resolve, no depthwise conv, no
+`Split`), and a fixed-length input (no attention-mask handling at all) that
+avoids the one thing this survey could not settle statically. wav2vec2 is the
+second choice, gated on confirming the `Where`-family ops stay off the
+trainable slice's backward path -- worth trying once the Whisper trial is
+working, not before. Wav2Vec2-Conformer needs the depthwise-conv and `Split`
+gaps closed first and should wait.
+
+## Reproducing the exports
+
+```python
+from transformers import WhisperConfig, WhisperModel
+cfg = WhisperConfig(vocab_size=51865, num_mel_bins=80, encoder_layers=2,
+                     encoder_attention_heads=2, decoder_layers=2,
+                     decoder_attention_heads=2, d_model=32, decoder_ffn_dim=64,
+                     encoder_ffn_dim=64, max_source_positions=32,
+                     max_target_positions=32)
+enc = WhisperModel(cfg).eval().get_encoder()
+torch.onnx.export(enc, (torch.randn(1, 80, 64),), "whisper_enc.onnx",
+                   opset_version=17, dynamo=False)
+```
+
+wav2vec2 and Wav2Vec2-Conformer follow the same shape with
+`Wav2Vec2Config`/`Wav2Vec2Model` and `Wav2Vec2ConformerConfig`/
+`Wav2Vec2ConformerModel`; `conv_depthwise_kernel_size=31` on the Conformer
+config is what produces the `group=32` node above. None of these need
+pretrained weights -- random initialization is enough to get a real op graph,
+which is all this survey needed.

--- a/onnxsim/graph_grad.py
+++ b/onnxsim/graph_grad.py
@@ -338,6 +338,17 @@ class _Backward:
 # gradient -- a ``Reshape``'s shape operand, a ``Clip``'s bounds).
 Rule = Callable[[_Backward, onnx.NodeProto, str], List[Optional[str]]]
 
+# A multi-output rule takes one gradient *per node output* instead of one --
+# ``None`` in the same position where nothing downstream needs that output --
+# and otherwise returns exactly what :data:`Rule` does. Kept as a distinct
+# type (rather than widening :data:`Rule` itself) so every existing
+# single-output rule's shape stays exactly what it always was; see
+# :data:`_MULTI_OUTPUT_RULES` for why this is not just :data:`_CUSTOM_RULES`
+# with a wider value type.
+MultiOutputRule = Callable[
+    [_Backward, onnx.NodeProto, List[Optional[str]]], List[Optional[str]]
+]
+
 
 def _grad_matmul(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
     a, b = node.input[0], node.input[1]
@@ -1811,6 +1822,149 @@ def _grad_gather(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[
     return [ddata, None]
 
 
+def _grad_split(
+    ctx: _Backward, node: onnx.NodeProto, gs: List[Optional[str]]
+) -> List[Optional[str]]:
+    """``Split``'s gradient, as one ``MatMul`` per output against a constant
+    0/1 selection matrix -- not a ``Concat`` of the incoming gradients, even
+    though that is the textbook VJP of a split-along-an-axis.
+
+    **Why not Concat.** It is not in :data:`BACKWARD_OPS` (this module's own
+    WebGPU/WebNN/NPU-portable op allowlist -- see that set's own comment),
+    and adding an op there is a real, separately-justified decision (see the
+    ``Conv``/``ConvTranspose`` note beside :data:`onnxsim.qat_graph.EP_FRIENDLY_OPS`
+    for the shape that justification takes) this rule does not need to
+    force, because the same result is reachable with what the allowlist
+    already has.
+
+    **The identity.** Move the split axis to the last position (a
+    ``Transpose``, skipped when it is already there) and "insert output
+    ``i``'s gradient at its own offset in a zero tensor the width of the
+    input" becomes "right-multiply by a constant selection matrix": for
+    output ``i`` with ``k_i`` entries starting at offset ``o_i`` (out of the
+    input's full width ``N`` along that axis), that matrix is ``E_i =
+    eye(N)[o_i : o_i + k_i, :]``, because ``g_i @ E_i`` places ``g_i``'s
+    ``k_i`` columns at columns ``[o_i, o_i + k_i)`` of an ``N``-wide result
+    and zero elsewhere -- exactly Split's adjoint (Split is a linear
+    projection; this is that projection's transpose). Outputs accumulate by
+    ``Add``; an output with no incoming gradient (nothing downstream needs
+    it) simply contributes no term rather than an explicit zero, which is
+    cheaper and still correct since ``Add`` needs nothing from a term that
+    was never there. The final ``Transpose`` (skipped under the same
+    condition as the first) restores the original axis order. Only
+    ``Transpose``/``MatMul``/``Add`` are used, all already in
+    :data:`BACKWARD_OPS` -- the same "arithmetic primitives, not fused ops"
+    discipline :func:`_grad_conv`'s own docstring states directly.
+
+    This is a :data:`MultiOutputRule`, not a :data:`Rule` -- ``Split`` is the
+    one op type in :data:`_MULTI_OUTPUT_RULES` rather than :data:`_RULES`,
+    which is where :func:`build_backward` looks first (see that function and
+    :data:`_MULTI_OUTPUT_RULES`'s own comment for why).
+
+    Geometry comes from each output's own *declared shape* (``ctx.shape``)
+    rather than parsing ``Split``'s ``split``-as-attribute (opset <13),
+    ``split``-as-optional-second-input (opset 13-17) or ``num_outputs``
+    attribute (opset 18+) spellings -- the same "derive from what the graph
+    actually says the shapes are, not from re-deriving the attribute that
+    produced them" discipline :func:`_conv_geometry`/:func:`_pool_geometry`
+    already use for exactly this reason (a misread attribute cannot survive
+    to become a wrong gradient), and it means this one rule needs no opset
+    branching at all.
+
+    Only ``node.input[0]`` (the tensor actually split) ever gets a gradient;
+    an optional second ``split`` sizes input (opset 13+) is an integer list,
+    not a function of anything float, the same "no gradient for a shape/axes
+    operand" convention every other rule with a non-differentiable extra
+    input already follows (``Reshape``'s ``shape``, ``Gather``'s ``indices``).
+
+    **What it costs.** Each ``E_i`` is ``k_i * N`` elements, materialized as
+    a constant initializer -- small for a modest channel-axis split (the
+    Conformer GLU gating this rule exists for splits one axis of a few
+    hundred channels into two), real and bounded for a very wide one, the
+    same cost :func:`_grad_conv`'s own index/mask tables carry and document
+    for the identical reason: no scatter op is in :data:`BACKWARD_OPS`, so a
+    constant selection stands in for one.
+    """
+    x = node.input[0]
+    in_shape = ctx.shape(x)
+    rank = len(in_shape)
+    axis = int(_attr(node, "axis", 0))
+    if axis < 0:
+        axis += rank
+    if axis < 0 or axis >= rank:
+        raise UnsupportedOpError(
+            f"Split's axis {axis} is out of range for a rank-{rank} input "
+            f"(node {node.output[0]!r})"
+        )
+    if all(g is None for g in gs):
+        return [None] * len(node.input)
+
+    width = int(in_shape[axis])
+    out_sizes = []
+    for out_name in node.output:
+        out_shape = ctx.shape(out_name)
+        if len(out_shape) != rank:
+            raise UnsupportedOpError(
+                f"Split output {out_name!r} has rank {len(out_shape)}, its "
+                f"input {x!r} has rank {rank} (node {node.output[0]!r})"
+            )
+        out_sizes.append(int(out_shape[axis]))
+    if sum(out_sizes) != width:
+        raise UnsupportedOpError(
+            f"Split's outputs sum to {sum(out_sizes)} along axis {axis}, but "
+            f"its input {x!r} has {width} there (node {node.output[0]!r})"
+        )
+
+    perm = [i for i in range(rank) if i != axis] + [axis]
+    identity_perm = perm == list(range(rank))
+    inv_perm = [perm.index(i) for i in range(rank)]
+
+    acc = None
+    offset = 0
+    for g, size in zip(gs, out_sizes):
+        if g is not None:
+            g_t = g if identity_perm else ctx.b.transpose(g, perm)
+            selector = np.zeros((size, width), dtype=np.float32)
+            selector[np.arange(size), offset + np.arange(size)] = 1.0
+            term = ctx.b.matmul(g_t, ctx.b.const(selector, "split_sel"))
+            acc = term if acc is None else ctx.b.add(acc, term)
+        offset += size
+
+    dx = acc if identity_perm else ctx.b.transpose(acc, inv_perm)
+    return [dx] + [None] * (len(node.input) - 1)
+
+
+# --- Multi-output rules --------------------------------------------------
+#
+# :data:`Rule` (and therefore :data:`_RULES`/:data:`SUPPORTED_OPS`) assumes
+# exactly one incoming gradient per node -- true of every builtin rule this
+# module has ever needed until now, and load-bearing elsewhere:
+# ``tests/test_qat_parity.py`` pins ``sorted(SUPPORTED_OPS)`` byte-for-byte
+# against a checked-in fixture that also has to match ``qat_entry.cpp``'s own
+# hardcoded C++ rule table -- see :data:`SUPPORTED_OPS`'s own comment. A rule
+# for an op with more than one *output* (``Split`` is the only one so far --
+# GLU gating in a Conformer-style audio-model block, see
+# ``docs/axera-audio-speech-op-coverage.md``) genuinely needs a different
+# argument shape (one gradient per output, not one), so it is kept in this
+# separate table rather than forced into :data:`_RULES`'s contract or
+# :data:`_CUSTOM_RULES`'s (which promises the *single-output* :data:`Rule`
+# signature to anything that reads it, e.g. a future caller iterating
+# ``_CUSTOM_RULES.values()`` expecting to call each with one ``g``).
+#
+# The direct consequence: an op registered here is **not** part of
+# :data:`SUPPORTED_OPS` and has **no C++/WASM mirror** -- differentiating it
+# is a Python-only capability today, the same divergence
+# :func:`register_gradient`'s docstring already warns ``override=True``
+# causes for a *builtin* op, just reached by a different door. It *is*
+# visible through :func:`supported_ops`, so QAT/LoRA block discovery
+# (``onnxsim.qat.discover_qat_blocks``/``onnxsim.lora.discover_lora_blocks``,
+# both already keyed off ``supported_ops()`` rather than the raw constant)
+# correctly treats a block containing it as differentiable.
+_MULTI_OUTPUT_RULES: Dict[str, MultiOutputRule] = {
+    "Split": _grad_split,
+}
+
+
 # --- Templated rules ---------------------------------------------------
 #
 # An alternative to hand-transcribing a rule's graph construction directly in
@@ -1972,11 +2126,12 @@ _CUSTOM_RULES: Dict[str, Rule] = {}
 
 
 def supported_ops() -> frozenset:
-    """:data:`SUPPORTED_OPS` (the builtin rules) unioned with every op type
-    currently registered via :func:`register_gradient`. This is the set
-    :func:`build_backward` (called the ordinary way, with ``rules=None``)
-    can actually differentiate right now."""
-    return SUPPORTED_OPS | frozenset(_CUSTOM_RULES)
+    """:data:`SUPPORTED_OPS` (the builtin single-output rules) unioned with
+    every op type currently registered via :func:`register_gradient` and
+    every op type in :data:`_MULTI_OUTPUT_RULES` (``Split`` today). This is
+    the set :func:`build_backward` (called the ordinary way, with
+    ``rules=None``) can actually differentiate right now."""
+    return SUPPORTED_OPS | frozenset(_CUSTOM_RULES) | frozenset(_MULTI_OUTPUT_RULES)
 
 
 def register_gradient(
@@ -2169,26 +2324,7 @@ def build_backward(
     ctx = _Backward(b, shapes)
     grads: Dict[str, str] = dict(grad_outputs)
 
-    for node in reversed(list(nodes)):
-        rule = rules.get(node.op_type)
-        if rule is None:
-            raise UnsupportedOpError(
-                f"no gradient rule for op type {node.op_type!r} "
-                f"(node {node.name or node.output[0]!r}); "
-                f"onnxsim.graph_grad differentiates {sorted(rules)}"
-            )
-        if len(node.output) != 1:
-            raise UnsupportedOpError(
-                f"{node.op_type} has {len(node.output)} outputs; only "
-                "single-output nodes are differentiated here"
-            )
-        g = grads.get(node.output[0])
-        if g is None:
-            # Nothing downstream depends on this node, so every gradient it
-            # would produce is zero. Emitting those zeros would be correct
-            # and pure waste.
-            continue
-        contributions = rule(ctx, node, g)
+    def accumulate(node: onnx.NodeProto, contributions: List[Optional[str]]) -> None:
         if len(contributions) != len(node.input):
             raise AssertionError(
                 f"the {node.op_type} rule returned {len(contributions)} gradients "
@@ -2205,6 +2341,47 @@ def build_backward(
             grads[name] = (
                 contribution if existing is None else b.add(existing, contribution)
             )
+
+    for node in reversed(list(nodes)):
+        multi_rule = _MULTI_OUTPUT_RULES.get(node.op_type)
+        if multi_rule is not None:
+            # A different dispatch path from the single-output one below:
+            # every one of this node's *outputs* may carry its own incoming
+            # gradient (or none), not just node.output[0] -- see
+            # :data:`_MULTI_OUTPUT_RULES`'s own comment for why this table is
+            # separate from :data:`_RULES`/:data:`_CUSTOM_RULES` rather than
+            # widening :data:`Rule`'s single-``g`` contract for everything.
+            gs = [grads.get(o) for o in node.output]
+            if all(g is None for g in gs):
+                # Nothing downstream depends on any output, so every
+                # gradient this node would produce is zero -- same "skip
+                # rather than emit waste" reasoning as the single-output
+                # path below, generalized to "none of the outputs" instead
+                # of "the one output".
+                continue
+            accumulate(node, multi_rule(ctx, node, gs))
+            continue
+
+        rule = rules.get(node.op_type)
+        if rule is None:
+            raise UnsupportedOpError(
+                f"no gradient rule for op type {node.op_type!r} "
+                f"(node {node.name or node.output[0]!r}); "
+                f"onnxsim.graph_grad differentiates {sorted(rules) + sorted(_MULTI_OUTPUT_RULES)}"
+            )
+        if len(node.output) != 1:
+            raise UnsupportedOpError(
+                f"{node.op_type} has {len(node.output)} outputs; only "
+                "single-output nodes are differentiated here (unless "
+                "registered in _MULTI_OUTPUT_RULES, checked above)"
+            )
+        g = grads.get(node.output[0])
+        if g is None:
+            # Nothing downstream depends on this node, so every gradient it
+            # would produce is zero. Emitting those zeros would be correct
+            # and pure waste.
+            continue
+        accumulate(node, rule(ctx, node, g))
 
     result: Dict[str, str] = {}
     for target in targets:

--- a/onnxsim/graph_grad.py
+++ b/onnxsim/graph_grad.py
@@ -1930,6 +1930,9 @@ def _grad_split(
             acc = term if acc is None else ctx.b.add(acc, term)
         offset += size
 
+    # at least one `g` is non-None (the all-None case already returned above),
+    # so the loop above set `acc` at least once.
+    assert acc is not None
     dx = acc if identity_perm else ctx.b.transpose(acc, inv_perm)
     return [dx] + [None] * (len(node.input) - 1)
 

--- a/scripts/axera/legalize.py
+++ b/scripts/axera/legalize.py
@@ -769,7 +769,19 @@ def act_weight_conv_to_matmul(model, fuse=True):
     activation transposed to `[N, spatial..., Cin]` each tap is one `MatMul`
     against `w[..., k]` reshaped to `[Cin, Cout]`, and the taps are added.
     Stride becomes the tap slice's `step`. Handles 1-D and 2-D, any stride,
-    dilation 1, group 1; anything else is declined rather than approximated.
+    dilation 1, any `group`; anything else is declined rather than
+    approximated.
+
+    `group > 1` (a depthwise or otherwise grouped Conv, e.g. the gated conv
+    module in a Conformer-style audio-model block) runs the exact same
+    per-tap matmul once per group, against that group's own channel slice of
+    the (already-transposed-once) activation and weight, and concatenates
+    the per-group outputs back onto the `Cout` axis before the shared bias
+    add -- ONNX's own grouping semantics, since each output channel only
+    ever contracts against its own group's input channels. `group == 1`
+    (every model this rule has run on before grouped support was added,
+    including resnet18) takes the untouched original path: no extra
+    Slice/Concat, byte-identical node sequence to before.
     """
     shapes = _value_shapes(model)
     out, changed = [], 0
@@ -789,14 +801,23 @@ def act_weight_conv_to_matmul(model, fuse=True):
             out.append(node)
             continue
         dil = list(attrs["dilations"].ints) if "dilations" in attrs else [1] * nd
-        if any(d != 1 for d in dil) or (
-            "group" in attrs and attrs["group"].i not in (0, 1)
-        ):
+        if any(d != 1 for d in dil):
             out.append(node)
+            continue
+        group = attrs["group"].i if "group" in attrs else 1
+        if group == 0:  # ONNX default; a handful of exporters emit this literally
+            group = 1
+        cout, cin = wshape[0], wshape[1]
+        if (
+            group < 1
+            or xshape[1] % group != 0
+            or cout % group != 0
+            or xshape[1] // group != cin
+        ):
+            out.append(node)  # W's own channel count disagrees with group; do not guess
             continue
         strides = list(attrs["strides"].ints) if "strides" in attrs else [1] * nd
         pads = list(attrs["pads"].ints) if "pads" in attrs else [0] * (2 * nd)
-        cout, cin = wshape[0], wshape[1]
         ksize = wshape[2:]
         spatial = xshape[2:]
         outdim = [
@@ -847,113 +868,179 @@ def act_weight_conv_to_matmul(model, fuse=True):
             )
         )
 
-        wshape_name = _unique_name(model, f"{stem}_wshape")
-        model.graph.initializer.append(
-            numpy_helper.from_array(np.array([cin, cout], np.int64), wshape_name)
-        )
-
-        acc = None
-        tap_x, tap_w = [], []
         taps = [()]
         for j in range(nd):
             taps = [t + (k,) for t in taps for k in range(ksize[j])]
-        for tap in taps:
-            label = "_".join(str(k) for k in tap)
-            cur_x, cur_w = xt, wt
-            for j, k in enumerate(tap):
-                nxt = _unique_name(model, f"{stem}_x{label}_{j}")
+
+        def taps_matmul(x_src, w_src, cout_g, label_prefix):
+            """One group's `sum_tap X_tap @ W_tap` over `x_src`/`w_src`
+            (already sliced to this group's channels, `cin` wide on `x_src`'s
+            last axis and `w_src`'s second-to-last), producing `[N,
+            spatial..., cout_g]`. Identical to the whole (group=1) computation
+            below, just parameterized so `group > 1` can call it once per
+            group over group-sliced inputs -- see the call sites below."""
+            wshape_name = _unique_name(model, f"{label_prefix}_wshape")
+            model.graph.initializer.append(
+                numpy_helper.from_array(np.array([cin, cout_g], np.int64), wshape_name)
+            )
+            acc = None
+            tap_x, tap_w = [], []
+            for tap in taps:
+                label = "_".join(str(k) for k in tap)
+                cur_x, cur_w = x_src, w_src
+                for j, k in enumerate(tap):
+                    nxt = _unique_name(model, f"{label_prefix}_x{label}_{j}")
+                    made.append(
+                        _slice(
+                            model,
+                            cur_x,
+                            nxt,
+                            1 + j,
+                            k,
+                            k + (outdim[j] - 1) * strides[j] + 1,
+                            f"{label_prefix}_SX{label}_{j}",
+                            step=strides[j],
+                        )
+                    )
+                    cur_x = nxt
+                    nxw = _unique_name(model, f"{label_prefix}_w{label}_{j}")
+                    made.append(
+                        _slice(
+                            model,
+                            cur_w,
+                            nxw,
+                            j,
+                            k,
+                            k + 1,
+                            f"{label_prefix}_SW{label}_{j}",
+                        )
+                    )
+                    cur_w = nxw
+                flat = _unique_name(model, f"{label_prefix}_wf{label}")
                 made.append(
-                    _slice(
-                        model,
-                        cur_x,
-                        nxt,
-                        1 + j,
-                        k,
-                        k + (outdim[j] - 1) * strides[j] + 1,
-                        f"{stem}_SX{label}_{j}",
-                        step=strides[j],
+                    helper.make_node(
+                        "Reshape",
+                        [cur_w, wshape_name],
+                        [flat],
+                        name=_unique_name(model, f"{label_prefix}_WR{label}"),
                     )
                 )
-                cur_x = nxt
-                nxw = _unique_name(model, f"{stem}_w{label}_{j}")
-                made.append(
-                    _slice(model, cur_w, nxw, j, k, k + 1, f"{stem}_SW{label}_{j}")
-                )
-                cur_w = nxw
-            flat = _unique_name(model, f"{stem}_wf{label}")
-            made.append(
-                helper.make_node(
-                    "Reshape",
-                    [cur_w, wshape_name],
-                    [flat],
-                    name=_unique_name(model, f"{stem}_WR{label}"),
-                )
-            )
-            tap_x.append(cur_x)
-            tap_w.append(flat)
+                tap_x.append(cur_x)
+                tap_w.append(flat)
 
-        # sum_k X_k @ W_k is one matmul over the concatenation:
-        #   [X_0 | ... | X_{K-1}] @ [W_0 ; ... ; W_{K-1}]
-        # exactly, because the taps share an output and differ only along the
-        # reduction axis. For a 3x3 that is 9 MatMuls and 8 Adds replaced by
-        # two Concats and one MatMul nine times deeper -- fewer nodes to
-        # schedule, and an arithmetic intensity the matrix unit can actually
-        # use. `fuse` exists so the unfused form stays reachable for
-        # bisecting a compiler that dislikes one of them.
-        if fuse and len(tap_x) > 1:
-            xcat = _unique_name(model, f"{stem}_xcat")
-            wcat = _unique_name(model, f"{stem}_wcat")
-            made.append(
-                helper.make_node(
-                    "Concat",
-                    tap_x,
-                    [xcat],
-                    axis=-1,
-                    name=_unique_name(model, f"{stem}_XC"),
+            # sum_k X_k @ W_k is one matmul over the concatenation:
+            #   [X_0 | ... | X_{K-1}] @ [W_0 ; ... ; W_{K-1}]
+            # exactly, because the taps share an output and differ only along
+            # the reduction axis. For a 3x3 that is 9 MatMuls and 8 Adds
+            # replaced by two Concats and one MatMul nine times deeper --
+            # fewer nodes to schedule, and an arithmetic intensity the matrix
+            # unit can actually use. `fuse` exists so the unfused form stays
+            # reachable for bisecting a compiler that dislikes one of them.
+            if fuse and len(tap_x) > 1:
+                xcat = _unique_name(model, f"{label_prefix}_xcat")
+                wcat = _unique_name(model, f"{label_prefix}_wcat")
+                made.append(
+                    helper.make_node(
+                        "Concat",
+                        tap_x,
+                        [xcat],
+                        axis=-1,
+                        name=_unique_name(model, f"{label_prefix}_XC"),
+                    )
                 )
-            )
-            made.append(
-                helper.make_node(
-                    "Concat",
-                    tap_w,
-                    [wcat],
-                    axis=0,
-                    name=_unique_name(model, f"{stem}_WC"),
+                made.append(
+                    helper.make_node(
+                        "Concat",
+                        tap_w,
+                        [wcat],
+                        axis=0,
+                        name=_unique_name(model, f"{label_prefix}_WC"),
+                    )
                 )
-            )
-            acc = _unique_name(model, f"{stem}_mm")
-            made.append(
-                helper.make_node(
-                    "MatMul",
-                    [xcat, wcat],
-                    [acc],
-                    name=_unique_name(model, f"{stem}_MM"),
-                )
-            )
-        else:
-            for i, (xk, wk) in enumerate(zip(tap_x, tap_w)):
-                prod = _unique_name(model, f"{stem}_m{i}")
+                acc = _unique_name(model, f"{label_prefix}_mm")
                 made.append(
                     helper.make_node(
                         "MatMul",
-                        [xk, wk],
-                        [prod],
-                        name=_unique_name(model, f"{stem}_MM{i}"),
+                        [xcat, wcat],
+                        [acc],
+                        name=_unique_name(model, f"{label_prefix}_MM"),
                     )
                 )
-                if acc is None:
-                    acc = prod
-                else:
-                    nxt = _unique_name(model, f"{stem}_a{i}")
+            else:
+                for i, (xk, wk) in enumerate(zip(tap_x, tap_w)):
+                    prod = _unique_name(model, f"{label_prefix}_m{i}")
                     made.append(
                         helper.make_node(
-                            "Add",
-                            [acc, prod],
-                            [nxt],
-                            name=_unique_name(model, f"{stem}_AD{i}"),
+                            "MatMul",
+                            [xk, wk],
+                            [prod],
+                            name=_unique_name(model, f"{label_prefix}_MM{i}"),
                         )
                     )
-                    acc = nxt
+                    if acc is None:
+                        acc = prod
+                    else:
+                        nxt = _unique_name(model, f"{label_prefix}_a{i}")
+                        made.append(
+                            helper.make_node(
+                                "Add",
+                                [acc, prod],
+                                [nxt],
+                                name=_unique_name(model, f"{label_prefix}_AD{i}"),
+                            )
+                        )
+                        acc = nxt
+            return acc
+
+        if group == 1:
+            # Exactly the pre-group-support node sequence -- no extra
+            # Slice/Concat for the common case, so this path (resnet18's, and
+            # every model without a grouped Conv) is untouched.
+            acc = taps_matmul(xt, wt, cout, stem)
+        else:
+            # `x`'s channels split into `group` equal ranges on `xt`'s last
+            # axis; `w`'s *output* channels (the only axis `wt` has not
+            # already reduced to one group's worth -- its Cin axis is a
+            # group's `cin` by construction, since ONNX's Conv spec makes W's
+            # second dimension `Cin/group` regardless of `group`) split the
+            # same way on `wt`'s last axis. Each group only ever contracts
+            # against its own `cin` input channels, matching ONNX Conv's own
+            # grouping semantics; the per-group outputs are independent and
+            # simply concatenate back into the full `Cout` axis, which is
+            # exactly what a depthwise/grouped Conv computes.
+            cout_g = cout // group
+            group_accs = []
+            for g in range(group):
+                gstem = f"{stem}_g{g}"
+                xt_g = _unique_name(model, f"{gstem}_xg")
+                made.append(
+                    _slice(
+                        model, xt, xt_g, nd + 1, g * cin, (g + 1) * cin, f"{gstem}_SXG"
+                    )
+                )
+                wt_g = _unique_name(model, f"{gstem}_wg")
+                made.append(
+                    _slice(
+                        model,
+                        wt,
+                        wt_g,
+                        nd + 1,
+                        g * cout_g,
+                        (g + 1) * cout_g,
+                        f"{gstem}_SWG",
+                    )
+                )
+                group_accs.append(taps_matmul(xt_g, wt_g, cout_g, gstem))
+            acc = _unique_name(model, f"{stem}_gcat")
+            made.append(
+                helper.make_node(
+                    "Concat",
+                    group_accs,
+                    [acc],
+                    axis=-1,
+                    name=_unique_name(model, f"{stem}_GC"),
+                )
+            )
         # A bias is [Cout], which broadcasts onto the trailing axis exactly
         # where the taps land -- before the output is transposed back. The
         # 1x1 downsample convolutions in resnet18 carry one, and skipping

--- a/tests/test_axera_training_legalize.py
+++ b/tests/test_axera_training_legalize.py
@@ -120,6 +120,121 @@ def test_a_live_weight_convolution_becomes_matmuls_in_1d_and_2d():
         }
 
 
+def _grouped_conv_live_weight_model(cin, cout, group, k, size, stride, pad, nd):
+    """A grouped/depthwise `Conv` with a *live* (runtime, non-initializer)
+    weight -- the shape a real audio model puts on the wire. Wav2Vec2-
+    Conformer's gated conv module uses a fully depthwise 1-D `Conv`
+    (`group == cin == cout`, per `docs/axera-audio-speech-op-coverage.md`);
+    built via `onnx.parser` per this repo's CLAUDE.md convention for new
+    test model-building code.
+    """
+    cin_pg = cin // group
+    out = (size + 2 * pad - k) // stride + 1
+    x_dims = ",".join(["1", str(cin)] + [str(size)] * nd)
+    w_dims = ",".join([str(cout), str(cin_pg)] + [str(k)] * nd)
+    y_dims = ",".join(["1", str(cout)] + [str(out)] * nd)
+    ks = ",".join([str(k)] * nd)
+    strides = ",".join([str(stride)] * nd)
+    pads = ",".join([str(pad)] * (2 * nd))
+    return onnx.parser.parse_model(f"""
+    <ir_version: 10, opset_import: ["": 17]>
+    g (float[{x_dims}] x, float[{w_dims}] w) => (float[{y_dims}] y)
+    {{
+        y = Conv<kernel_shape=[{ks}], strides=[{strides}], pads=[{pads}], group={group}>(x, w)
+    }}
+    """)
+
+
+def test_a_grouped_live_weight_convolution_becomes_per_group_matmuls():
+    """Depthwise/grouped convs are common in audio models (Wav2Vec2-
+    Conformer's gated conv module: a fully depthwise 1-D `Conv`,
+    `group == channels`) -- `act_weight_conv_to_matmul` must legalize these
+    too, not just `group=1`."""
+    rng = np.random.default_rng(7)
+    for nd, cin, cout, group, k, stride, pad in (
+        (1, 8, 8, 8, 3, 1, 1),  # fully depthwise, 1-D -- the Conformer shape
+        (2, 8, 16, 4, 3, 1, 1),  # grouped, not depthwise, 2-D
+        (1, 6, 6, 6, 5, 2, 2),  # depthwise, strided
+    ):
+        cin_pg = cin // group
+        model = _grouped_conv_live_weight_model(
+            cin, cout, group, k, 16, stride, pad, nd
+        )
+        feeds = {
+            "x": rng.standard_normal([1, cin] + [16] * nd).astype(np.float32),
+            "w": (rng.standard_normal([cout, cin_pg] + [k] * nd) * 0.2).astype(
+                np.float32
+            ),
+        }
+        ref = _run(model, feeds)[0]
+        after = onnx.ModelProto.FromString(model.SerializeToString())
+        assert legalize.act_weight_conv_to_matmul(after) == 1, (nd, cin, cout, group)
+        onnx.checker.check_model(after)
+        got = _run(after, feeds)[0]
+        assert got.shape == ref.shape
+        assert _snr(ref, got) > 100, (nd, cin, cout, group, _snr(ref, got))
+        # Same op vocabulary as the group=1 case -- just more Slice/Concat.
+        assert {n.op_type for n in after.graph.node} <= {
+            "Pad",
+            "Transpose",
+            "Slice",
+            "Reshape",
+            "MatMul",
+            "Add",
+            "Concat",
+        }
+
+
+def test_a_grouped_convolution_bias_broadcasts_over_the_full_concatenated_output():
+    """The bias add runs *after* the per-group outputs concatenate back onto
+    the full `Cout` axis, using the original unsliced `[Cout]` bias -- so a
+    grouped Conv's bias needs no group-aware slicing of its own, unlike the
+    activation/weight. Confirm that against onnxruntime rather than just
+    asserting the code takes that path."""
+    rng = np.random.default_rng(11)
+    cin, cout, group, k = 8, 16, 4, 3
+    bias = numpy_helper.from_array(rng.standard_normal(cout).astype(np.float32), "bb")
+    model = _model(
+        [
+            helper.make_node(
+                "Conv",
+                ["x", "w", "bb"],
+                ["y"],
+                kernel_shape=[k],
+                pads=[1, 1],
+                group=group,
+                name="c",
+            )
+        ],
+        {"x": [1, cin, 16], "w": [cout, cin // group, k]},
+        {"y": [1, cout, 16]},
+        [bias],
+    )
+    feeds = {
+        "x": rng.standard_normal((1, cin, 16)).astype(np.float32),
+        "w": (rng.standard_normal((cout, cin // group, k)) * 0.2).astype(np.float32),
+    }
+    ref = _run(model, feeds)[0]
+    assert legalize.act_weight_conv_to_matmul(model) == 1
+    onnx.checker.check_model(model)
+    assert _snr(ref, _run(model, feeds)[0]) > 100
+
+
+def test_a_grouped_convolution_whose_weight_is_constant_is_left_alone():
+    """Same fast-path guarantee as the ungrouped case: a constant weight
+    means an ordinary inference Conv, group or not, and this rule must not
+    touch it."""
+    w = numpy_helper.from_array(
+        np.random.default_rng(8).standard_normal((8, 1, 3)).astype(np.float32), "w"
+    )
+    node = helper.make_node(
+        "Conv", ["x", "w"], ["y"], kernel_shape=[3], pads=[1, 1], group=8, name="c"
+    )
+    model = _model([node], {"x": [1, 8, 16]}, {"y": [1, 8, 16]}, initializer=[w])
+    assert legalize.act_weight_conv_to_matmul(model) == 0
+    assert [n.op_type for n in model.graph.node] == ["Conv"]
+
+
 def test_a_convolution_whose_weight_is_constant_is_left_alone():
     """Only a *live* weight is a problem; an ordinary inference convolution
     must keep its fast path."""

--- a/tests/test_graph_grad.py
+++ b/tests/test_graph_grad.py
@@ -967,6 +967,48 @@ _CASES = {
         """,
         None,
     ),
+    # `Split` is a MultiOutputRule (`_MULTI_OUTPUT_RULES`, not `_RULES`) --
+    # both outputs consumed, equal sizes (opset 17 has no `split` attribute
+    # or `num_outputs`; omitting the optional `split` input means "divide
+    # evenly among however many outputs are named").
+    "split_add_both_outputs": (
+        """
+        g (float[4,6] A) => (float[4,3] Y) {
+          S0, S1 = Split <axis=1> (A)
+          Y = Add(S0, S1)
+        }
+        """,
+        None,
+    ),
+    # Uneven sizes (the `split` input, opset 13+) and a negative axis, with
+    # only *one* of the two outputs consumed -- exercises the "no term for a
+    # gradient-less output" path and the offset arithmetic for a piece that
+    # does not start at 0.
+    "split_uneven_negative_axis_one_output": (
+        """
+        g (float[2,6] A) => (float[2,4] Y)
+        <int64[2] sizes = {2, 4}>
+        {
+          S0, S1 = Split <axis=-1> (A, sizes)
+          Y = Identity(S1)
+        }
+        """,
+        None,
+    ),
+    # The split axis is not the last one -- the rule's own Transpose-to-last
+    # step actually has to move something, unlike the two cases above (both
+    # split their input's last axis).
+    "split_not_last_axis": (
+        """
+        g (float[6,4] A) => (float[4,4] Y)
+        <int64[2] sizes = {2, 4}>
+        {
+          S0, S1 = Split <axis=0> (A, sizes)
+          Y = Identity(S1)
+        }
+        """,
+        None,
+    ),
 }
 
 

--- a/tests/test_graph_grad_registry.py
+++ b/tests/test_graph_grad_registry.py
@@ -182,14 +182,18 @@ def test_supported_ops_stays_builtin_only_while_the_effective_set_grows():
     ``tests/test_qat_parity.py`` pins against ``qat_parity_fixtures.txt`` --
     it must never move just because some other test registered something, or
     that pin would become test-order-dependent. :func:`onnxsim.graph_grad.supported_ops`
-    is the one that reflects registrations."""
-    before = graph_grad.SUPPORTED_OPS
+    is the one that reflects registrations -- and, permanently, whatever is
+    in :data:`onnxsim.graph_grad._MULTI_OUTPUT_RULES` (``Split`` today),
+    which is why the "effective set" baseline below is `supported_ops()`
+    itself rather than the builtin-only constant."""
+    constant = graph_grad.SUPPORTED_OPS
+    before = graph_grad.supported_ops()
     with graph_grad.custom_gradient("Reciprocal", _grad_reciprocal):
-        assert graph_grad.SUPPORTED_OPS is before
+        assert graph_grad.SUPPORTED_OPS is constant
         assert "Reciprocal" not in graph_grad.SUPPORTED_OPS
         assert "Reciprocal" in graph_grad.supported_ops()
         assert graph_grad.supported_ops() == before | {"Reciprocal"}
-    assert graph_grad.SUPPORTED_OPS is before
+    assert graph_grad.SUPPORTED_OPS is constant
     assert graph_grad.supported_ops() == before
 
 


### PR DESCRIPTION
## Summary

Continues #1339's audio/speech op-coverage survey. That survey named three open questions for training audio/speech models on the AX650N; two are closed here (host-verified, no hardware needed) and the third turned out to have a real, worse-than-hoped answer instead of a guess:

- **Grouped/depthwise `Conv` — closed.** `act_weight_conv_to_matmul` (`scripts/axera/legalize.py`) now legalizes `group > 1` by running the existing per-tap matmul once per group over that group's own channel slice, then concatenating the outputs back onto `Cout`. `group=1` (resnet18, and every model this rule has ever run on) takes the exact pre-existing node sequence, byte-identical — nothing already shipped moves. Verified against onnxruntime at >100 dB SNR for a fully depthwise 1-D case (Wav2Vec2-Conformer's actual `conv_depthwise_kernel_size` shape) and a grouped-not-depthwise 2-D case, both biased and unbiased.

- **`Split` — closed.** New `onnxsim.graph_grad._grad_split`, registered in a new `_MULTI_OUTPUT_RULES` table (`build_backward`'s driver checks it before the single-output path, since a multi-output node needs one gradient per output, not one). Deliberately **not** the textbook `Concat` of the incoming gradients — `Concat` isn't in `BACKWARD_OPS` (this module's own WebGPU/WebNN/NPU-portable allowlist) and the existing test harness (`tests/test_graph_grad.py`) hard-asserts every emitted op stays inside it. Instead, each output's gradient right-multiplies a constant 0/1 selection matrix after moving the split axis to the last position — only `Transpose`/`MatMul`/`Add`, all already in `BACKWARD_OPS`, so no allowlist change was needed. Visible through `supported_ops()` (what QAT/LoRA block discovery already uses) but deliberately kept out of the parity-pinned `SUPPORTED_OPS` constant, since it has no C++/WASM mirror yet — a stated limitation, not an oversight. Verified against finite differences: both outputs consumed, one output consumed with uneven sizes and a negative axis, and a non-last split axis.

- **`Where`/`IsNaN` — confirmed, not fixed.** The survey guessed this mask-construction subgraph was probably excludable from a trainable tail's boundary. Tracing a real `Wav2Vec2Model` export shows that's wrong for plain wav2vec2: every encoder layer has its own `Where(IsNaN(attn_weights), 0, attn_weights)` sitting directly between that layer's own `Softmax` and its own `MatMul` with `V` — a fresh intermediate with nothing external to treat as a slice boundary. Any trainable tail touching attention output needs `Where`'s backward rule first, full stop. Not implemented in this PR; the doc records the shape it should take (a float mask via `Cast`, never `Where` itself in the backward graph — the same convention this module already applies everywhere else). Wav2Vec2-Conformer's own `Where` usage traces differently (no `IsNaN` at all anywhere in that export, a shared condition computed once outside the per-layer loop) and is left explicitly unresolved rather than assumed safe by analogy to the fixed conv-module gaps.

## Test plan

- [x] `pytest tests/test_axera_training_legalize.py` — 18 passed, including 3 new grouped-conv cases (depthwise 1-D, grouped 2-D, biased) against onnxruntime
- [x] `pytest tests/test_graph_grad.py tests/test_graph_grad_templates.py tests/test_graph_grad_registry.py tests/test_graph_grad_torch_autograd.py tests/test_qat_parity.py` — 331 passed, including 6 new `Split` finite-difference cases; `test_qat_parity.py`'s `SUPPORTED_OPS` byte-for-byte C++ pin is untouched (`Split` lives in the separate `_MULTI_OUTPUT_RULES` table on purpose)
- [x] `pytest tests/test_build_resident_train_step.py tests/test_compile_training.py tests/test_distributed.py tests/test_block_finetune.py tests/test_lora.py tests/test_qat.py tests/test_torch_training.py tests/test_formal_verify_grad_*.py` — 492 passed total across the full sweep, 9 pre-existing skips unrelated to this change
- [x] `ruff check` / `ruff format --check` on every touched file
- [ ] Real Wav2Vec2-Conformer compile on the AX650N (not attempted — no hardware/Docker access in this task; another concurrent task was using that toolchain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W