### PR TITLE
graph_grad: Where/IsNaN backward rules, unblocking wav2vec2 attention output

### DIFF
--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -72,7 +72,7 @@ simple. `Erf` is GELU's decomposed form -- `transformers`' export already
 emits the Erf-based GELU here, not the fused `Gelu` op, so the Gelu gap above
 does not block this model in practice.
 
-### wav2vec2 -- one gap, now confirmed real (not "maybe")
+### wav2vec2 -- one gap, confirmed real and now fixed
 
 `transformers.Wav2Vec2Model(...)`, 228 nodes:
 
@@ -102,15 +102,45 @@ projection) needs a gradient through its own layer's `Where`, because that
 `Where`'s input and output are both fresh intermediates computed inside that
 layer -- unlike an external bias tensor merely *added* to the scores, there
 is nothing outside the layer to treat as an opaque boundary input instead.
-**wav2vec2 (the plain, non-Conformer model) cannot train through any tail
-that includes attention output until `Where` has a backward rule.** That
-rule is not hard -- `Where`'s gradient is `dX = mask * g`, `dY = (1-mask) *
-g` with `mask = Cast(condition, FLOAT)`, i.e. the same "boolean condition
+**wav2vec2 (the plain, non-Conformer model) could not train through any
+tail that includes attention output until `Where` had a backward rule --
+and now it can.** `Where`'s gradient is `dX = mask * g`, `dY = (1-mask) *
+g` with `mask = Cast(condition, FLOAT)`, the same "boolean condition
 becomes a float 0/1 multiplied in, never re-emitted as `Where` itself"
 convention `graph_grad`'s own module docstring already states as a rule for
-every hand-written gradient here -- but it is real, unimplemented work, not
-a design workaround. Left for the next person who wants wav2vec2 itself
-(Whisper, below, remains gap-free and is still the better first trial).
+every hand-written gradient here, and it is now `onnxsim.graph_grad`'s
+`_grad_where`. `IsNaN` itself got a companion rule (`_grad_is_nan`,
+returning no gradient) for a narrower but load-bearing reason: this
+per-layer guard sits *inline* in the forward slice between `Softmax` and
+`Where`, and `build_backward` requires a registered rule for every node
+type it walks -- including one no gradient reaches -- not just the ones a
+seed actually flows through, so differentiating a slice containing
+`IsNaN(attn_weights)` raised `UnsupportedOpError` even though nothing ever
+needed its own gradient.
+
+Both rules live in a new `_PYTHON_ONLY_RULES` table (not `_RULES`): neither
+has a C++/WASM mirror yet, so folding them into the parity-pinned
+`SUPPORTED_OPS` `tests/test_qat_parity.py` checks against `qat_entry.cpp`
+would be a claim about the browser path that is not yet true. They *are*
+picked up automatically by every ordinary `build_backward(..., rules=None)`
+call and are visible through `graph_grad.supported_ops()`, so QAT/LoRA
+block discovery already treats a block containing them as differentiable --
+see `_PYTHON_ONLY_RULES`'s own comment in `onnxsim/graph_grad.py` for the
+full rationale, which mirrors `_grad_split`'s pre-existing
+`_MULTI_OUTPUT_RULES` precedent for the same "real rule, no C++ port yet"
+situation.
+
+**Not yet done:** an actual trainable tail spanning wav2vec2's attention
+output, built and verified on real AX650N hardware -- every wav2vec2 build
+script in `scripts/axera/` today (`build_w2v2_feature_extractor_step.py`,
+`build_w2v2fe_batch_calib.py`) still only trains the convolutional feature
+extractor, which never touches this `Where`. The backward rule itself is
+tested against finite differences on host
+(`tests/test_graph_grad.py`'s `where_branch_select`, `where_broadcasts_x`,
+and `where_isnan_guard` cases -- the last one mirroring this exact
+`Where(IsNaN(x), 0, x)` shape), but building the encoder-with-attention step
+graph, calibrating it, and confirming it compiles and trains on the card is
+real, separate, next work.
 
 ### Wav2Vec2-Conformer -- both gaps closed; one different, unresolved question
 
@@ -197,7 +227,7 @@ needs its own trace, not an inference from wav2vec2's). Flagged, not closed.
 | --- | --- | --- | --- |
 | Grouped/depthwise `Conv` has no forward-legalization path | **fixed** (`scripts/axera/legalize.py`'s `act_weight_conv_to_matmul`) | was: Conformer's `conv_module` | per-group tap-matmul + `Concat` back onto `Cout`, `group=1` path untouched |
 | `Split` has no backward rule | **fixed** (`onnxsim/graph_grad.py`'s `_grad_split`, via the new `_MULTI_OUTPUT_RULES` table) | was: Conformer's GLU gating | `MatMul` against a constant 0/1 selection matrix per output, no `Concat`, stays inside `BACKWARD_OPS` |
-| `Where`/`IsNaN` numerical-stability cleanup has no backward rule | **confirmed blocking**, not a design workaround | plain wav2vec2, any tail touching attention output -- Conformer's own (differently-shaped) `Where` usage is still unresolved | `dX = Cast(cond, FLOAT) * g`, `dY = (1 - that) * g` -- same "float mask, not `Where` itself" convention this module already uses everywhere else; not yet implemented |
+| `Where`/`IsNaN` numerical-stability cleanup has no backward rule | **fixed** (`onnxsim/graph_grad.py`'s `_grad_where`/`_grad_is_nan`, via the new `_PYTHON_ONLY_RULES` table) | was: plain wav2vec2, any tail touching attention output -- Conformer's own (differently-shaped) `Where` usage is a separate, still-open question (see below) | `dX = Cast(cond, FLOAT) * g`, `dY = (1 - that) * g` -- same "float mask, not `Where` itself" convention this module already uses everywhere else; `IsNaN` itself gets a no-gradient rule so `build_backward` can walk over it inline |
 | Raw `Gelu` has no backward rule | open, low priority | only an exporter emitting fused `Gelu` instead of decomposed Erf-GELU (neither Whisper's nor wav2vec2's `transformers` export does this) | a `legalize.py` rule decomposing `Gelu` into `Mul`/`Add`/`Erf`/`Div`-by-constant, all already covered |
 | LSTM/GRU have no backward rule at all, and the real ONNX op is opaque (no legalization route around it) | open, largest lift | any classic RNN-based ASR/TTS model, full stop | a dedicated LSTM-cell backward rule (the four gates are themselves ordinary `MatMul`/`Sigmoid`/`Tanh` arithmetic once unrolled) or accepting only models that unroll their own recurrence in ONNX |
 
@@ -237,21 +267,22 @@ fixed-length input (no attention-mask handling at all) that sidesteps every
 `Where`-shaped question this survey has now spent real effort on for the
 other two families.
 
-The ranking below it changed. Wav2Vec2-Conformer's conv-module gaps
-(depthwise `Conv`, `Split`) are now **closed** -- it is Conformer's
-still-open, differently-shaped `Where` question (see above) that gates it
-next, not the conv-module work this pass finished. Plain wav2vec2 dropped
-from "second choice, likely fine" to **blocked**: its `Where`/`IsNaN`
-numerical-stability cleanup is confirmed to sit inside every encoder layer's
-own attention computation with no external tensor to route a trainable
-tail's boundary around, so it needs `Where`'s backward rule implemented
-before any tail including attention output can train, not just a careful
-choice of trainable region. Concretely, after Whisper: either implement
-`Where`'s backward rule (unblocks wav2vec2 outright, and is the same
-"boolean condition, not the op, becomes a float mask" work either way) or
-trace Conformer's shared-condition `Where` end-to-end to confirm it is
-excludable by block boundary (cheaper if it pans out, but unproven, and
-resolves only Conformer -- `Where`'s backward rule resolves both).
+The ranking below it changed twice now. Wav2Vec2-Conformer's conv-module
+gaps (depthwise `Conv`, `Split`) are **closed**, and plain wav2vec2's own
+`Where`/`IsNaN` block is now **closed too** -- `onnxsim.graph_grad._grad_where`/
+`_grad_is_nan` (see the wav2vec2 section above) give both `Where`'s
+numerical-stability guard and Conformer's shared-condition `Where` a real
+backward rule, generically, regardless of which shape either usage takes.
+What is left is not implementing the rule (done) but *using* it: no
+`scripts/axera/` build script has yet built a wav2vec2 (or Conformer) step
+graph whose trainable tail spans attention output, so the concrete next
+step is that build-and-verify-on-hardware work, not further `graph_grad`
+coverage. Conformer's own shared-condition `Where` (see above) still has a
+narrower, separate open question -- whether its condition is in practice
+excludable by a careful block boundary, cheaper than differentiating
+through it at all -- but that is now an optimization question, not a
+blocker, since the rule handles either shape correctly if the boundary
+question is left unanswered.
 
 ## Reproducing the exports
 

--- a/onnxsim/graph_grad.py
+++ b/onnxsim/graph_grad.py
@@ -1711,6 +1711,45 @@ def _grad_clip(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[st
     return [ctx.b.mul(g, mask)] + rest
 
 
+def _grad_where(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    """``Y = Where(cond, X, Z)`` selects ``X`` where ``cond`` is true and
+    ``Z`` otherwise, elementwise, with all three inputs broadcasting together
+    against the output.
+
+    ``cond`` never gets a gradient -- it is a boolean, not a function of
+    anything float, the same "no gradient for a shape/axes/indices operand"
+    convention ``Reshape``/``Gather``/``Split`` already follow here. The
+    incoming gradient is *split* between the two branches by a float 0/1
+    mask built from ``cond`` with ``Cast`` -- not re-emitted as another
+    ``Where``, which is deliberately absent from :data:`BACKWARD_OPS` (see
+    that set's own comment): this rule only ever emits ``Cast``/``Sub``/
+    ``Mul``, all three already in it.
+    """
+    cond, x, z = node.input
+    out = ctx.shape(node.output[0])
+    mask = ctx.b.op("Cast", [cond], to=onnx.TensorProto.FLOAT)
+    not_mask = ctx.b.sub(ctx.b.const(1.0), mask)
+    dx = ctx.reduce_to(ctx.b.mul(g, mask), out, ctx.shape(x))
+    dz = ctx.reduce_to(ctx.b.mul(g, not_mask), out, ctx.shape(z))
+    return [None, dx, dz]
+
+
+def _grad_is_nan(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    """``IsNaN`` produces a boolean and has no gradient of its own -- in
+    every real graph this rule exists for, its only consumer is a
+    ``Where``'s ``cond`` input, which itself takes no gradient either.
+
+    This rule's whole job is letting :func:`build_backward` walk over an
+    ``IsNaN`` node in a differentiated slice at all: that function requires
+    a registered rule for *every* node type it visits, including one no
+    gradient reaches (see its own docstring), so a numerical-stability guard
+    like ``attn = Where(IsNaN(attn), 0, attn)`` sitting inline in a forward
+    slice would otherwise raise :class:`UnsupportedOpError` even though
+    nothing downstream ever asks this node for a gradient.
+    """
+    return [None]
+
+
 def _grad_gather(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
     """``Gather``'s gradient: a scatter-add into ``data``, ``indices`` itself
     untouched.
@@ -2103,6 +2142,26 @@ _RULES: Dict[str, Rule] = {
     "Transpose": _grad_transpose,
 }
 
+#: Single-output rules kept out of :data:`_RULES` for the same reason
+#: :data:`_MULTI_OUTPUT_RULES` is its own table (see that table's own
+#: comment): an op registered here has **no C++/WASM mirror** yet, so
+#: folding it into :data:`_RULES` would silently widen the parity-pinned
+#: :data:`SUPPORTED_OPS` that ``tests/test_qat_parity.py`` checks against
+#: ``qat_entry.cpp``'s hardcoded C++ rule table. Unlike
+#: :data:`_MULTI_OUTPUT_RULES`, every rule here is an ordinary
+#: single-``g`` :data:`Rule` -- ``Where``/``IsNaN`` (numerical-stability
+#: masking in wav2vec2's own attention output, see
+#: ``docs/axera-audio-speech-op-coverage.md``) each have exactly one output
+#: -- so the *only* reason they are not simply in :data:`_RULES` is the
+#: missing C++ port, not a signature mismatch. :func:`build_backward` merges
+#: this table into its default rule set right alongside :data:`_CUSTOM_RULES`,
+#: and :func:`supported_ops` includes it, so QAT/LoRA block discovery
+#: correctly treats a block containing ``Where``/``IsNaN`` as differentiable.
+_PYTHON_ONLY_RULES: Dict[str, Rule] = {
+    "IsNaN": _grad_is_nan,
+    "Where": _grad_where,
+}
+
 # The op types :func:`build_backward` can differentiate. Callers that pick
 # the slice themselves -- block discovery for QAT, say -- should test against
 # this rather than rediscovering the list by catching
@@ -2129,12 +2188,19 @@ _CUSTOM_RULES: Dict[str, Rule] = {}
 
 
 def supported_ops() -> frozenset:
-    """:data:`SUPPORTED_OPS` (the builtin single-output rules) unioned with
-    every op type currently registered via :func:`register_gradient` and
-    every op type in :data:`_MULTI_OUTPUT_RULES` (``Split`` today). This is
-    the set :func:`build_backward` (called the ordinary way, with
-    ``rules=None``) can actually differentiate right now."""
-    return SUPPORTED_OPS | frozenset(_CUSTOM_RULES) | frozenset(_MULTI_OUTPUT_RULES)
+    """:data:`SUPPORTED_OPS` (the builtin, parity-pinned single-output rules)
+    unioned with every op type currently registered via
+    :func:`register_gradient`, every op type in :data:`_MULTI_OUTPUT_RULES`
+    (``Split`` today), and every op type in :data:`_PYTHON_ONLY_RULES`
+    (``IsNaN``/``Where`` today). This is the set :func:`build_backward`
+    (called the ordinary way, with ``rules=None``) can actually
+    differentiate right now."""
+    return (
+        SUPPORTED_OPS
+        | frozenset(_CUSTOM_RULES)
+        | frozenset(_MULTI_OUTPUT_RULES)
+        | frozenset(_PYTHON_ONLY_RULES)
+    )
 
 
 def register_gradient(
@@ -2203,6 +2269,12 @@ def register_gradient(
                     "override=True to replace it (this affects Python-side "
                     "differentiation only -- see register_gradient's own "
                     "docstring for the C++/WASM divergence that implies)"
+                )
+            if op_type in _PYTHON_ONLY_RULES:
+                raise ValueError(
+                    f"{op_type!r} already has a builtin (Python-only) "
+                    "gradient rule; pass override=True to replace it (this "
+                    "affects Python-side differentiation only)"
                 )
             if op_type in _CUSTOM_RULES:
                 raise ValueError(
@@ -2323,7 +2395,9 @@ def build_backward(
             relationship :func:`torch.autograd.Function.backward` has to a
             custom torch op.
     """
-    rules = dict(_RULES, **_CUSTOM_RULES) if rules is None else rules
+    rules = (
+        dict(_RULES, **_PYTHON_ONLY_RULES, **_CUSTOM_RULES) if rules is None else rules
+    )
     ctx = _Backward(b, shapes)
     grads: Dict[str, str] = dict(grad_outputs)
 

--- a/tests/test_graph_grad.py
+++ b/tests/test_graph_grad.py
@@ -1009,6 +1009,62 @@ _CASES = {
         """,
         None,
     ),
+    # `Where`/`IsNaN` are `_PYTHON_ONLY_RULES` (no C++/WASM mirror, see that
+    # table's own comment) rather than `_RULES` -- otherwise ordinary
+    # single-output rules, tested the same way every other rule here is.
+    #
+    # `cond` is spelled as a plain `bool` initializer (ONNX text format
+    # supports the dtype directly), never a graph input: a `Where` whose
+    # condition depends on the very value being perturbed would put the
+    # decision boundary itself in the differentiated path, which is not what
+    # this rule's gradient (a *fixed* mask multiplied in) means to test --
+    # `docs/axera-audio-speech-op-coverage.md`'s wav2vec2 finding this rule
+    # exists for is exactly this shape: a condition computed once, reused as
+    # a constant selector against the branch tensors.
+    "where_branch_select": (
+        """
+        g (float[3,4] X, float[3,4] Y) => (float[3,4] Out)
+        <bool[3,4] cond = {1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0}>
+        {
+          Out = Where(cond, X, Y)
+        }
+        """,
+        None,
+    ),
+    # `X` is narrower than the output and `cond`/`Y`; the rule's dX has to
+    # reduce back down through the broadcast the same way `_grad_add`'s does,
+    # not just multiply-by-mask and stop.
+    "where_broadcasts_x": (
+        """
+        g (float[4] X, float[3,4] Y) => (float[3,4] Out)
+        <bool[4] cond = {1, 0, 1, 0}>
+        {
+          Out = Where(cond, X, Y)
+        }
+        """,
+        None,
+    ),
+    # The real shape this pair of rules exists for (see
+    # `docs/axera-audio-speech-op-coverage.md`'s wav2vec2 finding):
+    # numerical-stability cleanup sitting inline in a forward slice,
+    # `Y = Where(IsNaN(X), 0, X)`. `X` is ordinary random data and so never
+    # actually NaN, which is the point of this case -- it exercises
+    # `build_backward` walking over a live `IsNaN` node whose own gradient
+    # nothing needs (only `_grad_is_nan`'s existence, not its body, is
+    # actually load-bearing here), while confirming the always-taken `Y`
+    # branch still gets exactly `dOut` through, i.e. this guard is a no-op
+    # for well-formed data, the same property the real wav2vec2 graph needs.
+    "where_isnan_guard": (
+        """
+        g (float[3,4] X) => (float[3,4] Out)
+        <float zero = {0.0}>
+        {
+          nan_mask = IsNaN(X)
+          Out = Where(nan_mask, zero, X)
+        }
+        """,
+        None,
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- `docs/axera-audio-speech-op-coverage.md`'s coverage survey confirmed wav2vec2's per-layer `attn_weights = Where(IsNaN(attn_weights), 0, attn_weights)` numerical-stability guard sits inline between `Softmax` and the `V` projection in every encoder layer, blocking any trainable tail touching attention output — Conformer's own differently-shaped `Where` usage shares the gap.
- Adds `_grad_where` (`dX = mask*g`, `dY = (1-mask)*g`, `cond` gets no gradient) and `_grad_is_nan` (no gradient; exists so `build_backward` can walk over an inline `IsNaN` node whose own gradient nothing needs — it otherwise refuses regardless of demand).
- Both rules live in a new `_PYTHON_ONLY_RULES` table, mirroring `_MULTI_OUTPUT_RULES`'s existing "real rule, no C++/WASM mirror yet" precedent: picked up automatically by `build_backward`/`supported_ops()` without joining the parity-pinned `SUPPORTED_OPS` `tests/test_qat_parity.py` checks against the browser's C++ rule table.
- Updates the coverage doc's table row and wav2vec2 section from "confirmed blocking" to fixed, and notes what's still not done: an actual attention-output-spanning wav2vec2 step graph built and verified on real AX650N hardware (every wav2vec2 build script today only trains the feature extractor, which never reaches this `Where`).

## Test plan
- [x] `tests/test_graph_grad.py`: 3 new finite-difference cases (`where_branch_select`, `where_broadcasts_x`, `where_isnan_guard` — the last mirroring the real `Where(IsNaN(x), 0, x)` shape), plus the module's own operator-allowlist and unsupported-op tests, all passing (246 passed)
- [x] `tests/test_qat_parity.py` (Python<->C++ parity pin) still passes — confirms `SUPPORTED_OPS` is untouched
- [x] `tests/test_qat.py`, `tests/test_lora.py`, `tests/test_graph_grad_registry.py`, `tests/test_graph_grad_templates.py`, `tests/test_compile_training.py`, `tests/test_torch_training.py`, `tests/test_axera_legalize.py`, `tests/test_axera_training_legalize.py` all passing (no regressions)
- [x] `ruff check` clean on touched files
- [ ] Real-hardware wav2vec2 attention-output training — not attempted here, flagged as separate next work in the doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W