### PR TITLE
Skip custom schema import in step graph simplification

### DIFF
--- a/onnxsim/qat_graph.py
+++ b/onnxsim/qat_graph.py
@@ -651,6 +651,18 @@ def make_step_graph(
                 "fuse_matmul_add_bias_into_gemm",
                 "fuse_transpose_into_gemm",
             ],
+            # A step graph's nodes all come from this module's and
+            # graph_grad's own hand-written op vocabulary (plain default-
+            # domain ops), never a caller's custom onnx.defs.register_schema
+            # operator -- and any local FunctionProto calls are already
+            # inlined above via onnx.inliner.inline_local_functions. So
+            # simplify()'s default schema-bridging scan of the *entire* onnx
+            # operator registry (import_onnx_schemas(), on by default to
+            # support custom ops elsewhere) never finds anything to import
+            # here, yet still costs a few milliseconds every call -- pure
+            # waste for a helper called once per layer/candidate in tight
+            # loops like adaround's and adaquant's.
+            import_custom_schemas=False,
         )
     return StepGraph(
         model=model,


### PR DESCRIPTION
## Summary
Optimize `make_step_graph()` by disabling custom schema imports during ONNX model simplification, since step graphs only contain built-in operators and never use custom registered schemas.

## Changes
- Added `import_custom_schemas=False` parameter to the `simplify()` call in `make_step_graph()`
- Added detailed comment explaining why this optimization is safe and beneficial

## Details
Step graphs are constructed entirely from hand-written operators in the module's own vocabulary and `graph_grad`, with all local `FunctionProto` calls already inlined. They never reference custom operators registered via `onnx.defs.register_schema()`. 

The default behavior of `simplify()` scans the entire ONNX operator registry via `import_onnx_schemas()` to support custom ops, but this is unnecessary overhead for step graphs. Since `make_step_graph()` is called once per layer/candidate in tight loops (e.g., in adaround and adaquant), disabling this scan provides a measurable performance improvement with no functional impact.

https://claude.ai/code/session_01Ya4VApyoNqt52MAJeQruwF