### PR TITLE
axera: output_data_type on MatMul is dead; calibration-scale shaping is real

### DIFF
--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -78,6 +78,74 @@ the returned gradient sees a healthy tensor while the computation upstream is
 destroyed -- unlike fp16, where overflow makes an inf that propagates. Reliable
 back-off needs the graph to export `ReduceMax(|t|)` on those tensors.
 
+### The FP32 seed, the quantizer's own internals, and two more levers -- one real, one dead
+
+Follow-on work (branches `axera-fp32-gradient-seed` / PR #1353, `axera-quantizer-
+reverse-engineering` / PR #1354, not yet merged as of this section) took the
+"untried way out" above further. Confirmed the FP32 seed is real but plateaus:
+forcing the seed's elementwise `Mul` to `data_type: "FP32"` rescues 0% -> 20% of
+gradient elements as scale grows, then stops, because the gradient itself comes
+out of a `MatMul` and `layer_configs`' `data_type` override does not apply to
+`MatMul`/`Conv` at all (confirmed directly in the compiler's own
+`quant_axmodel.json`: the request is recorded but silently downgraded to U8).
+Reverse-engineering Pulsar2's calibration algorithm from archival build data
+then confirmed the range is a function of calibration *data*, not graph
+structure -- and found two more untried config-surface levers, `output_data_type`
+(a `LayerConfig` field distinct from `data_type`) and calibrating deliberately
+for the gradient's expected late-training scale. Tested both directly, on a
+minimal isolated `y=x@w`/`dW=grad(loss,w)` probe (`scripts/axera/
+build_matmul_grad_probe.py`) rather than the full pipeline, for fast iteration:
+
+**`output_data_type: "FP32"` on the gradient `MatMul`: dead, more silently than
+`data_type`.** Pulsar2's own protobuf source
+(`/opt/pulsar2/axnn/yamain/config/build_config.proto`) documents this field's
+own comment as *"quantize data type for **Conv**"* -- a different, Conv-scoped
+control, not a generic per-layer output-precision override. Tried anyway,
+targeting the gradient MatMul both by `op_types: ["MatMul"]` and by its exact
+post-fusion `layer_name` (`matmul_14`): both compile successfully, and both
+leave `matmul_14`'s own tensor config **byte-for-byte identical** to the
+baseline's (`bit_width: 8, quant_min: 0, quant_max: 255`, identical hash) --
+and unlike the `data_type` case, `mix_precision_configs` doesn't even record
+the request (empty `{}` in every variant). The override isn't downgraded; it's
+not recognized for this op type at all.
+
+**Calibrating for the expected gradient scale: real, exact, and confirmed on
+real hardware -- but a one-shot, build-time trade, not an adaptive fix.**
+Compiled the identical probe twice, differing only in the calibration data
+supplied for `grad_seed` -- `1.0` (this thread's default so far) vs. `1e-4`
+(a late-training-scale stand-in). The compiler's own recorded output scale
+moved by **exactly 10,000.00x** (`0.0966 -> 9.659e-6`), matching the calibration
+ratio to five significant figures -- textbook linear MinMax, not an
+approximation. On real AX650N hardware, feeding both compiled models a real
+`grad_seed = 1e-4`:
+
+| model | seed | nonzero elements | dW[0] |
+| --- | --- | --- | --- |
+| baseline (calibrated for seed~1.0) | 1e-4 | **0/128** | 0 |
+| recalibrated (calibrated for seed~1e-4) | 1e-4 | **115/128** | -2.8977e-05 |
+| baseline | 1.0 | 115/128 | -0.28977 |
+| recalibrated | 1.0 | 115/128 | **-2.8977e-05** (identical to its own 1e-4 result) |
+
+The recalibrated model recovers the exact late-training gradient (`-2.8977e-05
+= -0.28977 x 1e-4`, matching the seed's own linearity precisely) at the scale
+it was built for. The fourth row is the real limit, not a footnote: fed the
+*old*, large seed, the recalibrated model returns the **identical, saturated**
+value it gives for the tiny seed -- it has lost the ability to represent large
+gradients, clipped at the top of its now-much-smaller range. **This settles
+the adaptive-vs-one-shot question directly**: a single compiled model cannot
+serve both an early-training and a late-training gradient scale at once. Real,
+practical shape of the win: calibrate for the training regime a given deployed
+model will actually run (a short fine-tuning run, or a specific stage of a
+longer one), or swap to a differently-calibrated recompiled model at defined
+checkpoints as training progresses -- not a continuously-adaptive per-step
+scheme, since nothing about Pulsar2's build-time calibration is revisitable at
+runtime.
+
+Combining both levers (recalibration + `output_data_type` override) produced a
+compiled model byte-identical in every quantization-relevant field to
+recalibration alone -- confirming, independently, that `output_data_type` truly
+contributes nothing on `MatMul`.
+
 ## Speed
 
 `axcl_run_model` costs ~580 ms per invocation (process start, device open,

--- a/scripts/axera/_local_import.py
+++ b/scripts/axera/_local_import.py
@@ -47,6 +47,90 @@ import sys
 from types import ModuleType
 
 
+def ensure_repo_onnxsim() -> None:
+    """Make ``onnxsim``'s *pure-Python* submodules resolve to this checkout's
+    own ``onnxsim/`` first, without breaking the compiled extension.
+
+    A real, confirmed hazard for any script here run from an isolated ``git
+    worktree``: invoked directly (``python3 scripts/axera/foo.py``), a
+    script's ``sys.path[0]`` is its own ``scripts/axera`` directory, which
+    has no ``onnxsim`` package in it -- so the normal ``sys.path`` search
+    (``importlib.machinery.PathFinder``, tried first) finds nothing and
+    falls through to the editable install's own finder
+    (``sys.meta_path.append``ed, so tried *after* ``PathFinder`` -- checked
+    directly in the generated ``__editable___onnxsim_*_finder.py``), which
+    unconditionally maps ``onnxsim`` to the path recorded at ``pip install
+    -e .`` time -- the main checkout, regardless of which worktree's script
+    actually asked. A worktree editing ``onnxsim/*.py`` and "host-verifying"
+    the change by running one of these scripts is therefore silently
+    exercising the *main checkout's* code, not its own, unless something
+    puts this worktree's own repo root ahead of that fallback first.
+
+    **Must merge into the package's own ``__path__``, not replace resolution
+    on ``sys.path``.** An earlier version inserted the repo root at
+    ``sys.path[0]``, which makes ``importlib.machinery.PathFinder`` resolve
+    the top-level ``onnxsim`` package directly from this checkout's source
+    tree -- and once a package is found that way, every submodule import
+    (``onnxsim.onnxsim_cpp2py_export`` included) searches only *that*
+    package's own ``__path__``, never consulting ``sys.meta_path`` again.
+    The compiled extension is a build artifact, not a tracked source file --
+    it does not live in a plain checkout's ``onnxsim/`` directory the way
+    CI's `axera-integration.yml` `pulsar2-compat` job's own comment already
+    documents ("the repo root contains the `onnxsim/` source dir (no
+    compiled extension), which would shadow the installed wheel"). That job
+    deliberately runs from `runner.temp` to avoid exactly this -- and the
+    ``sys.path``-replacing version of this function broke that protection
+    anyway, since it does not look at ``cwd`` at all (confirmed: PR #1352
+    green, then this exact failure on every PR after it,
+    ``ModuleNotFoundError: No module named 'onnxsim.onnxsim_cpp2py_export'``
+    from `pulsar2-compat`'s `calibration.py` import).
+
+    The fix: import ``onnxsim`` first, however it would normally resolve
+    (the editable install's finder in a worktree, the properly-installed
+    wheel in CI) -- this is what discovers where the *real* compiled
+    extension lives. Then prepend this checkout's own ``onnxsim/`` directory
+    to the now-resolved package's ``__path__`` (not to ``sys.path``), so a
+    submodule search that reaches this checkout's directory finds its own
+    copy first, and one that doesn't (``onnxsim_cpp2py_export`` -- a plain
+    checkout never has the compiled extension) falls through to wherever
+    ``__path__``'s original entry already pointed, exactly as if this
+    function had never run.
+
+    **Known incomplete, confirmed by testing rather than assumed fixed**:
+    ``onnxsim/__init__.py`` eagerly imports the large majority of the
+    package's own submodules (``graph_grad`` included, transitively, via
+    other eagerly-imported modules like ``onnxsim.lora``) as part of running
+    ``import onnxsim`` itself -- before this function ever gets a chance to
+    touch ``__path__``. Those submodules are already bound in
+    ``sys.modules`` by the time the ``__path__`` prepend happens, so a later
+    ``import onnxsim.graph_grad`` returns the *already-resolved* module,
+    unaffected by this function -- confirmed directly: a worktree-invoked
+    script calling this still received the main checkout's
+    ``graph_grad.py``, not its own. This function therefore reliably
+    prevents the compiled-extension breakage above, and correctly redirects
+    any submodule that genuinely isn't already cached by the time it runs,
+    but does **not** reliably give a specific, heavily-imported submodule
+    (``graph_grad`` chief among them) worktree isolation. For a guaranteed
+    fix on one specific submodule, use :func:`fresh` instead -- e.g.
+    ``fresh("graph_grad", os.path.join(repo_root, "onnxsim"))`` -- the same
+    tool this module already uses for axera-local modules, which sidesteps
+    ``sys.modules``/``__path__`` entirely rather than trying to out-race
+    ``onnxsim/__init__.py``'s own eager imports.
+
+    Call this before any ``from onnxsim import ...``, as early in the
+    script as possible. A bare ``import onnxsim`` already happened by the
+    time this returns; that's required, not a side effect to avoid.
+    """
+    import onnxsim as _onnxsim
+
+    repo_onnxsim_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "onnxsim",
+    )
+    if repo_onnxsim_dir not in _onnxsim.__path__:
+        _onnxsim.__path__.insert(0, repo_onnxsim_dir)
+
+
 def fresh(name: str, directory: str) -> ModuleType:
     """Import ``<directory>/<name>.py`` as module ``name``, bypassing both
     ``sys.modules`` caching and ``sys.path`` search-order ambiguity -- the

--- a/scripts/axera/build_matmul_grad_probe.py
+++ b/scripts/axera/build_matmul_grad_probe.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Minimal MatMul-gradient probe, isolating the exact node the training-step
+gradient-underflow ceiling lives at (`docs/axera-on-device-training-handoff.md`'s
+"The ceiling: the gradient dies" section) from every other legalization/speed
+change elsewhere in that pipeline.
+
+Graph: `y = MatMul(x, w)`; `loss = ReduceSum(y*y)`; `dW = grad(loss, w)` via
+`graph_grad.build_backward`, with the loss's own incoming gradient seeded by
+a real runtime scalar `grad_seed` (a graph input, not baked in -- see the
+`grad_seed` fix in this same doc's "FP32 gradient seed" section). Outputs:
+`dW` only -- `loss` stays an internal tensor, not a graph output, because a
+true-scalar (rank-0) *output* tensor triggers Pulsar2's own
+"zero-dimensional tensor cannot be concatenated" calibration failure, the
+same class of issue as the scalar-*input* fix `grad_seed`/`lr` already needed
+(shape `[1]`, not `[]`), just on the output side.
+
+Used to test whether `quant.layer_configs`' `output_data_type: "FP32"` field
+(documented for `Conv`, not textually restricted to it) also applies when
+targeting the gradient-producing `MatMul` -- see the handoff doc's "Two more
+angles on controlling gradient quantization directly" section for the
+result (both angles tried there closed negative, with real compiler-level
+evidence). Kept as a standalone script rather than folded into
+`build_resident_train_step.py`: this graph has nothing to do with a resident
+training step (no state, no SGD update, no legalization) -- it exists purely
+to put one `MatMul` and its own gradient in front of Pulsar2 with as little
+else in the way as possible.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+from _local_import import ensure_repo_onnxsim  # noqa: E402
+
+ensure_repo_onnxsim()
+
+import onnx  # noqa: E402
+from onnx import TensorProto, helper  # noqa: E402
+
+from onnxsim import graph_grad, qat_graph  # noqa: E402
+
+N, K, M = 8, 16, 8
+
+
+def build() -> tuple[onnx.ModelProto, str, str]:
+    b = qat_graph.GraphBuilder()
+    x = "x"
+    w = "w"
+    y = b.matmul(x, w)
+    sq = b.mul(y, y)
+    loss = b.op("ReduceSum", [sq], keepdims=0)
+    forward_nodes = list(b.nodes)
+
+    grads = graph_grad.build_backward(
+        b,
+        nodes=forward_nodes,
+        shapes={
+            x: (N, K),
+            w: (K, M),
+            y: (N, M),
+            sq: (N, M),
+            loss: (),
+        },
+        grad_outputs={loss: "grad_seed"},
+        targets=[w],
+    )
+    dw = grads[w]
+    assert dw is not None
+
+    inputs = [
+        helper.make_tensor_value_info(x, TensorProto.FLOAT, [N, K]),
+        helper.make_tensor_value_info(w, TensorProto.FLOAT, [K, M]),
+        helper.make_tensor_value_info("grad_seed", TensorProto.FLOAT, [1]),
+    ]
+    outputs = [helper.make_tensor_value_info(dw, TensorProto.FLOAT, [K, M])]
+    graph = helper.make_graph(
+        b.nodes, "matmul_grad_probe", inputs, outputs, initializer=b.initializer
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    return model, loss, dw
+
+
+if __name__ == "__main__":
+    result_model, loss_name, dw_name = build()
+    out_path = sys.argv[1] if len(sys.argv) > 1 else "matmul_grad_probe.onnx"
+    onnx.save(result_model, out_path)
+    print(f"saved {out_path}  loss={loss_name!r}  dW={dw_name!r}")


### PR DESCRIPTION
## Summary
Tests PR #1354's two untried gradient-quantization levers on a minimal isolated MatMul-gradient probe (`scripts/axera/build_matmul_grad_probe.py`, reused from PR #1353), following up on the FP32-gradient-seed plateau (#1353) and the quantizer reverse-engineering (#1354).

- **`output_data_type: "FP32"` on the gradient `MatMul`: dead.** Confirmed via Pulsar2's own `build_config.proto` ("quantize data type for Conv") and empirically: `matmul_14`'s tensor config is byte-identical with/without the override across two targeting methods (`op_types`, post-fusion `layer_name`), and `mix_precision_configs` doesn't even record the request.
- **Calibration-scale shaping: real, exact, confirmed on real AX650N hardware.** A 10,000x calibration-data change moves the compiler's recorded output scale by exactly 10,000.00x. On real hardware, a model calibrated for a late-training-scale seed (1e-4) recovers the exact gradient where the original-scale-calibrated model returns zero -- but it's a one-shot build-time trade, not adaptive: the recalibrated model returns the identical saturated value for the old seed scale that it returns for the new one.
- Combining both levers matches recalibration alone exactly, independently confirming `output_data_type` contributes nothing on `MatMul`.

## Test plan
- [x] Compiled 5 real Pulsar2 builds (baseline, two `output_data_type` targeting variants, recalibrated, combined) via `pulsar2_docker.build()`, real Docker.
- [x] Verified via direct compiler evidence (`quant_axmodel.json` tensor configs, `quant_axmodel.onnx` `AxQuantizedMatMul`/`AxDequantizeLinear` scale attributes) rather than build-success alone.
- [x] Verified on real AX650N hardware: baseline vs. recalibrated model, at both seed scales, confirming the exact numerical recovery and the saturation limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W