### PR TITLE
axera: a real LSTM test bed -- NVIDIA Parakeet's own RNN-T prediction network

### DIFF
--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -293,8 +293,8 @@ needs its own trace, not an inference from wav2vec2's). Flagged, not closed.
 | `Split` has no backward rule | **fixed** (`onnxsim/graph_grad.py`'s `_grad_split`, via the new `_MULTI_OUTPUT_RULES` table) | was: Conformer's GLU gating | `MatMul` against a constant 0/1 selection matrix per output, no `Concat`, stays inside `BACKWARD_OPS` |
 | `Where`/`IsNaN` numerical-stability cleanup has no backward rule | **fixed** (`onnxsim/graph_grad.py`'s `_grad_where`/`_grad_is_nan`, via the new `_PYTHON_ONLY_RULES` table) | was: plain wav2vec2, any tail touching attention output -- Conformer's own (differently-shaped) `Where` usage is a separate, still-open question (see below) | `dX = Cast(cond, FLOAT) * g`, `dY = (1 - that) * g` -- same "float mask, not `Where` itself" convention this module already uses everywhere else; `IsNaN` itself gets a no-gradient rule so `build_backward` can walk over it inline |
 | Raw `Gelu` has no backward rule | open, low priority | only an exporter emitting fused `Gelu` instead of decomposed Erf-GELU (neither Whisper's nor wav2vec2's `transformers` export does this) | a `legalize.py` rule decomposing `Gelu` into `Mul`/`Add`/`Erf`/`Div`-by-constant, all already covered |
-| `LSTM` has no backward rule; NPU-executable otherwise | open, largest lift, **real test bed now found** | any classic RNN-based ASR model, full stop | a dedicated LSTM-cell backward rule (the four gates are themselves ordinary `MatMul`/`Sigmoid`/`Tanh` arithmetic once unrolled) or accepting only models that unroll their own recurrence in ONNX |
-| `GRU` has no backward rule *and* is not NPU-executable at all | open, stricter than `LSTM`, **real test bed now found** | any classic RNN-based TTS/vocoder model | needs Pulsar2 to support `GRU` on-device first (closed-source, not fixable from this project's side) -- a backward rule alone would not be enough |
+| `LSTM` has no backward rule; NPU-executable otherwise | **fixed** (`scripts/axera/legalize.py`'s `unroll_lstm`) | was: any classic RNN-based ASR model | unrolled into its own per-timestep `MatMul`/`Sigmoid`/`Tanh`/`Mul`/`Add`/`Concat` gate arithmetic, every op already covered on both axes |
+| `GRU` has no backward rule *and* is not NPU-executable at all | **fixed** (`scripts/axera/legalize.py`'s `unroll_gru`) | was: any classic RNN-based TTS/vocoder model | same unroll as `LSTM`, and a strictly bigger win here: this is the only way a `GRU`-containing model runs on this hardware **at all**, training or not |
 
 ### A real LSTM test bed: NVIDIA Parakeet's own RNN-T prediction network
 
@@ -349,26 +349,93 @@ architecture**: unlike `LSTM` (NPU-executable, only missing a backward
 rule), **`GRU` is not in `AX650_SUPPORTED_OPS` at all** -- both real
 `GRU` nodes in this export are absent from *both* tables. This is a
 strictly bigger gap than LSTM's: a GRU-containing model cannot even *run*
-on this hardware at inference, before training enters the picture at all,
-so a GRU backward rule alone would not be enough to unblock WaveRNN --
-Pulsar2's own NPU backend would need to gain `GRU` support first, something
-outside this project's control (closed-source compiler, same class of
-limitation as `IsNaN`'s own missing frontend support, PR #1384). Every
-other op in the export is either already covered (`Conv`, `MatMul`, `Add`,
-`Gather`, `Identity`, `Relu`, `Reshape`, `Transpose`) or, again, harmless
-shape/indexing scaffolding (`Concat`/`Constant`/`Expand`/`Slice`/`Squeeze`/
-`Tile`/`Unsqueeze`/`Shape`) around the upsampling network feeding the GRU
-stack -- confirming the gap is scoped to `GRU` itself, not something this
-export incidentally also needs.
+on this hardware at inference, before training enters the picture at all.
+Every other op in the export is either already covered (`Conv`, `MatMul`,
+`Add`, `Gather`, `Identity`, `Relu`, `Reshape`, `Transpose`) or, again,
+harmless shape/indexing scaffolding (`Concat`/`Constant`/`Expand`/`Slice`/
+`Squeeze`/`Tile`/`Unsqueeze`/`Shape`) around the upsampling network feeding
+the GRU stack -- confirming the gap is scoped to `GRU` itself, not
+something this export incidentally also needs. (The WaveRNN export itself
+turned out to hit a separate, unrelated `torch.onnx` exporter bug at
+session -- an `Unsqueeze` axis miscomputation in `UpsampleNetwork`'s own
+export path, reproducible across every config size tried, on this
+torch/torchaudio version pairing -- so this op-coverage finding rests on
+static graph inspection (`onnx.checker` plus op-type enumeration), not a
+real onnxruntime execution of the *whole* WaveRNN graph; `unroll_gru`
+itself, below, is verified independently against a clean, executing
+`nn.GRU`-only export instead.)
 
-**Net for LSTM/GRU as a pair**: LSTM now has a real target model and only
-needs a backward rule (or an unroll route) to become trainable; GRU has a
-real target model too, but needs Pulsar2 to support the op on-device before
-a backward rule would even matter -- a strictly higher bar, and not
-something a legalization rule on this project's side can route around, the
-same "closed-source backend gap, not fixable from the ONNX side" verdict
-several other findings in this project (`IsNaN`, `output_data_type` on
-`MatMul`) already reached.
+### Both closed: `unroll_lstm`/`unroll_gru` legalize both ops into what the pipeline already covers
+
+The natural follow-up question once both gaps had real target models: is
+either op's math actually *reachable* with ops this pipeline already
+covers, the same way `act_weight_conv_to_matmul` routes a live-weight `Conv`
+into `MatMul`s? Both are. `LSTM`'s four gates and `GRU`'s three are each
+ordinary `Sigmoid`/`Tanh` activations over a sum of two `MatMul`s and a
+bias -- textbook, and every one of those op types was already confirmed
+covered on both axes (a `graph_grad` backward rule and NPU support) earlier
+in this doc. `scripts/axera/legalize.py`'s `unroll_lstm`/`unroll_gru`
+replace a forward, single-direction `LSTM`/`GRU` node with exactly that
+per-timestep arithmetic, verified numerically exact (float32 precision, not
+an approximation) three ways: against a hand-built native ONNX node,
+against a real `torch.onnx.export`-produced node with the module's own
+learned weights extracted directly from the graph, and end-to-end against
+the real Parakeet decoder probe above (`2.98e-8` max output difference
+after unrolling both of its LSTM layers).
+
+**Gate order and exact semantics were pinned down empirically, not assumed
+from the spec text** -- both operators' bias/gate layouts have real,
+easy-to-get-backwards subtleties (`LSTM`'s gate order is `i, o, f, c`, not
+PyTorch's own `i, f, g, o`; `GRU`'s `linear_before_reset=1` -- what
+`torch.onnx.export` always emits for `nn.GRU` -- applies the reset gate to
+`h @ Rh + Rbh` as a whole, not `(reset * h) @ Rh`, and an initial attempt
+assuming the opposite convention was off by up to `0.48` before the correct
+formula was found by testing every gate-order/reset-variant/update-variant
+combination against a real onnxruntime-executed native node). This is the
+same "checked directly, not derived from memory of the spec" discipline
+`docs/axera-on-device-training-handoff.md`'s ONNX `LSTM`/`GRU` gate-order
+notes elsewhere in this project already follow.
+
+**One real, separate gap this surfaced along the way**: differentiating
+through the unrolled `Y` (full sequence) output -- what both Parakeet's
+decoder and WaveRNN actually consume downstream, not just the final
+`Y_h`/`Y_c` state -- needs a gradient through the `Concat` that stacks each
+timestep's hidden state. `Concat` had no backward rule at all before this.
+Fixed as `onnxsim.graph_grad._grad_concat` (a new `_PYTHON_ONLY_RULES`
+entry, no C++/WASM mirror yet): one `Gather` per input, each pulling that
+input's own contiguous slice back out of the incoming gradient along the
+concat axis -- `Split`'s adjoint, reached a different way than
+`_grad_split`'s own selection-matrix `MatMul` (that rule's docstring
+explains why it couldn't reuse `Concat` for its own, opposite direction;
+`Gather` with a compile-time-constant, single-axis index range is squarely
+the shape of use this module's `BACKWARD_OPS` note already permits for
+`_grad_conv`'s own indexing, so nothing needed to be *added* to that
+allowlist). Verified against finite differences directly, and exercised
+end-to-end in `tests/test_axera_legalize.py`'s own differentiability test
+(`build_backward` reaching every one of an unrolled 2-layer LSTM's 8
+per-gate weight tensors through its stacked `Concat` output).
+
+**What actually gets trained changes.** `unroll_lstm`/`unroll_gru` split
+each op's packed `W`/`R` weight into one initializer per gate (four for
+LSTM, three for GRU) rather than leaving one packed tensor -- the same
+kind of topology change `act_weight_conv_to_matmul` already makes for a
+live-weight `Conv`. A resident training step built from an unrolled
+LSTM/GRU would train those per-gate tensors, not a single packed one; nothing
+downstream of this project's `build_resident_step()` convention currently
+teaches the trainable-weight finder to recognize the pre-split packed
+name, so this is host-verified only -- a real hardware run (compile,
+calibrate, train an unrolled decoder end to end) is the natural next step,
+not attempted here.
+
+**Net for LSTM/GRU as a pair**: both gaps are closed at the legalization
+level. `LSTM` needed only a backward rule's worth of arithmetic, already
+NPU-executable as the opaque op; `GRU`'s fix is the bigger win, since
+unrolling is now the *only* way a `GRU`-containing model runs on this
+hardware at all, sidestepping the "Pulsar2 itself would need to support the
+op" ceiling a native-op fix would have hit. Both are registered in
+`legalize.TRAINING_RULES`, running before `graph_grad.build_backward` sees
+the graph, the same slot `act_weight_conv_to_matmul` already occupies for
+its own live-weight rewrite.
 
 ## Do the two silent vendor bugs generalize?
 

--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -293,7 +293,8 @@ needs its own trace, not an inference from wav2vec2's). Flagged, not closed.
 | `Split` has no backward rule | **fixed** (`onnxsim/graph_grad.py`'s `_grad_split`, via the new `_MULTI_OUTPUT_RULES` table) | was: Conformer's GLU gating | `MatMul` against a constant 0/1 selection matrix per output, no `Concat`, stays inside `BACKWARD_OPS` |
 | `Where`/`IsNaN` numerical-stability cleanup has no backward rule | **fixed** (`onnxsim/graph_grad.py`'s `_grad_where`/`_grad_is_nan`, via the new `_PYTHON_ONLY_RULES` table) | was: plain wav2vec2, any tail touching attention output -- Conformer's own (differently-shaped) `Where` usage is a separate, still-open question (see below) | `dX = Cast(cond, FLOAT) * g`, `dY = (1 - that) * g` -- same "float mask, not `Where` itself" convention this module already uses everywhere else; `IsNaN` itself gets a no-gradient rule so `build_backward` can walk over it inline |
 | Raw `Gelu` has no backward rule | open, low priority | only an exporter emitting fused `Gelu` instead of decomposed Erf-GELU (neither Whisper's nor wav2vec2's `transformers` export does this) | a `legalize.py` rule decomposing `Gelu` into `Mul`/`Add`/`Erf`/`Div`-by-constant, all already covered |
-| LSTM/GRU have no backward rule at all, and the real ONNX op is opaque (no legalization route around it) | open, largest lift, **real test bed now found** | any classic RNN-based ASR/TTS model, full stop | a dedicated LSTM-cell backward rule (the four gates are themselves ordinary `MatMul`/`Sigmoid`/`Tanh` arithmetic once unrolled) or accepting only models that unroll their own recurrence in ONNX |
+| `LSTM` has no backward rule; NPU-executable otherwise | open, largest lift, **real test bed now found** | any classic RNN-based ASR model, full stop | a dedicated LSTM-cell backward rule (the four gates are themselves ordinary `MatMul`/`Sigmoid`/`Tanh` arithmetic once unrolled) or accepting only models that unroll their own recurrence in ONNX |
+| `GRU` has no backward rule *and* is not NPU-executable at all | open, stricter than `LSTM`, **real test bed now found** | any classic RNN-based TTS/vocoder model | needs Pulsar2 to support `GRU` on-device first (closed-source, not fixable from this project's side) -- a backward rule alone would not be enough |
 
 ### A real LSTM test bed: NVIDIA Parakeet's own RNN-T prediction network
 
@@ -326,14 +327,48 @@ concrete real target the "open, largest lift" row above needed -- an actual
 LSTM-cell backward rule (or an unroll-based legalization route) can now be
 tested against a real published model, not just a hand-built probe.
 
-No real GRU-based architecture was found in an already-installed package
-(`transformers` has zero `nn.GRU` usage anywhere in its model zoo;
-`torchaudio`/`silero-vad`'s own GRU-based VAD model ships as a pretrained
-JIT/ONNX artifact requiring `torchaudio`, not a config-driven module fitting
-this project's tiny-random-init-export convention) -- lower priority than
-LSTM here regardless, since `nn.GRU` is structurally the same "opaque
-recurrent op, no legalization route" story and no current target model in
-this project's scope needs one.
+### A real GRU test bed too: DeepMind's WaveRNN vocoder -- a stricter gap than LSTM
+
+`transformers` has zero `nn.GRU` usage anywhere in its model zoo, and
+`silero-vad` (initially assumed to be GRU-based from its public reputation)
+turned out to use `nn.LSTMCell` in its current release, not `nn.GRU` --
+checked directly by loading it (`pip install torchaudio silero-vad`,
+`silero_vad.load_silero_vad(onnx=False)`, then inspecting the loaded
+`RecursiveScriptModule`'s printed module tree). `torchaudio.models.WaveRNN`
+is the real find: DeepMind's own WaveRNN vocoder ("Efficient Neural Audio
+Synthesis") has two real `nn.GRU` layers (`self.rnn1`, `self.rnn2` in
+`torchaudio/models/wavernn.py`) driving its autoregressive sample
+generation, with an ordinary config-driven constructor (`upsample_scales`,
+`n_rnn`, `n_freq`, ... all plain ints, no pretrained weights needed).
+`scripts/axera/build_wavernn_gru_probe.py` exports it at a tiny config
+(`n_rnn=16`, `n_freq=8`, `upsample_scales=[2, 2]`) the same way the LSTM
+probe above does.
+
+**A real, previously-only-assumed finding, now confirmed on a published
+architecture**: unlike `LSTM` (NPU-executable, only missing a backward
+rule), **`GRU` is not in `AX650_SUPPORTED_OPS` at all** -- both real
+`GRU` nodes in this export are absent from *both* tables. This is a
+strictly bigger gap than LSTM's: a GRU-containing model cannot even *run*
+on this hardware at inference, before training enters the picture at all,
+so a GRU backward rule alone would not be enough to unblock WaveRNN --
+Pulsar2's own NPU backend would need to gain `GRU` support first, something
+outside this project's control (closed-source compiler, same class of
+limitation as `IsNaN`'s own missing frontend support, PR #1384). Every
+other op in the export is either already covered (`Conv`, `MatMul`, `Add`,
+`Gather`, `Identity`, `Relu`, `Reshape`, `Transpose`) or, again, harmless
+shape/indexing scaffolding (`Concat`/`Constant`/`Expand`/`Slice`/`Squeeze`/
+`Tile`/`Unsqueeze`/`Shape`) around the upsampling network feeding the GRU
+stack -- confirming the gap is scoped to `GRU` itself, not something this
+export incidentally also needs.
+
+**Net for LSTM/GRU as a pair**: LSTM now has a real target model and only
+needs a backward rule (or an unroll route) to become trainable; GRU has a
+real target model too, but needs Pulsar2 to support the op on-device before
+a backward rule would even matter -- a strictly higher bar, and not
+something a legalization rule on this project's side can route around, the
+same "closed-source backend gap, not fixable from the ONNX side" verdict
+several other findings in this project (`IsNaN`, `output_data_type` on
+`MatMul`) already reached.
 
 ## Do the two silent vendor bugs generalize?
 

--- a/docs/axera-audio-speech-op-coverage.md
+++ b/docs/axera-audio-speech-op-coverage.md
@@ -293,7 +293,47 @@ needs its own trace, not an inference from wav2vec2's). Flagged, not closed.
 | `Split` has no backward rule | **fixed** (`onnxsim/graph_grad.py`'s `_grad_split`, via the new `_MULTI_OUTPUT_RULES` table) | was: Conformer's GLU gating | `MatMul` against a constant 0/1 selection matrix per output, no `Concat`, stays inside `BACKWARD_OPS` |
 | `Where`/`IsNaN` numerical-stability cleanup has no backward rule | **fixed** (`onnxsim/graph_grad.py`'s `_grad_where`/`_grad_is_nan`, via the new `_PYTHON_ONLY_RULES` table) | was: plain wav2vec2, any tail touching attention output -- Conformer's own (differently-shaped) `Where` usage is a separate, still-open question (see below) | `dX = Cast(cond, FLOAT) * g`, `dY = (1 - that) * g` -- same "float mask, not `Where` itself" convention this module already uses everywhere else; `IsNaN` itself gets a no-gradient rule so `build_backward` can walk over it inline |
 | Raw `Gelu` has no backward rule | open, low priority | only an exporter emitting fused `Gelu` instead of decomposed Erf-GELU (neither Whisper's nor wav2vec2's `transformers` export does this) | a `legalize.py` rule decomposing `Gelu` into `Mul`/`Add`/`Erf`/`Div`-by-constant, all already covered |
-| LSTM/GRU have no backward rule at all, and the real ONNX op is opaque (no legalization route around it) | open, largest lift | any classic RNN-based ASR/TTS model, full stop | a dedicated LSTM-cell backward rule (the four gates are themselves ordinary `MatMul`/`Sigmoid`/`Tanh` arithmetic once unrolled) or accepting only models that unroll their own recurrence in ONNX |
+| LSTM/GRU have no backward rule at all, and the real ONNX op is opaque (no legalization route around it) | open, largest lift, **real test bed now found** | any classic RNN-based ASR/TTS model, full stop | a dedicated LSTM-cell backward rule (the four gates are themselves ordinary `MatMul`/`Sigmoid`/`Tanh` arithmetic once unrolled) or accepting only models that unroll their own recurrence in ONNX |
+
+### A real LSTM test bed: NVIDIA Parakeet's own RNN-T prediction network
+
+Every earlier LSTM check in this project used a synthetic `torch.nn.LSTM`
+wrapper -- real enough to confirm *the op itself* exports opaque, but not a
+published architecture. `transformers` (already this project's dependency
+for every other real-model export here) ships one:
+`transformers.models.parakeet.modeling_parakeet.ParakeetRNNTDecoder` is
+NVIDIA Parakeet's real RNN-Transducer "prediction network" -- a plain
+`nn.Embedding` -> 2-layer `nn.LSTM` -> `nn.Linear` decoder, no attention, no
+Conformer (that lives in the model's separate FastConformer encoder, not
+exported here). `scripts/axera/build_parakeet_lstm_probe.py` exports it at a
+tiny config (`vocab_size=64`, `decoder_hidden_size=32`,
+`num_decoder_layers=2`) and cross-references every resulting op type against
+`onnxsim.graph_grad`'s rule tables and `scripts/axera/pulsar2_ops.py`'s
+`AX650_SUPPORTED_OPS`, the same two tables this doc's whole survey uses.
+
+**Confirms the synthetic finding on a real architecture**: the 2-layer LSTM
+exports as **two separate opaque `LSTM` nodes** (one per layer, each with
+its own `hidden_size` attribute) -- both `LSTM`-typed nodes are in
+`AX650_SUPPORTED_OPS` (the NPU runs them fine at inference) and absent from
+every one of `graph_grad`'s rule tables (no backward rule), so
+`build_backward` cannot differentiate through either. Every other op in the
+export (`Gather`, `MatMul`, `Add`, `Transpose` have backward rules;
+`Concat`/`Constant`/`Expand`/`Squeeze`/`Unsqueeze`/`Shape` are pure
+shape/indexing plumbing around `h0`/`c0` initialization, not real
+weight-adjacent computation) is exactly the kind of scaffolding this
+project's other coverage checks have already found harmless. This is the
+concrete real target the "open, largest lift" row above needed -- an actual
+LSTM-cell backward rule (or an unroll-based legalization route) can now be
+tested against a real published model, not just a hand-built probe.
+
+No real GRU-based architecture was found in an already-installed package
+(`transformers` has zero `nn.GRU` usage anywhere in its model zoo;
+`torchaudio`/`silero-vad`'s own GRU-based VAD model ships as a pretrained
+JIT/ONNX artifact requiring `torchaudio`, not a config-driven module fitting
+this project's tiny-random-init-export convention) -- lower priority than
+LSTM here regardless, since `nn.GRU` is structurally the same "opaque
+recurrent op, no legalization route" story and no current target model in
+this project's scope needs one.
 
 ## Do the two silent vendor bugs generalize?
 

--- a/onnxsim/graph_grad.py
+++ b/onnxsim/graph_grad.py
@@ -1861,6 +1861,49 @@ def _grad_gather(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[
     return [ddata, None]
 
 
+def _grad_concat(ctx: _Backward, node: onnx.NodeProto, g: str) -> List[Optional[str]]:
+    """``Concat``'s gradient: one ``Gather`` per input, each pulling that
+    input's own contiguous slice of ``g`` back out along the concat axis --
+    exactly ``Split``'s adjoint (:func:`_grad_split`'s own docstring), just
+    reached a different way.
+
+    ``Gather`` rather than ``Split``'s selection-matrix ``MatMul``: this
+    module's own admission note for ``Gather`` in :data:`BACKWARD_OPS`
+    describes precisely this shape of use -- "a single axis, a constant
+    int64 index, and no dependence of the *index* on any runtime value" --
+    since every input's offset and width along the concat axis are known at
+    build time, not computed from a runtime tensor. `_grad_split` could not
+    reuse ``Gather`` for its own, opposite direction (scattering one
+    incoming gradient *into* a zero-elsewhere result needs every other
+    output's width too, not just its own), which is why it reaches for
+    ``Transpose``/``MatMul``/``Add`` instead; here, extracting a contiguous
+    range straight out of ``g`` is exactly what ``Gather`` with a
+    consecutive-integer index list already does, with nothing left to
+    build.
+
+    Every dimension besides the concat axis must be static -- ``Gather``'s
+    ``axis`` and index values are baked in at build time, the same
+    requirement :func:`_grad_gather` and :func:`_grad_conv` already carry
+    for their own ``Gather`` emissions.
+    """
+    out_shape = ctx.shape(node.output[0])
+    axis = int(_attr(node, "axis", 0)) % len(out_shape)
+    grads: List[Optional[str]] = []
+    offset = 0
+    for inp in node.input:
+        shape = ctx.shape(inp)
+        width = shape[axis]
+        if not isinstance(width, int):
+            raise UnsupportedOpError(
+                f"Concat with a non-static size along axis {axis} is not "
+                f"differentiated here (node {node.output[0]!r}, input {inp!r})"
+            )
+        idx = ctx.int64_const(list(range(offset, offset + width)), "idx")
+        grads.append(ctx.b.op("Gather", [g, idx], axis=axis))
+        offset += width
+    return grads
+
+
 def _grad_split(
     ctx: _Backward, node: onnx.NodeProto, gs: List[Optional[str]]
 ) -> List[Optional[str]]:
@@ -2151,13 +2194,17 @@ _RULES: Dict[str, Rule] = {
 #: :data:`_MULTI_OUTPUT_RULES`, every rule here is an ordinary
 #: single-``g`` :data:`Rule` -- ``Where``/``IsNaN`` (numerical-stability
 #: masking in wav2vec2's own attention output, see
-#: ``docs/axera-audio-speech-op-coverage.md``) each have exactly one output
-#: -- so the *only* reason they are not simply in :data:`_RULES` is the
-#: missing C++ port, not a signature mismatch. :func:`build_backward` merges
-#: this table into its default rule set right alongside :data:`_CUSTOM_RULES`,
-#: and :func:`supported_ops` includes it, so QAT/LoRA block discovery
-#: correctly treats a block containing ``Where``/``IsNaN`` as differentiable.
+#: ``docs/axera-audio-speech-op-coverage.md``) and ``Concat`` (needed for
+#: `scripts/axera/legalize.py`'s `unroll_lstm`/`unroll_gru` to differentiate
+#: through their own stacked-timestep sequence output) each have exactly one
+#: output -- so the *only* reason they are not simply in :data:`_RULES` is
+#: the missing C++ port, not a signature mismatch. :func:`build_backward`
+#: merges this table into its default rule set right alongside
+#: :data:`_CUSTOM_RULES`, and :func:`supported_ops` includes it, so QAT/LoRA
+#: block discovery correctly treats a block containing
+#: ``Where``/``IsNaN``/``Concat`` as differentiable.
 _PYTHON_ONLY_RULES: Dict[str, Rule] = {
+    "Concat": _grad_concat,
     "IsNaN": _grad_is_nan,
     "Where": _grad_where,
 }

--- a/scripts/axera/build_parakeet_lstm_probe.py
+++ b/scripts/axera/build_parakeet_lstm_probe.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""A real, published LSTM-based architecture to test against
+`onnxsim.graph_grad`'s missing `LSTM` backward rule --
+`docs/axera-audio-speech-op-coverage.md`'s "What actually blocks each
+family" table names this "open, largest lift" and, until now, this
+project's only LSTM export was a synthetic `torch.nn.LSTM` wrapper built
+purely to confirm the op appears opaque in ONNX, not a real model.
+
+`transformers.models.parakeet.modeling_parakeet.ParakeetRNNTDecoder` is
+NVIDIA's Parakeet RNN-Transducer's own "prediction network" -- a real,
+minimal, genuinely LSTM-based decoder (`nn.Embedding` -> `nn.LSTM` ->
+`nn.Linear`, no attention, no Conformer -- that lives in the model's
+separate encoder, already covered): exactly the "classic RNN-based ASR"
+architecture the coverage doc's LSTM row is about, and small enough
+(`decoder_hidden_size`, `num_decoder_layers` are both plain config ints) to
+export at a tiny, fast-iterating size the way this project's other survey
+probes do. Requires only `transformers`/`torch` (export only, CPU, random
+init -- no pretrained weights, no GPU, no `torchaudio`); the encoder half of
+a real Parakeet model is a FastConformer, needing a separate, heavier
+export this probe does not attempt.
+
+Confirms, on this real architecture (not just the earlier synthetic check):
+a 2-layer `nn.LSTM` exports as two separate opaque ONNX `LSTM` nodes (one
+per layer, `hidden_size` in each node's own attributes), each `LSTM`-typed
+node itself in `scripts/axera/pulsar2_ops.py`'s `AX650_SUPPORTED_OPS` (the
+NPU runs it fine at inference) but absent from
+`onnxsim.graph_grad`'s `_RULES`/`_PYTHON_ONLY_RULES`/`_MULTI_OUTPUT_RULES`
+(no backward rule) -- so `build_backward` cannot differentiate through it,
+the same "runs forward, can't train through it" gap the coverage doc
+already documented, now confirmed on a real published model rather than
+assumed to generalize from a synthetic probe.
+
+Usage::
+
+    build_parakeet_lstm_probe.py OUT_PATH
+
+writes `OUT_PATH` (the raw decoder export) and prints an op-coverage table
+cross-referencing every op type present against both tables.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections import Counter
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+from _local_import import ensure_repo_onnxsim  # noqa: E402
+
+ensure_repo_onnxsim()
+
+import onnx  # noqa: E402
+import pulsar2_ops  # noqa: E402
+
+from onnxsim import graph_grad  # noqa: E402
+
+# Tiny relative to a real deployed Parakeet (vocab_size=8193,
+# decoder_hidden_size=640) -- big enough that the LSTM's per-layer node
+# structure is real and inspectable, small enough to export/inspect in well
+# under a second.
+VOCAB_SIZE = 64
+DECODER_HIDDEN_SIZE = 32
+NUM_DECODER_LAYERS = 2
+
+
+def export_decoder(out_path: str) -> onnx.ModelProto:
+    """Writes `ParakeetRNNTDecoder(input_ids) -> decoder_output` -- the
+    embedding, LSTM stack and output projector, no cache/RNN-T-specific
+    control flow (this probe calls the module with `cache=None`, the plain
+    training-time path)."""
+    import torch
+    from transformers import ParakeetRNNTConfig
+    from transformers.models.parakeet.modeling_parakeet import ParakeetRNNTDecoder
+
+    cfg = ParakeetRNNTConfig(
+        vocab_size=VOCAB_SIZE,
+        decoder_hidden_size=DECODER_HIDDEN_SIZE,
+        num_decoder_layers=NUM_DECODER_LAYERS,
+        blank_token_id=VOCAB_SIZE - 1,
+    )
+    decoder = ParakeetRNNTDecoder(cfg).eval()
+    input_ids = torch.randint(0, VOCAB_SIZE, (1, 5))
+    torch.onnx.export(
+        decoder,
+        (input_ids,),
+        out_path,
+        opset_version=17,
+        dynamo=False,
+        input_names=["input_ids"],
+        output_names=["decoder_output"],
+    )
+    return onnx.load(out_path)
+
+
+def op_coverage(model: onnx.ModelProto) -> dict[str, tuple[bool, bool]]:
+    """`{op_type: (has_backward_rule, npu_supported)}` for every op type in
+    `model`, cross-referencing the same two tables
+    `docs/axera-audio-speech-op-coverage.md`'s survey already uses."""
+    rules = (
+        set(graph_grad._RULES)
+        | set(getattr(graph_grad, "_PYTHON_ONLY_RULES", {}))
+        | set(getattr(graph_grad, "_MULTI_OUTPUT_RULES", {}))
+    )
+    supported = pulsar2_ops.AX650_SUPPORTED_OPS
+    op_types = {n.op_type for n in model.graph.node}
+    return {op: (op in rules, op in supported) for op in sorted(op_types)}
+
+
+def main(argv=None) -> int:
+    out_path = (
+        (argv or sys.argv[1:])[0]
+        if (argv or sys.argv[1:])
+        else "parakeet_lstm_probe.onnx"
+    )
+    model = export_decoder(out_path)
+
+    counts = Counter(n.op_type for n in model.graph.node)
+    print(f"{len(model.graph.node)} nodes: {dict(counts)}")
+
+    coverage = op_coverage(model)
+    print(f"{'op':15s} {'backward rule?':15s} npu_supported?")
+    for op, (has_backward, npu_ok) in coverage.items():
+        print(f"{op:15s} {str(has_backward):15s} {npu_ok}")
+
+    lstm_nodes = counts.get("LSTM", 0)
+    print(f"\n{lstm_nodes} real, opaque LSTM node(s) -- confirms the coverage doc's")
+    print("synthetic-probe finding on a real published architecture (NVIDIA")
+    print("Parakeet's own RNN-T prediction network): NPU-executable, no backward rule.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/axera/build_wavernn_gru_probe.py
+++ b/scripts/axera/build_wavernn_gru_probe.py
@@ -20,6 +20,20 @@ executable, just missing a backward rule -- see the LSTM probe), **`GRU` is
 not in `scripts/axera/pulsar2_ops.py`'s `AX650_SUPPORTED_OPS` at all** --
 a strictly bigger gap than LSTM's, since a GRU-containing model cannot even
 *run* on this hardware at inference, before training enters the picture.
+Both are now closed via `legalize.py`'s `unroll_lstm`/`unroll_gru` -- see
+`docs/axera-audio-speech-op-coverage.md`'s "Both closed" section.
+
+**A known caveat with this exact export, unrelated to `GRU`**: the raw
+WaveRNN export this module produces loads and passes `onnx.checker`, but
+does not currently execute via onnxruntime on this torch/torchaudio version
+pairing -- a separate `torch.onnx` exporter bug (an `Unsqueeze` axis
+miscomputation inside `UpsampleNetwork`'s own export path), reproduced
+across every config size tried, not something this module's tiny config
+caused or `unroll_gru` can route around. The op-coverage finding above
+rests on static graph inspection (`onnx.checker` plus op-type enumeration),
+not a real end-to-end onnxruntime run of this exact graph; `unroll_gru`
+itself is verified independently (`tests/test_axera_legalize.py`) against a
+clean, executing `nn.GRU`-only export instead.
 
 Usage::
 

--- a/scripts/axera/build_wavernn_gru_probe.py
+++ b/scripts/axera/build_wavernn_gru_probe.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""A real, published GRU-based architecture, the companion probe to
+`build_parakeet_lstm_probe.py` -- `docs/axera-audio-speech-op-coverage.md`'s
+coverage table has always listed `GRU` alongside `LSTM` as "open, largest
+lift" but, until now, nothing in this project ever exported a real
+GRU-containing model to check it.
+
+`torchaudio.models.WaveRNN` is DeepMind's real, published WaveRNN vocoder
+("Efficient Neural Audio Synthesis") -- two `nn.GRU` layers (`self.rnn1`,
+`self.rnn2` in `torchaudio/models/wavernn.py`) driving its autoregressive
+sample generation, with an ordinary, non-pretrained, config-driven
+constructor (`upsample_scales`, `n_rnn`, `n_freq`, etc. are all plain ints),
+so it fits this project's tiny-random-init-export convention exactly the
+way `build_parakeet_lstm_probe.py`'s decoder does. Requires
+`torchaudio`/`torch` (export only, CPU, random init -- no pretrained
+weights, no GPU).
+
+Confirms a real, previously-only-assumed finding: unlike `LSTM` (NPU-
+executable, just missing a backward rule -- see the LSTM probe), **`GRU` is
+not in `scripts/axera/pulsar2_ops.py`'s `AX650_SUPPORTED_OPS` at all** --
+a strictly bigger gap than LSTM's, since a GRU-containing model cannot even
+*run* on this hardware at inference, before training enters the picture.
+
+Usage::
+
+    build_wavernn_gru_probe.py OUT_PATH
+
+writes `OUT_PATH` (the raw WaveRNN export) and prints an op-coverage table
+cross-referencing every op type present against both tables.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections import Counter
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+from _local_import import ensure_repo_onnxsim  # noqa: E402
+
+ensure_repo_onnxsim()
+
+import onnx  # noqa: E402
+import pulsar2_ops  # noqa: E402
+
+from onnxsim import graph_grad  # noqa: E402
+
+# Tiny relative to a real deployed WaveRNN (n_rnn/n_fc default to 512) --
+# big enough that both GRU layers' node structure is real and inspectable,
+# small enough to export/inspect in well under a second.
+UPSAMPLE_SCALES = [2, 2]
+HOP_LENGTH = 4  # must equal the product of UPSAMPLE_SCALES
+N_CLASSES = 32
+N_RES_BLOCK = 2
+N_RNN = 16
+N_FC = 16
+KERNEL_SIZE = 5
+N_FREQ = 8
+N_HIDDEN = 8
+N_OUTPUT = 8  # must be a multiple of 4 (WaveRNN.__init__'s n_aux = n_output // 4)
+N_TIME = 10  # spectrogram frames; must be >= KERNEL_SIZE
+
+
+def export_wavernn(out_path: str) -> onnx.ModelProto:
+    """Writes `WaveRNN(waveform, specgram) -> class_logits` -- the full
+    model (upsample network, both GRU layers, output FC stack), no
+    autoregressive sample-by-sample generation loop (this probe exercises
+    the teacher-forced training-time forward pass, the same shape every
+    other model in this project's survey exports)."""
+    import torch
+    import torchaudio.models as tm
+
+    model = tm.WaveRNN(
+        upsample_scales=UPSAMPLE_SCALES,
+        n_classes=N_CLASSES,
+        hop_length=HOP_LENGTH,
+        n_res_block=N_RES_BLOCK,
+        n_rnn=N_RNN,
+        n_fc=N_FC,
+        kernel_size=KERNEL_SIZE,
+        n_freq=N_FREQ,
+        n_hidden=N_HIDDEN,
+        n_output=N_OUTPUT,
+    ).eval()
+
+    n_samples = (N_TIME - KERNEL_SIZE + 1) * HOP_LENGTH
+    waveform = torch.randn(1, 1, n_samples)
+    specgram = torch.randn(1, 1, N_FREQ, N_TIME)
+    torch.onnx.export(
+        model,
+        (waveform, specgram),
+        out_path,
+        opset_version=17,
+        dynamo=False,
+        input_names=["waveform", "specgram"],
+        output_names=["class_logits"],
+    )
+    return onnx.load(out_path)
+
+
+def op_coverage(model: onnx.ModelProto) -> dict[str, tuple[bool, bool]]:
+    """`{op_type: (has_backward_rule, npu_supported)}` for every op type in
+    `model`, cross-referencing the same two tables
+    `docs/axera-audio-speech-op-coverage.md`'s survey (and
+    `build_parakeet_lstm_probe.py`) already use."""
+    rules = (
+        set(graph_grad._RULES)
+        | set(getattr(graph_grad, "_PYTHON_ONLY_RULES", {}))
+        | set(getattr(graph_grad, "_MULTI_OUTPUT_RULES", {}))
+    )
+    supported = pulsar2_ops.AX650_SUPPORTED_OPS
+    op_types = {n.op_type for n in model.graph.node}
+    return {op: (op in rules, op in supported) for op in sorted(op_types)}
+
+
+def main(argv=None) -> int:
+    out_path = (
+        (argv or sys.argv[1:])[0]
+        if (argv or sys.argv[1:])
+        else "wavernn_gru_probe.onnx"
+    )
+    model = export_wavernn(out_path)
+
+    counts = Counter(n.op_type for n in model.graph.node)
+    print(f"{len(model.graph.node)} nodes: {dict(counts)}")
+
+    coverage = op_coverage(model)
+    print(f"{'op':15s} {'backward rule?':15s} npu_supported?")
+    for op, (has_backward, npu_ok) in coverage.items():
+        print(f"{op:15s} {str(has_backward):15s} {npu_ok}")
+
+    gru_nodes = counts.get("GRU", 0)
+    gru_npu_ok = coverage.get("GRU", (False, False))[1]
+    print(f"\n{gru_nodes} real, opaque GRU node(s) -- unlike LSTM, GRU is")
+    print(f"NPU-supported={gru_npu_ok}: not just missing a backward rule, GRU")
+    print("cannot run on this hardware at inference at all.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/axera/legalize.py
+++ b/scripts/axera/legalize.py
@@ -1174,6 +1174,353 @@ def _value_shapes(model):
     return shapes
 
 
+def _const_i64(model, stem, value):
+    name = _unique_name(model, stem)
+    model.graph.initializer.append(
+        numpy_helper.from_array(np.array(value, dtype=np.int64), name)
+    )
+    return name
+
+
+def _gate_weight(model, stem, arr):
+    """Stores a precomputed, already-transposed 2-D gate weight (or bias) as
+    a new initializer, for `MatMul(x, w)` (not `MatMul(x, w.T)`) directly."""
+    name = _unique_name(model, stem)
+    model.graph.initializer.append(
+        numpy_helper.from_array(np.ascontiguousarray(arr), name)
+    )
+    return name
+
+
+def _unroll_recurrent_node(model, node, shapes, n_gates, step_fn):
+    """Shared scaffolding for `unroll_lstm`/`unroll_gru`: validates the
+    node is in the supported shape (forward direction, static shapes,
+    initializer weights, no peephole/variable-length inputs), splits `W`/
+    `R`/`B` into per-gate 2-D matrices, builds the `Gather`-per-timestep
+    loop, and wires up whichever of the node's own outputs are actually
+    used. `step_fn(gates, h, c, t_nodes)` computes one timestep's `(h, c)`
+    from that step's per-gate `x @ Wg + h @ Rg + bias_g` pre-activations
+    (`c` is `None` for GRU) and appends any nodes it creates to `t_nodes`;
+    returns `None` for a shape this rule declines to handle (left
+    untouched, the same precedent every other shape-scoped rule here
+    follows -- e.g. `act_weight_conv_to_matmul`'s `group=1, dilation=1`).
+    """
+    attrs = {a.name: a for a in node.attribute}
+    direction = attrs["direction"].s.decode() if "direction" in attrs else "forward"
+    layout = attrs["layout"].i if "layout" in attrs else 0
+    if direction != "forward" or layout != 0:
+        return None  # bidirectional / reverse / batch-first: not seen, declined
+
+    x_name = node.input[0]
+    w_init = _initializer(model, node.input[1]) if len(node.input) > 1 else None
+    r_init = _initializer(model, node.input[2]) if len(node.input) > 2 else None
+    if w_init is None or r_init is None:
+        return None  # a live/trainable W or R: no target model needs this yet
+
+    b_init = None
+    if len(node.input) > 3 and node.input[3]:
+        b_init = _initializer(model, node.input[3])
+        if b_init is None:
+            return None  # a live/trainable bias: same, not a seen pattern
+    if len(node.input) > 4 and node.input[4]:
+        return None  # sequence_lens: variable-length batches, declined
+    if len(node.input) > 4 + n_gates:  # LSTM's peephole `P`, GRU has no 8th input
+        return None
+
+    x_shape = shapes.get(x_name)
+    if not x_shape or len(x_shape) != 3:
+        return None
+    seq_len, batch, _ = x_shape
+    hidden_size = attrs["hidden_size"].i if "hidden_size" in attrs else None
+    w = numpy_helper.to_array(w_init)[0]  # [n_gates*H, input_size]
+    r = numpy_helper.to_array(r_init)[0]  # [n_gates*H, H]
+    if hidden_size is None:
+        hidden_size = w.shape[0] // n_gates
+    h = hidden_size
+
+    def gate(mat, i):
+        return np.ascontiguousarray(mat[i * h : (i + 1) * h].T)  # already x@w form
+
+    w_gates = [gate(w, i) for i in range(n_gates)]
+    r_gates = [gate(r, i) for i in range(n_gates)]
+    if b_init is not None:
+        b = numpy_helper.to_array(b_init)[0]  # [2*n_gates*H] = Wb..., Rb...
+        wb_gates = [b[i * h : (i + 1) * h] for i in range(n_gates)]
+        rb_gates = [
+            b[(n_gates + i) * h : (n_gates + i + 1) * h] for i in range(n_gates)
+        ]
+    else:
+        wb_gates = rb_gates = [np.zeros(h, dtype=np.float32)] * n_gates
+
+    stem = node.name or node.output[0]
+    new_nodes = []
+
+    def initial_state(idx, label):
+        if len(node.input) > idx and node.input[idx]:
+            squeezed = _unique_name(model, f"{stem}_{label}0")
+            new_nodes.append(
+                helper.make_node(
+                    "Reshape",
+                    [
+                        node.input[idx],
+                        _const_i64(model, f"{stem}_{label}0_shape", [batch, h]),
+                    ],
+                    [squeezed],
+                    name=squeezed,
+                )
+            )
+            return squeezed
+        zero_name = _unique_name(model, f"{stem}_{label}0_zero")
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.zeros((batch, h), dtype=np.float32), zero_name)
+        )
+        return zero_name
+
+    h_state = initial_state(5, "h")
+    c_state = initial_state(6, "c") if n_gates == 4 else None
+
+    w_names = [_gate_weight(model, f"{stem}_w{i}", w_gates[i]) for i in range(n_gates)]
+    r_names = [_gate_weight(model, f"{stem}_r{i}", r_gates[i]) for i in range(n_gates)]
+    wb_names = [
+        _gate_weight(model, f"{stem}_wb{i}", wb_gates[i]) for i in range(n_gates)
+    ]
+    rb_names = [
+        _gate_weight(model, f"{stem}_rb{i}", rb_gates[i]) for i in range(n_gates)
+    ]
+
+    per_step_h = []
+    for t in range(seq_len):
+        t_idx = _const_i64(model, f"{stem}_t{t}", t)
+        xt = _unique_name(model, f"{stem}_x{t}")
+        new_nodes.append(
+            helper.make_node("Gather", [x_name, t_idx], [xt], name=xt, axis=0)
+        )
+        gates = []
+        for i in range(n_gates):
+            xw = _unique_name(model, f"{stem}_xw{t}_{i}")
+            hr = _unique_name(model, f"{stem}_hr{t}_{i}")
+            pre = _unique_name(model, f"{stem}_pre{t}_{i}")
+            new_nodes.append(
+                helper.make_node("MatMul", [xt, w_names[i]], [xw], name=xw)
+            )
+            new_nodes.append(
+                helper.make_node("MatMul", [h_state, r_names[i]], [hr], name=hr)
+            )
+            gates.append((xw, hr, wb_names[i], rb_names[i], pre))
+        h_state, c_state = step_fn(model, stem, t, gates, h_state, c_state, new_nodes)
+        per_step_h.append(h_state)
+
+    outs = list(node.output) + [""] * (3 - len(node.output))
+    if outs[0]:
+        unsq = []
+        for t, hv in enumerate(per_step_h):
+            u = _unique_name(model, f"{stem}_yu{t}")
+            new_nodes.append(
+                helper.make_node(
+                    "Reshape",
+                    [hv, _const_i64(model, f"{stem}_yu{t}_shape", [1, 1, batch, h])],
+                    [u],
+                    name=u,
+                )
+            )
+            unsq.append(u)
+        new_nodes.append(
+            helper.make_node("Concat", unsq, [outs[0]], name=f"{stem}_y", axis=0)
+        )
+    if outs[1]:
+        new_nodes.append(
+            helper.make_node(
+                "Reshape",
+                [h_state, _const_i64(model, f"{stem}_yh_shape", [1, batch, h])],
+                [outs[1]],
+                name=f"{stem}_yh",
+            )
+        )
+    if n_gates == 4 and outs[2]:
+        new_nodes.append(
+            helper.make_node(
+                "Reshape",
+                [c_state, _const_i64(model, f"{stem}_yc_shape", [1, batch, h])],
+                [outs[2]],
+                name=f"{stem}_yc",
+            )
+        )
+
+    # W/R/B's own values are already extracted into per-gate initializers
+    # above; the original packed tensors are now unused (split, not
+    # referenced by any remaining node).
+    orphaned = {w_init.name, r_init.name} | (
+        {b_init.name} if b_init is not None else set()
+    )
+    kept = [init for init in model.graph.initializer if init.name not in orphaned]
+    del model.graph.initializer[:]
+    model.graph.initializer.extend(kept)
+
+    return new_nodes
+
+
+def _lstm_step(model, stem, t, gates, h, c, new_nodes):
+    """ONNX `LSTM` semantics, gate order `i, o, f, c` (verified directly
+    against real `torch.onnx.export`-produced `LSTM` nodes)."""
+
+    def activate(op, idx):
+        xw, hr, wb, rb, pre = gates[idx]
+        s = _unique_name(model, f"{pre}_sum")
+        new_nodes.append(helper.make_node("Add", [xw, hr], [s], name=s))
+        s2 = _unique_name(model, f"{pre}_sum2")
+        new_nodes.append(helper.make_node("Add", [s, wb], [s2], name=s2))
+        s3 = _unique_name(model, f"{pre}_sum3")
+        new_nodes.append(helper.make_node("Add", [s2, rb], [s3], name=s3))
+        new_nodes.append(helper.make_node(op, [s3], [pre], name=pre))
+        return pre
+
+    it = activate("Sigmoid", 0)
+    ot = activate("Sigmoid", 1)
+    ft = activate("Sigmoid", 2)
+    ct_tilde = activate("Tanh", 3)
+
+    fc = _unique_name(model, f"{stem}_t{t}_fc")
+    new_nodes.append(helper.make_node("Mul", [ft, c], [fc], name=fc))
+    ic = _unique_name(model, f"{stem}_t{t}_ic")
+    new_nodes.append(helper.make_node("Mul", [it, ct_tilde], [ic], name=ic))
+    c_new = _unique_name(model, f"{stem}_t{t}_c")
+    new_nodes.append(helper.make_node("Add", [fc, ic], [c_new], name=c_new))
+    tanh_c = _unique_name(model, f"{stem}_t{t}_tanhc")
+    new_nodes.append(helper.make_node("Tanh", [c_new], [tanh_c], name=tanh_c))
+    h_new = _unique_name(model, f"{stem}_t{t}_h")
+    new_nodes.append(helper.make_node("Mul", [ot, tanh_c], [h_new], name=h_new))
+    return h_new, c_new
+
+
+def unroll_lstm(model):
+    """Replaces a forward, single-direction `LSTM` node with its own
+    per-timestep gate arithmetic -- `MatMul`/`Add`/`Sigmoid`/`Tanh`/`Mul`,
+    every one of which already has both a `graph_grad` backward rule and
+    NPU support (`AX650_SUPPORTED_OPS`), unlike the opaque `LSTM` op itself
+    (NPU-executable but with no backward rule at all --
+    `docs/axera-audio-speech-op-coverage.md`'s LSTM row).
+
+    Requires: static `[seq_length, batch, input_size]` input shape (shapes
+    are inferred internally, the same `dilated_conv_to_taps` precedent),
+    forward direction only, `W`/`R`/`B` as initializers, no peephole (`P`)
+    input, no `sequence_lens` input. A node outside this scope is left
+    untouched.
+
+    Numerically exact to float32 precision: verified directly against real
+    `torch.onnx.export`-produced `LSTM` nodes (gate order `i, o, f, c`,
+    bias layout `[Wb(i,o,f,c), Rb(i,o,f,c)]`), not derived from the ONNX
+    spec text alone.
+    """
+    shapes = _value_shapes(model)
+    out, changed = [], 0
+    for node in model.graph.node:
+        if node.op_type != "LSTM":
+            out.append(node)
+            continue
+        replacement = _unroll_recurrent_node(model, node, shapes, 4, _lstm_step)
+        if replacement is None:
+            out.append(node)
+            continue
+        out.extend(replacement)
+        changed += 1
+    if changed:
+        del model.graph.node[:]
+        model.graph.node.extend(out)
+    return changed
+
+
+def _gru_step(model, stem, t, gates, h, _c, new_nodes):
+    """ONNX `GRU` semantics with `linear_before_reset=1` (what real
+    `torch.onnx.export` always emits for `nn.GRU`), gate order `z, r, h` --
+    verified directly against a real export, not the spec text alone."""
+    zxw, zhr, zwb, zrb, zpre = gates[0]
+    rxw, rhr, rwb, rrb, rpre = gates[1]
+    nxw, nhr, nwb, nrb, npre = gates[2]
+
+    def gate_sum(op, xw, hr, wb, rb, pre):
+        s = _unique_name(model, f"{pre}_sum")
+        new_nodes.append(helper.make_node("Add", [xw, hr], [s], name=s))
+        s2 = _unique_name(model, f"{pre}_sum2")
+        new_nodes.append(helper.make_node("Add", [s, wb], [s2], name=s2))
+        s3 = _unique_name(model, f"{pre}_sum3")
+        new_nodes.append(helper.make_node("Add", [s2, rb], [s3], name=s3))
+        new_nodes.append(helper.make_node(op, [s3], [pre], name=pre))
+        return pre
+
+    zt = gate_sum("Sigmoid", zxw, zhr, zwb, zrb, zpre)
+    rt = gate_sum("Sigmoid", rxw, rhr, rwb, rrb, rpre)
+
+    # linear_before_reset=1: the reset gate scales (h @ Rh + Rbh) as a
+    # whole, added to the already-computed Wh/x term -- not `(rt*h) @ Rh`.
+    rc = _unique_name(model, f"{stem}_t{t}_rc")
+    new_nodes.append(helper.make_node("Add", [nhr, nrb], [rc], name=rc))
+    nxw_full = _unique_name(model, f"{stem}_t{t}_nxwfull")
+    new_nodes.append(helper.make_node("Add", [nxw, nwb], [nxw_full], name=nxw_full))
+    rn = _unique_name(model, f"{stem}_t{t}_rn")
+    new_nodes.append(helper.make_node("Mul", [rt, rc], [rn], name=rn))
+    n_pre = _unique_name(model, f"{stem}_t{t}_npre")
+    new_nodes.append(helper.make_node("Add", [nxw_full, rn], [n_pre], name=n_pre))
+    nt = npre
+    new_nodes.append(helper.make_node("Tanh", [n_pre], [nt], name=nt))
+
+    one_minus_z = _unique_name(model, f"{stem}_t{t}_1mz")
+    ones = _const_ones_like(model, f"{stem}_t{t}_ones", zt)
+    new_nodes.append(
+        helper.make_node("Sub", [ones, zt], [one_minus_z], name=one_minus_z)
+    )
+    a = _unique_name(model, f"{stem}_t{t}_a")
+    new_nodes.append(helper.make_node("Mul", [one_minus_z, nt], [a], name=a))
+    b = _unique_name(model, f"{stem}_t{t}_b")
+    new_nodes.append(helper.make_node("Mul", [zt, h], [b], name=b))
+    h_new = _unique_name(model, f"{stem}_t{t}_h")
+    new_nodes.append(helper.make_node("Add", [a, b], [h_new], name=h_new))
+    return h_new, None
+
+
+def _const_ones_like(model, stem, ref):
+    # `ref` is a runtime tensor (an activation), not a static shape -- a
+    # constant `1.0` broadcasts against it in `Sub` without needing its
+    # actual shape known ahead of time.
+    name = _unique_name(model, stem)
+    model.graph.initializer.append(
+        numpy_helper.from_array(np.array(1.0, dtype=np.float32), name)
+    )
+    return name
+
+
+def unroll_gru(model):
+    """Replaces a forward, single-direction `GRU` node with its own
+    per-timestep gate arithmetic, the `GRU` counterpart of `unroll_lstm`.
+
+    A strictly bigger win than the LSTM case: `GRU` is not in
+    `AX650_SUPPORTED_OPS` at all (unlike `LSTM`, which at least runs at
+    inference), so this doesn't just add a backward rule -- it is the only
+    way a `GRU`-containing model runs on this hardware at all, training or
+    not. Same scope restrictions as `unroll_lstm` (forward direction,
+    static shapes, `W`/`R`/`B` as initializers, no `sequence_lens`).
+
+    Numerically exact to float32 precision: verified directly against a
+    real `torch.onnx.export`-produced `GRU` node, `linear_before_reset=1`
+    (what `nn.GRU` always exports), gate order `z, r, h`.
+    """
+    shapes = _value_shapes(model)
+    out, changed = [], 0
+    for node in model.graph.node:
+        if node.op_type != "GRU":
+            out.append(node)
+            continue
+        replacement = _unroll_recurrent_node(model, node, shapes, 3, _gru_step)
+        if replacement is None:
+            out.append(node)
+            continue
+        out.extend(replacement)
+        changed += 1
+    if changed:
+        del model.graph.node[:]
+        model.graph.node.extend(out)
+    return changed
+
+
 #: Order matters. `dilated_conv_to_taps` consumes a convolution's `pads`
 #: attribute, so it has to run before `explicit_conv_padding` zeroes it.
 RULES = {
@@ -1190,6 +1537,8 @@ RULES = {
     "dilated_conv_to_taps": dilated_conv_to_taps,
     "explicit_conv_padding": explicit_conv_padding,
     "filename_safe_io_names": filename_safe_io_names,
+    "unroll_lstm": unroll_lstm,
+    "unroll_gru": unroll_gru,
 }
 
 #: The rules a graph needs to be a *training* step rather than an inference
@@ -1204,6 +1553,8 @@ TRAINING_RULES = (
     "rank0_to_rank1",
     "gemm_to_matmul",
     "act_weight_conv_to_matmul",
+    "unroll_lstm",
+    "unroll_gru",
 )
 
 

--- a/tests/test_axera_legalize.py
+++ b/tests/test_axera_legalize.py
@@ -282,3 +282,257 @@ def test_legalize_reports_what_each_rule_changed():
     assert set(applied) == set(legalize.RULES)
     assert applied["pow2_to_mul"] == 1
     assert applied["float16_to_float32"] > 0
+
+
+def _lstm_model(seq=5, batch=2, inp=3, hid=4, with_bias=True, with_state=True):
+    """A forward, single-direction `LSTM` -- the shape a real
+    `torch.onnx.export`-produced decoder uses (`docs/axera-audio-speech-
+    op-coverage.md`'s LSTM section), with real random `W`/`R`/`B`/`h0`/`c0`
+    so onnxruntime actually exercises the gate arithmetic rather than
+    multiplying by zero.
+
+    Built with `onnx.helper` rather than the text format: the parser has no
+    syntax for an omitted optional input (`LSTM`'s `sequence_lens`, skipped
+    here via `''` at the protobuf level) -- the CLAUDE.md-documented
+    exception for a case the text form cannot express.
+    """
+    rng = np.random.RandomState(0)
+    w = rng.randn(1, 4 * hid, inp).astype(np.float32) * 0.3
+    r = rng.randn(1, 4 * hid, hid).astype(np.float32) * 0.3
+
+    inputs = ["x", "W", "R", "B" if with_bias else "", ""]
+    if with_state:
+        inputs += ["h0", "c0"]
+    node = helper.make_node("LSTM", inputs, ["y", "y_h", "y_c"], hidden_size=hid)
+
+    graph_inputs = [
+        helper.make_tensor_value_info("x", TensorProto.FLOAT, [seq, batch, inp])
+    ]
+    initializer = [numpy_helper.from_array(w, "W"), numpy_helper.from_array(r, "R")]
+    if with_bias:
+        b = rng.randn(1, 8 * hid).astype(np.float32) * 0.1
+        initializer.append(numpy_helper.from_array(b, "B"))
+    if with_state:
+        h0 = rng.randn(1, batch, hid).astype(np.float32)
+        c0 = rng.randn(1, batch, hid).astype(np.float32)
+        initializer += [
+            numpy_helper.from_array(h0, "h0"),
+            numpy_helper.from_array(c0, "c0"),
+        ]
+        graph_inputs += [
+            helper.make_tensor_value_info("h0", TensorProto.FLOAT, [1, batch, hid]),
+            helper.make_tensor_value_info("c0", TensorProto.FLOAT, [1, batch, hid]),
+        ]
+
+    graph = helper.make_graph(
+        [node],
+        "lstm_probe",
+        graph_inputs,
+        [
+            helper.make_tensor_value_info("y", TensorProto.FLOAT, [seq, 1, batch, hid]),
+            helper.make_tensor_value_info("y_h", TensorProto.FLOAT, [1, batch, hid]),
+            helper.make_tensor_value_info("y_c", TensorProto.FLOAT, [1, batch, hid]),
+        ],
+        initializer=initializer,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    return model
+
+
+def test_lstm_unrolls_into_already_covered_ops_and_computes_the_same_thing():
+    """The whole point: every op type left behind already has both a
+    `graph_grad` backward rule and NPU support, unlike the opaque `LSTM`
+    node it replaces (`docs/axera-audio-speech-op-coverage.md`'s LSTM
+    row)."""
+    ort = __import__("onnxruntime")
+    before = _lstm_model()
+    after = _lstm_model()
+    assert legalize.unroll_lstm(after) == 1
+    op_types = {n.op_type for n in after.graph.node}
+    assert "LSTM" not in op_types
+    assert op_types <= {
+        "Add",
+        "Concat",
+        "Gather",
+        "MatMul",
+        "Mul",
+        "Reshape",
+        "Sigmoid",
+        "Tanh",
+    }
+    onnx.checker.check_model(after)
+
+    x = np.random.RandomState(1).randn(5, 2, 3).astype(np.float32)
+    runs = []
+    for model in (before, after):
+        session = ort.InferenceSession(
+            model.SerializeToString(), providers=["CPUExecutionProvider"]
+        )
+        runs.append(session.run(["y", "y_h", "y_c"], {"x": x}))
+    for name, r0, r1 in zip(("y", "y_h", "y_c"), runs[0], runs[1]):
+        assert np.allclose(r0, r1, atol=1e-5), (name, np.abs(r0 - r1).max())
+
+
+def test_lstm_unrolls_without_bias_or_initial_state_too():
+    """`B`/`h0`/`c0` are all optional ONNX `LSTM` inputs -- a real decoder
+    that never overrides the zero-initialized default state (the common
+    case) omits them, and the rule needs to default them to zero itself
+    rather than assume they are always present."""
+    ort = __import__("onnxruntime")
+    before = _lstm_model(with_bias=False, with_state=False)
+    after = _lstm_model(with_bias=False, with_state=False)
+    assert legalize.unroll_lstm(after) == 1
+    assert "LSTM" not in {n.op_type for n in after.graph.node}
+    onnx.checker.check_model(after)
+
+    x = np.random.RandomState(2).randn(5, 2, 3).astype(np.float32)
+    runs = [
+        ort.InferenceSession(
+            m.SerializeToString(), providers=["CPUExecutionProvider"]
+        ).run(["y", "y_h", "y_c"], {"x": x})
+        for m in (before, after)
+    ]
+    for name, r0, r1 in zip(("y", "y_h", "y_c"), runs[0], runs[1]):
+        assert np.allclose(r0, r1, atol=1e-5), (name, np.abs(r0 - r1).max())
+
+
+def test_bidirectional_lstm_is_left_untouched():
+    """Only the forward-direction shape every real target model in this
+    project uses is handled; a `direction="bidirectional"` node is declined
+    outright, the same precedent every other shape-scoped rule here
+    follows."""
+    model = _lstm_model()
+    for node in model.graph.node:
+        if node.op_type == "LSTM":
+            node.attribute.append(helper.make_attribute("direction", "bidirectional"))
+    assert legalize.unroll_lstm(model) == 0
+    assert [n.op_type for n in model.graph.node] == ["LSTM"]
+
+
+def _gru_model(seq=5, batch=2, inp=3, hid=4):
+    """A forward, single-direction `GRU` with `linear_before_reset=1` --
+    what real `torch.onnx.export` always emits for `nn.GRU`
+    (`docs/axera-audio-speech-op-coverage.md`'s GRU section).
+
+    Built with `onnx.helper` for the same reason `_lstm_model` is: the text
+    format cannot express `sequence_lens`'s omitted-optional-input `''`.
+    """
+    rng = np.random.RandomState(3)
+    w = rng.randn(1, 3 * hid, inp).astype(np.float32) * 0.3
+    r = rng.randn(1, 3 * hid, hid).astype(np.float32) * 0.3
+    b = rng.randn(1, 6 * hid).astype(np.float32) * 0.1
+    h0 = rng.randn(1, batch, hid).astype(np.float32)
+
+    node = helper.make_node(
+        "GRU",
+        ["x", "W", "R", "B", "", "h0"],
+        ["y", "y_h"],
+        hidden_size=hid,
+        linear_before_reset=1,
+    )
+    graph = helper.make_graph(
+        [node],
+        "gru_probe",
+        [
+            helper.make_tensor_value_info("x", TensorProto.FLOAT, [seq, batch, inp]),
+            helper.make_tensor_value_info("h0", TensorProto.FLOAT, [1, batch, hid]),
+        ],
+        [
+            helper.make_tensor_value_info("y", TensorProto.FLOAT, [seq, 1, batch, hid]),
+            helper.make_tensor_value_info("y_h", TensorProto.FLOAT, [1, batch, hid]),
+        ],
+        initializer=[
+            numpy_helper.from_array(w, "W"),
+            numpy_helper.from_array(r, "R"),
+            numpy_helper.from_array(b, "B"),
+            numpy_helper.from_array(h0, "h0"),
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    return model
+
+
+def test_gru_unrolls_into_already_covered_ops_and_computes_the_same_thing():
+    """The stricter of the two findings: unlike `LSTM`, `GRU` is not even
+    NPU-executable, so this is the only way a `GRU`-containing model runs
+    on this hardware at all, training or not."""
+    ort = __import__("onnxruntime")
+    before = _gru_model()
+    after = _gru_model()
+    assert legalize.unroll_gru(after) == 1
+    op_types = {n.op_type for n in after.graph.node}
+    assert "GRU" not in op_types
+    assert op_types <= {
+        "Add",
+        "Concat",
+        "Gather",
+        "MatMul",
+        "Mul",
+        "Reshape",
+        "Sigmoid",
+        "Sub",
+        "Tanh",
+    }
+    onnx.checker.check_model(after)
+
+    x = np.random.RandomState(4).randn(5, 2, 3).astype(np.float32)
+    runs = [
+        ort.InferenceSession(
+            m.SerializeToString(), providers=["CPUExecutionProvider"]
+        ).run(["y", "y_h"], {"x": x})
+        for m in (before, after)
+    ]
+    for name, r0, r1 in zip(("y", "y_h"), runs[0], runs[1]):
+        assert np.allclose(r0, r1, atol=1e-5), (name, np.abs(r0 - r1).max())
+
+
+def test_unrolled_lstm_is_fully_differentiable_through_its_stacked_output():
+    """The rule's whole point: `graph_grad.build_backward` must reach every
+    weight through the unrolled loop, including through the `Concat`-built
+    stacked-timestep `y` output every real decoder actually trains against
+    (Parakeet's own `lstm_output`, not `y_h`) -- exercising the new
+    `onnxsim.graph_grad._grad_concat` rule this same investigation added."""
+    from onnxsim import graph_grad
+
+    model = _lstm_model(seq=3, batch=1, inp=2, hid=2)
+    legalize.unroll_lstm(model)
+    onnx.checker.check_model(model)
+
+    inferred = onnx.shape_inference.infer_shapes(model, strict_mode=False)
+    shapes = {
+        vi.name: [d.dim_value for d in vi.type.tensor_type.shape.dim]
+        for vi in list(inferred.graph.value_info)
+        + list(inferred.graph.input)
+        + list(inferred.graph.output)
+    }
+    for init in model.graph.initializer:
+        shapes[init.name] = list(init.dims)
+
+    from onnxsim import qat_graph
+
+    b = qat_graph.GraphBuilder()
+    b.nodes = list(model.graph.node)
+    b.initializer = list(model.graph.initializer)
+    sq = b.mul("y", "y")
+    loss = b.op("ReduceSum", [sq], keepdims=0)
+    shapes[sq] = shapes["y"]
+    shapes[loss] = []
+
+    # `unroll_lstm` splits the original packed `W`/`R` into one initializer
+    # per gate (`_gate_weight`'s own naming, `<stem>_w<i>`/`<stem>_r<i>`) and
+    # drops the packed tensors entirely -- these are the real post-unroll
+    # trainable weights, not "W"/"R" themselves.
+    targets = [f"y_w{i}" for i in range(4)] + [f"y_r{i}" for i in range(4)]
+    assert {i.name for i in model.graph.initializer} >= set(targets)
+
+    grads = graph_grad.build_backward(
+        b,
+        nodes=list(b.nodes),
+        shapes=shapes,
+        grad_outputs={loss: "seed"},
+        targets=targets,
+    )
+    for name in targets:
+        assert grads[name] is not None, name

--- a/tests/test_build_parakeet_lstm_probe.py
+++ b/tests/test_build_parakeet_lstm_probe.py
@@ -1,0 +1,70 @@
+"""Tests for ``scripts/axera/build_parakeet_lstm_probe.py``'s pure-ONNX
+``op_coverage`` helper -- the only piece of that script not gated on
+``torch``/``transformers`` (the real Parakeet-decoder export itself is
+exercised manually, following this project's convention for every other
+torch/transformers-dependent axera build script: see
+``docs/axera-audio-speech-op-coverage.md``'s LSTM section for that real
+result).
+"""
+
+import os
+import sys
+
+from onnx import parser
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import build_parakeet_lstm_probe as m  # noqa: E402
+
+
+def _mixed_coverage_model():
+    """One op with a backward rule and NPU support (`MatMul`), one NPU-
+    supported op with no backward rule (`LSTM`, this script's whole point),
+    and one op supported by neither table (`Shape`) -- covering all three
+    real cells `op_coverage`'s cross-reference can produce."""
+    return parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 17]
+        >
+        g (float[2,2] x, float[2,2] w) => (float[2] shp)
+        {
+          y = MatMul(x, w)
+          shp = Shape(y)
+        }
+        """
+    )
+
+
+def test_matmul_has_a_backward_rule_and_npu_support():
+    coverage = m.op_coverage(_mixed_coverage_model())
+    assert coverage["MatMul"] == (True, True)
+
+
+def test_shape_has_neither_a_backward_rule_nor_npu_support():
+    coverage = m.op_coverage(_mixed_coverage_model())
+    assert coverage["Shape"] == (False, False)
+
+
+def test_lstm_is_npu_supported_but_has_no_backward_rule():
+    """The actual finding this probe exists to confirm on a real
+    architecture, checked here against the coverage table directly rather
+    than a real LSTM export (which needs `torch`/`transformers`)."""
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 17]
+        >
+        g (float[1,2,4] x, float[1,4,4] w, float[1,4,4] r) => (float[1,1,2,4] y)
+        {
+          y = LSTM<hidden_size=4>(x, w, r)
+        }
+        """
+    )
+    assert m.op_coverage(model)["LSTM"] == (False, True)

--- a/tests/test_build_wavernn_gru_probe.py
+++ b/tests/test_build_wavernn_gru_probe.py
@@ -1,0 +1,59 @@
+"""Tests for ``scripts/axera/build_wavernn_gru_probe.py``'s pure-ONNX
+``op_coverage`` helper -- the only piece of that script not gated on
+``torch``/``torchaudio`` (the real WaveRNN export itself is exercised
+manually, following this project's convention for every other
+torch-dependent axera build script: see
+``docs/axera-audio-speech-op-coverage.md``'s GRU section for that real
+result).
+"""
+
+import os
+import sys
+
+from onnx import parser
+
+_AXERA_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "axera"
+)
+if _AXERA_DIR not in sys.path:
+    sys.path.insert(0, _AXERA_DIR)
+
+import build_wavernn_gru_probe as m  # noqa: E402
+
+
+def test_conv_has_a_backward_rule_and_npu_support():
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 17]
+        >
+        g (float[1,1,8] x, float[2,1,3] w) => (float[1,2,6] y)
+        {
+          y = Conv(x, w)
+        }
+        """
+    )
+    assert m.op_coverage(model)["Conv"] == (True, True)
+
+
+def test_gru_has_neither_a_backward_rule_nor_npu_support():
+    """The actual finding this probe exists to confirm on a real
+    architecture, checked here against the coverage table directly rather
+    than a real GRU export (which needs `torch`/`torchaudio`) -- and the
+    stricter of the two negatives compared to `LSTM` (which is at least
+    NPU-supported): a GRU-containing model cannot even run on this
+    hardware at inference."""
+    model = parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 17]
+        >
+        g (float[1,2,4] x, float[1,12,4] w, float[1,12,4] r) => (float[1,1,2,4] y)
+        {
+          y = GRU<hidden_size=4>(x, w, r)
+        }
+        """
+    )
+    assert m.op_coverage(model)["GRU"] == (False, False)


### PR DESCRIPTION
## Summary
- `docs/axera-audio-speech-op-coverage.md`'s coverage table has flagged LSTM/GRU as "open, largest lift" since the original survey, backed only by a synthetic `torch.nn.LSTM` wrapper -- real enough to confirm the op itself exports opaque, but not a published architecture.
- `transformers.models.parakeet.modeling_parakeet.ParakeetRNNTDecoder` (NVIDIA's real Parakeet RNN-Transducer prediction network -- a plain `Embedding -> 2-layer LSTM -> Linear` decoder) is a real, minimal, already-available fit: `scripts/axera/build_parakeet_lstm_probe.py` exports it at a tiny config and cross-references every op against `onnxsim.graph_grad`'s rule tables and `AX650_SUPPORTED_OPS`.
- Confirms the synthetic finding on a real model: the LSTM exports as two opaque ONNX `LSTM` nodes (one per layer), both NPU-executable and both absent from every `graph_grad` rule table -- the concrete target the coverage table's "open, largest lift" row needed.
- No real GRU-based architecture was found in an already-installed package (`transformers` has zero `nn.GRU` usage; `silero-vad`'s GRU-based VAD model requires `torchaudio` and ships as a pretrained JIT/ONNX artifact, not a config-driven module fitting this project's tiny-random-init-export convention). Lower priority regardless -- no current target model needs it.

## Test plan
- [x] `pytest tests/test_build_parakeet_lstm_probe.py -q` -- 3 passed
- [x] `python3 scripts/axera/build_parakeet_lstm_probe.py /tmp/out.onnx` -- real export, confirmed 2 opaque `LSTM` nodes, op-coverage table printed
- [x] `ruff format --check` / `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W