### PR TITLE
axera: wav2vec2 feature extractor compiles under INT8; highest_mix_precision fails a third way

### DIFF
--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -345,3 +345,73 @@ step graph on Pulsar2/AX650N and confirming the gradient survives multiple
 step for whoever picks this up -- the host-side evidence says it should
 behave like resnet18, not like Whisper, but only a real compile+run settles
 it the way this project settles everything else.
+
+### Real hardware follow-up: compiles, `highest_mix_precision` fails a third way, and quantized gradient dies for a different reason than Whisper's
+
+Rebuilt the training-step graph at the real `Wav2Vec2Config()` default scale
+(4.2M-param feature extractor, matching the section above exactly --
+`fe.conv_layers.0.conv.weight` trainable rather than layer 6, since
+`build_resident_step`'s own `onnxsim.simplify()` pass renames later layers'
+weight initializers via CSE, e.g. `fe.conv_layers.6.conv.weight` ->
+`_v_100`, while layer 0's name survives -- picking layer 0 sidesteps the
+naming churn rather than fighting it). 172 nodes, matching the host-only
+survey's own count exactly. Host-verified again on this exact build:
+perturbing along the gradient's own direction (the fix this project's own
+Whisper work already established for finite-difference noise at this scale)
+gives 0.2-0.3% agreement against a reference at properly-tuned step sizes.
+
+**Compiles cleanly under standard INT8** (`pulsar2:7.0-lite`, 31.9s) -- the
+first real compile of any wav2vec2-family training graph in this project's
+history.
+
+**`highest_mix_precision` fails here too, a third distinct way.** Not
+Whisper's `LayerNorm` tiling limit (PR #1359's architecture has none) or
+resnet18's `AvgPool` scheduler `TypeError` (this graph has none either) --
+a real `TileFailException` on `AxErf`: `'dont support lut_float opr in
+AXOPS/ONNXOPS/CUSTOM_OPS'`, on the GELU activation's `Erf` node, forced to
+FP32 by the flag. Tried the same escape hatch PR #1359 tried for Whisper's
+LayerNorm -- a `layer_configs` entry forcing just `Erf` back to `U8`
+alongside `highest_mix_precision` -- and got the identical error, confirming
+(a third time, on a third architecture) that `highest_mix_precision` does
+not compose with `layer_configs` overrides at all; it is genuinely
+whole-graph-only. Three architectures, three different real ops
+(`LayerNorm`, `AvgPool`, `Erf`), three different real NPU-backend failure
+signatures (a `TileFailException` on a tiling-workspace limit, a Python
+`TypeError` inside the closed-source scheduler, and a `TileFailException`
+on an unsupported float lookup-table operator) -- this is now a consistent
+pattern, not a one-off: Pulsar2's FP32 tiling path does not reliably support
+ordinary ops that appear in almost any real model, and `highest_mix_precision`
+is not currently usable end-to-end on anything this project has actually
+built.
+
+**Standard INT8 compiles and runs, but the quantized gradient still dies
+after step 0 -- for a different, more mundane reason than Whisper's SNR
+floor.** Real hardware run (resident runner adapted to this model's real
+I/O order, confirmed via `probe_io`: inputs `[x, y,
+fe.conv_layers.0.conv.weight, lr, grad_seed]`, outputs `[updated weight,
+loss]`):
+
+| step | `w[0]` | loss |
+| --- | --- | --- |
+| initial | 0.453123 | -- |
+| 0 | 0.4580865502 | 0 |
+| 1-14 | 0.4580865502 (unchanged) | 0 |
+
+A real, nonzero step-0 update happens (delta +0.00496), then the weight
+freezes bit-identical from step 1 on, with loss reading exactly 0
+throughout -- the same *symptom* as Whisper's "dies at step 1," but not the
+same *cause*. The host-side evidence above already established this
+model's true gradient-to-weight ratio (~0.032) is easily resolvable by an
+8-bit quantizer -- there is no SNR floor here the way there is for Whisper.
+The step-0 delta itself is the tell: `(0.453123 - 0.458087) / 1e-4 ≈ -49.6`
+effective gradient magnitude, roughly five orders of magnitude larger than
+the host-measured true gradient (~0.0013 mean absolute) -- this is a
+calibration-range mismatch, the same class of bug PR #1346 found and fixed
+for resnet18 (arbitrary, unmeasured `weight_scale`/`x_scale` guesses fed to
+`make_training_calib.py` rather than values matched to this model's real
+activation statistics), not a new fundamental limit. **Not chased further
+here** -- fixing it needs proper calibration data (real or realistically-
+scaled `x`/weight statistics, following PR #1354's confirmed textbook-MinMax
+calibration behavior, or PR #1346's own fix pattern) rather than a config
+flag, and is the concrete next step for whoever wants this model actually
+training multiple real steps on hardware.

--- a/scripts/axera/build_calib_signal_probe.py
+++ b/scripts/axera/build_calib_signal_probe.py
@@ -35,11 +35,16 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
-from _local_import import ensure_repo_onnxsim  # noqa: E402
+from _local_import import ensure_repo_onnxsim, fresh  # noqa: E402
 
 ensure_repo_onnxsim()
 
-import legalize  # noqa: E402
+# scripts/axera/legalize.py and scripts/axelera/legalize.py are two
+# different, same-named modules sharing one `sys.modules["legalize"]` entry
+# -- a plain `import legalize` risks silently getting axelera's copy if
+# something upstream already claimed that bare name. `fresh` reloads
+# directly from this file's own directory regardless of what's cached.
+legalize = fresh("legalize", HERE)
 
 from onnxsim import graph_grad, qat_graph  # noqa: E402
 

--- a/scripts/axera/build_resident_train_step.py
+++ b/scripts/axera/build_resident_train_step.py
@@ -88,11 +88,16 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
-from _local_import import ensure_repo_onnxsim  # noqa: E402
+from _local_import import ensure_repo_onnxsim, fresh  # noqa: E402
 
 ensure_repo_onnxsim()
 
-import legalize  # noqa: E402
+# scripts/axera/legalize.py and scripts/axelera/legalize.py are two
+# different, same-named modules sharing one `sys.modules["legalize"]` entry
+# -- a plain `import legalize` risks silently getting axelera's copy if
+# something upstream already claimed that bare name. `fresh` reloads
+# directly from this file's own directory regardless of what's cached.
+legalize = fresh("legalize", HERE)
 
 from onnxsim import graph_grad, qat_graph  # noqa: E402
 from onnxsim.compile_training import _static_shapes_and_types  # noqa: E402

--- a/scripts/axera/build_w2v2_feature_extractor_step.py
+++ b/scripts/axera/build_w2v2_feature_extractor_step.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Build the wav2vec2 CNN feature extractor's training-step graph -- the
+smaller, shallower audio target `docs/axera-audio-speech-op-coverage.md`'s
+"A smaller target than Whisper" section surveyed and this script actually
+compiles.
+
+`Wav2Vec2Model(Wav2Vec2Config()).feature_extractor` (7 Conv1D layers, 4.2M
+params, no attention/LayerNorm chain) exports to `{Add, Constant, Conv, Div,
+Erf, InstanceNormalization, Mul, Reshape, Shape, Unsqueeze}` -- every op
+except `Unsqueeze` already has a `graph_grad` gradient rule. `Unsqueeze`
+only appears on the non-trainable raw-waveform input's own path (adding the
+channel axis), so it is rewritten to an equivalent `Reshape` before
+`build_resident_step` ever sees it -- the same trick `legalize.py`'s
+`flatten_to_reshape` already uses for the analogous case, not new gradient
+machinery.
+
+`fe.conv_layers.0.conv.weight` (not a later layer) is the trainable weight:
+`build_resident_step`'s own `onnxsim.simplify()` pass renames later
+layers' weight initializers via CSE (e.g. `fe.conv_layers.6.conv.weight`
+-> `_v_100`) while layer 0's name survives, so picking layer 0 sidesteps
+that renaming churn rather than fighting it.
+
+Usage::
+
+    build_w2v2_feature_extractor_step.py out/step.onnx
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import build_resident_train_step as brts  # noqa: E402
+
+
+def _export_feature_extractor(onnx_path: str) -> None:
+    import torch
+    import torch.nn as nn
+    from transformers import Wav2Vec2Model
+
+    fe = Wav2Vec2Model(_default_config()).feature_extractor.eval()
+
+    class Wrapped(nn.Module):
+        def __init__(self, fe):
+            super().__init__()
+            self.fe = fe
+
+        def forward(self, x):
+            return self.fe(x)
+
+    x = torch.randn(1, 4000)
+    torch.onnx.export(
+        Wrapped(fe),
+        (x,),
+        onnx_path,
+        input_names=["x"],
+        output_names=["feat"],
+        opset_version=17,
+        dynamo=False,
+    )
+
+
+def _default_config():
+    from transformers import Wav2Vec2Config
+
+    return Wav2Vec2Config()
+
+
+def _unsqueeze_to_reshape(model: onnx.ModelProto) -> onnx.ModelProto:
+    """Replaces the one `Unsqueeze` on `x`'s own path with an equivalent
+    `Reshape` -- `graph_grad` has no gradient rule for `Unsqueeze`, but
+    `build_backward` demands one for every node it walks regardless of
+    whether a gradient actually flows through it (`onnxsim.qat_graph`'s own
+    docstring), so it must go before `build_resident_step` runs.
+    """
+    g = model.graph
+    (idx, node) = next((i, n) for i, n in enumerate(g.node) if n.op_type == "Unsqueeze")
+    x_info = next(inp for inp in g.input if inp.name == node.input[0])
+    x_shape = [d.dim_value for d in x_info.type.tensor_type.shape.dim]
+    new_shape = [x_shape[0], 1, x_shape[1]]
+    shape_name = "unsqueeze_to_reshape_shape"
+    g.initializer.append(
+        numpy_helper.from_array(np.array(new_shape, dtype=np.int64), shape_name)
+    )
+    new_node = helper.make_node(
+        "Reshape", [node.input[0], shape_name], list(node.output), name="x_reshape"
+    )
+    del g.node[idx]
+    g.node.insert(idx, new_node)
+    onnx.checker.check_model(model)
+    return model
+
+
+def build(out_path: str, param: str = "fe.conv_layers.0.conv.weight"):
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".onnx") as f:
+        _export_feature_extractor(f.name)
+        model = onnx.load(f.name)
+
+    model = _unsqueeze_to_reshape(model)
+    model = onnx.shape_inference.infer_shapes(model)
+
+    feat_shape = next(
+        [d.dim_value for d in vi.type.tensor_type.shape.dim]
+        for vi in list(model.graph.value_info) + list(model.graph.output)
+        if vi.name == "feat"
+    )
+    batch, ch, seq = feat_shape
+    flat_dim = ch * seq
+    flat_shape_name = "flatten_shape"
+    model.graph.initializer.append(
+        numpy_helper.from_array(
+            np.array([batch, flat_dim], dtype=np.int64), flat_shape_name
+        )
+    )
+    model.graph.node.append(
+        helper.make_node(
+            "Reshape", ["feat", flat_shape_name], ["logits"], name="flatten_feat"
+        )
+    )
+    del model.graph.output[:]
+    model.graph.output.append(
+        helper.make_tensor_value_info("logits", TensorProto.FLOAT, [batch, flat_dim])
+    )
+    onnx.checker.check_model(model)
+    model = onnx.shape_inference.infer_shapes(model)
+
+    with_loss = brts.add_mse_loss(model, "logits", num_classes=flat_dim)
+    step_model, state = brts.build_resident_step(with_loss, params=[param])
+    onnx.checker.check_model(step_model)
+    onnx.save(step_model, out_path)
+    return step_model, state
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("out_path")
+    p.add_argument("--param", default="fe.conv_layers.0.conv.weight")
+    args = p.parse_args(argv)
+    step_model, state = build(args.out_path, args.param)
+    print(f"wrote {args.out_path}: {len(step_model.graph.node)} nodes, state={state}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/axera/build_whisper_train_step.py
+++ b/scripts/axera/build_whisper_train_step.py
@@ -59,7 +59,14 @@ if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
 import build_resident_train_step as brts  # noqa: E402
-import legalize  # noqa: E402
+from _local_import import fresh  # noqa: E402
+
+# scripts/axera/legalize.py and scripts/axelera/legalize.py are two
+# different, same-named modules sharing one `sys.modules["legalize"]` entry
+# -- a plain `import legalize` risks silently getting axelera's copy if
+# something upstream already claimed that bare name. `fresh` reloads
+# directly from this file's own directory regardless of what's cached.
+legalize = fresh("legalize", HERE)
 
 _STEM = {"conv1.weight", "conv1.bias", "conv2.weight", "conv2.bias"}
 

--- a/scripts/axera/tools/README.md
+++ b/scripts/axera/tools/README.md
@@ -1,6 +1,6 @@
 # AXCL runtime tools
 
-Eight small C programs against the AXCL engine API (`/usr/include/axcl`), for
+Nine small C programs against the AXCL engine API (`/usr/include/axcl`), for
 things `axcl_run_model` cannot do.
 
 `axcl_run_model` only ever runs a model's **first** shape group. An
@@ -85,6 +85,16 @@ prefill cannot be timed with the shipped CLI. These talk to
   `-g` mode is written and correct but has nothing to run yet, since the
   `Gather`-off-a-resident-dataset variant doesn't currently compile on real
   hardware (a genuine Pulsar2 NPU-backend gap, not a bug in this runner).
+- `w2v2fe_runner.c` -- resident runner for `../build_w2v2_feature_extractor_step.py`'s
+  training step (one trainable state tensor, its own I/O layout, real
+  `probe_io`-confirmed). Compiles under standard INT8; `highest_mix_precision`
+  fails a third distinct way here (`AxErf`'s `lut_float` path, not
+  Whisper's `LayerNorm` tiling limit or resnet18's `AvgPool` scheduler
+  crash) -- see the audio-speech coverage doc's real-hardware follow-up
+  section. Prints `w[0]` alongside loss every step, the same
+  read-the-raw-state-buffer diagnostic this project has needed twice
+  before to catch a gradient dying silently behind a healthy-looking loss
+  output.
 
 Build and run them where the card is visible (inside the VM, if the device is
 passed through -- see `../vm/README.md`):

--- a/scripts/axera/tools/w2v2fe_runner.c
+++ b/scripts/axera/tools/w2v2fe_runner.c
@@ -1,0 +1,136 @@
+/* Resident runner for the wav2vec2 feature-extractor training-step
+ * .axmodel (`../build_w2v2_feature_extractor_step.py`). I/O order confirmed
+ * via probe_io on a real compiled model: inputs [x, y,
+ * fe.conv_layers.0.conv.weight, lr, grad_seed], outputs [updated weight,
+ * loss] -- one trainable state tensor, unlike resnet18's four or Whisper's
+ * fourteen, so this is its own small runner rather than a generalization of
+ * resident_runner.c's N_STATE=4 layout.
+ *
+ * Usage: w2v2fe_runner model.axmodel steps [warmup]
+ *
+ * Seeds the trainable weight from <model.axmodel>.state0 (raw float32
+ * bytes, matching resident_runner.c's convention) and prints w[0] alongside
+ * loss every step so a dying gradient (the weight freezing bit-identical
+ * after a real step-0 update) is visible directly, the same diagnostic this
+ * project has needed twice before (PRs #1343/#1346's loss=0 investigations,
+ * PR #1359's Whisper step-1 death) -- reading the raw state buffer, not
+ * trusting the runner's own loss output alone.
+ */
+#define _POSIX_C_SOURCE 199309L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "axcl.h"
+
+#define CK(e) do { axclError _r = (e); if (_r != 0) { \
+    fprintf(stderr, "%s failed: 0x%x\n", #e, _r); return 1; } } while (0)
+
+static double now_ms(void) {
+    struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1e6;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s model.axmodel steps [warmup]\n", argv[0]);
+        return 2;
+    }
+    int steps = atoi(argv[2]);
+    int warmup = argc > 3 ? atoi(argv[3]) : 3;
+
+    CK(axclInit(NULL));
+    axclrtDeviceList devs; CK(axclrtGetDeviceList(&devs));
+    if (!devs.num) { fprintf(stderr, "no device\n"); return 1; }
+    CK(axclrtSetDevice(devs.devices[0]));
+    CK(axclrtEngineInit(AXCL_VNPU_DISABLE));
+
+    uint64_t modelId = 0, ctx = 0;
+    CK(axclrtEngineLoadFromFile(argv[1], &modelId));
+    CK(axclrtEngineCreateContext(modelId, &ctx));
+
+    axclrtEngineIOInfo info; CK(axclrtEngineGetIOInfo(modelId, &info));
+    uint32_t ni = axclrtEngineGetNumInputs(info), no = axclrtEngineGetNumOutputs(info);
+    fprintf(stderr, "inputs=%u outputs=%u\n", ni, no);
+
+    axclrtEngineIO io; CK(axclrtEngineCreateIO(info, &io));
+
+    const int x_in = 0, y_in = 1, w_in = 2, lr_in = 3, seed_in = 4;
+    const int w_out = 0, loss_out = 1;
+
+    void *in_bufs[5] = {0}, *out_bufs[2] = {0};
+    uint64_t in_sz[5], out_sz[2];
+
+    for (uint32_t i = 0; i < ni; i++) {
+        in_sz[i] = axclrtEngineGetInputSizeByIndex(info, 0, i);
+        CK(axclrtMalloc(&in_bufs[i], in_sz[i], AXCL_MEM_MALLOC_NORMAL_ONLY));
+        CK(axclrtEngineSetInputBufferByIndex(io, i, in_bufs[i], in_sz[i]));
+    }
+    for (uint32_t i = 0; i < no; i++) {
+        out_sz[i] = axclrtEngineGetOutputSizeByIndex(info, 0, i);
+        CK(axclrtMalloc(&out_bufs[i], out_sz[i], AXCL_MEM_MALLOC_NORMAL_ONLY));
+        CK(axclrtEngineSetOutputBufferByIndex(io, i, out_bufs[i], out_sz[i]));
+    }
+
+    char path[1024];
+    snprintf(path, sizeof(path), "%s.state0", argv[1]);
+    FILE *f = fopen(path, "rb");
+    if (!f) { fprintf(stderr, "missing %s\n", path); return 1; }
+    void *host = malloc(in_sz[w_in]);
+    size_t got = fread(host, 1, in_sz[w_in], f);
+    fclose(f);
+    if (got != in_sz[w_in]) {
+        fprintf(stderr, "short read %s (%zu != %llu)\n", path, got,
+                (unsigned long long)in_sz[w_in]);
+        return 1;
+    }
+    CK(axclrtMemcpy(in_bufs[w_in], host, in_sz[w_in], AXCL_MEMCPY_HOST_TO_DEVICE));
+    free(host);
+
+    { float lr = 1e-4f; CK(axclrtMemcpy(in_bufs[lr_in], &lr, sizeof(lr), AXCL_MEMCPY_HOST_TO_DEVICE)); }
+    { float seed = 1.0f; CK(axclrtMemcpy(in_bufs[seed_in], &seed, sizeof(seed), AXCL_MEMCPY_HOST_TO_DEVICE)); }
+
+    void *hx = malloc(in_sz[x_in]);
+    void *hy = malloc(in_sz[y_in]);
+    memset(hx, 0x11, in_sz[x_in]);
+    memset(hy, 0x22, in_sz[y_in]);
+
+    float loss_host, w0;
+    CK(axclrtMemcpy(&w0, in_bufs[w_in], sizeof(float), AXCL_MEMCPY_DEVICE_TO_HOST));
+    fprintf(stderr, "initial w[0] = %g\n", w0);
+
+    for (int i = 0; i < warmup; i++) {
+        CK(axclrtMemcpy(in_bufs[x_in], hx, in_sz[x_in], AXCL_MEMCPY_HOST_TO_DEVICE));
+        CK(axclrtMemcpy(in_bufs[y_in], hy, in_sz[y_in], AXCL_MEMCPY_HOST_TO_DEVICE));
+        CK(axclrtEngineExecute(modelId, ctx, 0, io));
+        CK(axclrtMemcpy(in_bufs[w_in], out_bufs[w_out], out_sz[w_out], AXCL_MEMCPY_DEVICE_TO_DEVICE));
+        CK(axclrtMemcpy(&loss_host, out_bufs[loss_out], sizeof(loss_host), AXCL_MEMCPY_DEVICE_TO_HOST));
+    }
+
+    double best = 1e30, sum = 0, t_start = now_ms();
+    for (int i = 0; i < steps; i++) {
+        double t0 = now_ms();
+        CK(axclrtMemcpy(in_bufs[x_in], hx, in_sz[x_in], AXCL_MEMCPY_HOST_TO_DEVICE));
+        CK(axclrtMemcpy(in_bufs[y_in], hy, in_sz[y_in], AXCL_MEMCPY_HOST_TO_DEVICE));
+        CK(axclrtEngineExecute(modelId, ctx, 0, io));
+        CK(axclrtMemcpy(in_bufs[w_in], out_bufs[w_out], out_sz[w_out], AXCL_MEMCPY_DEVICE_TO_DEVICE));
+        CK(axclrtMemcpy(&loss_host, out_bufs[loss_out], sizeof(loss_host), AXCL_MEMCPY_DEVICE_TO_HOST));
+        double dt = now_ms() - t0;
+        if (dt < best) best = dt;
+        sum += dt;
+        CK(axclrtMemcpy(&w0, in_bufs[w_in], sizeof(float), AXCL_MEMCPY_DEVICE_TO_HOST));
+        fprintf(stderr, "step %d: %.3f ms  loss=%g  w[0]=%.10g\n", i, dt, loss_host, w0);
+    }
+    double total = now_ms() - t_start;
+    printf("steps=%d min=%.3fms avg=%.3fms total=%.3fms throughput=%.1f steps/s\n",
+           steps, best, sum / steps, total, 1000.0 * steps / total);
+
+    for (uint32_t i = 0; i < ni; i++) axclrtFree(in_bufs[i]);
+    for (uint32_t i = 0; i < no; i++) axclrtFree(out_bufs[i]);
+    axclrtEngineDestroyIO(io);
+    axclrtEngineDestroyIOInfo(info);
+    axclrtEngineUnload(modelId);
+    axclrtEngineFinalize();
+    axclFinalize();
+    return 0;
+}

--- a/tests/test_axera_legalize.py
+++ b/tests/test_axera_legalize.py
@@ -8,6 +8,7 @@ it should, and it does not change what the graph computes.
 Neither needs Docker or a card.
 """
 
+import importlib.util
 import os
 import sys
 
@@ -21,7 +22,19 @@ _AXERA_DIR = os.path.join(
 if _AXERA_DIR not in sys.path:
     sys.path.insert(0, _AXERA_DIR)
 
-import legalize  # noqa: E402
+# scripts/axera/legalize.py and scripts/axelera/legalize.py are two
+# different, same-named modules -- a plain `import legalize` here would
+# share one `sys.modules["legalize"]` entry with whichever of the two test
+# files collects first, silently handing this one the wrong module. Load
+# this one under a private key instead, so the two never collide regardless
+# of collection order (see tests/test_axelera_legalize.py, which already
+# does this on its own side of the same collision).
+_spec = importlib.util.spec_from_file_location(
+    "axera_legalize", os.path.join(_AXERA_DIR, "legalize.py")
+)
+legalize = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = legalize
+_spec.loader.exec_module(legalize)
 
 
 def _snake_model(dtype=TensorProto.FLOAT, exponent_as_initializer=True):

--- a/tests/test_axera_training_legalize.py
+++ b/tests/test_axera_training_legalize.py
@@ -11,6 +11,7 @@ the graph still computes what it did.
 Neither needs Docker nor a card.
 """
 
+import importlib.util
 import os
 import sys
 
@@ -25,7 +26,19 @@ _AXERA_DIR = os.path.join(
 if _AXERA_DIR not in sys.path:
     sys.path.insert(0, _AXERA_DIR)
 
-import legalize  # noqa: E402
+# scripts/axera/legalize.py and scripts/axelera/legalize.py are two
+# different, same-named modules -- a plain `import legalize` here would
+# share one `sys.modules["legalize"]` entry with whichever of the two test
+# files collects first, silently handing this one the wrong module. Load
+# this one under a private key instead, so the two never collide regardless
+# of collection order (see tests/test_axelera_legalize.py, which already
+# does this on its own side of the same collision).
+_spec = importlib.util.spec_from_file_location(
+    "axera_legalize", os.path.join(_AXERA_DIR, "legalize.py")
+)
+legalize = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = legalize
+_spec.loader.exec_module(legalize)
 
 
 def _model(nodes, inputs, outputs, initializer=(), opset=17, functions=()):


### PR DESCRIPTION
## Summary
- Real hardware follow-up to PR #1363 (host-only wav2vec2 feature-extractor survey) and PR #1365/#1366 (`highest_mix_precision` discovery + its failure on Whisper/resnet18).
- Built the real `Wav2Vec2Config()` default-scale training-step graph (4.2M params, 172 nodes, matching #1363's own count exactly). Host-verified via a gradient-direction finite-difference check (0.2-0.3% agreement at properly tuned step sizes).
- **Compiles cleanly under standard INT8** (`pulsar2:7.0-lite`, 31.9s) -- the first real compile of any wav2vec2-family training graph in this project.
- **`highest_mix_precision` fails here too, a third distinct way**: not Whisper's `LayerNorm` tiling limit or resnet18's `AvgPool` scheduler `TypeError` (this graph has neither op) -- a real `TileFailException` on `AxErf`'s GELU activation, `'dont support lut_float opr'`. A `layer_configs` override forcing just `Erf` back to `U8` produces the identical error, confirming a third time that `highest_mix_precision` doesn't compose with per-op overrides at all.
- **Standard INT8 runs on real hardware, but the quantized gradient still dies after step 0** -- a real nonzero update happens, then the weight freezes bit-identical, loss reads exactly 0. Unlike Whisper, this is **not** an SNR floor (host gradient/weight ratio ~0.032 is easily resolvable) -- the step-0 delta implies an effective gradient ~5 orders of magnitude larger than the true one, pointing at a calibration-range mismatch (the same class of bug PR #1346 found for resnet18), not a new fundamental limit. Not fixed here -- flagged as the concrete next step.

## Test plan
- [x] Host-verified graph correctness via gradient-direction finite differences.
- [x] Compiled on real AX650N hardware (via `axcl-vm`) under both standard INT8 and `highest_mix_precision`.
- [x] Ran a real 15-step training loop on real hardware via a new adapted resident runner (`w2v2fe_runner.c`), confirmed via `probe_io`'s real I/O order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W