### PR TITLE
axera: wav2vec2 batch=8 confirmed, vNPU+batch composition weaker than resnet18

### DIFF
--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -576,15 +576,45 @@ Real step times, now trustworthy since correctness is confirmed at batch=4:
 | 1 | 5.590ms / 5.865ms | 11.039 MiB |
 | 4 | 18.838ms / 19.353ms | 25.534 MiB |
 
-Batch=8 was not re-verified in this pass (the same `grad_seed` fix should
-apply identically, since the bug and fix are batch-size-independent in
-mechanism -- flagged as the remaining confirmation step, not assumed).
-vNPU+batching compounding was not re-checked here either -- both are now
-individually real, but composing them is a follow-on, not done in this pass.
+**Batch=8: re-verified with the `grad_seed` fix, confirmed working.** Same
+`build_w2v2fe_batch_calib.py` driver, `batch=8`. Real hardware, `lr=100`,
+8 steps: loss moves smoothly and monotonically, `1.03951 -> 1.00037`
+(plateauing over the last two steps at the same tracked-weight-quantization
+granularity already documented for batch=4 -- not a bug). Step time
+35.577ms min / 36.186ms avg, cmm 45.957 MiB.
+
+**vNPU + batching composition: real, but weaker than resnet18's, and
+saturates earlier.** `-v` at batch=8, N=1: bit-identical loss/weight
+trajectory vs. disabled, confirming non-corrupting at this batch size too
+(same check PRs #1345/#1346/#1372 already established at batch=1). Real
+concurrent throughput, batch=8, separate OS processes per context, all
+converging to the identical loss (`0.965574`) confirming correctness held
+under concurrency:
+
+| config | aggregate steps/s | aggregate samples/s | vs. batch=1,N=1 baseline (164.3 samples/s) |
+| --- | --- | --- | --- |
+| batch=8, N=1 | 27.3 | 218.4 | 1.33x |
+| batch=8, N=4 | 82.5 | 660.0 | 4.02x |
+| batch=8, N=8 | 85.6 | 684.8 | 4.17x |
+| batch=1, N=8 (PR #1372) | -- | 607.9 | 3.70x |
+
+Unlike resnet18 (PR #1346: 6.5x batching alone x 2.5x vNPU alone -> 18.1x
+combined, cleanly multiplicative), this model's batching gain alone is
+much smaller (1.33x, not 6.5x -- Conv1D quantize/glue overhead dominates
+differently here) and the combination **saturates by N=4** (660 -> 684.8
+samples/s from N=4 to N=8, a 3.8% gain for double the contexts) rather than
+continuing to scale to N=8 the way resnet18 did. Real, honest result: the
+two levers still both help, but this architecture's per-step compute at
+batch=8 already occupies enough of the NPU that fewer concurrent contexts
+saturate it, so the combination is additive-ish rather than cleanly
+multiplicative. Best practical point here is N=4 (nearly all of N=8's gain
+for half the contexts), not N=8.
 
 **Net**: three real calibration bugs found and fixed for this model across
-PRs #1367/#1370/this fix -- `x_scale`/`weight_scale` mismatch, degenerate
-constant-`lr` range, and now uncalibrated `grad_seed` -- all in the same
+PRs #1367/#1370/#1373 -- `x_scale`/`weight_scale` mismatch, degenerate
+constant-`lr` range, and uncalibrated `grad_seed` -- all in the same
 family (a scalar or tensor whose calibration data was never matched to its
-real runtime distribution). Batching is now confirmed working at batch=4;
-batch=8 and vNPU+batch composition remain open, low-risk follow-ons.
+real runtime distribution). Batching is now confirmed working at batch=4
+and batch=8; vNPU+batch composition is confirmed real but weaker and
+earlier-saturating than resnet18's own result -- both flagged follow-ons
+from PR #1373 are now closed.

--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -493,3 +493,73 @@ caught it. Whether this explains any part of PR #1353's own "seed sweep
 returns bit-identical gradients at every value" finding on a *different*
 model is an open, real question this task did not have scope to chase --
 noted here as a concrete follow-on, not asserted.
+
+### Batching and vNPU concurrency: vNPU compounds cleanly at batch=1, batching itself regresses correctness
+
+Applied this project's two already-proven speed levers (batching, PR #1342;
+vNPU concurrency, PR #1345/#1346) to the now-working feature-extractor case
+-- the first real audio model where this is worth trying.
+
+**Made the training-step graph batch-parametric.** Unlike resnet18's
+`set_batch()` (a post-hoc shape edit, since nothing downstream of `x` bakes
+a batch-specific constant), this model's `build()` computes a `flatten_shape`
+initializer from the *exported* batch dim -- Conv1D's per-sample output
+length threads through several strided layers before the manual flatten step,
+unlike resnet18's pooling-then-Gemm tail. So batch is a real **export**
+parameter here (`_export_feature_extractor(..., batch=N)`,
+`torch.randn(N, 4000)`), not a graph edit after the fact --
+`build_w2v2fe_batch_calib.py` is the new driver. Confirmed the raw export's
+own op sequence is identical at batch 1 and 4 (74 nodes, same op list) before
+trusting anything downstream. Host-verified the batched graph's gradient
+correctness the way `test_set_batch_gradient_is_the_mean_of_per_sample_
+gradients` already does for resnet18: batch=4's returned gradient matches
+the mean of four separately-run batch=1 gradients to 3.2e-5 relative error
+-- but only once every non-trainable layer's random initialization was
+pinned identical across the two builds (`torch.manual_seed(42)` before each
+export) -- the first attempt compared two *differently randomly initialized*
+models and failed at ~116% relative error, a test-methodology bug, not a
+graph bug, caught before it was mistaken for one.
+
+**Real hardware, batch=1 (correctness already confirmed above): both levers
+work.**
+
+| config | throughput | notes |
+| --- | --- | --- |
+| solo (`AXCL_VNPU_DISABLE`) | 164.3 steps/s | min 5.590ms/step |
+| 4x concurrent (`-v`) | 519.2 steps/s aggregate | 3.16x solo |
+| 8x concurrent (`-v`) | 607.9 steps/s aggregate | 3.70x solo |
+
+Confirmed non-corrupting first, the same check PR #1345 used: `-v` and
+non-`-v` runs of the same model produce bit-identical loss/weight
+trajectories, only step timing differs. The sub-linear scaling shape (3.16x
+at N=4, 3.70x at N=8, saturating) matches resnet18's own qualitative finding
+(2.53x at N=8) -- vNPU concurrency generalizes to this architecture.
+
+**Real hardware, batch=4/8: compiles and times, but the gradient is
+completely dead -- a new, unfixed calibration-range regression, not a
+throughput result.** Both compiled cleanly (68.4s and 107.7s, well under the
+batch-16+ compile-time wall) and ran without error, but **loss is
+bit-identical across all 8 real steps at both batch sizes** (`1.11174`
+constant at batch=4, `1.10973` at batch=8) -- unlike batch=1, where loss
+moved smoothly every step. The calibration for both reused this model's own
+*batch-shaped* real trajectory (not stale batch=1 data), so this is not a
+repeat of the already-fixed generic-defaults or degenerate-constant-`lr`
+bugs -- something about batch>1's real quantization range specifically
+kills the gradient, not yet root-caused. Real step times measured anyway,
+since timing doesn't depend on numerical correctness, but they should **not**
+be read as "batching gives N.Nx throughput for training" the way resnet18's
+own batching section can be -- there is no confirmed-correct training
+happening at either batch size to be fast *at*:
+
+| batch | step time (min/avg) | cmm |
+| --- | --- | --- |
+| 1 | 5.590ms / 5.865ms | 11.039 MiB |
+| 4 | 18.820ms / 18.891ms | 25.534 MiB |
+| 8 | 35.113ms / 35.270ms | 45.957 MiB |
+
+**Net**: vNPU concurrency is a real, confirmed, generalizable win for this
+architecture at batch=1. Batching needs its own dedicated diagnosis (likely
+the same class of investigation PR #1370 already did twice -- direct
+`quant_axmodel.json` inspection, an `lr`-style sweep -- applied to whichever
+tensor's calibrated range is wrong at batch>1) before it can be trusted here;
+flagged as the concrete next step, not chased further in this pass.

--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -535,31 +535,56 @@ trajectories, only step timing differs. The sub-linear scaling shape (3.16x
 at N=4, 3.70x at N=8, saturating) matches resnet18's own qualitative finding
 (2.53x at N=8) -- vNPU concurrency generalizes to this architecture.
 
-**Real hardware, batch=4/8: compiles and times, but the gradient is
-completely dead -- a new, unfixed calibration-range regression, not a
-throughput result.** Both compiled cleanly (68.4s and 107.7s, well under the
-batch-16+ compile-time wall) and ran without error, but **loss is
-bit-identical across all 8 real steps at both batch sizes** (`1.11174`
-constant at batch=4, `1.10973` at batch=8) -- unlike batch=1, where loss
-moved smoothly every step. The calibration for both reused this model's own
-*batch-shaped* real trajectory (not stale batch=1 data), so this is not a
-repeat of the already-fixed generic-defaults or degenerate-constant-`lr`
-bugs -- something about batch>1's real quantization range specifically
-kills the gradient, not yet root-caused. Real step times measured anyway,
-since timing doesn't depend on numerical correctness, but they should **not**
-be read as "batching gives N.Nx throughput for training" the way resnet18's
-own batching section can be -- there is no confirmed-correct training
-happening at either batch size to be fast *at*:
+**Real hardware, batch=4/8: fixed -- a third calibration bug, same class as
+the first two, on a tensor nobody had calibrated at all.** Direct
+`quant_axmodel.json` inspection (the same method PR #1346/#1370 used)
+traced the frozen gradient to the raw pre-`lr`-scaling gradient tensor
+(`resident_step__reshape_406`, feeding `Mul_124: lr * grad`): its calibrated
+range was `[-5.4e-5, 6.8e-5]` (scale `4.79e-7`), while a real batch=4
+forward+backward at the intended `grad_seed=1.0` produces gradients up to
+`1.87e-3` -- **~27x too narrow**, saturating almost the entire tensor.
+Root cause: `grad_seed` (the backward-pass seed multiplying the *entire*
+gradient before it ever reaches this tensor) had **never been given
+`real_data` calibration anywhere in this pipeline, not even at batch=1** --
+it fell through to `make_training_calib.py`'s generic
+`weight_scale=0.05`-scaled random-draw branch, producing calibration values
+near 0 rather than the real runtime value of 1.0. Same bug *class* as PR
+#1370's `lr` fix (a scalar multiplier whose calibration was never matched to
+its real runtime usage) on a *different* scalar -- batch=1 happened not to
+manifest it (its naturally larger unbatched gradient apparently still fit
+inside the resulting undersized range), batch=4/8's more-averaged gradient
+did not.
+
+Fixed by adding `real_data` for `grad_seed` (jittered around 1.0, matching
+the `lr` fix's own pattern) to `build_w2v2fe_batch_calib.py`. Confirmed on
+the compiled model: the raw-gradient scale widened `4.79e-7 -> 1.41e-5`
+(~29x, matching the ~27x under-calibration found). **Real hardware, batch=4,
+8 steps, `lr=100`: loss moves smoothly and monotonically -- `1.02927 ->
+0.98068`** -- where it was bit-identical before. (The tracked weight
+readback itself steps in coarse ~0.0102 increments across a few repeated
+values -- expected, not a bug: that tensor's own state-output quantization
+scale is `0.01018`, so consecutive real updates smaller than one
+quantization step legitimately round to the same U8 code; loss, quantized
+far more finely relative to its own dynamic range, is the reliable signal
+here, the same distinction PR #1346's per-sample-vs-final-scalar debug tap
+already established.)
+
+Real step times, now trustworthy since correctness is confirmed at batch=4:
 
 | batch | step time (min/avg) | cmm |
 | --- | --- | --- |
 | 1 | 5.590ms / 5.865ms | 11.039 MiB |
-| 4 | 18.820ms / 18.891ms | 25.534 MiB |
-| 8 | 35.113ms / 35.270ms | 45.957 MiB |
+| 4 | 18.838ms / 19.353ms | 25.534 MiB |
 
-**Net**: vNPU concurrency is a real, confirmed, generalizable win for this
-architecture at batch=1. Batching needs its own dedicated diagnosis (likely
-the same class of investigation PR #1370 already did twice -- direct
-`quant_axmodel.json` inspection, an `lr`-style sweep -- applied to whichever
-tensor's calibrated range is wrong at batch>1) before it can be trusted here;
-flagged as the concrete next step, not chased further in this pass.
+Batch=8 was not re-verified in this pass (the same `grad_seed` fix should
+apply identically, since the bug and fix are batch-size-independent in
+mechanism -- flagged as the remaining confirmation step, not assumed).
+vNPU+batching compounding was not re-checked here either -- both are now
+individually real, but composing them is a follow-on, not done in this pass.
+
+**Net**: three real calibration bugs found and fixed for this model across
+PRs #1367/#1370/this fix -- `x_scale`/`weight_scale` mismatch, degenerate
+constant-`lr` range, and now uncalibrated `grad_seed` -- all in the same
+family (a scalar or tensor whose calibration data was never matched to its
+real runtime distribution). Batching is now confirmed working at batch=4;
+batch=8 and vNPU+batch composition remain open, low-risk follow-ons.

--- a/scripts/axera/build_w2v2_feature_extractor_step.py
+++ b/scripts/axera/build_w2v2_feature_extractor_step.py
@@ -42,7 +42,19 @@ if HERE not in sys.path:
 import build_resident_train_step as brts  # noqa: E402
 
 
-def _export_feature_extractor(onnx_path: str) -> None:
+def _export_feature_extractor(onnx_path: str, batch: int = 1) -> None:
+    """Exports with a *static* leading dim of `batch` -- not a dynamic axis.
+
+    Every trainable-weight training-step graph in this pipeline (resnet18,
+    Whisper) is built from a static-batch export and gets its batch scaled
+    later via `build_resident_train_step.set_batch()`. That trick doesn't
+    apply cleanly here: `build()` below bakes a `flatten_shape` initializer
+    from the *exported* batch dim (the CNN feature extractor's per-sample
+    output length depends on the input's own static shape through several
+    strided Conv1D layers, unlike resnet18's pooling-then-Gemm tail, which
+    is batch-shape-agnostic downstream of `x`). So batch is a real *export*
+    parameter here, not a post-hoc graph edit -- see `build`'s own docstring.
+    """
     import torch
     import torch.nn as nn
     from transformers import Wav2Vec2Model
@@ -57,7 +69,7 @@ def _export_feature_extractor(onnx_path: str) -> None:
         def forward(self, x):
             return self.fe(x)
 
-    x = torch.randn(1, 4000)
+    x = torch.randn(batch, 4000)
     torch.onnx.export(
         Wrapped(fe),
         (x,),
@@ -100,11 +112,11 @@ def _unsqueeze_to_reshape(model: onnx.ModelProto) -> onnx.ModelProto:
     return model
 
 
-def build(out_path: str, param: str = "fe.conv_layers.0.conv.weight"):
+def build(out_path: str, param: str = "fe.conv_layers.0.conv.weight", batch: int = 1):
     import tempfile
 
     with tempfile.NamedTemporaryFile(suffix=".onnx") as f:
-        _export_feature_extractor(f.name)
+        _export_feature_extractor(f.name, batch=batch)
         model = onnx.load(f.name)
 
     model = _unsqueeze_to_reshape(model)
@@ -146,8 +158,9 @@ def main(argv=None) -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("out_path")
     p.add_argument("--param", default="fe.conv_layers.0.conv.weight")
+    p.add_argument("--batch", type=int, default=1)
     args = p.parse_args(argv)
-    step_model, state = build(args.out_path, args.param)
+    step_model, state = build(args.out_path, args.param, batch=args.batch)
     print(f"wrote {args.out_path}: {len(step_model.graph.node)} nodes, state={state}")
     return 0
 

--- a/scripts/axera/build_w2v2fe_batch_calib.py
+++ b/scripts/axera/build_w2v2fe_batch_calib.py
@@ -113,6 +113,22 @@ def main():
                 np.array([v], np.float32)
                 for v in [0.01, 0.1, 1.0, 10.0, 100.0, 1.0, 50.0, 100.0]
             ],
+            # grad_seed was never given real_data anywhere in this pipeline
+            # (not even at batch=1) -- it fell through to make_work_dir's
+            # generic weight_scale=0.05 random-draw branch, uncorrelated
+            # with its real runtime value (1.0). A real batch=4 forward+
+            # backward with grad_seed=1.0 and a fresh random weight
+            # (matching ws[0]'s own scale) produces a raw gradient up to
+            # ~1.9e-3 in magnitude -- but the compiled model's calibrated
+            # range for that same tensor was only [-5.4e-5, 6.8e-5], ~27x
+            # too narrow, because calibration saw grad_seed values near 0
+            # instead of 1.0. Same bug *class* as PR #1370's `lr` fix (a
+            # scalar multiplier whose calibration was never matched to its
+            # real runtime usage), on a different scalar.
+            "grad_seed": [
+                np.array([v], np.float32)
+                for v in [1.0, 0.9, 1.1, 1.0, 0.95, 1.05, 1.0, 1.0]
+            ],
         },
     )
     print("wrote calib work dir:", work_dir)

--- a/scripts/axera/build_w2v2fe_batch_calib.py
+++ b/scripts/axera/build_w2v2fe_batch_calib.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Build+calibrate the wav2vec2 feature-extractor training step at a given
+batch size, reusing PR #1370's real-data calibration fix (measure the real
+host float32 trajectory, jitter lr) rather than PR #1367's arbitrary
+x_scale/weight_scale defaults that produced a dead gradient.
+
+**Confirmed real on hardware at batch=1 only.** batch=4/8 compile and run,
+but their real trajectory-derived calibration still leaves the gradient
+completely dead (loss bit-identical across all 8 real steps) -- a new
+calibration-range regression at batch>1, not yet root-caused. See
+`docs/axera-on-device-training-handoff.md`'s wav2vec2 batching section.
+Treat batch>1 output here as "compiles and times, correctness unconfirmed,"
+not as working training.
+
+Usage: build_w2v2fe_batch_calib.py OUT_DIR BATCH
+Writes OUT_DIR/step.onnx, OUT_DIR/calib/{dataset,config,step.onnx} (via
+make_training_calib.make_work_dir -- pass OUT_DIR/calib as pulsar2_docker.
+build()'s own work_dir, config_path="config/step.json"), and
+OUT_DIR/step.onnx.state0 / .x0 / .y0 for the resident runner's seeding
+convention (a single real sample, regardless of batch -- the runner reads
+exactly `in_sz[x_in]` bytes, which already reflects the compiled model's
+own batch size).
+"""
+
+import os
+import sys
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import torch
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import build_w2v2_feature_extractor_step as m  # noqa: E402
+import make_training_calib as mtc  # noqa: E402
+
+WNAME = "fe.conv_layers.0.conv.weight"
+
+
+def run(path, feeds):
+    sess = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
+    names = [o.name for o in sess.get_outputs()]
+    return dict(zip(names, sess.run(names, feeds)))
+
+
+def main():
+    out_dir, batch = sys.argv[1], int(sys.argv[2])
+    os.makedirs(out_dir, exist_ok=True)
+    step_path = os.path.join(out_dir, "step.onnx")
+
+    torch.manual_seed(42)
+    step_model, state = m.build(step_path, batch=batch)
+    onnx.save(step_model, step_path)
+    state_out = state[WNAME]
+
+    rng = np.random.default_rng(0)
+    w_shape = tuple(
+        d.dim_value
+        for d in next(
+            i for i in step_model.graph.input if i.name == WNAME
+        ).type.tensor_type.shape.dim
+    )
+    w0 = (rng.standard_normal(w_shape) * 0.36).astype(np.float32)
+    x_shape = tuple(
+        d.dim_value
+        for d in next(
+            i for i in step_model.graph.input if i.name == "x"
+        ).type.tensor_type.shape.dim
+    )
+    y_shape = tuple(
+        d.dim_value
+        for d in next(
+            i for i in step_model.graph.input if i.name == "y"
+        ).type.tensor_type.shape.dim
+    )
+    # real host float32 trajectory: 8 real SGD steps at lr=100 (PR #1370's
+    # own working config), recording w/x/y at each step for calibration.
+    ws, xs, ys = [w0.copy()], [], []
+    w = w0.copy()
+    lr = 100.0
+    for _ in range(8):
+        x = rng.standard_normal(x_shape).astype(np.float32)
+        y = rng.standard_normal(y_shape).astype(np.float32)
+        xs.append(x)
+        ys.append(y)
+        feeds = {
+            "x": x,
+            "y": y,
+            "lr": np.array([lr], np.float32),
+            "grad_seed": np.array([1.0], np.float32),
+            WNAME: w,
+        }
+        out = run(step_path, feeds)
+        w = out[state_out]
+        ws.append(w.copy())
+
+    print("host trajectory: mean|w| ->", [float(np.abs(v).mean()) for v in ws])
+
+    work_dir = os.path.join(out_dir, "calib")
+    mtc.make_work_dir(
+        step_path,
+        work_dir,
+        n=8,
+        label_inputs=(),
+        real_data={
+            WNAME: ws[:-1],
+            "x": xs,
+            "y": ys,
+            "lr": [
+                np.array([v], np.float32)
+                for v in [0.01, 0.1, 1.0, 10.0, 100.0, 1.0, 50.0, 100.0]
+            ],
+        },
+    )
+    print("wrote calib work dir:", work_dir)
+
+    # runner companion files: initial weight + one real x/y sample.
+    w0.tofile(step_path + ".state0")
+    xs[0].tofile(step_path + ".x0")
+    ys[0].tofile(step_path + ".y0")
+    print("wrote", step_path + ".state0/.x0/.y0")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/axera/tools/README.md
+++ b/scripts/axera/tools/README.md
@@ -103,7 +103,16 @@ prefill cannot be timed with the shipped CLI. These talk to
   and the two calibration bugs (input-scale mismatch, a degenerate constant
   `lr` calibration range) it found along the way. `argv[4]` overrides `lr`
   at runtime for sweeping it against the compiled model's own calibrated
-  range.
+  range. Also gained a `-v` flag (`AXCL_VNPU_ENABLE`, same lever/methodology
+  as `resident_runner.c`'s own -- PRs #1345/#1346) and real device-memory
+  reporting (`axclrtEngineGetUsageFromModelId`, PR #1347) -- confirmed
+  non-corrupting and 3.16x/3.70x aggregate throughput at N=4/8 concurrent
+  contexts on the batch=1 model, the audio-speech coverage doc's "Batching
+  and vNPU concurrency" section has the full numbers. The loop itself is
+  batch-size-agnostic (buffer sizes come from the compiled model's own
+  IOInfo), but batch>1 builds currently train incorrectly on real hardware
+  (a calibration-range regression, not a runner bug) -- see that same
+  section before trusting a batch>1 run's loss/weight output.
 
 Build and run them where the card is visible (inside the VM, if the device is
 passed through -- see `../vm/README.md`):

--- a/scripts/axera/tools/w2v2fe_runner_realdata.c
+++ b/scripts/axera/tools/w2v2fe_runner_realdata.c
@@ -4,9 +4,12 @@
  * fe.conv_layers.0.conv.weight, lr, grad_seed], outputs [updated weight,
  * loss] -- one trainable state tensor, unlike resnet18's four or Whisper's
  * fourteen, so this is its own small runner rather than a generalization of
- * resident_runner.c's N_STATE=4 layout.
+ * resident_runner.c's N_STATE=4 layout. Batch is not a runner concern: a
+ * batch>1 build just changes the .state0/.x0/.y0 file sizes this runner
+ * reads (in_sz[...] comes from the compiled model's own IOInfo), the loop
+ * itself is batch-size-agnostic.
  *
- * Usage: w2v2fe_runner model.axmodel steps [warmup]
+ * Usage: w2v2fe_runner model.axmodel steps [warmup] [lr] [-v]
  *
  * Seeds the trainable weight from <model.axmodel>.state0 (raw float32
  * bytes, matching resident_runner.c's convention) and prints w[0] alongside
@@ -15,6 +18,13 @@
  * project has needed twice before (PRs #1343/#1346's loss=0 investigations,
  * PR #1359's Whisper step-1 death) -- reading the raw state buffer, not
  * trusting the runner's own loss output alone.
+ *
+ * -v: AXCL_VNPU_ENABLE instead of AXCL_VNPU_DISABLE, same lever/methodology
+ * as resident_runner.c's own -v (PRs #1345/#1346) -- run several copies of
+ * this binary at once (each its own model-file copy) for real concurrent
+ * throughput. Also reports real device memory via
+ * axclrtEngineGetUsageFromModelId (PR #1347's tool), the same way
+ * resident_runner.c does.
  */
 #define _POSIX_C_SOURCE 199309L
 #include <stdio.h>
@@ -38,12 +48,18 @@ int main(int argc, char **argv) {
     }
     int steps = atoi(argv[2]);
     int warmup = argc > 3 ? atoi(argv[3]) : 3;
+    float lr_arg = argc > 4 ? (float)atof(argv[4]) : 1e-4f;
+    int vnpu_enable = 0;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-v") == 0) vnpu_enable = 1;
+    }
 
     CK(axclInit(NULL));
     axclrtDeviceList devs; CK(axclrtGetDeviceList(&devs));
     if (!devs.num) { fprintf(stderr, "no device\n"); return 1; }
     CK(axclrtSetDevice(devs.devices[0]));
-    CK(axclrtEngineInit(AXCL_VNPU_DISABLE));
+    CK(axclrtEngineInit(vnpu_enable ? AXCL_VNPU_ENABLE : AXCL_VNPU_DISABLE));
+    fprintf(stderr, "vnpu: %s\n", vnpu_enable ? "AXCL_VNPU_ENABLE" : "AXCL_VNPU_DISABLE");
 
     uint64_t modelId = 0, ctx = 0;
     CK(axclrtEngineLoadFromFile(argv[1], &modelId));
@@ -52,6 +68,12 @@ int main(int argc, char **argv) {
     axclrtEngineIOInfo info; CK(axclrtEngineGetIOInfo(modelId, &info));
     uint32_t ni = axclrtEngineGetNumInputs(info), no = axclrtEngineGetNumOutputs(info);
     fprintf(stderr, "inputs=%u outputs=%u\n", ni, no);
+
+    int64_t sys_bytes = 0, cmm_bytes = 0;
+    CK(axclrtEngineGetUsageFromModelId(modelId, &sys_bytes, &cmm_bytes));
+    double cmm_mib = cmm_bytes / (1024.0 * 1024.0);
+    fprintf(stderr, "engine usage: sys=%lld B cmm=%.3f MiB\n",
+            (long long)sys_bytes, cmm_mib);
 
     axclrtEngineIO io; CK(axclrtEngineCreateIO(info, &io));
 
@@ -87,7 +109,7 @@ int main(int argc, char **argv) {
     CK(axclrtMemcpy(in_bufs[w_in], host, in_sz[w_in], AXCL_MEMCPY_HOST_TO_DEVICE));
     free(host);
 
-    { float lr = argc > 4 ? (float)atof(argv[4]) : 1e-4f; fprintf(stderr, "lr=%g\n", lr); CK(axclrtMemcpy(in_bufs[lr_in], &lr, sizeof(lr), AXCL_MEMCPY_HOST_TO_DEVICE)); }
+    { float lr = lr_arg; fprintf(stderr, "lr=%g\n", lr); CK(axclrtMemcpy(in_bufs[lr_in], &lr, sizeof(lr), AXCL_MEMCPY_HOST_TO_DEVICE)); }
     { float seed = 1.0f; CK(axclrtMemcpy(in_bufs[seed_in], &seed, sizeof(seed), AXCL_MEMCPY_HOST_TO_DEVICE)); }
 
     void *hx = malloc(in_sz[x_in]);
@@ -131,8 +153,8 @@ int main(int argc, char **argv) {
         fprintf(stderr, "step %d: %.3f ms  loss=%g  w[0]=%.10g\n", i, dt, loss_host, w0);
     }
     double total = now_ms() - t_start;
-    printf("steps=%d min=%.3fms avg=%.3fms total=%.3fms throughput=%.1f steps/s\n",
-           steps, best, sum / steps, total, 1000.0 * steps / total);
+    printf("steps=%d min=%.3fms avg=%.3fms total=%.3fms throughput=%.1f steps/s cmm=%.3fMiB\n",
+           steps, best, sum / steps, total, 1000.0 * steps / total, cmm_mib);
 
     for (uint32_t i = 0; i < ni; i++) axclrtFree(in_bufs[i]);
     for (uint32_t i = 0; i < no; i++) axclrtFree(out_bufs[i]);


### PR DESCRIPTION
## Summary
- Closes the two follow-ons PR #1373 flagged as open: batch=8 re-verification with the `grad_seed` real-data fix, and vNPU+batching composition.
- **Batch=8 confirmed working on real hardware**: loss moves smoothly and monotonically (`1.03951 -> 1.00037`) across 8 real steps at `lr=100`. Step time 35.577ms min / 36.186ms avg, cmm 45.957 MiB.
- **vNPU concurrency confirmed non-corrupting at batch=8** (bit-identical loss/weight vs. disabled), and real concurrent throughput measured up to 4.17x at N=8 (684.8 samples/s vs. the 164.3 samples/s batch=1/N=1 baseline).
- **Composition is real but weaker and earlier-saturating than resnet18's** (PR #1346: 6.5x batching x 2.5x vNPU -> 18.1x cleanly multiplicative). This model's batching gain alone is only 1.33x (Conv1D quantize/glue overhead dominates differently), and the combination saturates by N=4 (660 -> 684.8 samples/s from N=4 to N=8, a 3.8% gain for double the contexts) rather than continuing to scale to N=8. N=4 is the practical sweet spot here.

## Test plan
- [x] Real AX650N hardware: batch=8 solo, batch=8 vNPU N=1 (bit-identical vs. disabled), batch=8 vNPU N=4, batch=8 vNPU N=8 -- all converging to identical loss values confirming correctness held throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W