### PR TITLE
axera: port float16_to_float32, dilated_conv_to_taps, rank0_to_rank1 to onnxsim core

### DIFF
--- a/docs/axera-legalize-onnxsim-core-migration.md
+++ b/docs/axera-legalize-onnxsim-core-migration.md
@@ -68,39 +68,95 @@ rewrite, target-agnostic, the vendor-specific "why" stays in the script)
   representation for `float64`/`float16`/integer `Neg`; the vendor script's
   own Python version has the identical latent limitation (it always emits a
   `float32` constant too), just without a guard that declines other types.
-- **`pow2_to_mul`** -- not ported this session (time-boxed to one complete
-  promotion per the task's own instruction), but the same class exactly:
-  `Pow(x, 2) -> Mul(x, x)`, exact, no vendor-specific formula in the
-  rewrite itself (the vendor-specific part is *why* -- avoiding a fused
-  `AxQuantizedSnake` activation that fails Pulsar2's tiler -- which would
-  stay in `scripts/axera/legalize.py`/its README exactly like the
-  precedent's own three rules keep their vendor rationale).
-- **`float16_to_float32`** -- promotable. Retyping an fp16 graph to fp32
-  throughout (initializers, `Constant` values, `Cast` targets, value_info)
-  is a generic normalization need for any tool/backend that only wants
-  fp32, not an AX650N-specific formula.
-- **`explicit_conv_padding`** -- promotable, and **not a duplicate of
-  axelera's `explicit_auto_pad`** despite the similar name: `explicit_auto_pad`
+- **`pow2_to_mul`**, **`explicit_conv_padding`** -- promoted on a separate
+  branch (`axera-legalize-more-rules`, PR #1378, open but not yet merged as
+  of this survey): `onnxsim/passes/pow2_to_mul.h`,
+  `onnxsim/passes/explicit_conv_padding.h`, both `PredicateBasedPass`. Not
+  re-verified here (this survey's own branch forked from `master`, which
+  does not yet contain that PR) -- noted for completeness, not part of this
+  round's work. `explicit_conv_padding` is **not a duplicate of axelera's
+  `explicit_auto_pad`** despite the similar name: `explicit_auto_pad`
   converts a symbolic `auto_pad` mode (`SAME_UPPER`/`SAME_LOWER`/`VALID`)
   into explicit `pads`; `explicit_conv_padding` converts an *already*-explicit
   but *asymmetric* `pads` attribute into a separate `Pad` node plus symmetric
   (zero) `pads` on the convolution. Different backend limitation (auto_pad
   support vs. asymmetric-padding support), genuinely worth two separate
   passes, not one.
-- **`dilated_conv_to_taps`** -- promotable. `y[t] = sum_j w[:,:,j] .
-  xp[t+j*d]` decomposed into one 1x1 conv per tap, summed, is exact and
-  carries no Pulsar2-specific math -- any backend without dilated-conv
-  support could use it. (The rule's own docstring notes it *also* happens to
-  match how the AX650N's weight table stores a dilated conv internally --
-  that's a bonus property of this target, not a dependency the rewrite has
-  on it.)
-- **`rank0_to_rank1`** -- promotable, on the same "generic rewrite,
-  vendor-specific why" split the precedent already established. A scalar
-  (rank-0) graph output getting a trailing axis is not itself
-  training-specific or AX650N-specific; the *reason* this project needs it
-  (Pulsar2's calibration step can't concatenate a rank-0 tensor across
-  samples, and a training graph's loss is always scalar) is specific and
-  stays put.
+- **`float16_to_float32`** -- **promoted this session**.
+  `onnxsim/passes/float16_to_float32.h`, registered, tested
+  (`tests/test_float16_to_float32.py`, 4 cases), cross-referenced from the
+  vendor's own docstring. Retyping an fp16 graph to fp32 throughout
+  (initializers, `Constant` values, `Cast` targets, every `Value`'s own
+  elemType) is a generic normalization need for any tool/backend that only
+  wants fp32, not an AX650N-specific formula -- and, unlike `neg_to_mul`/
+  `pow2_to_mul`/`explicit_conv_padding`, it is graph-*output*-driven rather
+  than node-pattern-driven (see the architecture note below), so it is a
+  `FullGraphBasedPass`, not a `PredicateBasedPass`.
+- **`dilated_conv_to_taps`** -- **promoted this session**.
+  `onnxsim/passes/dilated_conv_to_taps.h`, registered, tested
+  (`tests/test_dilated_conv_to_taps.py`, 7 cases -- three dilation/padding
+  combinations, a bias-added-exactly-once check, low-dilation and grouped-
+  conv skip cases, and the disabled-by-default case), cross-referenced from
+  the vendor's own docstring. `y[t] = sum_j w[:,:,j] . xp[t+j*d]` decomposed
+  into one 1x1 conv per tap, summed, is exact and carries no Pulsar2-specific
+  math -- any backend without dilated-conv support could use it. (The rule's
+  own docstring notes it *also* happens to match how the AX650N's weight
+  table stores a dilated conv internally -- that's a bonus property of this
+  target, not a dependency the rewrite has on it.) A `PredicateBasedPass`,
+  following `rewrite_deform_conv_to_gather.h`'s own precedent for "one node
+  becomes many" via `graph.create()`/`insertBefore()` (see the architecture
+  note below); `min_dilation` is fixed at 2 in the core pass rather than
+  exposed as a parameter, since every call site in this project uses the
+  vendor rule's own default.
+- **`rank0_to_rank1`** -- **promoted this session**.
+  `onnxsim/passes/rank0_to_rank1.h`, registered, tested
+  (`tests/test_rank0_to_rank1.py`, 6 cases, including both the attribute-
+  form and opset>=18 input-form of a Reduce*'s `axes`), cross-referenced
+  from the vendor's own docstring. A scalar (rank-0) graph output getting a
+  trailing axis is not itself training-specific or AX650N-specific; the
+  *reason* this project needs it (Pulsar2's calibration step can't
+  concatenate a rank-0 tensor across samples, and a training graph's loss is
+  always scalar) is specific and stays in the vendor script. Driven by the
+  graph's own output list, not a node pattern, so a `FullGraphBasedPass`,
+  the same split `float16_to_float32.h` uses.
+
+### An architecture note this survey exists to settle
+
+Before this session, three rules above (`float16_to_float32`,
+`dilated_conv_to_taps`, `rank0_to_rank1`) sat in "promotable" limbo without
+being ported, and it was worth checking first whether that was because they
+genuinely didn't fit anything onnxsim's C++ core already had, or simply
+hadn't been gotten to. They fit, on two different existing mechanisms, both
+real precedent already compiled into onnxsim before this session touched it:
+
+- **`PredicateBasedPass`** (`third_party/onnx-optimizer/onnxoptimizer/pass.h`)
+  -- the one every already-ported rule (`neg_to_mul`, `pow2_to_mul`,
+  `explicit_conv_padding`) uses: `patternMatchPredicate(Node*)` triggers a
+  per-node match, `runTransform(Node*, Graph&, NodeDestroyType&)` rewrites
+  it. Its `runTransform` receives the whole `Graph&`, not just the matched
+  node, so "one node becomes many" is not actually out of scope for it --
+  `onnxsim/passes/rewrite_deform_conv_to_gather.h` was already real
+  precedent for exactly that ("one node becomes dozens to low hundreds")
+  before this session, via `graph.create()` + `insertBefore()`. This is what
+  `dilated_conv_to_taps.h` follows.
+- **`FullGraphBasedPass`** (same header) -- "the most general pass which
+  allows the user to run a pass given only a graph," its own doc comment
+  says: `runPass(Graph&)` with no per-node predicate at all. Already real,
+  compiled-in precedent for this before this session too:
+  `onnxsim/passes/quantize_fp16.h` (and `quantize_fp8.h`/`quantize_bf16.h`/
+  `magnitude_pruning.h`) -- `quantize_fp16.h` in particular is close to a
+  mirror image of `float16_to_float32.h`'s own need (a whole-graph dtype
+  retype touching initializers, `Constant` values, and every `Value`'s own
+  elemType, including graph inputs/outputs). Both `float16_to_float32.h` and
+  `rank0_to_rank1.h` use this base class, registered into the same registry
+  via the same `RegisterOrReplace<T>` template as any `PredicateBasedPass`
+  (`custom_optimizer_passes.cpp` neither knows nor cares which base class a
+  pass uses).
+
+Net: nothing here needed new C++ pass infrastructure. The earlier
+"promotable, not yet ported" state was a scheduling gap (each of the
+three already-ported rules was one complete round-trip's worth of work,
+time-boxed one at a time), not an architectural one.
 
 ### Not a graph-rewrite pass -- doesn't fit `PredicateBasedPass`'s shape
 
@@ -159,19 +215,22 @@ These rules are correctly scoped to `scripts/axera`.
 `tests/test_axelera_legalize.py`, `tests/test_explicit_auto_pad.py`,
 `tests/test_gemm_transa_to_transpose.py`,
 `tests/test_maxpool_rowmajor_when_indices_unused.py`,
-`tests/test_neg_to_mul.py`, `tests/test_build_resident_train_step.py`: **77
-passed**, after the rebuild above. `ruff format`/`ruff check` clean on all
-touched Python; `clang-format` clean on the new C++.
+`tests/test_neg_to_mul.py`, `tests/test_quantize_fp16.py`,
+`tests/test_float16_to_float32.py`, `tests/test_rank0_to_rank1.py`,
+`tests/test_dilated_conv_to_taps.py`, `tests/test_build_resident_train_step.py`:
+**100 passed**, after an incremental rebuild (`pip install
+--no-build-isolation -e .`, ~25s) in a fresh worktree off `origin/master`.
+`ruff format`/`ruff check` clean on all touched Python; `clang-format` clean
+on all three new C++ headers and `custom_optimizer_passes.cpp`.
 
 ## What's left, if this is picked up further
 
-`pow2_to_mul`, `float16_to_float32`, `explicit_conv_padding`,
-`dilated_conv_to_taps` are classified as promotable above but not yet
-ported (time-boxed to one complete round-trip this session, per the task's
-own instruction to prioritize getting the survey right over rushing every
-promotion partially) -- each would follow `neg_to_mul.h`'s exact structure:
-new `onnxsim/passes/<name>.h`, register in `custom_optimizer_passes.cpp`,
-`onnx.parser`-based test in `tests/test_<name>.py`, a cross-reference
-paragraph added to the vendor function's docstring (Python implementation
-kept, not deleted, matching the standalone-usability constraint discussed
-above).
+Every rule classified "promotable" above is now ported (`pow2_to_mul` and
+`explicit_conv_padding` on PR #1378, not yet merged; `float16_to_float32`,
+`dilated_conv_to_taps`, `rank0_to_rank1` this session) -- nothing left in
+that category. What remains unported is the training-specific group
+(`inline_local_functions`, `avgpool_ceil_to_floor`, `flatten_to_reshape`,
+`global_pool_to_reduce`, `gemm_to_matmul`, `act_weight_conv_to_matmul`,
+`TRAINING_RULES`) and `filename_safe_io_names`, both deliberately scoped to
+stay in `scripts/axera` per the sections above -- there is no further
+"pick this up" item pending on the promotable side of this migration.

--- a/onnxsim/custom_optimizer_passes.cpp
+++ b/onnxsim/custom_optimizer_passes.cpp
@@ -12,6 +12,7 @@
 #include "passes/any_precision_llm.h"
 #include "passes/cross_layer_equalization.h"
 #include "passes/defuse_matmul_integer_to_float.h"
+#include "passes/dilated_conv_to_taps.h"
 #include "passes/double_quantization.h"
 #include "passes/dynamic_quantize_attention.h"
 #include "passes/dynamic_quantize_matmul.h"
@@ -27,6 +28,7 @@
 #include "passes/eliminate_sequence_at_construct.h"
 #include "passes/eliminate_sequence_length_construct.h"
 #include "passes/explicit_auto_pad.h"
+#include "passes/float16_to_float32.h"
 #include "passes/fp6_llm.h"
 #include "passes/fuse_add_bias_into_conv.h"
 #include "passes/fuse_attention.h"
@@ -70,6 +72,7 @@
 #include "passes/quantize_fp16.h"
 #include "passes/quantize_fp8.h"
 #include "passes/quarot.h"
+#include "passes/rank0_to_rank1.h"
 #include "passes/rewrite_arg_reduce_select_last_index.h"
 #include "passes/rewrite_bev_pool_to_scatter.h"
 #include "passes/rewrite_bool_where.h"
@@ -134,6 +137,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::AnyPrecisionLlm>(registry);
     RegisterOrReplace<p::CrossLayerEqualization>(registry);
     RegisterOrReplace<p::DefuseMatMulIntegerToFloat>(registry);
+    RegisterOrReplace<p::DilatedConvToTaps>(registry);
     RegisterOrReplace<p::DoubleQuantization>(registry);
     RegisterOrReplace<p::DynamicQuantizeAttention>(registry);
     RegisterOrReplace<p::DynamicQuantizeMatMul>(registry);
@@ -147,6 +151,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::EliminateSequenceAtConstruct>(registry);
     RegisterOrReplace<p::EliminateSequenceLengthConstruct>(registry);
     RegisterOrReplace<p::ExplicitAutoPad>(registry);
+    RegisterOrReplace<p::Float16ToFloat32Pass>(registry);
     RegisterOrReplace<p::Fp6Llm>(registry);
     RegisterOrReplace<p::FuseAttention>(registry);
     RegisterOrReplace<p::FuseConsecutiveMul>(registry);
@@ -188,6 +193,7 @@ void RegisterCustomOptimizerPasses() {
     RegisterOrReplace<p::QuantizeFp16Pass>(registry);
     RegisterOrReplace<p::QuantizeFp8Pass>(registry);
     RegisterOrReplace<p::Quarot>(registry);
+    RegisterOrReplace<p::Rank0ToRank1>(registry);
     RegisterOrReplace<p::RewriteArgReduceSelectLastIndex>(registry);
     RegisterOrReplace<p::RewriteBevPoolToScatter>(registry);
     RegisterOrReplace<p::RewriteBoolWhere>(registry);

--- a/onnxsim/passes/dilated_conv_to_taps.h
+++ b/onnxsim/passes/dilated_conv_to_taps.h
@@ -1,0 +1,216 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// A widely dilated 1-D convolution becomes one 1x1 convolution per tap,
+// summed -- a port of scripts/axera/legalize.py's dilated_conv_to_taps rule,
+// kept there for the compiler that motivated it (Pulsar2, which the vendor
+// script's own docstring notes stores a dilated convolution internally as
+// one weight block per tap already -- this rewrite moves the graph towards
+// what the compiler does internally rather than away from it), but the
+// rewrite itself carries no vendor-specific formula: `y[t] = sum_j w[:, :,
+// j] . xp[t + j*d]` is the definition of a dilated convolution, so slicing
+// the (explicitly) padded input at each tap offset and convolving with a
+// kernel of one is exactly the same function, for any backend without
+// dilated-conv support.
+//
+// Scoped identically to the vendor rule: only a plain (`group == 1`,
+// `strides == [1]`), single-spatial-axis (1-D) convolution with a constant
+// weight and a statically known output length qualifies -- see
+// `patternMatchPredicate`. `min_dilation` is fixed at 2 (every call site in
+// this project uses the vendor rule's own default; a Conv with dilation 1 is
+// already what every backend supports, so there would be nothing to gain
+// rewriting it).
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/quantize_conv_common.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct DilatedConvToTaps final : public PredicateBasedPass {
+  explicit DilatedConvToTaps()
+      : PredicateBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+  std::string getPassName() const override { return "dilated_conv_to_taps"; }
+
+  static constexpr int64_t kMinDilation = 2;
+
+  bool patternMatchPredicate(Node* node) override {
+    if (node->kind() != kConv) {
+      return false;
+    }
+    const size_t num_inputs = node->inputs().size();
+    if (num_inputs != 2 && num_inputs != 3) {
+      return false;
+    }
+    if (node->hasAttribute(kgroup) && node->i(kgroup) != 1) {
+      return false;
+    }
+    if (node->hasAttribute(kstrides)) {
+      const auto& strides = node->is(kstrides);
+      if (strides.size() != 1 || strides[0] != 1) {
+        return false;
+      }
+    }
+    if (!node->hasAttribute(kdilations)) {
+      return false;
+    }
+    const auto& dil = node->is(kdilations);
+    if (dil.size() != 1 || dil[0] < kMinDilation) {
+      return false;
+    }
+    const Tensor* w = FetchConstantTensor(node->input(1));
+    if (w == nullptr || w->elem_type() != TensorProto_DataType_FLOAT ||
+        w->sizes().size() != 3) {
+      return false;
+    }
+    Value* out = node->output();
+    if (!out->has_sizes() || out->sizes().size() != 3) {
+      return false;
+    }
+    const Dimension& length_dim = out->sizes()[2];
+    return length_dim.is_int && length_dim.dim > 0;
+  }
+
+  static Value* ConstI64Vec1(Graph& graph, int64_t v) {
+    Tensor t;
+    t.elem_type() = TensorProto_DataType_INT64;
+    t.sizes().push_back(1);
+    t.int64s().push_back(v);
+    return graph.addInitializerAndCreateValue(std::move(t));
+  }
+
+  // `w[:, :, j:j+1]` -- the j-th tap's [Cout, Cin, 1] slice out of a
+  // [Cout, Cin, taps] weight, read flat and row-major (ReadFloatTensorFlat
+  // already normalizes raw_data vs. a typed field into this layout).
+  static Tensor TapWeight(const std::vector<float>& flat, int64_t cout,
+                          int64_t cin, int64_t taps, int64_t j) {
+    Tensor out;
+    out.elem_type() = TensorProto_DataType_FLOAT;
+    out.sizes() = {cout, cin, 1};
+    std::vector<float> data(static_cast<size_t>(cout * cin));
+    for (int64_t co = 0; co < cout; ++co) {
+      for (int64_t ci = 0; ci < cin; ++ci) {
+        data[static_cast<size_t>(co * cin + ci)] =
+            flat[static_cast<size_t>((co * cin + ci) * taps + j)];
+      }
+    }
+    out.set_raw_data(WriteRawDataLittleEndian(data));
+    // No name set: addInitializerAndCreateValue(Tensor&&) auto-assigns a
+    // fresh, guaranteed-unique one (getNextUniqueName()) when empty, rather
+    // than risk a collision from two dilated Convs in the same graph
+    // sharing a `stem`.
+    return out;
+  }
+
+  bool runTransform(Node* node, Graph& graph,
+                    NodeDestroyType& destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+
+    const auto& dil = node->is(kdilations);
+    const int64_t d = dil[0];
+    const Tensor* w_t = FetchConstantTensor(node->input(1));
+    if (w_t == nullptr) {
+      return false;  // predicate already checked this; defensive only.
+    }
+    const int64_t cout = w_t->sizes()[0];
+    const int64_t cin = w_t->sizes()[1];
+    const int64_t taps = w_t->sizes()[2];
+    const std::vector<float> w_flat = ReadFloatTensorFlat(*w_t);
+    const int64_t length = node->output()->sizes()[2].dim;
+
+    std::vector<int64_t> pads = {0, 0};
+    if (node->hasAttribute(kpads)) {
+      const auto& p = node->is(kpads);
+      if (p.size() == 2) {
+        pads = {p[0], p[1]};
+      }
+    }
+
+    // Pad(x, [0, 0, pads[0], 0, 0, pads[1]]) -- ONNX Pad's 2*rank layout
+    // (begin per axis, then end per axis) for this rank-3 [N, C, L] input,
+    // padding only the trailing spatial axis.
+    Tensor pads_t;
+    pads_t.elem_type() = TensorProto_DataType_INT64;
+    pads_t.sizes().push_back(6);
+    pads_t.int64s() = {0, 0, pads[0], 0, 0, pads[1]};
+    Node* pad = graph.create(kPad, 1);
+    pad->addInput(node->input(0));
+    pad->addInput(graph.addInitializerAndCreateValue(std::move(pads_t)));
+    pad->s_(kmode, "constant");
+    pad->insertBefore(node);
+    pad->output()->setElemType(node->input(0)->elemType());
+
+    std::vector<Value*> partials;
+    partials.reserve(static_cast<size_t>(taps));
+    for (int64_t j = 0; j < taps; ++j) {
+      Tensor tap_w = TapWeight(w_flat, cout, cin, taps, j);
+      Value* tap_w_v = graph.addInitializerAndCreateValue(std::move(tap_w));
+
+      Node* slice = graph.create(kSlice, 1);
+      slice->addInput(pad->output());
+      slice->addInput(ConstI64Vec1(graph, j * d));
+      slice->addInput(ConstI64Vec1(graph, j * d + length));
+      slice->addInput(ConstI64Vec1(graph, 2));
+      slice->insertBefore(node);
+      slice->output()->setElemType(node->input(0)->elemType());
+
+      Node* tap_conv = graph.create(kConv, 1);
+      tap_conv->addInput(slice->output());
+      tap_conv->addInput(tap_w_v);
+      if (j == 0 && node->inputs().size() > 2) {
+        tap_conv->addInput(node->input(2));
+      }
+      tap_conv->is_(kkernel_shape, std::vector<int64_t>{1});
+      tap_conv->is_(kpads, std::vector<int64_t>{0, 0});
+      tap_conv->is_(kdilations, std::vector<int64_t>{1});
+      tap_conv->is_(kstrides, std::vector<int64_t>{1});
+      tap_conv->insertBefore(node);
+      tap_conv->output()->setElemType(node->output()->elemType());
+      tap_conv->output()->setSizes(node->output()->sizes());
+
+      partials.push_back(tap_conv->output());
+    }
+
+    Value* acc = partials[0];
+    Node* last_add = nullptr;
+    for (size_t j = 1; j < partials.size(); ++j) {
+      Node* add = graph.create(kAdd, 1);
+      add->addInput(acc);
+      add->addInput(partials[j]);
+      add->insertBefore(node);
+      add->output()->setElemType(node->output()->elemType());
+      add->output()->setSizes(node->output()->sizes());
+      acc = add->output();
+      last_add = add;
+    }
+
+    // taps == 1 (dilation with a single-tap kernel, e.g. a 1x1 conv that
+    // still declared a dilation) never happens in practice for a rewrite
+    // gated on kMinDilation, but stay correct: with no Add at all, the sole
+    // tap convolution's own node is what replaces `node`.
+    Node* replacement = last_add != nullptr ? last_add : partials[0]->node();
+    if (!tryReplacingAllUsesWith(node, replacement)) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/float16_to_float32.h
+++ b/onnxsim/passes/float16_to_float32.h
@@ -1,0 +1,223 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Retypes an all-float16 graph to float32 -- the widening mirror of
+// quantize_fp16.h's QuantizeFp16Pass, and a port of
+// scripts/axera/legalize.py's float16_to_float32 (the "port scripts/axera/
+// legalize.py rules to onnxsim core" migration this project has been
+// running, alongside pow2_to_mul.h/explicit_conv_padding.h/neg_to_mul.h;
+// see docs/axera-legalize-onnxsim-core-migration.md). It exists for the
+// Axera AX650N Pulsar2 compiler, which takes float32 only: an fp16 export
+// has its constants in three places, and converting only one leaves a graph
+// that mixes precisions, which onnxruntime rejects outright at load time.
+//
+// Unlike QuantizeFp16Pass, this is unconditional and total, not a partial/
+// mixed-precision transform with a keep_io_types choice: every FLOAT16
+// declaration anywhere in the graph -- constant tensors (initializers and
+// Constant nodes), a Cast node's `to` attribute, and every Value's own
+// elemType (graph inputs, graph outputs, and interior node outputs alike)
+// -- becomes FLOAT, full stop. That is a safe, always-correct rewrite
+// exactly because it is total: unlike QuantizeFp16Pass (which cannot assume
+// every float32-declared output actually becomes float16, since a mixed-
+// precision graph may deliberately keep some values at float32, e.g. past a
+// Cast(to=FLOAT) placed mid-graph on purpose) this pass's precondition is
+// that the *whole* graph is already float16, so every FLOAT16-declared
+// Value's true new type is unambiguously FLOAT once its producers are
+// retyped -- no guessing, no wiping-to-UNDEFINED-and-letting-a-later-pass-
+// re-infer needed.
+//
+// float16->float32 is also exact (every float16 value has a precise float32
+// representation), unlike float32->float16 (QuantizeFp16Pass's
+// FloatToFloat16Bits rounds and clamps) -- so this pass never loses
+// precision or changes a single computed value, only how it is spelled.
+//
+// Only the top-level graph is converted -- nodes inside control-flow
+// subgraphs (If/Loop/Scan bodies) are left untouched, the same known
+// limitation quantize_fp16.h documents for itself.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+#include "passes/endian_read.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+// Converts the bit pattern of an IEEE 754 binary16 (float16) value to the
+// float32 value it exactly represents -- the widening direction is always
+// exact, unlike quantize_fp16.h's FloatToFloat16Bits (which rounds).
+inline float Float16BitsToFloat(uint16_t bits) {
+  const uint32_t sign = static_cast<uint32_t>(bits & 0x8000u) << 16;
+  const uint32_t exp16 = (bits >> 10) & 0x1Fu;
+  uint32_t mant16 = bits & 0x3FFu;
+
+  uint32_t out_bits;
+  if (exp16 == 0) {
+    if (mant16 == 0) {
+      out_bits = sign;  // +-0
+    } else {
+      // Subnormal float16: shift the mantissa left until its leading 1
+      // lands in the implicit-bit position, adjusting the exponent to
+      // match, then rebias into float32's exponent range.
+      int32_t shift = 0;
+      while ((mant16 & 0x400u) == 0) {
+        mant16 <<= 1;
+        shift += 1;
+      }
+      mant16 &= 0x3FFu;
+      const uint32_t exp32 = static_cast<uint32_t>(127 - 15 - shift);
+      out_bits = sign | (exp32 << 23) | (mant16 << 13);
+    }
+  } else if (exp16 == 0x1Fu) {
+    // Inf/NaN: float16's max exponent maps to float32's max exponent, the
+    // mantissa carried through unchanged (0 for Inf, nonzero for NaN).
+    out_bits = sign | (0xFFu << 23) | (mant16 << 13);
+  } else {
+    const uint32_t exp32 = exp16 - 15u + 127u;
+    out_bits = sign | (exp32 << 23) | (mant16 << 13);
+  }
+
+  float out;
+  std::memcpy(&out, &out_bits, sizeof(out));
+  return out;
+}
+
+// Reads a constant float16 tensor's bit patterns, widened to a flat float32
+// buffer -- the read-side counterpart of quantize_fp16.h's
+// ConvertFloatTensorToFp16, direction reversed. float16 has no dedicated
+// typed TensorProto field (see WriteRawDataLittleEndian's doc comment in
+// endian_read.h): onnx.numpy_helper.from_array always uses raw_data for it,
+// but int32_data (each entry the 16-bit pattern zero-extended) is also
+// spec-legal, so both are handled here.
+inline std::vector<float> ReadFloat16TensorFlat(const Tensor& t) {
+  int64_t numel = 1;
+  for (const auto& s : t.sizes()) {
+    numel *= s;
+  }
+  std::vector<uint16_t> bits;
+  if (t.is_raw_data()) {
+    // Tensor::data<T>() is only explicitly instantiated for the handful of
+    // types ir.h's own define_data() macro lists (float/double/int32_t/
+    // int64_t/uint64_t) -- uint16_t is not among them, so raw_data is read
+    // by reinterpreting raw() directly instead, the same way it is stored
+    // (ConvertFloat16TensorToFloat32 below writes uint16_t bit patterns via
+    // WriteRawDataLittleEndian, never through data<uint16_t>() either).
+    bits = ReadRawDataHostOrder<uint16_t>(
+        reinterpret_cast<const uint16_t*>(t.raw().data()), numel);
+  } else {
+    bits.reserve(static_cast<size_t>(numel));
+    for (int32_t v : t.int32s()) {
+      bits.push_back(static_cast<uint16_t>(v));
+    }
+  }
+  std::vector<float> out(bits.size());
+  for (size_t i = 0; i < bits.size(); ++i) {
+    out[i] = Float16BitsToFloat(bits[i]);
+  }
+  return out;
+}
+
+// Converts a constant float16 tensor of any rank/shape to float32, keeping
+// the same shape.
+inline Tensor ConvertFloat16TensorToFloat32(const Tensor& t) {
+  const std::vector<float> data = ReadFloat16TensorFlat(t);
+  Tensor out;
+  out.elem_type() = TensorProto_DataType_FLOAT;
+  out.sizes() = t.sizes();
+  out.set_raw_data(WriteRawDataLittleEndian(data));
+  return out;
+}
+
+struct Float16ToFloat32Pass final : public FullGraphBasedPass {
+  explicit Float16ToFloat32Pass()
+      : FullGraphBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::None) {}
+  std::string getPassName() const override { return "float16_to_float32"; }
+  PassAnalysisType getPassAnalysisType() const override {
+    return PassAnalysisType::Empty;
+  }
+
+  std::shared_ptr<PostPassAnalysis> runPass(Graph& graph) override {
+    // 1. Every constant float16 tensor (a true initializer, or a Constant
+    // node's embedded value -- FetchConstantTensor covers both uniformly)
+    // becomes float32, once per unique value.
+    std::unordered_set<std::string> seen;
+    std::vector<Value*> candidates;
+    for (Node* n : graph.nodes()) {
+      for (Value* in : n->inputs()) {
+        if (!seen.insert(in->uniqueName()).second) {
+          continue;
+        }
+        const Tensor* t = FetchConstantTensor(in);
+        if (t != nullptr && t->elem_type() == TensorProto_DataType_FLOAT16) {
+          candidates.push_back(in);
+        }
+      }
+    }
+    for (Value* old_v : candidates) {
+      const Tensor* t = FetchConstantTensor(old_v);
+      if (t == nullptr) {
+        continue;  // Defensive: shouldn't happen, nothing else touches these.
+      }
+      Tensor f32_t = ConvertFloat16TensorToFloat32(*t);
+      Value* new_v = graph.addInitializerAndCreateValue(f32_t);
+      tryReplacingAllUsesWith(old_v, new_v);
+    }
+
+    // 2. Every Cast node's `to` attribute, wherever it names FLOAT16.
+    for (Node* n : graph.nodes()) {
+      if (n->kind() == kCast && n->hasAttribute(kto) &&
+          n->i(kto) == static_cast<int64_t>(TensorProto_DataType_FLOAT16)) {
+        n->i_(kto, static_cast<int64_t>(TensorProto_DataType_FLOAT));
+      }
+    }
+
+    // 3. Every Value's own declared elemType -- graph inputs, graph
+    // outputs, and every node's output alike. Safe to relabel directly
+    // (rather than wipe, as QuantizeFp16Pass does for its narrowing,
+    // partial-conversion case) because this pass's precondition is a
+    // wholly float16 graph: once step 1 retypes every constant that feeds
+    // it, a Value still declared FLOAT16 has no other correct type left to
+    // have.
+    std::unordered_set<Value*> retyped;
+    for (Value* v : graph.inputs()) {
+      if (v->elemType() == TensorProto_DataType_FLOAT16) {
+        v->setElemType(TensorProto_DataType_FLOAT);
+        retyped.insert(v);
+      }
+    }
+    for (Value* v : graph.outputs()) {
+      if (v->elemType() == TensorProto_DataType_FLOAT16) {
+        v->setElemType(TensorProto_DataType_FLOAT);
+        retyped.insert(v);
+      }
+    }
+    for (Node* n : graph.nodes()) {
+      for (Value* out : n->outputs()) {
+        if (out->elemType() == TensorProto_DataType_FLOAT16) {
+          out->setElemType(TensorProto_DataType_FLOAT);
+          retyped.insert(out);
+        }
+      }
+    }
+
+    return std::shared_ptr<PostPassAnalysis>(new PostPassAnalysis());
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxsim/passes/rank0_to_rank1.h
+++ b/onnxsim/passes/rank0_to_rank1.h
@@ -1,0 +1,159 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+// Gives every rank-0 (scalar) graph output a trailing axis, so it becomes
+// rank-1 with a single element -- a port of scripts/axera/legalize.py's
+// rank0_to_rank1 rule, kept for the compiler/runtime that motivated it
+// (Pulsar2's calibration step concatenates each output tensor across
+// calibration samples, and a rank-0 tensor cannot be concatenated), but
+// generic: any consumer of an ONNX graph that cannot handle a scalar output
+// -- a calibration/batching pipeline is the common case -- has the same
+// need, and nothing here is Pulsar2- or AX650N-specific.
+//
+// This is graph-output-driven, not node-pattern-driven (there is no fixed
+// node kind or shape to match against -- the trigger is "this graph output
+// is declared rank 0", wherever it comes from), which is why it is a
+// FullGraphBasedPass rather than a PredicateBasedPass, the same split
+// float16_to_float32.h documents for itself.
+//
+// Two things change for each affected output:
+//  1. If the value is produced directly by a ReduceMean/Sum/Max/Min/Prod
+//     node, that node is switched to `keepdims=1` (instead of reducing the
+//     axis away) and, when its axes are not already named explicitly, given
+//     an explicit axes list covering every axis of its input -- because
+//     ONNX's own "no axes named" default (reduce every axis) is not always
+//     what a real runtime does: a bare `ReduceMean` observed reducing only
+//     the last axis of its input, rather than every axis, on the motivating
+//     target. This has no effect on what the *node* computes when axes are
+//     already given, and reduces every axis either way when they are not --
+//     naming them only makes explicit what the default already meant.
+//  2. Regardless of what produced it, the graph now needs a rank-1
+//     `[1]`-shaped value under the *original* output name: the actual
+//     producer's output is renamed internally, and a `Reshape(..., [1])`
+//     node takes its place, its output carrying the original name and
+//     redirecting every prior consumer of the value (the graph-output slot,
+//     and any other internal use) to the reshaped result. `keepdims=1`
+//     already leaves a same-numel tensor (a size-1 dim per reduced axis
+//     instead of none), so this reshape is exact regardless of the
+//     producer's actual rank.
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "onnx/common/assertions.h"
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+namespace onnxsim_passes {
+
+struct Rank0ToRank1 final : public FullGraphBasedPass {
+  explicit Rank0ToRank1()
+      : FullGraphBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::None) {}
+  std::string getPassName() const override { return "rank0_to_rank1"; }
+  PassAnalysisType getPassAnalysisType() const override {
+    return PassAnalysisType::Empty;
+  }
+
+  // The Reduce* kinds scripts/axera/legalize.py's rank0_to_rank1 special-
+  // cases -- deliberately not every reduction op ONNX defines (e.g.
+  // ReduceL1/L2/LogSum(Exp)/SumSquare are left out there too), to stay a
+  // faithful, behavior-preserving port rather than a broadened rewrite.
+  static bool IsHandledReduceKind(NodeKind k) {
+    static const std::unordered_set<NodeKind> kKinds{
+        Symbol("ReduceMean"), Symbol("ReduceSum"), Symbol("ReduceMax"),
+        Symbol("ReduceMin"), Symbol("ReduceProd")};
+    return kKinds.count(k) != 0;
+  }
+
+  static Value* ConstI64Vec1(Graph& graph, int64_t v) {
+    Tensor t;
+    t.elem_type() = TensorProto_DataType_INT64;
+    t.sizes().push_back(1);
+    t.int64s().push_back(v);
+    return graph.addInitializerAndCreateValue(std::move(t));
+  }
+
+  std::shared_ptr<PostPassAnalysis> runPass(Graph& graph) override {
+    // Snapshot: redirecting a graph output's producer below mutates
+    // return_node()'s own inputs (graph.outputs() itself), which would
+    // invalidate a live iteration over it.
+    std::vector<Value*> orig_outputs(graph.outputs().begin(),
+                                     graph.outputs().end());
+
+    for (Value* v : orig_outputs) {
+      if (!v->has_sizes() || !v->sizes().empty()) {
+        continue;  // not a declared-rank-0 output
+      }
+
+      Node* producer = v->node();
+      if (IsHandledReduceKind(producer->kind()) &&
+          producer->inputs().size() >= 1) {
+        producer->i_(kkeepdims, int64_t{1});
+
+        Value* x = producer->input(0);
+        const bool named =
+            producer->hasAttribute(kaxes) || producer->inputs().size() > 1;
+        if (!named && x->has_sizes() && !x->sizes().empty()) {
+          std::vector<int64_t> axes(x->sizes().size());
+          for (size_t i = 0; i < axes.size(); ++i) {
+            axes[i] = static_cast<int64_t>(i);
+          }
+          // `axes` moved from a Reduce* attribute to its second input at
+          // opset 18 (scripts/axera/legalize.py's own `_set_axes` --
+          // uniformly for every Reduce* kind, not per-op like
+          // fuse_consecutive_reduce.h's more precise ReduceSum-at-13
+          // handling, since real graphs in this project are always one
+          // opset end to end). getOpsetVersion returns 0 when no opset
+          // import is found, which onnxsim's own opset-lookup helpers treat
+          // as "assume unversioned/legacy" -- the attribute form.
+          const int opset = PredicateBasedPass::getOpsetVersion(graph);
+          if (opset >= 18) {
+            Tensor axes_t;
+            axes_t.elem_type() = TensorProto_DataType_INT64;
+            axes_t.sizes().push_back(static_cast<int64_t>(axes.size()));
+            axes_t.int64s().assign(axes.begin(), axes.end());
+            producer->addInput(
+                graph.addInitializerAndCreateValue(std::move(axes_t)));
+          } else {
+            producer->is_(kaxes, std::move(axes));
+          }
+        }
+      }
+
+      // Snapshot uses() before creating the Reshape node, so the reshape's
+      // own new use of `v` is never among the uses redirected to it.
+      auto use_list = v->uses();
+
+      const std::string original_name = v->uniqueName();
+      v->setUniqueName(graph.getNextUniqueName());
+
+      Node* reshape = graph.create(kReshape, 1);
+      reshape->addInput(v);
+      reshape->addInput(ConstI64Vec1(graph, 1));
+      reshape = graph.appendNode(reshape);
+      reshape->output()->setUniqueName(original_name);
+      reshape->output()->setElemType(v->elemType());
+      reshape->output()->setSizes({Dimension(int64_t{1})});
+
+      for (auto& use : use_list) {
+        use.user->replaceInput(use.offset, reshape->output());
+      }
+    }
+
+    return std::shared_ptr<PostPassAnalysis>(new PostPassAnalysis());
+  }
+};
+
+}  // namespace onnxsim_passes
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/scripts/axera/legalize.py
+++ b/scripts/axera/legalize.py
@@ -39,6 +39,13 @@ def float16_to_float32(model):
     codec decoder, against 1,174 `Constant` nodes -- produces a model ONNX
     Runtime rejects with "Type parameter (T) of Optype (Div) bound to
     different types (tensor(float) and tensor(float16))".
+
+    Also has a target-agnostic C++ counterpart in onnxsim's own core
+    (`onnxsim/passes/float16_to_float32.h`), usable from any binding via
+    `onnxsim.simplify(model, extra_optimizers=["float16_to_float32"])` --
+    see `tests/test_float16_to_float32.py`. This module's own version stays:
+    it needs nothing beyond the `onnx` package (no onnxsim build), which
+    `legalize.py in.onnx out.onnx`'s standalone-script usage depends on.
     """
     changed = 0
     for init in model.graph.initializer:
@@ -194,6 +201,16 @@ def dilated_conv_to_taps(model, min_dilation=2):
     dilated convolution as one block per tap already (see "A widely dilated
     convolution is K convolutions"), so the rewrite moves the graph towards
     what the compiler does internally rather than away from it.
+
+    Also has a target-agnostic C++ counterpart in onnxsim's own core
+    (`onnxsim/passes/dilated_conv_to_taps.h`), usable from any binding via
+    `onnxsim.simplify(model, extra_optimizers=["dilated_conv_to_taps"])` --
+    see `tests/test_dilated_conv_to_taps.py`. This module's own version
+    stays: it needs nothing beyond the `onnx` package (no onnxsim build),
+    which `legalize.py in.onnx out.onnx`'s standalone-script usage depends
+    on. The core pass fixes `min_dilation` at 2 rather than exposing it as a
+    parameter -- every call site in this project (and the vendor rule's own
+    tests) uses the default.
     """
     # Shapes are needed to size each tap's slice, and a graph that was cut out
     # of a larger one carries no `value_info` at all -- which made an earlier
@@ -393,6 +410,13 @@ def rank0_to_rank1(model):
     Only the declared rank changes; `ReduceMean`/`ReduceSum` grow a
     `keepdims=1` instead of reducing away, which is the same number in a
     1-element tensor.
+
+    Also has a target-agnostic C++ counterpart in onnxsim's own core
+    (`onnxsim/passes/rank0_to_rank1.h`), usable from any binding via
+    `onnxsim.simplify(model, extra_optimizers=["rank0_to_rank1"])` -- see
+    `tests/test_rank0_to_rank1.py`. This module's own version stays: it
+    needs nothing beyond the `onnx` package (no onnxsim build), which
+    `legalize.py in.onnx out.onnx`'s standalone-script usage depends on.
     """
     scalars = {
         v.name

--- a/tests/test_dilated_conv_to_taps.py
+++ b/tests/test_dilated_conv_to_taps.py
@@ -1,0 +1,156 @@
+"""Tests for the ``dilated_conv_to_taps`` C++ pass
+(onnxsim/passes/dilated_conv_to_taps.h).
+
+A widely dilated 1-D convolution becomes one 1x1 convolution per tap, summed
+-- the onnxsim-core counterpart of ``scripts/axera/legalize.py``'s
+``dilated_conv_to_taps`` rule (see ``tests/test_axera_legalize.py``'s own
+``test_dilated_conv_becomes_one_convolution_per_tap`` for that rule's
+Pulsar2 motivation). Usable from any binding via
+``extra_optimizers=["dilated_conv_to_taps"]``.
+
+Models are built with ``onnx.parser`` per CLAUDE.md's convention; the
+convolution weight/bias are numpy-built ``numpy_helper.from_array``
+initializers attached after parsing, per CLAUDE.md's guidance for
+random/deterministic weight arrays.
+"""
+
+import numpy as np
+import pytest
+from onnx import numpy_helper, parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=17, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _dilated_conv_model(pads, dilation, k=3, c=4, length=16, with_bias=True):
+    w = numpy_helper.from_array(
+        np.random.RandomState(0).randn(c, c, k).astype(np.float32), "w"
+    )
+    out_len = length + pads[0] + pads[1] - ((k - 1) * dilation + 1) + 1
+    initializer = [w]
+    inputs = "x, w, b" if with_bias else "x, w"
+    if with_bias:
+        b = numpy_helper.from_array(
+            np.random.RandomState(1).randn(c).astype(np.float32), "b"
+        )
+        initializer.append(b)
+    return _model(
+        f"""
+        g (float[1,{c},{length}] x) => (float[1,{c},{out_len}] y)
+        {{
+          y = Conv<kernel_shape=[{k}], pads=[{pads[0]},{pads[1]}],
+                   dilations=[{dilation}], strides=[1]>({inputs})
+        }}
+        """,
+        initializer=initializer,
+    )
+
+
+@pytest.mark.parametrize("pads,dilation", [((4, 0), 2), ((2, 2), 2), ((0, 0), 3)])
+def test_dilated_conv_becomes_one_conv_per_tap_and_computes_the_same_thing(
+    pads, dilation
+):
+    model = _dilated_conv_model(pads, dilation)
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["dilated_conv_to_taps"])
+    assert ok
+    op_types = [n.op_type for n in sim_model.graph.node]
+    assert op_types.count("Conv") == 3
+    # A zero-valued Pad (the pads=(0, 0) case) is a genuine no-op, which
+    # onnxsim's own default `eliminate_nop_pad` pass removes as part of the
+    # same simplify() call -- expected, not this pass's own concern.
+    if any(pads):
+        assert "Pad" in op_types
+    assert "Slice" in op_types
+    for node in sim_model.graph.node:
+        if node.op_type == "Conv":
+            dilations = next(
+                (a.ints for a in node.attribute if a.name == "dilations"), [1]
+            )
+            assert list(dilations) == [1]
+
+    x = np.random.RandomState(2).randn(1, 4, 16).astype(np.float32)
+    (before,) = _run(model, {"x": x})
+    (after,) = _run(sim_model, {"x": x})
+    assert np.allclose(before, after, atol=1e-4), np.abs(before - after).max()
+
+
+def test_bias_is_added_exactly_once():
+    """Splitting a Conv with a bias into per-tap Convs must add the bias
+    input to exactly one tap -- adding it to every tap would multiply it by
+    the number of taps once the partials are summed."""
+    model = _dilated_conv_model((4, 0), 2, with_bias=True)
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["dilated_conv_to_taps"])
+    assert ok
+    convs_with_bias = sum(
+        1 for n in sim_model.graph.node if n.op_type == "Conv" and len(n.input) == 3
+    )
+    assert convs_with_bias == 1
+
+    x = np.random.RandomState(3).randn(1, 4, 16).astype(np.float32)
+    (before,) = _run(model, {"x": x})
+    (after,) = _run(sim_model, {"x": x})
+    assert np.allclose(before, after, atol=1e-4), np.abs(before - after).max()
+
+
+def test_low_dilation_is_left_alone():
+    """`min_dilation` is 2 -- an ordinary (dilation=1) Conv has nothing to
+    gain from this rewrite and must be left untouched."""
+    model = _dilated_conv_model((1, 1), 1)
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["dilated_conv_to_taps"])
+    assert ok
+    assert [n.op_type for n in sim_model.graph.node] == ["Conv"]
+
+
+def test_grouped_conv_is_left_alone():
+    """The rewrite reads the weight as [Cout, Cin, taps] and slices the
+    *input* channel-wise -- wrong for `group > 1`, whose weight is
+    [Cout, Cin/groups, taps], so a grouped conv must be skipped."""
+    c = 4
+    k, dilation = 3, 2
+    w = numpy_helper.from_array(
+        np.random.RandomState(0).randn(c, 1, k).astype(np.float32), "w"
+    )
+    model = _model(
+        f"""
+        g (float[1,{c},16] x) => (float[1,{c},12] y)
+        {{
+          y = Conv<kernel_shape=[{k}], pads=[0,0], dilations=[{dilation}],
+                   strides=[1], group={c}>(x, w)
+        }}
+        """,
+        initializer=[w],
+    )
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["dilated_conv_to_taps"])
+    assert ok
+    assert [n.op_type for n in sim_model.graph.node] == ["Conv"]
+
+
+def test_disabled_by_default():
+    """`dilated_conv_to_taps` is `PassType::Other`, so a plain `simplify()`
+    call (no `extra_optimizers`) must leave a dilated Conv alone."""
+    model = _dilated_conv_model((4, 0), 2)
+    sim_model, ok = onnxsim.simplify(model)
+    assert ok
+    assert [n.op_type for n in sim_model.graph.node] == ["Conv"]

--- a/tests/test_float16_to_float32.py
+++ b/tests/test_float16_to_float32.py
@@ -1,0 +1,159 @@
+"""Tests for the ``float16_to_float32`` C++ pass
+(onnxsim/passes/float16_to_float32.h).
+
+Retypes an all-float16 graph to float32 -- the onnxsim-core counterpart of
+``scripts/axera/legalize.py``'s ``float16_to_float32`` rule (see
+``tests/test_axera_legalize.py``'s own
+``test_float16_graph_is_retyped_everywhere_it_matters``, which this file's
+cases mirror at the C++-pass level). Usable from any binding via
+``extra_optimizers=["float16_to_float32"]``.
+
+Models are built with ``onnx.parser`` per CLAUDE.md's convention, except for
+the float16 tensor literals themselves -- the text format has no float16
+literal syntax, so those are built with ``numpy_helper.from_array`` and
+attached as initializers after parsing, also per CLAUDE.md.
+
+``onnxsim.simplify``'s own ``check_n`` correctness check compares the
+*converted* model against itself with the *same* feed dict -- no use here,
+since this pass changes the graph's own declared input/output dtype (float16
+-> float32), so the two models need differently-typed feeds. Numeric
+equivalence is instead checked by running both models through ONNX Runtime
+directly, each with its own correctly-typed input.
+"""
+
+import numpy as np
+import onnx
+import pytest
+from onnx import TensorProto, numpy_helper, parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=17, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _f16(array, name):
+    return numpy_helper.from_array(array.astype(np.float16), name)
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _chained_model():
+    """`y = (x + w) * w` in float16 throughout -- a couple of chained ops,
+    like quantize_fp16's own tests use, rather than one op in isolation."""
+    w = np.array([[1.5, -2.0, 0.25], [3.0, 0.5, -1.25]], np.float16)
+    return _model(
+        """
+        g (float16[2,3] x) => (float16[2,3] y)
+        {
+          s = Add(x, w)
+          y = Mul(s, w)
+        }
+        """,
+        initializer=[_f16(w, "w")],
+    )
+
+
+def test_float16_graph_becomes_float32_and_computes_close_to_the_same_thing():
+    model = _chained_model()
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["float16_to_float32"])
+    assert ok
+    assert sim_model.graph.input[0].type.tensor_type.elem_type == TensorProto.FLOAT
+    assert sim_model.graph.output[0].type.tensor_type.elem_type == TensorProto.FLOAT
+    for init in sim_model.graph.initializer:
+        assert init.data_type != TensorProto.FLOAT16
+    onnx.checker.check_model(sim_model)
+
+    x = np.random.RandomState(0).randn(2, 3).astype(np.float16)
+    (before,) = _run(model, {"x": x})
+    (after,) = _run(sim_model, {"x": x.astype(np.float32)})
+    # float16 has ~3 decimal digits of precision, and the converted graph
+    # computes in true float32 (a different rounding path than the
+    # original's float16 kernels), so this is a looser tolerance than an
+    # exact-conversion pass would need -- the same reasoning
+    # test_quantize_fp16.py's _assert_close uses for its own precision
+    # change, direction reversed.
+    assert np.allclose(
+        before.astype(np.float64), after.astype(np.float64), rtol=0.05, atol=0.05
+    ), np.abs(before.astype(np.float64) - after.astype(np.float64)).max()
+
+
+def test_float16_is_converted_wherever_it_is_stored():
+    """Constants live in three places -- initializers, a `Constant` node's
+    `value` attribute, and a `Cast`'s `to` attribute -- and converting only
+    one leaves a graph mixing precisions, which onnxruntime rejects
+    outright at load time (the same failure mode
+    ``test_axera_legalize.py``'s Python-level version of this rule exists
+    to prevent)."""
+    two = _f16(np.array(2.0, np.float16), "two")
+    model = _model(
+        """
+        g (float16[4] x) => (float16[4] y16)
+        {
+          c = Constant<value = float16[1] {3}>()
+          d = Mul(x, c)
+          e = Add(d, two)
+          y = Div(e, two)
+          y16 = Cast<to = 10>(y)
+        }
+        """,
+        initializer=[two],
+    )
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["float16_to_float32"])
+    assert ok
+
+    assert all(
+        init.data_type != TensorProto.FLOAT16 for init in sim_model.graph.initializer
+    )
+    for node in sim_model.graph.node:
+        for attr in node.attribute:
+            if attr.name == "value":
+                assert attr.t.data_type != TensorProto.FLOAT16
+            if node.op_type == "Cast" and attr.name == "to":
+                assert attr.i != TensorProto.FLOAT16
+    for value in list(sim_model.graph.input) + list(sim_model.graph.output):
+        assert value.type.tensor_type.elem_type != TensorProto.FLOAT16
+
+    # Loads under onnxruntime, which the half-converted graph would not.
+    ort.InferenceSession(
+        sim_model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+
+
+def test_float32_graph_is_left_alone():
+    model = _model(
+        """
+        g (float[2,3] x) => (float[2,3] y)
+        { y = Add(x, x) }
+        """
+    )
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["float16_to_float32"])
+    assert ok
+    assert sim_model.graph.input[0].type.tensor_type.elem_type == TensorProto.FLOAT
+
+
+def test_disabled_by_default():
+    """`float16_to_float32` is `PassType::Other`, so a plain `simplify()`
+    call (no `extra_optimizers`) must leave a float16 graph alone."""
+    model = _chained_model()
+    sim_model, ok = onnxsim.simplify(model)
+    assert ok
+    assert sim_model.graph.input[0].type.tensor_type.elem_type == TensorProto.FLOAT16

--- a/tests/test_rank0_to_rank1.py
+++ b/tests/test_rank0_to_rank1.py
@@ -1,0 +1,195 @@
+"""Tests for the ``rank0_to_rank1`` C++ pass
+(onnxsim/passes/rank0_to_rank1.h).
+
+Gives every rank-0 (scalar) graph output a trailing axis -- the onnxsim-core
+counterpart of ``scripts/axera/legalize.py``'s ``rank0_to_rank1`` rule (see
+``tests/test_axera_legalize.py`` for that rule's own Pulsar2-calibration
+motivation). Usable from any binding via
+``extra_optimizers=["rank0_to_rank1"]``.
+
+Models are built with ``onnx.parser`` per CLAUDE.md's convention, except for
+the rank-0 output's ``shape`` field, which the text format has no way to
+spell explicitly ("no shape" and "shape with zero dims" both parse the same
+way) -- ``ClearField``/an explicit empty ``dim`` list is set programmatically
+after parsing instead, per CLAUDE.md's documented exception for that case.
+"""
+
+import numpy as np
+import onnx
+import pytest
+from onnx import parser
+
+import onnxsim
+
+ort = pytest.importorskip("onnxruntime")
+
+
+def _model(body, initializer=(), opset=17, ir_version=10):
+    model = parser.parse_model(
+        f"""
+        <
+          ir_version: {ir_version},
+          opset_import: ["": {opset}]
+        >
+        {body}
+        """
+    )
+    model.graph.initializer.extend(initializer)
+    return model
+
+
+def _run(model, feeds):
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    return sess.run(None, feeds)
+
+
+def _mark_rank0(model, name):
+    """Declares `name` a rank-0 (scalar) value -- an explicit, zero-length
+    `shape` -- for whichever graph output already carries that name."""
+    for value in model.graph.output:
+        if value.name == name:
+            value.type.tensor_type.ClearField("shape")
+            value.type.tensor_type.shape.SetInParent()
+
+
+def test_reduce_mean_output_gets_keepdims_and_explicit_axes():
+    """The motivating case: a training loss, `ReduceMean` with no axes
+    named, over a graph output Pulsar2's calibration step cannot concatenate
+    at rank 0."""
+    model = _model(
+        """
+        g (float[2,3] x) => (float loss)
+        { loss = ReduceMean(x) }
+        """
+    )
+    _mark_rank0(model, "loss")
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["rank0_to_rank1"])
+    assert ok
+
+    out = sim_model.graph.output[0]
+    assert len(out.type.tensor_type.shape.dim) == 1
+    assert out.type.tensor_type.shape.dim[0].dim_value == 1
+
+    reduce = next(n for n in sim_model.graph.node if n.op_type == "ReduceMean")
+    keepdims = next(a.i for a in reduce.attribute if a.name == "keepdims")
+    assert keepdims == 1
+    axes_attr = next((a for a in reduce.attribute if a.name == "axes"), None)
+    if axes_attr is not None:
+        assert list(axes_attr.ints) == [0, 1]
+    else:
+        # opset >= 18: axes is reduce.input[1], a constant initializer.
+        axes_init = next(
+            i for i in sim_model.graph.initializer if i.name == reduce.input[1]
+        )
+        assert list(onnx.numpy_helper.to_array(axes_init)) == [0, 1]
+
+    x = np.random.RandomState(0).randn(2, 3).astype(np.float32)
+    (before,) = _run(model, {"x": x})
+    (after,) = _run(sim_model, {"x": x})
+    assert np.asarray(after).shape == (1,)
+    assert np.allclose(np.asarray(before).reshape(-1), np.asarray(after))
+
+
+def test_reduce_mean_output_gets_axes_as_input_at_opset18():
+    """`axes` moved from a Reduce* attribute to its second input at opset
+    18 -- the unnamed-axes case must add the right kind of value for the
+    graph's own opset, not always the attribute form."""
+    model = _model(
+        """
+        g (float[2,3] x) => (float loss)
+        { loss = ReduceMean(x) }
+        """,
+        opset=18,
+    )
+    _mark_rank0(model, "loss")
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["rank0_to_rank1"])
+    assert ok
+
+    reduce = next(n for n in sim_model.graph.node if n.op_type == "ReduceMean")
+    assert not any(a.name == "axes" for a in reduce.attribute)
+    assert len(reduce.input) == 2
+    axes_init = next(
+        i for i in sim_model.graph.initializer if i.name == reduce.input[1]
+    )
+    assert list(onnx.numpy_helper.to_array(axes_init)) == [0, 1]
+    keepdims = next(a.i for a in reduce.attribute if a.name == "keepdims")
+    assert keepdims == 1
+
+    x = np.random.RandomState(2).randn(2, 3).astype(np.float32)
+    (before,) = _run(model, {"x": x})
+    (after,) = _run(sim_model, {"x": x})
+    assert np.allclose(np.asarray(before).reshape(-1), np.asarray(after))
+
+
+def test_named_axes_are_left_alone():
+    """Only the *default* "reduce everything" case needs naming -- a
+    `ReduceMean` that already names its own axes must not be rewritten."""
+    model = _model(
+        """
+        g (float[2,3] x) => (float loss)
+        { loss = ReduceMean<axes=[0,1]>(x) }
+        """
+    )
+    _mark_rank0(model, "loss")
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["rank0_to_rank1"])
+    assert ok
+    reduce = next(n for n in sim_model.graph.node if n.op_type == "ReduceMean")
+    axes_attr = next(a for a in reduce.attribute if a.name == "axes")
+    assert list(axes_attr.ints) == [0, 1]
+
+
+def test_non_reduce_scalar_output_still_gets_reshaped():
+    """A scalar output from any other op is still wrapped in a `Reshape` to
+    `[1]` -- the keepdims/axes special-casing is Reduce*-only, but the rank
+    fix-up applies to every rank-0 output."""
+    model = _model(
+        """
+        g (float[2] x) => (float y)
+        {
+          a = ReduceSum<keepdims=0>(x)
+          b = ReduceSum<keepdims=0>(x)
+          y = Add(a, b)
+        }
+        """
+    )
+    _mark_rank0(model, "y")
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["rank0_to_rank1"])
+    assert ok
+    out = sim_model.graph.output[0]
+    assert len(out.type.tensor_type.shape.dim) == 1
+    assert out.type.tensor_type.shape.dim[0].dim_value == 1
+    assert any(n.op_type == "Reshape" for n in sim_model.graph.node)
+
+    x = np.random.RandomState(1).randn(2).astype(np.float32)
+    (before,) = _run(model, {"x": x})
+    (after,) = _run(sim_model, {"x": x})
+    assert np.allclose(np.asarray(before).reshape(-1), np.asarray(after))
+
+
+def test_rank1_output_is_left_alone():
+    model = _model(
+        """
+        g (float[2,3] x) => (float[3] y)
+        { y = ReduceMean<axes=[0], keepdims=0>(x) }
+        """
+    )
+    sim_model, ok = onnxsim.simplify(model, extra_optimizers=["rank0_to_rank1"])
+    assert ok
+    assert [n.op_type for n in sim_model.graph.node] == ["ReduceMean"]
+
+
+def test_disabled_by_default():
+    """`rank0_to_rank1` is `PassType::Other`, so a plain `simplify()` call
+    (no `extra_optimizers`) must leave a scalar output alone."""
+    model = _model(
+        """
+        g (float[2,3] x) => (float loss)
+        { loss = ReduceMean(x) }
+        """
+    )
+    _mark_rank0(model, "loss")
+    sim_model, ok = onnxsim.simplify(model)
+    assert ok
+    assert len(sim_model.graph.output[0].type.tensor_type.shape.dim) == 0


### PR DESCRIPTION
## Summary

Completes the promotable side of the legalize-to-onnxsim-core migration
(`docs/axera-legalize-onnxsim-core-migration.md`). These three
`scripts/axera/legalize.py` rules were classified "promotable" in that
doc but left unported. This PR surveys onnxsim's C++ pass architecture
to check whether that was a real architectural gap or just a scheduling
one, finds real precedent for both shapes needed, and ports all three:

- **`float16_to_float32`** (`onnxsim/passes/float16_to_float32.h`) --
  retypes an all-float16 graph to float32 throughout (initializers,
  `Constant` values, `Cast` targets, every `Value`'s own elemType). A
  `FullGraphBasedPass`, closely mirroring `quantize_fp16.h`'s own
  whole-graph retype (direction reversed).
- **`dilated_conv_to_taps`** (`onnxsim/passes/dilated_conv_to_taps.h`) --
  a widely dilated 1-D convolution becomes one 1x1 convolution per tap,
  summed. A `PredicateBasedPass`, following
  `rewrite_deform_conv_to_gather.h`'s own precedent for "one node becomes
  many" via `graph.create()`/`insertBefore()`.
- **`rank0_to_rank1`** (`onnxsim/passes/rank0_to_rank1.h`) -- gives every
  rank-0 (scalar) graph output a trailing axis, fixing up a producing
  `Reduce*`'s `keepdims`/`axes` when applicable. A `FullGraphBasedPass`,
  driven by the graph's own output list rather than a node pattern.

**The architectural finding**: nothing here needed new C++ infrastructure.
`PredicateBasedPass`'s `runTransform` already receives the whole `Graph&`
(not just the matched node), and `FullGraphBasedPass` ("the most general
pass ... given only a graph") already existed and was already used by
`quantize_fp16.h`/`quantize_fp8.h`/`quantize_bf16.h`/`magnitude_pruning.h`
before this PR touched anything. See the doc's new "An architecture note
this survey exists to settle" section for the full writeup.

Each pass is registered in `custom_optimizer_passes.cpp`, usable from any
binding via `onnxsim.simplify(model, extra_optimizers=["<name>"])`, and
cross-referenced from `scripts/axera/legalize.py`'s own docstring -- the
vendor Python implementations stay unchanged, for standalone (no onnxsim
build) usage, matching this migration's established dual-implementation
convention.

Note: `pow2_to_mul`/`explicit_conv_padding` (the other two "promotable"
rules) are already ported on a separate, still-open PR (#1378,
`axera-legalize-more-rules`) that this branch does not depend on or
duplicate.

## Test plan

- [x] New C++ passes build cleanly (`pip install --no-build-isolation -e .`,
      ~25s incremental, in a fresh worktree off `origin/master`)
- [x] `tests/test_float16_to_float32.py` (4 cases), `tests/test_rank0_to_rank1.py`
      (6 cases, both Reduce-axes-as-attribute and axes-as-input/opset>=18
      forms), `tests/test_dilated_conv_to_taps.py` (7 cases: three
      dilation/padding combinations verified numerically against the
      pre-rewrite graph via onnxruntime, bias-added-exactly-once, low-dilation
      and grouped-conv skip cases, disabled-by-default) -- all new, all pass
- [x] Full relevant regression set (`tests/test_axera_legalize.py` and 9
      related files): 100 passed
- [x] `ruff format`/`ruff check` clean on touched Python; `clang-format` clean
      on all new/touched C++

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W