### PR TITLE
axera: report real device memory usage in resident_runner

### DIFF
--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -573,6 +573,50 @@ and is not degenerate the way this one was; its batch is 1 throughout, where
 this exact bug is invisible by construction. That caveat remains open; see
 its own note below for the current best guess and the concrete next step.
 
+### Device memory: nowhere close to the constraint
+
+Measured with `axcl-smi` and cross-checked against a real API (below), not
+estimated from `.axmodel` file sizes:
+
+| state | CMM usage | vs. 7040 MiB total | NPU util |
+| --- | --- | --- | --- |
+| idle | 12 MiB | 0.2% | 0% |
+| resnet18, batch=1, one context | 69 MiB | 1.0% | 61% |
+| resnet18, batch=8, one context | 72 MiB | 1.0% | 65% |
+| resnet50, one context | 88 MiB | 1.3% | 61% |
+| 8 concurrent vNPU contexts, batch=8 each | 432 MiB | 6.1% | **100%** |
+
+Per-process CMM tracks the compiled `.axmodel` size directly (`axcl-smi`'s
+own per-PID column: ~6.9 MiB for resnet18's 6.6 MB file, ~19.6 MiB for
+resnet50's 20.1 MB file), plus a fixed per-context overhead of roughly
+45-57 MiB (I/O buffers, per-context firmware/task state) that does **not**
+get shared across concurrent vNPU contexts -- it compounds per context, which
+is most of why 8 contexts cost 432 MiB rather than 8 x 7 MiB = 56 MiB.
+
+The headline: even at 8-way vNPU concurrency saturating NPU compute (100%
+utilization, confirming the previous section's "saturating" finding), CMM
+usage is 6.1% of the card's total. Compute saturates *long* before memory
+would become a constraint at any concurrency level measured so far.
+
+**A real, working API for this**, found and verified on hardware rather than
+assumed from the header (`axclrtEngineExecuteAsync` was declared but
+`AXCL_ERR_UNSUPPORT` on this SDK, so header presence alone proves nothing):
+`axclrtEngineGetUsage(modelPath, &sysSize, &cmmSize)` reports the engine's
+own required-memory accounting **from the file path alone, before loading**;
+`axclrtEngineGetUsageFromMem`/`axclrtEngineGetUsageFromModelId` are the same
+query from an in-memory model buffer or an already-loaded `modelId`. Now
+wired into `resident_runner.c` (its stderr diagnostics and the parseable
+`cmm=...MiB` field on the final summary line), queried once per run right
+after load. One discrepancy worth flagging rather than resolving: this API
+reports a larger number than `axcl-smi`'s live per-process column for the
+same model (15.3 MiB vs. ~6.9 MiB for resnet18) -- read it as the engine's
+planned working-set budget, not a live-usage snapshot, and don't expect the
+two to match. A lower-level, system-wide family
+(`AXCL_SYS_MemQueryStatus`/`AXCL_SYS_MemGetPartitionInfo` in `axcl_sys.h`,
+likely what `axcl-smi`'s own aggregate row queries) exists but was **not**
+verified here -- flagged as an unconfirmed lead, not a fact, following this
+doc's own standard of not claiming a header's presence as working capability.
+
 ## Two vendor bugs, both silent
 
 **`ReduceMean` with no `axes` reduces only the last axis.** ONNX reduces all of

--- a/scripts/axera/tools/README.md
+++ b/scripts/axera/tools/README.md
@@ -28,7 +28,13 @@ prefill cannot be timed with the shipped CLI. These talk to
   copy) and the NPU schedules them concurrently instead of serializing. See
   the handoff doc's "Execution overlap" section for the scaling numbers and
   for why `axclrtEngineExecuteAsync` -- AXCL's other overlap primitive --
-  is not an option (`AXCL_ERR_UNSUPPORT` on this device/SDK build).
+  is not an option (`AXCL_ERR_UNSUPPORT` on this device/SDK build). Also
+  reports device memory: `axclrtEngineGetUsageFromModelId()` is queried once
+  after load and printed both as a stderr diagnostic and as the `cmm=...MiB`
+  field on the final summary line -- confirmed real and working (unlike
+  `axclrtEngineExecuteAsync`), see the handoff doc's "Device memory" section
+  for what it reports versus `axcl-smi`'s own numbers, which don't match and
+  aren't supposed to (one is a planned budget, the other a live snapshot).
 
 Build and run them where the card is visible (inside the VM, if the device is
 passed through -- see `../vm/README.md`):

--- a/scripts/axera/tools/resident_runner.c
+++ b/scripts/axera/tools/resident_runner.c
@@ -79,6 +79,19 @@ int main(int argc, char **argv) {
     uint32_t ni = axclrtEngineGetNumInputs(info), no = axclrtEngineGetNumOutputs(info);
     fprintf(stderr, "inputs=%u outputs=%u\n", ni, no);
 
+    /* Real, verified-on-hardware API (unlike axclrtEngineExecuteAsync, this
+     * one actually works): the engine's own accounting of what it reserves
+     * for this model, queried by modelId now that it's loaded rather than
+     * shelling out to axcl-smi. Reports more than axcl-smi's own per-process
+     * column does (confirmed ~15.3 MiB here against axcl-smi's ~6.9 MiB for
+     * the same resnet18 model) -- this is the engine's planned budget, not
+     * a live-usage snapshot, so don't expect the two to match. */
+    int64_t sys_bytes = 0, cmm_bytes = 0;
+    CK(axclrtEngineGetUsageFromModelId(modelId, &sys_bytes, &cmm_bytes));
+    double cmm_mib = cmm_bytes / (1024.0 * 1024.0);
+    fprintf(stderr, "engine usage: sys=%lld B cmm=%.3f MiB\n",
+            (long long)sys_bytes, cmm_mib);
+
     axclrtEngineIO io; CK(axclrtEngineCreateIO(info, &io));
 
     /* input indices: 0=x 1=y 2.._v_231 3.._v_233 4.._v_235 5=fc.weight 6=lr
@@ -180,8 +193,8 @@ int main(int argc, char **argv) {
             fprintf(stderr, "step %d: %.3f ms  loss=%g\n", i, dt, loss_host);
     }
     double total = now_ms() - t_start;
-    printf("steps=%d min=%.3fms avg=%.3fms total=%.3fms throughput=%.1f steps/s\n",
-           steps, best, sum / steps, total, 1000.0 * steps / total);
+    printf("steps=%d min=%.3fms avg=%.3fms total=%.3fms throughput=%.1f steps/s cmm=%.3fMiB\n",
+           steps, best, sum / steps, total, 1000.0 * steps / total, cmm_mib);
 
     for (uint32_t i = 0; i < ni; i++) axclrtFree(in_bufs[i]);
     for (uint32_t i = 0; i < no; i++) axclrtFree(out_bufs[i]);


### PR DESCRIPTION
## Summary
- Wires `axclrtEngineGetUsageFromModelId()` into `resident_runner.c` -- queried once after model load, printed as a stderr diagnostic and folded into the parseable `cmm=...MiB` field on the final summary line, so a training-step run reports its own device memory footprint without needing a separate `axcl-smi` call.
- Verified real on real AX650N hardware first (unlike `axclrtEngineExecuteAsync`, which is declared in the headers but returns `AXCL_ERR_UNSUPPORT` on this SDK) -- confirmed across resnet18 (batch=1), resnet50, `-v` (vNPU), and `-n` (non-resident) code paths with no timing/correctness regression.
- Adds a "Device memory" section to `docs/axera-on-device-training-handoff.md` recording real `axcl-smi` measurements across every compiled model/concurrency configuration this session measured: device memory usage is 0.2-6.1% of the card's 7040 MiB CMM even at 8-way vNPU concurrency saturating NPU compute at 100% utilization -- compute is the constraint here, not memory, by a wide margin.
- Documents a real discrepancy rather than glossing over it: the API reports a larger number than `axcl-smi`'s live per-process column for the same model (15.3 MiB vs. ~6.9 MiB for resnet18) -- read as the engine's planned working-set budget, not a live-usage snapshot.

## Test plan
- [x] Built and ran on real AX650N hardware (via the `axcl-vm` LXD VM) with resnet18 batch=1, resnet50, `-v`, and `-n` -- all report a stable `cmm=...MiB` value matching a standalone `axclrtEngineGetUsage`/`GetUsageFromModelId` test program, with no change to step timing or loss values.
- [x] Confirmed idle/single-model/8-way-concurrent CMM usage against `axcl-smi` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W