### PR TITLE
axera: port pow2_to_mul and explicit_conv_padding to onnxsim core

### DIFF
--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -27,6 +27,7 @@
 #include "passes/eliminate_sequence_at_construct.h"
 #include "passes/eliminate_sequence_length_construct.h"
 #include "passes/explicit_auto_pad.h"
+#include "passes/explicit_conv_padding.h"
 #include "passes/fp6_llm.h"
 #include "passes/fuse_add_bias_into_conv.h"
 #include "passes/fuse_attention.h"
@@ -57,6 +58,7 @@
 #include "passes/magnitude_pruning.h"
 #include "passes/maxpool_rowmajor_when_indices_unused.h"
 #include "passes/neg_to_mul.h"
+#include "passes/pow2_to_mul.h"
 #include "passes/qoperator_quantize_activation.h"
 #include "passes/qoperator_quantize_concat.h"
 #include "passes/qoperator_quantize_conv.h"
@@ -147,6 +149,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::EliminateSequenceAtConstruct>(registry);
     RegisterOrReplace<p::EliminateSequenceLengthConstruct>(registry);
     RegisterOrReplace<p::ExplicitAutoPad>(registry);
+    RegisterOrReplace<p::ExplicitConvPadding>(registry);
     RegisterOrReplace<p::Fp6Llm>(registry);
     RegisterOrReplace<p::FuseAttention>(registry);
     RegisterOrReplace<p::FuseConsecutiveMul>(registry);
@@ -175,6 +178,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::MagnitudePruningMatMul>(registry);
     RegisterOrReplace<p::MaxPoolRowMajorWhenIndicesUnused>(registry);
     RegisterOrReplace<p::NegToMul>(registry);
+    RegisterOrReplace<p::Pow2ToMul>(registry);
     RegisterOrReplace<p::QOperatorQuantizeActivation>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConcat>(registry);
     RegisterOrReplace<p::QOperatorQuantizeConv>(registry);

--- a/onnxsim/passes/explicit_conv_padding.h
+++ b/onnxsim/passes/explicit_conv_padding.h
@@ -1,0 +1,111 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// A `Conv` with asymmetric explicit `pads` (the per-axis begin/end amounts
+// differ) gets a `Pad` node hoisted in front of it carrying that padding,
+// and the convolution's own `pads` become all-zero. Semantics are
+// unchanged: zero-padding explicitly and then convolving with no padding is
+// what an asymmetric `pads` attribute already means, just spelled as two
+// ops instead of one -- a way past a backend whose fused convolution kernel
+// only accepts symmetric padding (see `scripts/axera/legalize.py`'s Python
+// counterpart of this rule for the concrete case that motivated it: a
+// causal convolution with all its padding on one side).
+//
+// This is a different fix from `explicit_auto_pad.h`: that pass turns a
+// *symbolic* `auto_pad` mode (`SAME_UPPER`/`SAME_LOWER`/`VALID`) into
+// explicit `pads`, computed from the operator spec's formula. This pass
+// starts from `pads` that are *already* explicit and only acts when they
+// are asymmetric -- a `Conv` with `auto_pad == "NOTSET"` and symmetric
+// explicit `pads` (the common case) is left alone by both passes, and a
+// `Conv` with a symbolic `auto_pad` needs `explicit_auto_pad` to run first
+// before this pass has an explicit `pads` attribute to inspect at all.
+//
+// Only `Conv`'s spatial `pads` are handled -- `AveragePool`/`MaxPool` are
+// not, since their own asymmetric-padding requirement hasn't come up in a
+// real target and pooling additionally needs the padding to affect the
+// output's counted denominator (`count_include_pad`), which a hoisted `Pad`
+// node does not replicate.
+//
+// This is a pure graph-shape rewrite -- not a node-count reduction -- so it
+// is `PassType::Other` and never runs by default. Opt in with
+// `extra_optimizers=["explicit_conv_padding"]` (Python) or
+// `--enable-optimization explicit_conv_padding` (CLI).
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct ExplicitConvPadding final : public PredicateBasedPass {
+  explicit ExplicitConvPadding()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override { return "explicit_conv_padding"; }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (node->kind() != kConv || !node->hasAttribute(kpads)) {
+      return false;
+    }
+    const std::vector<int64_t>& pads = node->is(kpads);
+    if (pads.empty() || pads.size() % 2 != 0) {
+      return false;
+    }
+    const size_t half = pads.size() / 2;
+    for (size_t i = 0; i < half; ++i) {
+      if (pads[i] != pads[half + i]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+
+    const std::vector<int64_t> pads = node->is(kpads);
+    const size_t half = pads.size() / 2;
+
+    Tensor pads_init;
+    pads_init.elem_type() = TensorProto_DataType_INT64;
+    pads_init.sizes().push_back(static_cast<int64_t>(2 * (half + 2)));
+    std::vector<int64_t>& data = pads_init.int64s();
+    data.push_back(0);
+    data.push_back(0);
+    for (size_t i = 0; i < half; ++i) {
+      data.push_back(pads[i]);
+    }
+    data.push_back(0);
+    data.push_back(0);
+    for (size_t i = 0; i < half; ++i) {
+      data.push_back(pads[half + i]);
+    }
+    Value* pads_v = graph.addInitializerAndCreateValue(pads_init);
+
+    Node* pad = graph.create(kPad, 1);
+    pad->addInput(node->input(0));
+    pad->addInput(pads_v);
+    pad->s_(kmode, std::string("constant"));
+    pad->output()->setElemType(node->input(0)->elemType());
+    pad->insertBefore(node);
+
+    node->replaceInput(0, pad->output());
+    node->is_(kpads, std::vector<int64_t>(pads.size(), 0));
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/pow2_to_mul.h
+++ b/onnxsim/passes/pow2_to_mul.h
@@ -1,0 +1,73 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// `Pow(x, 2)` becomes `Mul(x, x)` -- exact for floats, one fewer
+// transcendental op, and a way past a backend whose fused-activation
+// matcher recognizes `Pow(x, 2)` as part of a larger pattern it cannot
+// lower at every shape (see `scripts/axera/legalize.py`'s Python
+// counterpart of this rule for the concrete case that motivated it: a
+// vendor compiler that fuses this exact shape into an activation kernel
+// with no tiling support, so the unfused arithmetic is the only form that
+// builds).
+//
+// Scoped to a `float` base and a constant, single-element exponent equal to
+// exactly `2.0` -- `Pow`'s exponent can be a full tensor (elementwise
+// power), and this rule only ever fires for the scalar-two case; anything
+// else is left alone rather than approximated.
+//
+// This is a pure graph-shape rewrite -- not a node-count reduction -- so it
+// is `PassType::Other` and never runs by default. Opt in with
+// `extra_optimizers=["pow2_to_mul"]` (Python) or
+// `--enable-optimization pow2_to_mul` (CLI).
+
+#include <string>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct Pow2ToMul final : public PredicateBasedPass {
+  explicit Pow2ToMul()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override { return "pow2_to_mul"; }
+
+  bool patternMatchPredicate(Node* node) override {
+    if (node->kind() != Symbol("Pow") || node->inputs().size() != 2 ||
+        node->input(0)->elemType() != TensorProto_DataType_FLOAT) {
+      return false;
+    }
+    float exponent = 0.0f;
+    return GetValueFromInput(node, 1, exponent) && exponent == 2.0f;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    Node* mul = graph.create(kMul, 1);
+    mul->addInput(node->input(0));
+    mul->addInput(node->input(0));
+    mul->output()->setElemType(node->output()->elemType());
+    if (node->output()->has_sizes()) {
+      mul->output()->setSizes(node->output()->sizes());
+    }
+    mul->insertBefore(node);
+
+    node->output()->replaceAllUsesWith(mul->output());
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/scripts/axera/legalize.py
+++ b/scripts/axera/legalize.py
@@ -103,6 +103,18 @@ def pow2_to_mul(model):
     at every size tried: `NoTilerException` on a `(1,384,28160)` tensor, and
     `OpBuildException: broadcast dim 2: 32 1536 mismatch` on a small one. The
     unfused `Sin`/`Mul`/`Div`/`Add` are each on the supported list.
+
+    Also has a target-agnostic C++ counterpart in onnxsim's own core
+    (`onnxsim/passes/pow2_to_mul.h`), usable from any binding via
+    `onnxsim.simplify(model, extra_optimizers=["pow2_to_mul"])` -- see
+    `tests/test_pow2_to_mul.py`. This module's own version stays: it needs
+    nothing beyond the `onnx` package (no onnxsim build), which
+    `legalize.py in.onnx out.onnx`'s standalone-script usage depends on. The
+    core pass is scoped to `float32` and a constant single-element exponent
+    (this Python version checks the exponent value the same way but doesn't
+    restrict the element type) -- fine for this project's own use, where
+    every Pulsar2-bound graph is float32 throughout (`float16_to_float32`
+    runs first in `TRAINING_RULES`/`RULES` when it doesn't).
     """
     changed = 0
     for node in model.graph.node:
@@ -129,6 +141,22 @@ def explicit_conv_padding(model):
 
     Semantics are unchanged: zero-padding explicitly and then convolving with
     no padding is what the attribute means.
+
+    This is not the same fix as `explicit_auto_pad`: that rule turns a
+    *symbolic* `auto_pad` mode (`SAME_UPPER`/`SAME_LOWER`/`VALID`) into
+    explicit `pads`; this rule starts from `pads` that are *already*
+    explicit and only acts when they are asymmetric. A `Conv` needs at most
+    one of the two -- `explicit_auto_pad` first if `auto_pad` is symbolic,
+    then this rule if what it produces (or what the graph already had) is
+    asymmetric.
+
+    Also has a target-agnostic C++ counterpart in onnxsim's own core
+    (`onnxsim/passes/explicit_conv_padding.h`), usable from any binding via
+    `onnxsim.simplify(model, extra_optimizers=["explicit_conv_padding"])` --
+    see `tests/test_explicit_conv_padding.py`. This module's own version
+    stays: it needs nothing beyond the `onnx` package (no onnxsim build),
+    which `legalize.py in.onnx out.onnx`'s standalone-script usage depends
+    on.
     """
     changed = 0
     nodes = list(model.graph.node)

--- a/tests/test_explicit_conv_padding.py
+++ b/tests/test_explicit_conv_padding.py
@@ -1,0 +1,110 @@
+"""Tests for the ``explicit_conv_padding`` C++ pass
+(onnxsim/passes/explicit_conv_padding.h).
+
+A ``Conv`` with asymmetric explicit ``pads`` gets a ``Pad`` node hoisted in
+front of it and its own ``pads`` zeroed -- the onnxsim-core counterpart of
+``scripts/axera/legalize.py``'s ``explicit_conv_padding`` rule (that file's
+docstring records this as the fix for a causal convolution whose padding is
+entirely on one side, which a vendor backend's fused convolution kernel
+refuses). Usable from any binding via
+``extra_optimizers=["explicit_conv_padding"]``.
+
+Models are built with ``onnx.parser`` per CLAUDE.md's convention. Numeric
+equivalence comes from ``onnxsim.simplify``'s own ``check_n``.
+"""
+
+import numpy as np
+from onnx import parser
+
+import onnxsim
+
+
+def _model(body, opset=17, ir_version=10):
+    return parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+
+
+def _find(model, op_type):
+    return next(n for n in model.graph.node if n.op_type == op_type)
+
+
+def test_asymmetric_pads_become_a_pad_node_and_compute_the_same_thing():
+    model = _model(
+        """
+        g (float[1,1,10] x) => (float[1,1,10] y)
+        <float[1,1,3] w = {1.0, -2.0, 0.5}>
+        {
+          y = Conv<pads = [2, 0], kernel_shape = [3]>(x, w)
+        }
+        """
+    )
+    x = np.random.RandomState(0).randn(1, 1, 10).astype(np.float32)
+    sim_model, ok = onnxsim.simplify(
+        model,
+        check_n=1,
+        input_data={"x": x},
+        extra_optimizers=["explicit_conv_padding"],
+    )
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types == ["Pad", "Conv"]
+
+    conv = _find(sim_model, "Conv")
+    pads_attr = next(a for a in conv.attribute if a.name == "pads")
+    assert list(pads_attr.ints) == [0, 0]
+
+    pad = _find(sim_model, "Pad")
+    assert pad.input[0] == "x"
+
+
+def test_symmetric_pads_are_left_alone():
+    """Symmetric explicit `pads` are already the form every backend wants --
+    hoisting a `Pad` node here would be pure churn, not a fix."""
+    model = _model(
+        """
+        g (float[1,1,10] x) => (float[1,1,10] y)
+        <float[1,1,3] w = {1.0, -2.0, 0.5}>
+        {
+          y = Conv<pads = [1, 1], kernel_shape = [3]>(x, w)
+        }
+        """
+    )
+    x = np.random.RandomState(0).randn(1, 1, 10).astype(np.float32)
+    sim_model, ok = onnxsim.simplify(
+        model,
+        check_n=1,
+        input_data={"x": x},
+        extra_optimizers=["explicit_conv_padding"],
+    )
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types == ["Conv"]
+
+
+def test_disabled_by_default():
+    """`explicit_conv_padding` is `PassType::Other`, so a plain `simplify()`
+    call (no `extra_optimizers`) must leave the asymmetric `Conv` alone."""
+    model = _model(
+        """
+        g (float[1,1,10] x) => (float[1,1,10] y)
+        <float[1,1,3] w = {1.0, -2.0, 0.5}>
+        {
+          y = Conv<pads = [2, 0], kernel_shape = [3]>(x, w)
+        }
+        """
+    )
+    x = np.zeros((1, 1, 10), np.float32)
+    sim_model, ok = onnxsim.simplify(model, check_n=1, input_data={"x": x})
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types == ["Conv"]
+    conv = _find(sim_model, "Conv")
+    pads_attr = next(a for a in conv.attribute if a.name == "pads")
+    assert list(pads_attr.ints) == [2, 0]

--- a/tests/test_pow2_to_mul.py
+++ b/tests/test_pow2_to_mul.py
@@ -1,0 +1,110 @@
+"""Tests for the ``pow2_to_mul`` C++ pass (onnxsim/passes/pow2_to_mul.h).
+
+``Pow(x, 2)`` becomes ``Mul(x, x)`` -- the onnxsim-core counterpart of
+``scripts/axera/legalize.py``'s ``pow2_to_mul`` rule (that file's docstring
+records this as the fix for a vendor compiler's fused-activation matcher,
+which recognizes ``Pow(x, 2)`` as part of a larger pattern it cannot tile at
+every shape). Usable from any binding via ``extra_optimizers=["pow2_to_mul"]``.
+
+Models are built with ``onnx.parser`` per CLAUDE.md's convention. Numeric
+equivalence comes from ``onnxsim.simplify``'s own ``check_n``.
+"""
+
+import numpy as np
+from onnx import parser
+
+import onnxsim
+
+
+def _model(body, opset=17, ir_version=10):
+    return parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+
+
+def _find(model, op_type):
+    return next(n for n in model.graph.node if n.op_type == op_type)
+
+
+def test_pow_by_2_becomes_mul_by_self_and_computes_the_same_thing():
+    model = _model(
+        """
+        g (float[2,3] x) => (float[2,3] y)
+        <float exponent = {2.0}>
+        { y = Pow(x, exponent) }
+        """
+    )
+    x = np.random.RandomState(0).randn(2, 3).astype(np.float32)
+    sim_model, ok = onnxsim.simplify(
+        model, check_n=1, input_data={"x": x}, extra_optimizers=["pow2_to_mul"]
+    )
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert "Pow" not in op_types
+    mul = _find(sim_model, "Mul")
+    assert mul.input[0] == mul.input[1] == "x"
+
+
+def test_pow_by_a_different_exponent_is_left_alone():
+    """Only the exact scalar-two case fires -- `Pow(x, 3)` is not
+    `Mul(x, x)`, and must not be rewritten."""
+    model = _model(
+        """
+        g (float[4] x) => (float[4] y)
+        <float exponent = {3.0}>
+        { y = Pow(x, exponent) }
+        """
+    )
+    x = np.array([1.0, 2.0, -1.0, 0.5], np.float32)
+    sim_model, ok = onnxsim.simplify(
+        model, check_n=1, input_data={"x": x}, extra_optimizers=["pow2_to_mul"]
+    )
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types == ["Pow"]
+
+
+def test_pow_with_a_non_constant_exponent_is_left_alone():
+    """The exponent must be a constant scalar -- an elementwise `Pow` with a
+    runtime-input exponent (which may not even be 2 everywhere) is not this
+    rule's shape."""
+    model = _model(
+        """
+        g (float[3] x, float[3] p) => (float[3] y)
+        { y = Pow(x, p) }
+        """
+    )
+    x = np.array([1.0, 2.0, 3.0], np.float32)
+    p = np.array([2.0, 2.0, 2.0], np.float32)
+    sim_model, ok = onnxsim.simplify(
+        model,
+        check_n=1,
+        input_data={"x": x, "p": p},
+        extra_optimizers=["pow2_to_mul"],
+    )
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types == ["Pow"]
+
+
+def test_disabled_by_default():
+    """`pow2_to_mul` is `PassType::Other`, so a plain `simplify()` call (no
+    `extra_optimizers`) must leave `Pow` alone."""
+    model = _model(
+        """
+        g (float[2,3] x) => (float[2,3] y)
+        <float exponent = {2.0}>
+        { y = Pow(x, exponent) }
+        """
+    )
+    x = np.zeros((2, 3), np.float32)
+    sim_model, ok = onnxsim.simplify(model, check_n=1, input_data={"x": x})
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types == ["Pow"]


### PR DESCRIPTION
## Summary

Continues PR #1369's migration of `scripts/axera/legalize.py` rules into native onnxsim-core C++ passes. Of the five rules that PR classified as promotable-but-unported, this ports two, following `neg_to_mul`'s exact precedent:

- **`pow2_to_mul`**: `Pow(x, 2)` -> `Mul(x, x)`. Scoped to `float32` and a constant scalar exponent of exactly `2.0`. New: `onnxsim/passes/pow2_to_mul.h`, `tests/test_pow2_to_mul.py`.
- **`explicit_conv_padding`**: a `Conv` with asymmetric explicit `pads` gets a `Pad` node hoisted in front of it, and its own `pads` zeroed. New: `onnxsim/passes/explicit_conv_padding.h`, `tests/test_explicit_conv_padding.py`.

Both are `PassType::Other` (opt-in only, via `extra_optimizers=[...]` or `--enable-optimization`), the vendor script's Python implementation is kept as-is (needs nothing beyond `onnx`, no onnxsim build dependency), and each function's docstring in `legalize.py` now cross-references the new core pass.

### `explicit_conv_padding` / `explicit_auto_pad` consolidation

Confirmed these are genuinely different fixes, not duplicates:
- `explicit_auto_pad` turns a *symbolic* `auto_pad` mode (`SAME_UPPER`/`SAME_LOWER`/`VALID`) into explicit `pads`, computed from the operator spec's formula.
- `explicit_conv_padding` starts from `pads` that are *already* explicit and only acts when they're asymmetric, hoisting them into a separate `Pad` node.

A `Conv` needs at most one of the two, and a graph with symbolic `auto_pad` needs `explicit_auto_pad` to run first before `explicit_conv_padding` has an explicit `pads` attribute to inspect. Documented in both `explicit_conv_padding.h`'s docstring and `legalize.py`'s.

### Not ported (left for a future pass)

`float16_to_float32`, `dilated_conv_to_taps`, and `rank0_to_rank1` remain unported. Each needs graph-level rewriting (initializers/I/O/value_info, shape-inference-dependent multi-node subgraphs, or graph-output handling) that doesn't fit `PredicateBasedPass`'s per-node predicate/transform shape as cleanly as the two ported here -- consistent with this task's guidance to prefer a smaller number of complete, correct ports over rushed ones.

## Test plan

- [x] `tests/test_pow2_to_mul.py` (4 tests) and `tests/test_explicit_conv_padding.py` (3 tests) pass
- [x] Full targeted regression (`test_axera_legalize.py`, `test_axera_training_legalize.py`, `test_axelera_legalize.py`, `test_explicit_auto_pad.py`, `test_gemm_transa_to_transpose.py`, `test_maxpool_rowmajor_when_indices_unused.py`, `test_neg_to_mul.py`, `test_pow2_to_mul.py`, `test_explicit_conv_padding.py`, `test_build_resident_train_step.py`): 84 passed
- [x] `clang-format -n --Werror` clean on the touched/new C++ files
- [x] `ruff check` / `ruff format --check` clean on the touched/new Python files
- [x] C++ extension rebuilds cleanly via `pip install --no-build-isolation -e .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W