### PR TITLE
axera: retroactive check on PR #1353's chaotic grad_seed finding -- inconclusive, real evidence either way

### DIFF
--- a/docs/axera-on-device-training-handoff.md
+++ b/docs/axera-on-device-training-handoff.md
@@ -127,6 +127,34 @@ Two things confirmed, one real limit found:
   characterization, so treat the *qualitative* finding (baseline doesn't scale
   correctly, FP32 does something real) as the transferable result, not the
   exact percentages.
+
+  **Retroactive check, prompted by two later, separate findings on a
+  different model** (`docs/axera-audio-speech-op-coverage.md`'s wav2vec2
+  work): a scalar input never given real, varied calibration data --
+  producing a degenerate MinMax range that silently clips/saturates the real
+  runtime value -- broke `lr` and then `grad_seed` there (a zero-width range
+  from identical calibration samples in one case, a generic small-random
+  default uncorrelated with the real runtime magnitude in the other). Worth
+  asking whether the *same* mechanism explains this "chaotic ratio" finding.
+  Rebuilt this exact probe fresh and inspected its `grad_seed` calibration
+  directly: with `make_training_calib.py`'s current generic fallback (no
+  `real_data`), `grad_seed`'s calibrated range comes out `[-0.039, 0.081]`
+  (`scale=0.00047`, `zero_point=83`, U8) -- the same class of narrow,
+  uncorrelated range as the two wav2vec2 bugs, on a fourth model/probe now.
+  But swept on real hardware (seed = 1, 100, 1000, 100,000 against this
+  fresh build), the result was **0% nonzero at every seed** -- bit-identical
+  zero, not the originally-reported 100%-nonzero-but-chaotic-ratio pattern.
+  **Inconclusive, not confirmed or refuted**: this rebuild's baseline
+  behavior does not match the one being explained closely enough to serve as
+  a stand-in for it, most likely because `make_training_calib.py`'s default
+  `x_scale`/`weight_scale` (and therefore the *output* `dW` tensor's own
+  calibrated range, separate from `grad_seed`'s) have been retuned by the
+  fixes this doc's own later sections describe, since PR #1353's original run
+  -- a moving target a fresh rebuild can't reproduce. The narrow-`grad_seed`-
+  calibration finding stands on its own as a fourth real instance of the
+  pattern (worth the same `real_data`/jitter treatment if this probe is
+  revisited), but it does not settle what specifically made the *original*
+  baseline's ratio chaotic rather than constant.
 * **It plateaus.** 20.1% nonzero at seed=1,000 and at seed=100,000 -- unchanged
   over two more orders of magnitude of seed. This is not the seed failing to
   reach the graph again; it is the *next* quantised boundary downstream taking


### PR DESCRIPTION
## Summary
- Follows up on an open question PR #1370 flagged: does the same degenerate-scalar-calibration bug class confirmed twice on wav2vec2 (`lr` in #1370, `grad_seed` in #1373) retroactively explain PR #1353's "chaotic per-element ratio" finding on a resnet18-family probe?
- Rebuilt `scripts/axera/build_matmul_grad_probe.py`'s exact probe fresh (no archival artifacts from PR #1353's original run were findable) and inspected `grad_seed`'s calibrated range directly via `quant_axmodel.json`: `[-0.039, 0.081]` (U8, scale=0.00047, zero_point=83) -- the same narrow, uncorrelated-with-runtime-value class of range as the two wav2vec2 bugs, a fourth real instance of the pattern.
- Swept on real AX650N hardware (seed = 1, 100, 1000, 100000): this fresh build's `dW` came back **0% nonzero at every seed** -- bit-identical zero. PR #1353 originally reported **100% nonzero but a chaotic per-element ratio** between seed=1000 and seed=1 -- a different signature.
- **Verdict: inconclusive.** The rebuild's baseline behavior doesn't match the phenomenon being explained closely enough to serve as a direct stand-in -- most likely because `make_training_calib.py`'s `x_scale`/`weight_scale` defaults (and therefore `dW`'s own output calibration) have been retuned by later fixes since PR #1353's original run, a moving target a fresh rebuild can't reproduce exactly. Reported honestly rather than forcing a confirm/refute the evidence doesn't support.
- The narrow-`grad_seed`-calibration finding stands on its own as a real, fourth instance of the pattern worth fixing with the same `real_data`/jitter treatment if this probe is revisited -- just doesn't settle what specifically made the *original* baseline's ratio chaotic rather than constant.

## Test plan
- [x] Rebuilt probe compiled cleanly on real Pulsar2 hardware; `quant_axmodel.json` inspected directly for `grad_seed`'s scale/zero_point.
- [x] Real hardware sweep (seed = 1/100/1000/100000) against the fresh build, read back via direct AXCL buffer reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W