### PR TITLE
axera: multi-phase calibration swap for the gradient ceiling -- real training step, real hardware

### DIFF
--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -146,6 +146,90 @@ compiled model byte-identical in every quantization-relevant field to
 recalibration alone -- confirming, independently, that `output_data_type` truly
 contributes nothing on `MatMul`.
 
+### Multi-phase calibration swap: the mechanism, hardware-verified past the isolated probe
+
+Turned the recalibration lever above into a real, working demonstration
+rather than leaving it as a design note. Not on the full resnet18 pipeline --
+`resnet18d_folded.onnx` (the forward model earlier sections' compiles used) is
+no longer present in this session's scratch, and regenerating it (BN-folding
+included) was out of scope for the time this task had -- but on
+`tests/test_build_resident_train_step.py`'s own small real forward model
+(`x -> Conv -> Relu -> Flatten -> Gemm -> logits`, trainable `cw`/`gw`)
+through the **real, unmodified pipeline**
+(`add_mse_loss`/`build_resident_step`/`pulsar2_docker.build()`) -- a genuine
+multi-node training-step graph (35 nodes after simplify), not the single-`MatMul`
+isolated probe the levers above were tested on. `gb` (the Gemm bias) was left
+frozen: trained, it hits a real, separate compiler crash
+(`TileFailException("AxQuantizedSub, tuple index out of range")` on the SGD
+subtract for that specific tiny 10-element tensor) unrelated to anything this
+task investigated -- worth a bug report if this model shape is revisited, not
+chased further here.
+
+Built two compiles, identical graph, differing only in `make_training_calib`'s
+`weight_scale` (0.05 -- "early training" -- vs. 0.0005 -- "late training", the
+same 100x ratio methodology as the isolated-probe result above), each in
+**~15s** (this graph's own size, not resnet18's -- the batching section's
+70-450s figures don't apply here). Confirmed the compiler-recorded scales
+move by **exactly 100.00x** between the two builds, for both trainable
+tensors and their SGD-updated state outputs alike (`quant_axmodel.json`'s
+`tensor_configs`/`values`, same evidentiary method as the isolated-probe
+result):
+
+| tensor | phase 1 scale (weight_scale=0.05) | phase 2 scale (weight_scale=0.0005) | ratio |
+| --- | --- | --- | --- |
+| `cw` | 0.0012102693 | 1.2102693e-05 | 100.00x |
+| `cw`'s updated state | 0.0012102675 | 1.2102679e-05 | 100.00x |
+| `gw` | 0.0013282200 | 1.3282201e-05 | 100.00x |
+| `gw`'s updated state | 0.0013282195 | 1.3282196e-05 | 100.00x |
+
+This confirms the isolated probe's finding generalizes past one `MatMul` to a
+real multi-node graph with a real Conv, a real SGD update, and simplify()
+in the loop.
+
+**Real hardware demonstration**: fed the identical late-training-scale weight
+state (`cw`/`gw` values ~100x smaller than phase 1's own calibration) and the
+identical batch/lr into both compiled models, 5 steps each:
+
+| model | fed | `cw[0]` before | `cw[0]` after | relative update |
+| --- | --- | --- | --- | --- |
+| phase 1 (calibrated for scale 0.05) | late-scale weights | 0.000152358538 | **0** | dead |
+| phase 2 (calibrated for scale 0.0005) | the same late-scale weights | 0.000152358538 | **0.000157334827** | **1.03266x** |
+| phase 1 (reference) | its own matching early-scale weights | 0.0152358543 | 0.0157334786 | 1.03266x |
+
+Phase 2 recovers the **exact same relative update** (1.03266x) that phase 1
+gets on weights at its own calibrated scale -- a real, correctly-proportioned
+SGD step -- while phase 1 fed the same late-scale state loses it completely,
+landing on exactly zero. This is the "swap to a recalibrated model when the
+current one's gradient dies" mechanism working end to end: the same weight
+*values* handed from one compiled model to the next (via ordinary host-side
+files -- `resident_runner.c`'s existing `.state<k>` convention, no
+graph-level coupling between the two compiles needed), only the calibration
+differs.
+
+**What this does and doesn't prove.** This demonstrates the mechanism with
+one real transition (2 phases, chosen and swapped by hand) -- not a 3-phase
+sweep, and not an automatic controller. Real, open costs and questions for
+whoever builds on this:
+
+- **A phase swap costs a full recompile** -- ~15s on this small graph, and
+  per the batching section's own numbers, 70-450s+ on the real resnet18
+  pipeline. Not free, and not something to do every few steps.
+- **How many phases a genuinely long run needs, and where to place the
+  boundaries, is open.** This demo used one 100x jump because that's the
+  ratio already validated on the isolated probe; a real schedule would likely
+  want smaller, more numerous steps, chosen from the actual gradient-decay
+  curve of a real training run rather than picked by hand.
+- **Triggering is manual here.** `finetune.LossScaler`'s existing
+  `zero_fraction`/`DEFAULT_UNDERFLOW` detector is the natural fit for
+  deciding *when* to swap (its role changes from "grow/backoff a scale" to
+  "signal a model swap"), but wiring that up, and actually swapping the
+  running `resident_runner` process out from under a live loop, is
+  unbuilt.
+- **Hiding the recompile cost** (building phase N+1 speculatively while phase
+  N is still training, so the swap is instant when it's needed) is a real,
+  unexplored option given a spare CPU core and Docker daemon are cheap
+  relative to the AX650N itself.
+
 ## Speed
 
 `axcl_run_model` costs ~580 ms per invocation (process start, device open,

--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -78,6 +78,74 @@ the returned gradient sees a healthy tensor while the computation upstream is
 destroyed -- unlike fp16, where overflow makes an inf that propagates. Reliable
 back-off needs the graph to export `ReduceMax(|t|)` on those tensors.
 
+### The FP32 seed, the quantizer's own internals, and two more levers -- one real, one dead
+
+Follow-on work (branches `axera-fp32-gradient-seed` / PR #1353, `axera-quantizer-
+reverse-engineering` / PR #1354, not yet merged as of this section) took the
+"untried way out" above further. Confirmed the FP32 seed is real but plateaus:
+forcing the seed's elementwise `Mul` to `data_type: "FP32"` rescues 0% -> 20% of
+gradient elements as scale grows, then stops, because the gradient itself comes
+out of a `MatMul` and `layer_configs`' `data_type` override does not apply to
+`MatMul`/`Conv` at all (confirmed directly in the compiler's own
+`quant_axmodel.json`: the request is recorded but silently downgraded to U8).
+Reverse-engineering Pulsar2's calibration algorithm from archival build data
+then confirmed the range is a function of calibration *data*, not graph
+structure -- and found two more untried config-surface levers, `output_data_type`
+(a `LayerConfig` field distinct from `data_type`) and calibrating deliberately
+for the gradient's expected late-training scale. Tested both directly, on a
+minimal isolated `y=x@w`/`dW=grad(loss,w)` probe (`scripts/axera/
+build_matmul_grad_probe.py`) rather than the full pipeline, for fast iteration:
+
+**`output_data_type: "FP32"` on the gradient `MatMul`: dead, more silently than
+`data_type`.** Pulsar2's own protobuf source
+(`/opt/pulsar2/axnn/yamain/config/build_config.proto`) documents this field's
+own comment as *"quantize data type for **Conv**"* -- a different, Conv-scoped
+control, not a generic per-layer output-precision override. Tried anyway,
+targeting the gradient MatMul both by `op_types: ["MatMul"]` and by its exact
+post-fusion `layer_name` (`matmul_14`): both compile successfully, and both
+leave `matmul_14`'s own tensor config **byte-for-byte identical** to the
+baseline's (`bit_width: 8, quant_min: 0, quant_max: 255`, identical hash) --
+and unlike the `data_type` case, `mix_precision_configs` doesn't even record
+the request (empty `{}` in every variant). The override isn't downgraded; it's
+not recognized for this op type at all.
+
+**Calibrating for the expected gradient scale: real, exact, and confirmed on
+real hardware -- but a one-shot, build-time trade, not an adaptive fix.**
+Compiled the identical probe twice, differing only in the calibration data
+supplied for `grad_seed` -- `1.0` (this thread's default so far) vs. `1e-4`
+(a late-training-scale stand-in). The compiler's own recorded output scale
+moved by **exactly 10,000.00x** (`0.0966 -> 9.659e-6`), matching the calibration
+ratio to five significant figures -- textbook linear MinMax, not an
+approximation. On real AX650N hardware, feeding both compiled models a real
+`grad_seed = 1e-4`:
+
+| model | seed | nonzero elements | dW[0] |
+| --- | --- | --- | --- |
+| baseline (calibrated for seed~1.0) | 1e-4 | **0/128** | 0 |
+| recalibrated (calibrated for seed~1e-4) | 1e-4 | **115/128** | -2.8977e-05 |
+| baseline | 1.0 | 115/128 | -0.28977 |
+| recalibrated | 1.0 | 115/128 | **-2.8977e-05** (identical to its own 1e-4 result) |
+
+The recalibrated model recovers the exact late-training gradient (`-2.8977e-05
+= -0.28977 x 1e-4`, matching the seed's own linearity precisely) at the scale
+it was built for. The fourth row is the real limit, not a footnote: fed the
+*old*, large seed, the recalibrated model returns the **identical, saturated**
+value it gives for the tiny seed -- it has lost the ability to represent large
+gradients, clipped at the top of its now-much-smaller range. **This settles
+the adaptive-vs-one-shot question directly**: a single compiled model cannot
+serve both an early-training and a late-training gradient scale at once. Real,
+practical shape of the win: calibrate for the training regime a given deployed
+model will actually run (a short fine-tuning run, or a specific stage of a
+longer one), or swap to a differently-calibrated recompiled model at defined
+checkpoints as training progresses -- not a continuously-adaptive per-step
+scheme, since nothing about Pulsar2's build-time calibration is revisitable at
+runtime.
+
+Combining both levers (recalibration + `output_data_type` override) produced a
+compiled model byte-identical in every quantization-relevant field to
+recalibration alone -- confirming, independently, that `output_data_type` truly
+contributes nothing on `MatMul`.
+
 ## Speed
 
 `axcl_run_model` costs ~580 ms per invocation (process start, device open,

--- a/scripts/axera/_local_import.py
+++ b/scripts/axera/_local_import.py
@@ -47,6 +47,90 @@ import sys
 from types import ModuleType
 
 
+def ensure_repo_onnxsim() -> None:
+    """Make ``onnxsim``'s *pure-Python* submodules resolve to this checkout's
+    own ``onnxsim/`` first, without breaking the compiled extension.
+
+    A real, confirmed hazard for any script here run from an isolated ``git
+    worktree``: invoked directly (``python3 scripts/axera/foo.py``), a
+    script's ``sys.path[0]`` is its own ``scripts/axera`` directory, which
+    has no ``onnxsim`` package in it -- so the normal ``sys.path`` search
+    (``importlib.machinery.PathFinder``, tried first) finds nothing and
+    falls through to the editable install's own finder
+    (``sys.meta_path.append``ed, so tried *after* ``PathFinder`` -- checked
+    directly in the generated ``__editable___onnxsim_*_finder.py``), which
+    unconditionally maps ``onnxsim`` to the path recorded at ``pip install
+    -e .`` time -- the main checkout, regardless of which worktree's script
+    actually asked. A worktree editing ``onnxsim/*.py`` and "host-verifying"
+    the change by running one of these scripts is therefore silently
+    exercising the *main checkout's* code, not its own, unless something
+    puts this worktree's own repo root ahead of that fallback first.
+
+    **Must merge into the package's own ``__path__``, not replace resolution
+    on ``sys.path``.** An earlier version inserted the repo root at
+    ``sys.path[0]``, which makes ``importlib.machinery.PathFinder`` resolve
+    the top-level ``onnxsim`` package directly from this checkout's source
+    tree -- and once a package is found that way, every submodule import
+    (``onnxsim.onnxsim_cpp2py_export`` included) searches only *that*
+    package's own ``__path__``, never consulting ``sys.meta_path`` again.
+    The compiled extension is a build artifact, not a tracked source file --
+    it does not live in a plain checkout's ``onnxsim/`` directory the way
+    CI's `axera-integration.yml` `pulsar2-compat` job's own comment already
+    documents ("the repo root contains the `onnxsim/` source dir (no
+    compiled extension), which would shadow the installed wheel"). That job
+    deliberately runs from `runner.temp` to avoid exactly this -- and the
+    ``sys.path``-replacing version of this function broke that protection
+    anyway, since it does not look at ``cwd`` at all (confirmed: PR #1352
+    green, then this exact failure on every PR after it,
+    ``ModuleNotFoundError: No module named 'onnxsim.onnxsim_cpp2py_export'``
+    from `pulsar2-compat`'s `calibration.py` import).
+
+    The fix: import ``onnxsim`` first, however it would normally resolve
+    (the editable install's finder in a worktree, the properly-installed
+    wheel in CI) -- this is what discovers where the *real* compiled
+    extension lives. Then prepend this checkout's own ``onnxsim/`` directory
+    to the now-resolved package's ``__path__`` (not to ``sys.path``), so a
+    submodule search that reaches this checkout's directory finds its own
+    copy first, and one that doesn't (``onnxsim_cpp2py_export`` -- a plain
+    checkout never has the compiled extension) falls through to wherever
+    ``__path__``'s original entry already pointed, exactly as if this
+    function had never run.
+
+    **Known incomplete, confirmed by testing rather than assumed fixed**:
+    ``onnxsim/__init__.py`` eagerly imports the large majority of the
+    package's own submodules (``graph_grad`` included, transitively, via
+    other eagerly-imported modules like ``onnxsim.lora``) as part of running
+    ``import onnxsim`` itself -- before this function ever gets a chance to
+    touch ``__path__``. Those submodules are already bound in
+    ``sys.modules`` by the time the ``__path__`` prepend happens, so a later
+    ``import onnxsim.graph_grad`` returns the *already-resolved* module,
+    unaffected by this function -- confirmed directly: a worktree-invoked
+    script calling this still received the main checkout's
+    ``graph_grad.py``, not its own. This function therefore reliably
+    prevents the compiled-extension breakage above, and correctly redirects
+    any submodule that genuinely isn't already cached by the time it runs,
+    but does **not** reliably give a specific, heavily-imported submodule
+    (``graph_grad`` chief among them) worktree isolation. For a guaranteed
+    fix on one specific submodule, use :func:`fresh` instead -- e.g.
+    ``fresh("graph_grad", os.path.join(repo_root, "onnxsim"))`` -- the same
+    tool this module already uses for axera-local modules, which sidesteps
+    ``sys.modules``/``__path__`` entirely rather than trying to out-race
+    ``onnxsim/__init__.py``'s own eager imports.
+
+    Call this before any ``from onnxsim import ...``, as early in the
+    script as possible. A bare ``import onnxsim`` already happened by the
+    time this returns; that's required, not a side effect to avoid.
+    """
+    import onnxsim as _onnxsim
+
+    repo_onnxsim_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "onnxsim",
+    )
+    if repo_onnxsim_dir not in _onnxsim.__path__:
+        _onnxsim.__path__.insert(0, repo_onnxsim_dir)
+
+
 def fresh(name: str, directory: str) -> ModuleType:
     """Import ``<directory>/<name>.py`` as module ``name``, bypassing both
     ``sys.modules`` caching and ``sys.path`` search-order ambiguity -- the

--- a/scripts/axera/build_matmul_grad_probe.py
+++ b/scripts/axera/build_matmul_grad_probe.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Minimal MatMul-gradient probe, isolating the exact node the training-step
+gradient-underflow ceiling lives at (`docs/axera-on-device-training-handoff.md`'s
+"The ceiling: the gradient dies" section) from every other legalization/speed
+change elsewhere in that pipeline.
+
+Graph: `y = MatMul(x, w)`; `loss = ReduceSum(y*y)`; `dW = grad(loss, w)` via
+`graph_grad.build_backward`, with the loss's own incoming gradient seeded by
+a real runtime scalar `grad_seed` (a graph input, not baked in -- see the
+`grad_seed` fix in this same doc's "FP32 gradient seed" section). Outputs:
+`dW` only -- `loss` stays an internal tensor, not a graph output, because a
+true-scalar (rank-0) *output* tensor triggers Pulsar2's own
+"zero-dimensional tensor cannot be concatenated" calibration failure, the
+same class of issue as the scalar-*input* fix `grad_seed`/`lr` already needed
+(shape `[1]`, not `[]`), just on the output side.
+
+Used to test whether `quant.layer_configs`' `output_data_type: "FP32"` field
+(documented for `Conv`, not textually restricted to it) also applies when
+targeting the gradient-producing `MatMul` -- see the handoff doc's "Two more
+angles on controlling gradient quantization directly" section for the
+result (both angles tried there closed negative, with real compiler-level
+evidence). Kept as a standalone script rather than folded into
+`build_resident_train_step.py`: this graph has nothing to do with a resident
+training step (no state, no SGD update, no legalization) -- it exists purely
+to put one `MatMul` and its own gradient in front of Pulsar2 with as little
+else in the way as possible.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+from _local_import import ensure_repo_onnxsim  # noqa: E402
+
+ensure_repo_onnxsim()
+
+import onnx  # noqa: E402
+from onnx import TensorProto, helper  # noqa: E402
+
+from onnxsim import graph_grad, qat_graph  # noqa: E402
+
+N, K, M = 8, 16, 8
+
+
+def build() -> tuple[onnx.ModelProto, str, str]:
+    b = qat_graph.GraphBuilder()
+    x = "x"
+    w = "w"
+    y = b.matmul(x, w)
+    sq = b.mul(y, y)
+    loss = b.op("ReduceSum", [sq], keepdims=0)
+    forward_nodes = list(b.nodes)
+
+    grads = graph_grad.build_backward(
+        b,
+        nodes=forward_nodes,
+        shapes={
+            x: (N, K),
+            w: (K, M),
+            y: (N, M),
+            sq: (N, M),
+            loss: (),
+        },
+        grad_outputs={loss: "grad_seed"},
+        targets=[w],
+    )
+    dw = grads[w]
+    assert dw is not None
+
+    inputs = [
+        helper.make_tensor_value_info(x, TensorProto.FLOAT, [N, K]),
+        helper.make_tensor_value_info(w, TensorProto.FLOAT, [K, M]),
+        helper.make_tensor_value_info("grad_seed", TensorProto.FLOAT, [1]),
+    ]
+    outputs = [helper.make_tensor_value_info(dw, TensorProto.FLOAT, [K, M])]
+    graph = helper.make_graph(
+        b.nodes, "matmul_grad_probe", inputs, outputs, initializer=b.initializer
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    return model, loss, dw
+
+
+if __name__ == "__main__":
+    result_model, loss_name, dw_name = build()
+    out_path = sys.argv[1] if len(sys.argv) > 1 else "matmul_grad_probe.onnx"
+    onnx.save(result_model, out_path)
+    print(f"saved {out_path}  loss={loss_name!r}  dW={dw_name!r}")

--- a/scripts/axera/build_multiphase_calib_swap_probe.py
+++ b/scripts/axera/build_multiphase_calib_swap_probe.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Build the real (not isolated-`MatMul`-probe) training-step graph used for
+the multi-phase calibration-swap demonstration
+(`docs/axera-on-device-training-handoff.md`'s "Multi-phase calibration swap"
+section): the same small `x -> Conv -> Relu -> Flatten -> Gemm -> logits`
+forward model `tests/test_build_resident_train_step.py` already uses,
+through the real, unmodified pipeline (`add_mse_loss`/`build_resident_step`).
+
+`gb` (the Gemm bias) is deliberately **not** trained here -- it hits a real,
+separate Pulsar2 compiler crash (`TileFailException("AxQuantizedSub, tuple
+index out of range")` on the SGD subtract for that specific tiny 10-element
+tensor), unrelated to calibration and not investigated further; only `cw`/
+`gw` are trainable.
+
+Usage: build once per calibration phase, e.g.::
+
+    python3 build_multiphase_calib_swap_probe.py step.onnx
+    python3 -c "import sys; sys.path.insert(0,'.'); from _local_import import \
+        ensure_repo_onnxsim; ensure_repo_onnxsim(); import make_training_calib \
+        as m; m.make_work_dir('step.onnx', 'phase1', weight_scale=0.05); \
+        m.make_work_dir('step.onnx', 'phase2', weight_scale=0.0005)"
+
+then `pulsar2_docker.build()` each `phaseN/` work dir with
+`config_path='config/step.json'`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import onnx
+from onnx import parser
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+from _local_import import ensure_repo_onnxsim  # noqa: E402
+
+ensure_repo_onnxsim()
+
+import build_resident_train_step as brts  # noqa: E402
+
+
+def _f32(array, name):
+    return onnx.numpy_helper.from_array(array.astype(np.float32), name)
+
+
+def forward_model() -> onnx.ModelProto:
+    rng = np.random.default_rng(0)
+    cw = rng.standard_normal((2, 1, 3, 3)).astype(np.float32) * 0.3
+    gw = rng.standard_normal((10, 32)).astype(np.float32) * 0.2
+    gb = rng.standard_normal((10,)).astype(np.float32) * 0.1
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 17]
+        >
+        g (float[1,1,4,4] x) => (float[1,10] logits)
+        {
+          h = Conv<kernel_shape=[3,3], pads=[1,1,1,1]>(x, cw)
+          r = Relu(h)
+          f = Flatten<axis=1>(r)
+          logits = Gemm<transB=1>(f, gw, gb)
+        }
+        """
+    )
+    model.graph.initializer.extend([_f32(cw, "cw"), _f32(gw, "gw"), _f32(gb, "gb")])
+    return model
+
+
+def main(argv=None) -> int:
+    out_path = (argv or sys.argv[1:])[0]
+    forward = forward_model()
+    with_loss = brts.add_mse_loss(forward, "logits", num_classes=10)
+    step_model, state = brts.build_resident_step(with_loss, ["cw", "gw"])
+    print(f"step graph: {len(step_model.graph.node)} nodes")
+    for p, out_name in state.items():
+        print(f"  state: {p} -> {out_name}")
+    onnx.save(step_model, out_path)
+    print("wrote", out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/axera/tools/README.md
+++ b/scripts/axera/tools/README.md
@@ -1,6 +1,6 @@
 # AXCL runtime tools
 
-Three small C programs against the AXCL engine API (`/usr/include/axcl`), for
+Four small C programs against the AXCL engine API (`/usr/include/axcl`), for
 things `axcl_run_model` cannot do.
 
 `axcl_run_model` only ever runs a model's **first** shape group. An
@@ -35,6 +35,12 @@ prefill cannot be timed with the shipped CLI. These talk to
   `axclrtEngineExecuteAsync`), see the handoff doc's "Device memory" section
   for what it reports versus `axcl-smi`'s own numbers, which don't match and
   aren't supposed to (one is a planned budget, the other a live snapshot).
+- `mp_calib_swap_runner.c` -- runner for the multi-phase calibration-swap
+  demonstration (`docs/axera-on-device-training-handoff.md`'s "Multi-phase
+  calibration swap" section) against the small Conv+Gemm training step
+  `build_multiphase_calib_swap_probe.py` builds -- fixed I/O order (`x y cw
+  gw lr`), CLI `lr` and a `y` host file so the exact "does the update
+  survive" experiment can be run without rebuilding.
 
 Build and run them where the card is visible (inside the VM, if the device is
 passed through -- see `../vm/README.md`):

--- a/scripts/axera/tools/mp_calib_swap_runner.c
+++ b/scripts/axera/tools/mp_calib_swap_runner.c
@@ -1,0 +1,113 @@
+/* Minimal resident runner for the multi-phase calibration-swap demo
+ * (docs/axera-on-device-training-handoff.md's "Multi-phase calibration
+ * swap" section), against the small Conv+Gemm training step
+ * build_multiphase_calib_swap_probe.py builds. Inputs: x, y, cw, gw, lr
+ * (fixed order, matching that model's own I/O -- confirm with probe_io.c
+ * before reusing against a different compile). Outputs:
+ * resident_step__sub_74 (cw_next), resident_step__sub_76 (gw_next), loss.
+ *
+ * Usage: mp_calib_swap_runner model.axmodel steps cw.bin gw.bin y.bin lr
+ *
+ * Seeds cw/gw state from host .bin files (raw float32, no header) so the
+ * same weight values can be handed from one compiled phase to the next
+ * without any graph-level coupling between them. x is a small fixed
+ * pattern baked in below (not a calibration/demo concern); y and lr are
+ * host files/an argv float, respectively, so the exact "does the update
+ * survive" experiment (a controlled lr change, or a near-converged y) can
+ * be run without rebuilding this binary.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "axcl.h"
+
+#define CK(e) do { axclError _r = (e); if (_r != 0) { \
+    fprintf(stderr, "%s failed: 0x%x\n", #e, _r); return 1; } } while (0)
+
+int main(int argc, char **argv) {
+    if (argc < 7) {
+        fprintf(stderr, "usage: %s model.axmodel steps cw.bin gw.bin y.bin lr\n", argv[0]);
+        return 2;
+    }
+    int steps = atoi(argv[2]);
+
+    CK(axclInit(NULL));
+    axclrtDeviceList devs; CK(axclrtGetDeviceList(&devs));
+    if (!devs.num) { fprintf(stderr, "no device\n"); return 1; }
+    CK(axclrtSetDevice(devs.devices[0]));
+    CK(axclrtEngineInit(AXCL_VNPU_DISABLE));
+
+    uint64_t modelId = 0, ctx = 0;
+    CK(axclrtEngineLoadFromFile(argv[1], &modelId));
+    CK(axclrtEngineCreateContext(modelId, &ctx));
+
+    axclrtEngineIOInfo info; CK(axclrtEngineGetIOInfo(modelId, &info));
+    uint32_t ni = axclrtEngineGetNumInputs(info), no = axclrtEngineGetNumOutputs(info);
+    axclrtEngineIO io; CK(axclrtEngineCreateIO(info, &io));
+
+    /* indices per probe_io: 0=x 1=y 2=cw 3=gw 4=lr ; out 0=cw_next 1=gw_next 2=loss */
+    void *in_bufs[5] = {0}, *out_bufs[3] = {0};
+    uint64_t in_sz[5], out_sz[3];
+    for (uint32_t i = 0; i < ni; i++) {
+        in_sz[i] = axclrtEngineGetInputSizeByIndex(info, 0, i);
+        CK(axclrtMalloc(&in_bufs[i], in_sz[i], AXCL_MEM_MALLOC_NORMAL_ONLY));
+        CK(axclrtEngineSetInputBufferByIndex(io, i, in_bufs[i], in_sz[i]));
+    }
+    for (uint32_t i = 0; i < no; i++) {
+        out_sz[i] = axclrtEngineGetOutputSizeByIndex(info, 0, i);
+        CK(axclrtMalloc(&out_bufs[i], out_sz[i], AXCL_MEM_MALLOC_NORMAL_ONLY));
+        CK(axclrtEngineSetOutputBufferByIndex(io, i, out_bufs[i], out_sz[i]));
+    }
+
+    /* seed cw, gw from host files */
+    {
+        FILE *f = fopen(argv[3], "rb");
+        void *h = malloc(in_sz[2]); size_t n = fread(h, 1, in_sz[2], f); (void)n; fclose(f);
+        CK(axclrtMemcpy(in_bufs[2], h, in_sz[2], AXCL_MEMCPY_HOST_TO_DEVICE));
+        free(h);
+    }
+    {
+        FILE *f = fopen(argv[4], "rb");
+        void *h = malloc(in_sz[3]); size_t n = fread(h, 1, in_sz[3], f); (void)n; fclose(f);
+        CK(axclrtMemcpy(in_bufs[3], h, in_sz[3], AXCL_MEMCPY_HOST_TO_DEVICE));
+        free(h);
+    }
+    { float lr = atof(argv[6]); CK(axclrtMemcpy(in_bufs[4], &lr, sizeof(lr), AXCL_MEMCPY_HOST_TO_DEVICE)); }
+
+    /* x, y: fixed small pattern (not all-zero, matches calibration x_scale~0.3) */
+    float hx[16]; for (int i = 0; i < 16; i++) hx[i] = 0.1f * ((i % 5) - 2);
+    float hy[10];
+    { FILE *f = fopen(argv[5], "rb"); size_t n = fread(hy, 1, sizeof(hy), f); (void)n; fclose(f); }
+    CK(axclrtMemcpy(in_bufs[0], hx, in_sz[0], AXCL_MEMCPY_HOST_TO_DEVICE));
+    CK(axclrtMemcpy(in_bufs[1], hy, in_sz[1], AXCL_MEMCPY_HOST_TO_DEVICE));
+
+    float cw_before[18], cw_after[18], loss_v;
+    CK(axclrtMemcpy(cw_before, in_bufs[2], sizeof(cw_before), AXCL_MEMCPY_DEVICE_TO_HOST));
+
+    for (int i = 0; i < steps; i++) {
+        CK(axclrtEngineExecute(modelId, ctx, 0, io));
+        /* resident: copy state output back into state input, device-to-device */
+        CK(axclrtMemcpy(in_bufs[2], out_bufs[0], out_sz[0], AXCL_MEMCPY_DEVICE_TO_DEVICE));
+        CK(axclrtMemcpy(in_bufs[3], out_bufs[1], out_sz[1], AXCL_MEMCPY_DEVICE_TO_DEVICE));
+    }
+    CK(axclrtMemcpy(cw_after, out_bufs[0], sizeof(cw_after), AXCL_MEMCPY_DEVICE_TO_HOST));
+    CK(axclrtMemcpy(&loss_v, out_bufs[2], sizeof(loss_v), AXCL_MEMCPY_DEVICE_TO_HOST));
+
+    double max_abs_delta = 0;
+    for (int i = 0; i < 18; i++) {
+        double d = cw_after[i] - cw_before[i];
+        if (d < 0) d = -d;
+        if (d > max_abs_delta) max_abs_delta = d;
+    }
+    printf("cw[0] before=%.9g after=%.9g  max|delta|=%.9g  loss=%.9g  steps=%d\n",
+           cw_before[0], cw_after[0], max_abs_delta, loss_v, steps);
+
+    for (uint32_t i = 0; i < ni; i++) axclrtFree(in_bufs[i]);
+    for (uint32_t i = 0; i < no; i++) axclrtFree(out_bufs[i]);
+    axclrtEngineDestroyIO(io);
+    axclrtEngineDestroyIOInfo(info);
+    axclrtEngineUnload(modelId);
+    axclrtEngineFinalize();
+    axclFinalize();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Continues #1354/#1355 (both still open -- this branches from #1355's tip since it directly extends that section of the handoff doc; rebase trivially once those merge). Turns the calibration-scale-shaping finding (Pulsar2's calibration range tracks calibration data, confirmed on an isolated single-`MatMul` probe in #1355) into a real, working multi-phase demonstration:

- Real, unmodified `build_resident_train_step.py` pipeline (not the isolated probe) -- the same small `Conv+Relu+Flatten+Gemm+MSE` forward model `tests/test_build_resident_train_step.py` already uses, `cw`/`gw` trainable (35-node step graph after simplify).
- Two compiles, ~15s each, differing only in `make_training_calib`'s `weight_scale` (0.05 vs 0.0005, the same 100x ratio methodology as #1355). Compiler-recorded scales for `cw`/`gw` and their SGD-updated state outputs move by **exactly 100.00x** between builds.
- Real AX650N hardware: feeding identical late-training-scale weight state to both compiled models, 5 steps each -- the correctly-calibrated phase recovers the exact same relative update (1.03266x) the other phase gets on its own matching-scale weights, while the mismatched phase collapses to exactly zero.
- Honest accounting of what this does and doesn't prove: one real transition, not a 3-phase sweep; manual boundaries, no automatic controller; a real recompile cost per swap.

`gb` (Gemm bias) hit a real, separate Pulsar2 compiler crash when trained (`TileFailException` on its SGD subtract) -- left frozen and flagged, not investigated further.

## Test plan
- [x] `pytest tests/test_build_resident_train_step.py tests/test_make_training_calib.py` -- 11 passed, no regressions.
- [x] `ruff format --check` / `ruff check` / `mypy` -- clean.
- [x] Real hardware: both phase builds compiled cleanly via `pulsar2_docker.build()`; the swap demonstration run on the AX650N via `axcl-vm`, output captured in the handoff doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W