### PR TITLE
axera: phase 3 confirms the multi-phase swap is diminishing-returns, not repeatable

### DIFF
--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -709,3 +709,64 @@ trajectory -- to gain further. Each phase buys a fixed, shrinking amount of
 additional resolution, not unbounded continued training; whether repeated
 phases converge to the real minimum or hit diminishing returns quickly is
 unmeasured, a real follow-on.
+
+### Phase 3: same mechanism, but diminishing returns -- the technique hits a floor after one real gain
+
+The follow-on above, answered for real. First, confirmed phase 2's plateau
+is the *same class* of problem as phase 1's, not a new one: a fresh
+`w2v2fe_runner_capture.c` run against the real `w2v2_phase2.axmodel`
+(steps 5-24, squarely inside its plateau) shows real loss alternating
+between exactly two adjacent values, `0.862318` and `0.865753` -- a span
+of `0.0034356`, matching phase 2's own `quant_axmodel.json` `loss` scale
+(`0.0034355`) almost to the last digit. So phase 2's calibrated
+representable span (`255*scale=0.876`) is not ~7x too wide like phase 1's
+was -- it is ~255x too wide, the identical "MinMax calibrates to the
+captures' own min/max, not the far tighter band a continuing run settles
+into" mechanism as phase 1's, just compounded by another round. Not an
+SNR-floor problem like Whisper's; still a resolution-mismatch problem.
+
+**Built phase 3** (`build_w2v2fe_mp_swap_phase3.py`, same shape as phase
+2's generator): recalibrated the trainable weight against 20 real captures
+of phase 2's own trajectory (steps 5-24), paired with the same fixed
+`x0`/`y0` batch every phase has used. A host check confirms this
+combination reproduces the real plateau band closely (`0.8661-0.8702`
+across the 20 captures, against real hardware's `0.8623-0.8658` for the
+same steps). Compiled for real (`pulsar2_docker.build`, same config shape).
+
+**The recalibration barely moved anything this time.** Phase 3's `loss`
+scale came back `0.0034118` -- a change of under 1% from phase 2's
+`0.0034355`, despite calibrating against a genuinely different, directly
+relevant real trajectory (not the "unrelated x/y" bug this project has hit
+before). Unlike phase 1 -> 2's real ~23% narrowing (`1.131` -> `0.876`),
+phase 2 -> 3's calibration essentially reproduced the same representable
+span (`0.876` -> `0.870`).
+
+**Real hardware, seeded from phase 2's actual plateaued state
+(`w[0]=0.2563081682`, byte-identical continuation)**: 200 steps read loss
+alternating between exactly two values, `0.863183` and `0.866594` -- a
+span of `0.003411`, again matching the new build's own calibrated scale
+almost exactly, the same one-quantization-step signature as phase 2's own
+plateau. But this time there is **no net progress**: phase 3's low value
+(`0.863183`) is *higher* than phase 2's low value (`0.862318`) -- a real,
+if tiny, regression, not a gain. Plateaus within single-digit steps, same
+as phase 2 did.
+
+**Net across all three phases**: phase 1 -> 2 bought a real gain
+(`0.87024146` -> `0.862318`, `Δ=-0.00792`, ~14% of the whole PR #1376 run's
+total reduction, in one recalibration). Phase 2 -> 3 bought nothing
+(`0.862318` -> `0.863183`, `Δ=+0.00086`). **This settles the repeatability
+question the phase-2 writeup left open: the technique is a diminishing-
+returns, not-repeatable-indefinitely fix, not a "few large steps" one.**
+Each recalibration can only narrow the calibrated range by as much as the
+real variation still present in the captured trajectory allows -- and by
+phase 2, that variation had already collapsed to a single quantization
+step's worth of oscillation, leaving nothing left for a phase-3
+recalibration to exploit. The first swap worked because phase 1's real
+captures still spanned a meaningfully wide band (weight actively
+transitioning into its plateau); by the second swap, the captures
+themselves were already as narrow as the model's own resolution ceiling,
+so recalibrating against them just reproduces the same ceiling. Phases
+1/2/3's full artifacts and captures are on the AX650N VM
+(`/root/auto_phase1.axmodel`, `/root/w2v2_phase{2,3}.axmodel*`,
+`/root/w2v2_capture_p{2,3}/`) for any follow-on that wants to inspect them
+directly.

--- a/scripts/axera/build_w2v2fe_mp_swap_phase3.py
+++ b/scripts/axera/build_w2v2fe_mp_swap_phase3.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Phase 3 of the wav2vec2 multi-phase calibration swap
+(`docs/axera-audio-speech-op-coverage.md`'s "Multi-phase calibration swap"
+section): same mechanism as `build_w2v2fe_mp_swap_phase2.py`, one step
+further -- recalibrate against phase 2's *own* real late-training
+trajectory, captured directly off the AX650N running the phase-2 compile
+(`w2v2fe_runner_capture.c` again), instead of phase 1's.
+
+Direct evidence this is the same class of problem, not a new one: phase 2's
+`quant_axmodel.json` calibrates `loss` to `scale=0.0034355`, a representable
+span of `255*scale=0.876`. A fresh real capture off `w2v2_phase2.axmodel`
+(steps 5-24, squarely inside its plateau) confirms the real observed
+trajectory alternates between exactly two adjacent quantized codes,
+`0.862318` and `0.865753` -- a span of `0.0034356`, matching the calibrated
+`scale` itself almost exactly. So phase 2's calibration is still ~252x wider
+than what the real post-swap trajectory actually uses: the same "MinMax
+calibrates to the captures' own min/max, not the much tighter band a
+continuing run settles into" mechanism as phase 1's ~7x-too-wide span, just
+compounded -- not a different, harder (e.g. SNR-floor) problem.
+
+Usage: build_w2v2fe_mp_swap_phase3.py OUT_DIR CAPTURE_DIR N_CAPTURES
+       X0_PATH Y0_PATH FINAL_STATE_PATH
+Writes OUT_DIR/step.onnx, OUT_DIR/calib/{dataset,config,step.onnx}, and
+OUT_DIR/step.onnx.state0 (seeded from FINAL_STATE_PATH -- phase 2's own real
+final weight, for a same-state continuation run against the phase-3 compile)
+/ .x0 / .y0 (byte-identical to phase 1/2's, passed in as X0_PATH/Y0_PATH so
+all three phases see the same repeating batch).
+"""
+
+import os
+import shutil
+import sys
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import torch
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import build_w2v2_feature_extractor_step as m  # noqa: E402
+import make_training_calib as mtc  # noqa: E402
+
+WNAME = "fe.conv_layers.0.conv.weight"
+
+
+def run(path, feeds):
+    sess = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
+    names = [o.name for o in sess.get_outputs()]
+    return dict(zip(names, sess.run(names, feeds)))
+
+
+def main():
+    out_dir, capture_dir, n_captures = sys.argv[1], sys.argv[2], int(sys.argv[3])
+    x0_path, y0_path, final_state_path = sys.argv[4], sys.argv[5], sys.argv[6]
+    os.makedirs(out_dir, exist_ok=True)
+    step_path = os.path.join(out_dir, "step.onnx")
+
+    torch.manual_seed(42)
+    step_model, state = m.build(step_path, batch=4)
+    onnx.save(step_model, step_path)
+    state_out = state[WNAME]
+
+    w_shape = tuple(
+        d.dim_value
+        for d in next(
+            i for i in step_model.graph.input if i.name == WNAME
+        ).type.tensor_type.shape.dim
+    )
+    x_shape = tuple(
+        d.dim_value
+        for d in next(
+            i for i in step_model.graph.input if i.name == "x"
+        ).type.tensor_type.shape.dim
+    )
+    y_shape = tuple(
+        d.dim_value
+        for d in next(
+            i for i in step_model.graph.input if i.name == "y"
+        ).type.tensor_type.shape.dim
+    )
+
+    # Real late-stage trajectory, captured off the AX650N running phase 2
+    # (see this module's docstring) -- phase 2's own plateau, not phase 1's.
+    w_captures = []
+    for i in range(n_captures):
+        arr = np.fromfile(
+            os.path.join(capture_dir, f"w_capture_{i}.bin"), dtype=np.float32
+        ).reshape(w_shape)
+        w_captures.append(arr)
+    print(
+        "real phase-2 trajectory: mean|w| ->",
+        [float(np.abs(v).mean()) for v in w_captures],
+    )
+
+    # x/y: the runner's own fixed, repeating batch, byte-identical across
+    # all three phases -- see build_w2v2fe_mp_swap_phase2.py's docstring for
+    # why this (not a diverse trajectory) is the real runtime distribution.
+    x0 = np.fromfile(x0_path, dtype=np.float32).reshape(x_shape)
+    y0 = np.fromfile(y0_path, dtype=np.float32).reshape(y_shape)
+
+    n = len(w_captures)
+    host_loss = []
+    for w in w_captures:
+        feeds = {
+            "x": x0,
+            "y": y0,
+            "lr": np.array([100.0], np.float32),
+            "grad_seed": np.array([1.0], np.float32),
+            WNAME: w,
+        }
+        out = run(step_path, feeds)
+        host_loss.append(float(np.asarray(out["loss"]).ravel()[0]))
+    print("host loss at each real phase-2 capture (x0/y0 fixed):", host_loss)
+
+    work_dir = os.path.join(out_dir, "calib")
+    mtc.make_work_dir(
+        step_path,
+        work_dir,
+        n=n,
+        label_inputs=(),
+        real_data={
+            WNAME: w_captures,
+            "x": [x0] * n,
+            "y": [y0] * n,
+            "lr": [
+                np.array([v], np.float32)
+                for v in [0.01, 0.1, 1.0, 10.0, 100.0, 1.0, 50.0, 100.0]
+            ],
+            "grad_seed": [
+                np.array([v], np.float32)
+                for v in [1.0, 0.9, 1.1, 1.0, 0.95, 1.05, 1.0, 1.0]
+            ],
+        },
+    )
+    print("wrote calib work dir:", work_dir)
+
+    # Runner companion files: seed from phase 2's real plateaued state (the
+    # same weight its own run actually ended at), and phase 1/2's own x/y
+    # batch byte-for-byte -- a genuine same-state continuation.
+    final_w = np.fromfile(final_state_path, dtype=np.float32)
+    final_w.tofile(step_path + ".state0")
+    shutil.copyfile(x0_path, step_path + ".x0")
+    shutil.copyfile(y0_path, step_path + ".y0")
+    print("wrote", step_path + ".state0/.x0/.y0 (seeded from real phase-2 plateau)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/axera/tools/README.md
+++ b/scripts/axera/tools/README.md
@@ -137,12 +137,16 @@ prefill cannot be timed with the shipped CLI. These talk to
   (raw float32, full weight tensor) for `capture_count` steps starting at
   `capture_start` every `capture_stride` steps, `out_dir/loss_capture.txt`,
   and `out_dir/final.state0` (the run's last weight state, in
-  `resident_runner.c`'s own `.state0` convention -- feed it straight to a
-  phase-2 compile as its seed). See the audio-speech coverage doc's "Multi-
-  phase calibration swap breaks the plateau, then hits a new one" section
-  for the real result this produced: a genuine, confirmed loss decrease past
-  PR #1376's plateau, though phase 2 hits its own new resolution ceiling
-  quickly rather than resuming unbounded training.
+  `resident_runner.c`'s own `.state0` convention -- feed it straight to the
+  next phase's compile as its seed; also reused as-is to capture phase 2's
+  own trajectory for a phase-3 build). See the audio-speech coverage doc's
+  "Multi-phase calibration swap breaks the plateau, then hits a new one" and
+  "Phase 3" sections for the real result this produced: a genuine, confirmed
+  loss decrease past PR #1376's plateau on the first swap, but a
+  diminishing-returns, not-repeatable-indefinitely technique -- the second
+  swap (phase 2 -> 3) bought no further gain, since phase 2's own real
+  trajectory had already narrowed to a single quantization step with
+  nothing left for another recalibration to exploit.
 
 Build and run them where the card is visible (inside the VM, if the device is
 passed through -- see `../vm/README.md`):


### PR DESCRIPTION
## Summary
- Stacked on #1379 (open, not yet merged) -- phase 3 is a direct continuation and needs phase 1/2's artifacts, so this branches off `axera-w2v2fe-mp-swap-phase2` rather than master.
- Confirmed phase 2's plateau is the *same class* of problem as phase 1's (a loss-tensor calibration-range mismatch), not a new/harder one, via direct `quant_axmodel.json` inspection against a fresh real-hardware capture of phase 2's own trajectory.
- Built and compiled phase 3 the same way phase 2 was built (`build_w2v2fe_mp_swap_phase3.py`), recalibrating against phase 2's own real captures.
- Real hardware result: **no further gain**. Phase 1→2 bought a real `Δ=-0.00792`; phase 2→3 bought `Δ=+0.00086` (a tiny regression, not a gain) -- the technique is diminishing-returns, not a repeatable "few large steps" fix.

## Test plan
- [x] `pytest tests/test_axera_legalize.py tests/test_axera_training_legalize.py` (29 passed) -- unrelated to this change but the targeted check for anything touching `scripts/axera/`.
- [x] Real hardware: compiled phase 3 via `pulsar2_docker.build`, ran 200 real steps on the AX650N (`w2v2fe_runner_capture`) seeded from phase 2's exact plateaued state.
- [x] Host CPU sanity check (`onnxruntime`) confirms the phase-3 calibration captures reproduce the real plateau loss band before spending the real compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W