### PR TITLE
axera/axelera: survey legalize rules for onnxsim-core promotion, port neg_to_mul

### DIFF
--- a/docs/axera-legalize-onnxsim-core-migration.md
+++ b/docs/axera-legalize-onnxsim-core-migration.md
@@ -1,0 +1,177 @@
+# Moving vendor legalize rules into onnxsim's core -- what moved, what stayed, and why
+
+Answers: "could we move legalize passes to onnxsim library code and remove
+them from scripts?" There's already a real precedent for this
+(`git log`: `4073e4b7` "Port the Voyager legalizer's three rewrites to
+onnxsim's C++ core", `7757d73a` "Make the three legalization passes
+target-agnostic in onnxsim's core") -- this records finishing that
+precedent's open half, and doing the equivalent survey and one full
+promotion for `scripts/axera/legalize.py`, which is much larger.
+
+## A real constraint the precedent already discovered, worth stating plainly
+
+`scripts/axelera/legalize.py`'s own docstring is explicit about why its
+three already-ported rules (`explicit_auto_pad`, `gemm_transA_to_transpose`,
+`maxpool_rowmajor_when_indices_unused`) still carry a full standalone Python
+implementation *alongside* the new C++ core pass, rather than delegating to
+it: *"This file stays useful on its own: it needs nothing beyond the `onnx`
+package (no onnxsim build)."* Making the Python function call
+`onnxsim.simplify(model, extra_optimizers=[...])` internally would introduce
+a hard dependency on onnxsim's *compiled* extension being built and
+importable -- breaking that stated property for anyone using
+`legalize.py in.onnx out.onnx` as a bare script against just `pip install
+onnx`.
+
+`scripts/axera/legalize.py` doesn't document this as explicitly, but the
+same property holds today: it imports only `onnx`/`numpy`, nothing from
+`onnxsim`. **"Remove it from scripts" is not the right read of the
+precedent's own design** -- what the precedent actually does, and what this
+continues, is: promote the *rewrite* to a shared, target-agnostic C++ pass
+usable from every onnxsim binding, cross-reference it from the vendor
+script's docstring, and keep the vendor script's own Python version working
+standalone. Not deleted, not silently duplicated-and-forgotten -- documented
+as intentionally dual.
+
+## The rebuild gap, found and closed
+
+The three already-ported passes had never actually been rebuilt+tested in
+this checkout: `import onnxsim` resolved fine, but the compiled
+`onnxsim_cpp2py_export` extension predated the port, so all three
+(`explicit_auto_pad`, `gemm_transA_to_transpose`,
+`maxpool_rowmajor_when_indices_unused`) failed with `pass %s is
+unknown.<name>` from `onnxoptimizer`'s own `pass_registry.h`. An incremental
+`pip install --no-build-isolation -e .` (52s, not a from-scratch rebuild --
+protobuf/ONNX/onnx-optimizer were already built) picked them up; all 17
+existing tests across the three then pass. Worth knowing for anyone who
+lands a new `onnxsim/passes/*.h`/`custom_optimizer_passes.cpp` change in
+this environment: build artifacts aren't tracked by git, so a fresh
+checkout (or a worktree that never ran the C++ build) needs this rebuild
+step before its tests can pass, independent of anything about the
+change itself.
+
+## Classification: every top-level rule in `scripts/axera/legalize.py`
+
+Thirteen entries in `RULES`, eight of them also in `TRAINING_RULES` (the
+subset that makes a live-weight *training* graph, not just an inference
+graph, compile on Pulsar2).
+
+### Promoted, or clearly promotable on the same reasoning (generic ONNX
+rewrite, target-agnostic, the vendor-specific "why" stays in the script)
+
+- **`neg_to_mul`** -- **promoted this session**. `onnxsim/passes/neg_to_mul.h`,
+  registered, tested (`tests/test_neg_to_mul.py`, 3 cases including a real
+  dtype-scoping edge case), cross-referenced from the vendor's own
+  docstring. `Neg(x) -> Mul(x, -1)` is exact and the exact shape of rewrite
+  the precedent already promoted three of ("backend lacks this op" class).
+  Scoped to `float32` in the core pass -- the emitted `-1` constant is
+  written via `Tensor::floats()` (ONNX's `float_data` field), the wrong wire
+  representation for `float64`/`float16`/integer `Neg`; the vendor script's
+  own Python version has the identical latent limitation (it always emits a
+  `float32` constant too), just without a guard that declines other types.
+- **`pow2_to_mul`** -- not ported this session (time-boxed to one complete
+  promotion per the task's own instruction), but the same class exactly:
+  `Pow(x, 2) -> Mul(x, x)`, exact, no vendor-specific formula in the
+  rewrite itself (the vendor-specific part is *why* -- avoiding a fused
+  `AxQuantizedSnake` activation that fails Pulsar2's tiler -- which would
+  stay in `scripts/axera/legalize.py`/its README exactly like the
+  precedent's own three rules keep their vendor rationale).
+- **`float16_to_float32`** -- promotable. Retyping an fp16 graph to fp32
+  throughout (initializers, `Constant` values, `Cast` targets, value_info)
+  is a generic normalization need for any tool/backend that only wants
+  fp32, not an AX650N-specific formula.
+- **`explicit_conv_padding`** -- promotable, and **not a duplicate of
+  axelera's `explicit_auto_pad`** despite the similar name: `explicit_auto_pad`
+  converts a symbolic `auto_pad` mode (`SAME_UPPER`/`SAME_LOWER`/`VALID`)
+  into explicit `pads`; `explicit_conv_padding` converts an *already*-explicit
+  but *asymmetric* `pads` attribute into a separate `Pad` node plus symmetric
+  (zero) `pads` on the convolution. Different backend limitation (auto_pad
+  support vs. asymmetric-padding support), genuinely worth two separate
+  passes, not one.
+- **`dilated_conv_to_taps`** -- promotable. `y[t] = sum_j w[:,:,j] .
+  xp[t+j*d]` decomposed into one 1x1 conv per tap, summed, is exact and
+  carries no Pulsar2-specific math -- any backend without dilated-conv
+  support could use it. (The rule's own docstring notes it *also* happens to
+  match how the AX650N's weight table stores a dilated conv internally --
+  that's a bonus property of this target, not a dependency the rewrite has
+  on it.)
+- **`rank0_to_rank1`** -- promotable, on the same "generic rewrite,
+  vendor-specific why" split the precedent already established. A scalar
+  (rank-0) graph output getting a trailing axis is not itself
+  training-specific or AX650N-specific; the *reason* this project needs it
+  (Pulsar2's calibration step can't concatenate a rank-0 tensor across
+  samples, and a training graph's loss is always scalar) is specific and
+  stays put.
+
+### Not a graph-rewrite pass -- doesn't fit `PredicateBasedPass`'s shape
+
+- **`filename_safe_io_names`** -- a whole-graph I/O *renaming* utility (fixing
+  names like `/Add_10_output_0` that break as filenames), not a per-node
+  pattern-triggered semantic rewrite. It also exists for a specific
+  *consumer's* behavior (`axcl_run_model` writing `<input name>.bin` files),
+  not an ONNX-level or compiler-level limitation any other backend would
+  recognize. Onnxsim's `PredicateBasedPass` architecture -- `patternMatchPredicate(Node*)`
+  triggering per node -- isn't the right shape for "rename every I/O value
+  in the graph," and the motivating problem is genuinely this one tool's,
+  not a target's compiler constraint. Stays in `scripts/axera`.
+
+### Stay in `scripts/axera` -- specific to a *live-weight training* graph and
+Pulsar2's own compiler, not general ONNX inference legalization
+
+- **`inline_local_functions`** -- already delegates its actual work to
+  `onnx.inliner.inline_local_functions` (ONNX's own stdlib), so there's
+  nothing to "promote" -- the generic part is already shared. What's left
+  in this function is opset-import bookkeeping specific to
+  `onnxsim.graph_grad`'s own generated `FunctionProto`s (fixing an opset
+  mismatch between a hand-assembled model and the functions `graph_grad`
+  ships) -- training-pipeline-specific, correctly stays.
+- **`avgpool_ceil_to_floor`, `flatten_to_reshape`, `global_pool_to_reduce`**
+  -- exist because `onnxsim.graph_grad.build_backward` has no gradient rule
+  for `ceil_mode=1` pooling, `Flatten`, or `GlobalAveragePool`, so a
+  *forward* graph destined for differentiation needs these cleared before
+  `build_backward` ever runs -- an autodiff-coverage question, not an ONNX
+  inference-legalization one. A generic inference-graph legalizer (onnxsim's
+  pass architecture, used from CLI/C/Rust/npm bindings that never touch
+  `graph_grad`) has no use for "make this pool differentiable."
+- **`gemm_to_matmul`, `act_weight_conv_to_matmul`** -- exist specifically
+  because a **live** (runtime-input, not constant) weight breaks Pulsar2's
+  own `Gemm`/`Conv` lowering in ways a normal inference graph's constant
+  weight never does (`NotImplementedError('Should fuse Gemm ... to
+  MatMul.')`, `AxQuantizedActWeightConv, shapefn failed`). "The weight
+  might be a graph input, not a constant" is a training-graph-specific
+  precondition an inference-only legalizer has no reason to check for.
+- **`TRAINING_RULES`** itself -- an ordered tuple naming which of the above
+  apply to a training step specifically, not a rule.
+
+**Bottom line on the training-specific group**: onnxsim's pass architecture
+is built for legalizing *inference* graphs across arbitrary targets. "Make a
+live-weight backward-pass graph compile on one specific vendor's compiler"
+is a narrower, different problem than any of the already-promoted rules
+solve, and forcing it into the same architecture would mean either (a)
+teaching the generic pass system about `graph_grad`'s own conventions (a
+real coupling this project's onnxsim core has otherwise avoided), or (b)
+promoting a pass that's only ever meaningfully invoked from one training
+pipeline -- neither is a good trade for "runs from every onnxsim binding."
+These rules are correctly scoped to `scripts/axera`.
+
+## Regression verification
+
+`tests/test_axera_legalize.py`, `tests/test_axera_training_legalize.py`,
+`tests/test_axelera_legalize.py`, `tests/test_explicit_auto_pad.py`,
+`tests/test_gemm_transa_to_transpose.py`,
+`tests/test_maxpool_rowmajor_when_indices_unused.py`,
+`tests/test_neg_to_mul.py`, `tests/test_build_resident_train_step.py`: **77
+passed**, after the rebuild above. `ruff format`/`ruff check` clean on all
+touched Python; `clang-format` clean on the new C++.
+
+## What's left, if this is picked up further
+
+`pow2_to_mul`, `float16_to_float32`, `explicit_conv_padding`,
+`dilated_conv_to_taps` are classified as promotable above but not yet
+ported (time-boxed to one complete round-trip this session, per the task's
+own instruction to prioritize getting the survey right over rushing every
+promotion partially) -- each would follow `neg_to_mul.h`'s exact structure:
+new `onnxsim/passes/<name>.h`, register in `custom_optimizer_passes.cpp`,
+`onnx.parser`-based test in `tests/test_<name>.py`, a cross-reference
+paragraph added to the vendor function's docstring (Python implementation
+kept, not deleted, matching the standalone-usability constraint discussed
+above).

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -56,6 +56,7 @@
 #include "passes/iq4_nl.h"
 #include "passes/magnitude_pruning.h"
 #include "passes/maxpool_rowmajor_when_indices_unused.h"
+#include "passes/neg_to_mul.h"
 #include "passes/qoperator_quantize_activation.h"
 #include "passes/qoperator_quantize_concat.h"
 #include "passes/qoperator_quantize_conv.h"
@@ -173,6 +174,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::MagnitudePruningGlobal>(registry);
     RegisterOrReplace<p::MagnitudePruningMatMul>(registry);
     RegisterOrReplace<p::MaxPoolRowMajorWhenIndicesUnused>(registry);
+    RegisterOrReplace<p::NegToMul>(registry);
     RegisterOrReplace<p::QOperatorQuantizeActivation>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConcat>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConv>(registry);

--- a/onnxsim/passes/neg_to_mul.h
+++ b/onnxsim/passes/neg_to_mul.h
@@ -1,0 +1,73 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// `Neg(x)` becomes `Mul(x, -1)` -- exact, and a way past a backend that
+// implements elementwise `Mul` but not `Neg` (e.g. a hand-rolled
+// reverse-mode autodiff pass that differentiates a subtraction produces
+// exactly one `Neg` per occurrence, and some NPU op-support lists have
+// `Mul` but not `Neg` -- see `scripts/axera/legalize.py`'s Python
+// counterpart of this rule for the concrete case that motivated it).
+//
+// Scoped to `float32` only: the `-1` constant this emits is populated via
+// `Tensor::floats()` (ONNX's `float_data` field), which is only the right
+// wire representation for that one element type -- `float64`/`float16`/
+// integer `Neg` would need a different tensor field per type, not handled
+// here.
+//
+// This is a pure graph-shape rewrite -- not a node-count reduction -- so it
+// is `PassType::Other` and never runs by default. Opt in with
+// `extra_optimizers=["neg_to_mul"]` (Python) or
+// `--enable-optimization neg_to_mul` (CLI).
+
+#include <string>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct NegToMul final : public PredicateBasedPass {
+  explicit NegToMul()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override { return "neg_to_mul"; }
+
+  bool patternMatchPredicate(Node* node) override {
+    return node->kind() == Symbol("Neg") && node->inputs().size() == 1 &&
+           node->input(0)->elemType() == TensorProto_DataType_FLOAT;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    Tensor minus_one;
+    minus_one.elem_type() = TensorProto_DataType_FLOAT;
+    minus_one.floats().push_back(-1.0f);
+    Value* minus_one_v = graph.addInitializerAndCreateValue(minus_one);
+
+    Node* mul = graph.create(kMul, 1);
+    mul->addInput(node->input(0));
+    mul->addInput(minus_one_v);
+    mul->output()->setElemType(node->output()->elemType());
+    if (node->output()->has_sizes()) {
+      mul->output()->setSizes(node->output()->sizes());
+    }
+    mul->insertBefore(node);
+
+    node->output()->replaceAllUsesWith(mul->output());
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/scripts/axera/legalize.py
+++ b/scripts/axera/legalize.py
@@ -342,6 +342,17 @@ def neg_to_mul(model):
     `Neg` is the one op `onnxsim.graph_grad` emits that is absent from
     `AX650_SUPPORTED_OPS` -- differentiating a subtraction produces exactly
     one of them, so every backward pass hits it. The rewrite is exact.
+
+    Also has a target-agnostic C++ counterpart in onnxsim's own core
+    (`onnxsim/passes/neg_to_mul.h`), usable from any binding via
+    `onnxsim.simplify(model, extra_optimizers=["neg_to_mul"])` -- see
+    `tests/test_neg_to_mul.py`. This module's own version stays: it needs
+    nothing beyond the `onnx` package (no onnxsim build), which
+    `legalize.py in.onnx out.onnx`'s standalone-script usage depends on.
+    Both versions assume `float32` (this one emits a `float32` constant
+    unconditionally; the core pass checks and declines other element types
+    rather than emitting a mismatched one) -- fine for this project's own
+    float32 training graphs, not a general-dtype guarantee either way.
     """
     changed = 0
     for node in model.graph.node:

--- a/tests/test_neg_to_mul.py
+++ b/tests/test_neg_to_mul.py
@@ -1,0 +1,86 @@
+"""Tests for the ``neg_to_mul`` C++ pass (onnxsim/passes/neg_to_mul.h).
+
+``Neg(x)`` becomes ``Mul(x, -1)`` -- the onnxsim-core counterpart of
+``scripts/axera/legalize.py``'s ``neg_to_mul`` rule (that file's docstring
+records this as the fix for the one op ``onnxsim.graph_grad`` emits that is
+absent from a real NPU's op-support list). Usable from any binding via
+``extra_optimizers=["neg_to_mul"]``.
+
+Models are built with ``onnx.parser`` per CLAUDE.md's convention. Numeric
+equivalence comes from ``onnxsim.simplify``'s own ``check_n``.
+"""
+
+import numpy as np
+from onnx import parser
+
+import onnxsim
+
+
+def _model(body, opset=17, ir_version=10):
+    return parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+
+
+def _find(model, op_type):
+    return next(n for n in model.graph.node if n.op_type == op_type)
+
+
+def test_neg_becomes_mul_by_minus_one_and_computes_the_same_thing():
+    model = _model(
+        """
+        g (float[2,3] x) => (float[2,3] y)
+        { y = Neg(x) }
+        """
+    )
+    x = np.random.RandomState(0).randn(2, 3).astype(np.float32)
+    sim_model, ok = onnxsim.simplify(
+        model, check_n=1, input_data={"x": x}, extra_optimizers=["neg_to_mul"]
+    )
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert "Neg" not in op_types
+    mul = _find(sim_model, "Mul")
+    assert mul.input[0] == "x"
+
+
+def test_non_float_neg_is_left_alone():
+    """The emitted `-1` constant is written via `Tensor::floats()`, which is
+    only the right wire representation for `float32` -- an `int64` `Neg`
+    (exact and common: negating an axis/shape value) must not be rewritten
+    into a `Mul` carrying a `float32` constant against an `int64` input."""
+    model = _model(
+        """
+        g (int64[3] x) => (int64[3] y)
+        { y = Neg(x) }
+        """
+    )
+    x = np.array([1, -2, 3], np.int64)
+    sim_model, ok = onnxsim.simplify(
+        model, check_n=1, input_data={"x": x}, extra_optimizers=["neg_to_mul"]
+    )
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types == ["Neg"]
+
+
+def test_disabled_by_default():
+    """`neg_to_mul` is `PassType::Other`, so a plain `simplify()` call (no
+    `extra_optimizers`) must leave `Neg` alone."""
+    model = _model(
+        """
+        g (float[2,3] x) => (float[2,3] y)
+        { y = Neg(x) }
+        """
+    )
+    x = np.zeros((2, 3), np.float32)
+    sim_model, ok = onnxsim.simplify(model, check_n=1, input_data={"x": x})
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types == ["Neg"]


### PR DESCRIPTION
## Summary
- Answers "could we move legalize passes to onnxsim library code and remove them from scripts?" -- there's already a real precedent (`4073e4b7`/`7757d73a`, porting three Voyager/axelera rules into `onnxsim/passes/*.h`). This finds the constraint that precedent already respected: the vendor scripts stay useful standalone (no onnxsim build needed), so "remove from scripts" means *promote + cross-reference*, not *delete the Python version*. Full reasoning and a rebuild gap this also found and closed (the three existing ported passes had never been rebuilt in this checkout) in `docs/axera-legalize-onnxsim-core-migration.md`.
- Full per-rule classification of `scripts/axera/legalize.py`'s 13 rules: 6 promotable (generic ONNX rewrites), 1 already delegating to onnx's own stdlib, 1 not a graph-rewrite pass at all, 5 correctly staying (training-graph/Pulsar2-specific, not general inference legalization).
- Ports `neg_to_mul` as one complete round-trip: `onnxsim/passes/neg_to_mul.h`, registered in `custom_optimizer_passes.cpp`, `tests/test_neg_to_mul.py` (`onnx.parser`, including a real dtype-scoping edge case), cross-referenced from the vendor's own docstring.
- The remaining promotable rules (`pow2_to_mul`, `float16_to_float32`, `explicit_conv_padding`, `dilated_conv_to_taps`) are documented but not ported this round -- same mechanical pattern `neg_to_mul.h` establishes.

## Test plan
- [x] Rebuilt the C++ extension (`pip install --no-build-isolation -e .`) -- this also fixed the three already-merged Voyager passes, which were failing with `pass %s is unknown.<name>` before the rebuild.
- [x] `pytest tests/test_axera_legalize.py tests/test_axera_training_legalize.py tests/test_axelera_legalize.py tests/test_explicit_auto_pad.py tests/test_gemm_transa_to_transpose.py tests/test_maxpool_rowmajor_when_indices_unused.py tests/test_neg_to_mul.py tests/test_build_resident_train_step.py` -- 77 passed.
- [x] `ruff format`/`ruff check` clean; `clang-format` clean on the new C++.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W