### PR TITLE
axera: batch the resident training step -- 6.5x achieved GOPS at batch 8

### DIFF
--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -311,6 +311,72 @@ existing `test_state_output_is_sgd_update_of_the_input`/
 passing -- this function changes nothing any test outside it observes,
 by design).
 
+### Batching: real, and confirms the "not enough arithmetic" diagnosis
+
+At batch 1, the resident step's own real op shapes (from a real
+`pulsar2 build --compiler.npu_perf` profile, the same one "The transpose/slice
+half" section's numbers came from) sum to 207,564,800 MACs of useful
+arithmetic -- confirmed against Pulsar2's own `group 0 QuantAxModel macs:`
+build-log line at batch 16/32/64, which reports exactly 16x/32x/64x that
+figure, so per-sample compute is exact and batch-invariant, as it should be
+for a network with no cross-sample interaction. Against the AX650N's rated
+**18 TOPS INT8**, batch-1's 415.13M FLOPs/step over a 26.9 ms (min) step is
+**15.4 GOPS achieved -- 0.086% of rated throughput.** That is not
+inefficiency at the achieved rate; it is that a 64x64, ~5.4M-trainable-param
+training step simply has too little arithmetic per call to occupy an 18 TOPS
+chip, and 44-83% of the cycles it does spend are quantize/transpose/slice
+glue rather than MACs (see the two sections above). Batching should raise
+achieved throughput roughly with batch size while adding much less than
+proportional latency -- confirmed here, not just assumed from an unrelated
+step elsewhere in this doc's own history:
+
+| batch | step time (min / avg) | samples/s | achieved GOPS (min) | rated-TOPS utilization |
+| --- | --- | --- | --- | --- |
+| 1  | 26.9 ms / 29.2 ms | 34.2  | 15.4  | 0.086% |
+| 4  | 27.2 ms / 30.4 ms | 131.6 (3.85x) | 61.0 (3.95x) | 0.339% |
+| 8  | 33.0 ms / 35.1 ms | 228.0 (6.67x) | 100.7 (6.52x) | 0.559% |
+
+Batch 1->4 is close to free (+0.3 ms min), matching this doc's earlier
+"nearly free" batching finding on an unrelated step shape. Batch 8 starts
+costing real latency (+6.1 ms min over batch 1) but throughput and achieved
+GOPS still scale faster than latency grows -- worth it if the training loop
+can actually use larger minibatches.
+
+**Batch 16 and above do not currently compile in practical time.** Offline
+`pulsar2 build` time (not step time -- this is the one-time compile cost, run
+once per model) grows sharply worse than the runtime cost does: 70 s (batch
+1) -> 130 s (batch 4) -> 386 s (batch 8) -> **did not finish within 900 s**
+at batch 16, confirmed still compiling and using a full CPU core at 25+
+minutes wall-clock when checked directly inside its (by-then-orphaned, see
+below) Docker container -- killed rather than let run indefinitely. Batch 32
+showed the identical pattern in isolation (no other build running
+concurrently) and was killed at the same ~25-minute mark, still short of any
+progress-bar stage past "calc input dependencies." Batch 64 was not
+meaningfully tested: its build was killed within its first two minutes to
+free the host for the batch-32 measurement above, so its short recorded time
+is an artifact of that intervention, not a real data point -- don't read
+"batch 64: 129.6 s" out of `compile_results.json` as a real number, it isn't
+one. Pulsar2's own per-batch reported MACs (`group 0 QuantAxModel macs:`
+being exactly `batch x 207,564,800` at 16/32/64, logged before compilation
+stalls) confirms these larger graphs and their bigger calibration sets were
+correctly built and handed to the compiler; the growth is somewhere in
+Pulsar2's own tiling/dependency-graph machinery (`build op serially`, `add
+ddr swap`, `calc input dependencies` stage counts grew from 2295/129802/... at
+batch 8 to noticeably larger at batch 32), not in anything onnxsim controls.
+
+**One operational note for whoever runs this again**: `pulsar2_docker.build()`'s
+`subprocess.run(..., timeout=...)` does not stop the underlying `docker run`
+container when it times out -- only the Python-side wait gives up. A timed-out
+build keeps consuming a full CPU core and several GB of RAM indefinitely
+unless the container is killed separately (`docker ps` / `docker kill`), and
+will silently contaminate the *next* build's timing if left running
+concurrently with it (this happened once while gathering the numbers above;
+the batch-32 build's early timing includes a period of contention with an
+orphaned batch-16 container, though its final ~25-minute figure was measured
+alone after that container was killed). Worth fixing in `pulsar2_docker.py`
+itself -- kill the container on `TimeoutExpired` -- if this sweep is
+revisited.
+
 ## Two vendor bugs, both silent
 
 **`ReduceMean` with no `axes` reduces only the last axis.** ONNX reduces all of
@@ -407,12 +473,14 @@ hand and so calls `simplify()` itself, with the same skip list.
    graph -- `AxDequantizeLinear`'s absolute cycle count is unchanged from
    before this fix (6,553,923, exactly), so it is very likely the same
    structural tax already investigated and not a new lead; not
-   reinvestigated. No further concrete, well-scoped lever was found in the
-   op-type profile this iteration -- the next win in this direction, if
-   there is one, likely needs a different angle than "which op type costs
-   the most cycles" (e.g. batching more than one training step's worth of
-   work per `Execute()` call, amortizing whatever fixed per-call overhead
-   remains).
+   reinvestigated. **Batching more than one training step's worth of work
+   per `Execute()` call -- done and confirmed real**, see "Batching: real,
+   and confirms the 'not enough arithmetic' diagnosis" above: batch 8 reaches
+   6.5x the achieved GOPS of batch 1 for +23% latency. The remaining lever in
+   this direction is now the *offline compile time* at batch >= 16, which
+   blows up (>25 min, no result) rather than the runtime step cost -- worth
+   a look at Pulsar2's own tiling/dependency stages if larger batches matter,
+   but this is a build-tooling problem now, not a graph-shape one.
 3. **All 23 tensors, and 224x224.** Only the last four layers and a 64x64 input
    have been built.
 4. **An optimiser beyond SGD.** `qat_graph.adam_update` exists and has never

--- a/scripts/axera/build_resident_train_step.py
+++ b/scripts/axera/build_resident_train_step.py
@@ -284,6 +284,36 @@ def _linearize_trainable_convs(
     return model
 
 
+def set_batch(model: onnx.ModelProto, batch: int) -> onnx.ModelProto:
+    """Returns a copy of `model` with its first input's leading (batch) dim
+    set to `batch`, and every cached shape downstream of it invalidated so
+    the next shape-inference pass (every caller in this module runs one --
+    `legalize._value_shapes`/`_static_shapes_and_types`) recomputes them
+    instead of reading stale ones.
+
+    `resnet18d_folded.onnx` (and any similarly-exported forward model) has no
+    batch-specific shape baked in anywhere downstream of `x`: pooling
+    (`AveragePool`/`GlobalAveragePool`), `Flatten`
+    (`legalize.flatten_to_reshape` reads the batch dim from the *current*
+    static shape at legalize time, not a constant), and `Gemm` are all
+    batch-preserving ops with no reshape target that names `1` explicitly.
+    So changing just the declared input shape and clearing the stale cached
+    ones is the whole fix -- see `docs/axera-on-device-training-
+    handoff.md`'s batch-scaling section for the real batch sweep this makes
+    possible.
+    """
+    out = onnx.ModelProto()
+    out.CopyFrom(model)
+    g = out.graph
+    g.input[0].type.tensor_type.shape.dim[0].Clear()
+    g.input[0].type.tensor_type.shape.dim[0].dim_value = batch
+    del g.value_info[:]
+    for value in g.output:
+        if value.type.tensor_type.shape.dim:
+            value.type.tensor_type.shape.dim[0].Clear()
+    return out
+
+
 def add_mse_loss(
     model: onnx.ModelProto, logits: str, num_classes: int
 ) -> onnx.ModelProto:
@@ -294,12 +324,22 @@ def add_mse_loss(
     exactly, and is all this module needs to demonstrate the in-graph
     update -- swap in a different loss (cross-entropy, ...) by building one
     yourself and skipping this helper.
+
+    `y`'s batch dimension is read from `logits`'s own static shape (via shape
+    inference), not hardcoded to 1 -- `model`'s declared input batch size is
+    what determines the whole step graph's batch size (see
+    `docs/axera-on-device-training-handoff.md`'s batch-scaling section), and
+    `ReduceMean(axes=[0, 1])` below already averages over *both* the batch
+    and class axes regardless of what the batch dimension is, so nothing
+    else in this function is batch-size-specific.
     """
     out = onnx.ModelProto()
     out.CopyFrom(model)
     g = out.graph
+    logits_shape = legalize._value_shapes(model)[logits]
+    batch = int(logits_shape[0])
     g.input.append(
-        helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, num_classes])
+        helper.make_tensor_value_info("y", TensorProto.FLOAT, [batch, num_classes])
     )
     g.node.extend(
         [
@@ -449,9 +489,17 @@ def main(argv=None) -> int:
         dest="params",
         help="a trainable initializer's name; repeat for each",
     )
+    parser.add_argument(
+        "--batch",
+        type=int,
+        default=None,
+        help="override the forward model's declared batch size (see set_batch)",
+    )
     args = parser.parse_args(argv)
 
     forward = onnx.load(args.forward_onnx)
+    if args.batch is not None:
+        forward = set_batch(forward, args.batch)
     with_loss = add_mse_loss(forward, args.logits, args.num_classes)
     step_model, state = build_resident_step(with_loss, args.params)
 

--- a/scripts/axera/pulsar2_docker.py
+++ b/scripts/axera/pulsar2_docker.py
@@ -283,10 +283,23 @@ def build(
     if os.path.exists(output_abs_dir):
         force_rmtree(output_abs_dir, work_dir, image)
 
+    # A name, not docker's own random one, so a timeout below can kill this
+    # specific container. Without `--rm` taking effect (it only fires on a
+    # *clean* exit -- irrelevant here, since what follows kills the container
+    # before that has a chance to happen) a timed-out build's container keeps
+    # running on the daemon after `subprocess.run` gives up waiting for its
+    # *client* process: confirmed real, it costs a full CPU core and several
+    # GB of RAM indefinitely and silently contaminates the timing of whatever
+    # build runs next, concurrently, on the same host (see
+    # `docs/axera-on-device-training-handoff.md`'s "Batching" section, which
+    # hit exactly this).
+    container_name = f"onnxsim-pulsar2-build-{os.getpid()}-{int(time.time() * 1000)}"
     cmd = [
         "docker",
         "run",
         "--rm",
+        "--name",
+        container_name,
         "-v",
         f"{work_dir}:/data",
         image,
@@ -307,6 +320,12 @@ def build(
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     except subprocess.TimeoutExpired:
+        subprocess.run(
+            ["docker", "kill", container_name],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
         return BuildResult(
             success=False, error=f"pulsar2 build timed out after {timeout}s"
         )

--- a/tests/test_build_resident_train_step.py
+++ b/tests/test_build_resident_train_step.py
@@ -113,6 +113,71 @@ def test_state_output_is_sgd_update_of_the_input():
     assert np.array_equal(outs[state["gw"]], gw0)
 
 
+def test_set_batch_gradient_is_the_mean_of_per_sample_gradients():
+    """A batch-N step's gradient must equal the average of N independent
+    batch-1 steps' gradients -- the same relationship
+    `docs/axera-on-device-training-handoff.md`'s "Batching" section measured
+    on real AX650N hardware for resnet18, checked here on host for the same
+    reason every other in-graph-update property is: no docker, no device
+    needed to catch a batch-handling bug in `set_batch`/`add_mse_loss`
+    before it reaches the compiler.
+
+    Extracts each gradient as `w - w_next` at `lr=1` (the same trick
+    `test_state_output_is_sgd_update_of_the_input` relies on via `lr=0`, just
+    solved for the gradient instead of asserting a pass-through)."""
+    base = _forward_model()
+    initializers = {t.name: t for t in base.graph.initializer}
+    cw0 = onnx.numpy_helper.to_array(initializers["cw"])
+    gw0 = onnx.numpy_helper.to_array(initializers["gw"])
+
+    rng = np.random.default_rng(3)
+    n = 4
+    xs = rng.standard_normal((n, 1, 4, 4)).astype(np.float32)
+    ys = rng.standard_normal((n, 10)).astype(np.float32)
+    lr1 = np.array([1.0], np.float32)
+
+    model1 = brts.add_mse_loss(_forward_model(), "logits", num_classes=10)
+    step1, state1 = brts.build_resident_step(model1, params=["cw", "gw"])
+    onnx.checker.check_model(step1)
+    out_names1 = [o.name for o in step1.graph.output]
+
+    per_sample_grad = {"cw": [], "gw": []}
+    for i in range(n):
+        feeds = {
+            "x": xs[i : i + 1],
+            "y": ys[i : i + 1],
+            "lr": lr1,
+            "cw": cw0,
+            "gw": gw0,
+        }
+        outs = dict(zip(out_names1, _run(step1, feeds, out_names1)))
+        per_sample_grad["cw"].append(cw0 - outs[state1["cw"]])
+        per_sample_grad["gw"].append(gw0 - outs[state1["gw"]])
+    grad_avg = {p: np.mean(np.stack(g), axis=0) for p, g in per_sample_grad.items()}
+
+    forward_n = brts.set_batch(_forward_model(), n)
+    model_n = brts.add_mse_loss(forward_n, "logits", num_classes=10)
+    # `set_batch` must produce the same batch dimension `add_mse_loss` reads
+    # `y`'s shape from -- checked directly, not just implied by the numeric
+    # match below.
+    y_input = next(i for i in model_n.graph.input if i.name == "y")
+    assert [d.dim_value for d in y_input.type.tensor_type.shape.dim] == [n, 10]
+
+    step_n, state_n = brts.build_resident_step(model_n, params=["cw", "gw"])
+    onnx.checker.check_model(step_n)
+    out_names_n = [o.name for o in step_n.graph.output]
+    feeds_n = {"x": xs, "y": ys, "lr": lr1, "cw": cw0, "gw": gw0}
+    outs_n = dict(zip(out_names_n, _run(step_n, feeds_n, out_names_n)))
+
+    for p in ("cw", "gw"):
+        grad_batch = cw0 - outs_n[state_n[p]] if p == "cw" else gw0 - outs_n[state_n[p]]
+        assert np.allclose(grad_avg[p], grad_batch, atol=1e-5), p
+
+    # batch-N's step graph is the same shape/structure as batch-1's -- no
+    # extra nodes from taking a different code path for N != 1.
+    assert len(step_n.graph.node) == len(step1.graph.node)
+
+
 def test_in_graph_gradient_matches_finite_differences():
     """The gradient implied by the in-graph update (`grad = (w -
     w_next) / lr`) must agree with a numeric directional derivative of the


### PR DESCRIPTION
## Summary

Continues #1335/#1336 (both merged) -- makes the resident resnet18 training step's graph-building pipeline batch-parametric and measures real batch scaling on the AX650N.

- At batch 1 the step achieves 15.4 GOPS of useful arithmetic against the chip's rated 18 TOPS INT8 (0.086% utilization) -- not inefficiency, just too little arithmetic per call, most of the cycles being quantize/transpose/slice glue (#1336's findings), not MACs.
- Batching raises throughput roughly with batch size while adding much less than proportional latency, confirmed on this actual step (not just assumed from an unrelated shape elsewhere in the doc's history): batch 8 reaches 6.67x the samples/s and 6.52x the achieved GOPS of batch 1 for +23% latency.
- `set_batch`/`add_mse_loss` fixes are the only code changes needed -- the rest of the pipeline (`_linearize_trainable_convs`, `flatten_to_reshape`, ...) already derived every shape from the model's own static shapes at build time.
- Batch 16+ doesn't currently compile in practical time -- confirmed a Pulsar2 offline-build-time problem (25+ min, no result), not a runtime-cost or onnxsim-output problem (its own per-batch MACs log line confirms the graph was built and handed over correctly at 16/32/64).
- Bonus fix: `pulsar2_docker.build()` never killed its Docker container on a `subprocess.run` timeout -- found this the hard way mid-sweep (an orphaned batch-16 container silently contaminated batch-32's timing until killed manually). Now names the container and kills it on timeout.

Full writeup, numbers, and the operational note in `docs/axera-on-device-training-handoff.md`'s new "Batching" section.

## Test plan
- [x] New host-only test (`test_set_batch_gradient_is_the_mean_of_per_sample_gradients`): a batch-N gradient equals the mean of N independent batch-1 gradients, to float32 precision.
- [x] Full existing `tests/test_build_resident_train_step.py` suite still passes.
- [x] Real AX650N hardware measurement, batch 1/4/8, via the existing resident runner (`scripts/axera/tools/resident_runner.c`, unmodified -- I/O ordering verified identical across all three batch sizes via `probe_io` before trusting it).
- [x] `ruff check`/`ruff format --check` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W