### PR TITLE
axera: audit the unfed grad_seed worry -- real gap, zero actual impact

### DIFF
--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -1503,6 +1503,55 @@ matched calibration/seed values end to end (the way PR #1356's original
 manual demo did), not freshly-drawn ones** -- a concrete, scoped next step,
 not a re-open of the mechanism's own correctness.
 
+### Audited: the "unfed grad_seed" scare -- real gap, zero actual impact
+
+PR #1360 (investigating resident-dataset `Gather` minibatching) noticed while
+writing its own `gather_runner.c` that neither `resident_runner.c` nor
+`whisper_resident_runner.c` allocates a `grad_seed` buffer and then feeds it
+-- raising a real worry: had every gradient-magnitude claim through those two
+runners, since `grad_seed` became a real graph input (#1353), been computed
+against an unintended, unwritten device buffer instead of the intended
+`1.0`? Checked directly on real hardware rather than reasoned about --
+
+**Every compiled model those two runners have ever actually been run
+against has exactly the input count their hardcoded indices expect, and
+none of them include `grad_seed` at all**, confirmed by loading each one and
+reading `axclrtEngineGetNumInputs` back: `r18_b1.axmodel` (resnet18 speed/
+batching/vNPU/memory work) reports **7** inputs; `whisper_step.axmodel` and
+`whisper_p1.axmodel` (the Whisper section above) report **17**; both match
+`resident_runner.c`'s and `whisper_resident_runner.c`'s own hardcoded
+layouts exactly, with no 8th/18th slot to leave unfed. These models all
+predate `grad_seed`'s promotion to a graph input in the code that built them
+(confirmed from `master`'s own merge order: PR #1357 merged *before* #1353,
+so the Whisper build it produced still had `grad_seed` baked in as
+`build_backward`'s old default constant, not a runtime input) -- so **the
+central claims in this project's history that route through these two
+runners, Whisper's step-0/step-1 death included, were never exposed to this
+bug and need no correction.** The `mp_calib_swap_auto_runner.c`
+multi-phase-controller demo above checks out the same way: its own compiled
+probe reports 5 inputs (`x y cw gw lr`), no `grad_seed` slot either.
+
+The worry wasn't baseless, though -- it correctly spotted a real, *latent*
+landmine rather than an active one. `build_resident_step()` on current
+`master` unconditionally adds `grad_seed` (`scalars=["lr", "grad_seed"]`),
+so a *fresh* rebuild of any of these graphs today would produce a model with
+one more input than these two runners' fixed-size `in_bufs[]` arrays have
+room for -- silently overflowing the array (not just leaving a buffer
+unfed), since neither runner previously checked `ni` against what it
+expected. Fixed proactively: both now bound-check `ni` against their known-
+good count (refusing to guess if it's neither that nor one more), size
+`in_bufs[]` for the one-more-input case, and feed `grad_seed=1.0` if it's
+present -- exactly `gather_runner.c`'s own already-correct pattern, which is
+what caught this in the first place. Re-ran both against the same real
+models above after the fix: identical numbers (resnet18 29ms/step,
+loss=0.117937; Whisper 245-246ms/step, loss=1.00265 constant across steps)
+-- confirms the fix is a no-op for every model these runners have actually
+been pointed at, and now safe to point at a newer one. (Also fixed, found
+along the way: `whisper_resident_runner.c`'s header comment describing its
+own I/O order was still resnet18's, left over from copying
+`resident_runner.c` -- the actual index constants in the body were always
+right, only the prose above them was stale.)
+
 ## What to do next
 
 1. ~~The FP32 gradient seed.~~ **Tested: real effect, not a full fix.** See

--- a/scripts/axera/tools/resident_runner.c
+++ b/scripts/axera/tools/resident_runner.c
@@ -95,13 +95,27 @@ int main(int argc, char **argv) {
     axclrtEngineIO io; CK(axclrtEngineCreateIO(info, &io));
 
     /* input indices: 0=x 1=y 2.._v_231 3.._v_233 4.._v_235 5=fc.weight 6=lr
+     * [7=grad_seed, only on a model built after grad_seed became a real
+     * graph input (onnxsim#1353) instead of a build-time constant -- every
+     * model this file has actually been run against so far predates that
+     * change and has exactly 7 inputs; ni==8 is handled so a future rebuild
+     * doesn't silently overflow the fixed-size arrays below or leave the
+     * seed unfed, but it has never been the case in this project's own
+     * measurements (confirmed against the real compiled r18_b1.axmodel)]
      * output indices: 0.._v_231' 1.._v_233' 2.._v_235' 3=fc.weight' 4=loss */
     const int state_in[N_STATE]  = {2, 3, 4, 5};
     const int state_out[N_STATE] = {0, 1, 2, 3};
     const int x_in = 0, y_in = 1, lr_in = 6, loss_out = 4;
+    const int seed_in = 7;
+    if (ni != 7 && ni != 8) {
+        fprintf(stderr, "unexpected input count %u (expected 7, or 8 with "
+                "grad_seed) -- this file's hardcoded I/O indices do not "
+                "necessarily match this model, refusing to guess\n", ni);
+        return 1;
+    }
 
-    void *in_bufs[7] = {0}, *out_bufs[5] = {0};
-    uint64_t in_sz[7], out_sz[5];
+    void *in_bufs[8] = {0}, *out_bufs[5] = {0};
+    uint64_t in_sz[8], out_sz[5];
 
     for (uint32_t i = 0; i < ni; i++) {
         in_sz[i] = axclrtEngineGetInputSizeByIndex(info, 0, i);
@@ -133,6 +147,10 @@ int main(int argc, char **argv) {
     {
         float lr = 1e-4f;
         CK(axclrtMemcpy(in_bufs[lr_in], &lr, sizeof(lr), AXCL_MEMCPY_HOST_TO_DEVICE));
+    }
+    if (ni == 8) {
+        float seed = 1.0f;
+        CK(axclrtMemcpy(in_bufs[seed_in], &seed, sizeof(seed), AXCL_MEMCPY_HOST_TO_DEVICE));
     }
 
     /* x/y: reused synthetic batch, re-uploaded every step exactly as a real

--- a/scripts/axera/tools/whisper_resident_runner.c
+++ b/scripts/axera/tools/whisper_resident_runner.c
@@ -26,10 +26,17 @@
  * AXCL_ERR_UNSUPPORT on this device/SDK build.
  *
  * The model's own I/O order is fixed here rather than discovered generically
- * (see probe_io's dump): inputs x, y, _v_231, _v_233, _v_235, fc.weight, lr;
- * outputs sub_950 (_v_231'), sub_952 (_v_233'), sub_954 (_v_235'),
- * sub_956 (fc.weight'), loss. State pairing is positional: input i (for
- * i in 2..5) pairs with output i-2.
+ * (see probe_io's dump): inputs input.1, y, 14 trainable-weight state
+ * tensors, lr [, grad_seed on a model built after grad_seed became a real
+ * graph input (onnxsim#1353) instead of a build-time constant -- the real
+ * Whisper `last_half` compiles this file has actually been run against all
+ * predate that change and have exactly 17 inputs, confirmed against the
+ * real compiled whisper_step.axmodel]; outputs are the 14 updated state
+ * tensors, then loss. State pairing is positional: input i (for i in
+ * 2..15) pairs with output i-2. (This comment used to describe resnet18's
+ * tensor names -- `_v_231` etc -- left over from copying resident_runner.c;
+ * this file's own N_STATE/index constants below were always Whisper's own
+ * shape, only the comment was stale.)
  */
 #define _POSIX_C_SOURCE 199309L
 #include <stdio.h>
@@ -99,9 +106,16 @@ int main(int argc, char **argv) {
     const int state_in[N_STATE]  = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
     const int state_out[N_STATE] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
     const int x_in = 0, y_in = 1, lr_in = 16, loss_out = 14;
+    const int seed_in = 17;
+    if (ni != 17 && ni != 18) {
+        fprintf(stderr, "unexpected input count %u (expected 17, or 18 with "
+                "grad_seed) -- this file's hardcoded I/O indices do not "
+                "necessarily match this model, refusing to guess\n", ni);
+        return 1;
+    }
 
-    void *in_bufs[17] = {0}, *out_bufs[15] = {0};
-    uint64_t in_sz[17], out_sz[15];
+    void *in_bufs[18] = {0}, *out_bufs[15] = {0};
+    uint64_t in_sz[18], out_sz[15];
 
     for (uint32_t i = 0; i < ni; i++) {
         in_sz[i] = axclrtEngineGetInputSizeByIndex(info, 0, i);
@@ -133,6 +147,10 @@ int main(int argc, char **argv) {
     {
         float lr = 1e-4f;
         CK(axclrtMemcpy(in_bufs[lr_in], &lr, sizeof(lr), AXCL_MEMCPY_HOST_TO_DEVICE));
+    }
+    if (ni == 18) {
+        float seed = 1.0f;
+        CK(axclrtMemcpy(in_bufs[seed_in], &seed, sizeof(seed), AXCL_MEMCPY_HOST_TO_DEVICE));
     }
 
     /* x/y: reused synthetic batch, re-uploaded every step exactly as a real


### PR DESCRIPTION
## Summary
- PR #1360 flagged that `resident_runner.c`/`whisper_resident_runner.c` allocate a `grad_seed` buffer but never write to it -- raising a worry that gradient-magnitude claims through them since #1353 (Whisper's step-0/step-1 death included) were computed against an unintended device-buffer value.
- Checked directly on real hardware (`axclrtEngineGetNumInputs`, not assumed): every model these two runners have actually been run against (`r18_b1.axmodel`, `whisper_step.axmodel`, `whisper_p1.axmodel`) has exactly the input count their hardcoded indices expect (7 and 17) and **none include `grad_seed` at all** -- they predate its promotion to a graph input (PR #1357 merged before #1353 per master's own topology). **No prior finding needs correction.**
- Did catch a real, latent bug: `build_resident_step()` on current master unconditionally emits `grad_seed`, so a fresh rebuild of these graphs today would silently overflow these runners' fixed-size `in_bufs[]` arrays. Fixed proactively -- both now bound-check the real input count, size buffers for the one-more-input case, and feed `grad_seed=1.0` when present.
- Also fixed a stale header comment in `whisper_resident_runner.c` (described resnet18's I/O, left over from copying `resident_runner.c`).

## Test plan
- [x] Re-ran both fixed runners against the same real models on real AX650N hardware: identical numbers to before the fix (resnet18 29ms/step, loss=0.117937; Whisper 245-246ms/step, loss=1.00265 constant across steps) -- confirms the fix is a no-op for every model these runners have actually targeted.
- [x] Confirmed via `axclrtEngineGetNumInputs` on real hardware, not code-reading alone, that no historical model had a live `grad_seed` input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W