### PR TITLE
Intern Adam/SGD-momentum's shared hyperparameter constants

### DIFF
--- a/onnxsim/qat_graph.py
+++ b/onnxsim/qat_graph.py
@@ -264,6 +264,7 @@ class GraphBuilder:
         self._function_ids: set = set()
         self._prefix = prefix
         self._counter = 0
+        self._shared_consts: Dict[Tuple[str, bytes], str] = {}
 
     def name(self, hint: str = "t") -> str:
         self._counter += 1
@@ -274,6 +275,30 @@ class GraphBuilder:
         array = np.asarray(value, dtype=np.float32)
         name = self.name(hint)
         self.initializer.append(onnx.numpy_helper.from_array(array, name))
+        return name
+
+    def shared_const(self, value, hint: str = "c") -> str:
+        """Like :meth:`const`, but returns the same initializer for an
+        identical (shape, value) requested more than once on this builder.
+
+        For a genuinely per-call constant, :meth:`const` is what every rule
+        in :mod:`onnxsim.graph_grad` already uses. This is for the opposite
+        case: a *shared* hyperparameter -- Adam's beta1/beta2/eps, SGD
+        momentum's own decay -- that :func:`adam_update`/
+        :func:`sgd_momentum_update` re-derive from the same Python float on
+        every call, once per trained parameter. Without interning, a step
+        graph training ``N`` parameters carries ``N`` duplicate copies of
+        each one, all needing :func:`onnxsim.onnx_simplifier.simplify`'s
+        CSE to merge back down after the fact; this avoids creating the
+        duplicates in the first place.
+        """
+        array = np.asarray(value, dtype=np.float32)
+        key = (array.shape, array.tobytes())
+        cached = self._shared_consts.get(key)
+        if cached is not None:
+            return cached
+        name = self.const(array, hint)
+        self._shared_consts[key] = name
         return name
 
     def op(
@@ -432,17 +457,24 @@ def adam_update(
     counter inside the graph: they are two host-side floats per step, so
     computing them outside costs nothing and keeps the graph free of the state
     that a ``Pow`` over a step counter would need.
+
+    beta1/beta2/eps are looked up with :meth:`GraphBuilder.shared_const`, not
+    :meth:`GraphBuilder.const`: a caller updating several parameters against
+    the same ``b`` (every caller in this codebase) passes the same three
+    Python floats to every call, so interning them avoids leaving one
+    duplicate initializer per parameter for simplify()'s CSE to merge back
+    down afterward.
     """
-    beta1 = b.const(ADAM_BETA1)
-    beta2 = b.const(ADAM_BETA2)
-    one_minus_beta1 = b.const(1.0 - ADAM_BETA1)
-    one_minus_beta2 = b.const(1.0 - ADAM_BETA2)
+    beta1 = b.shared_const(ADAM_BETA1, "beta1")
+    beta2 = b.shared_const(ADAM_BETA2, "beta2")
+    one_minus_beta1 = b.shared_const(1.0 - ADAM_BETA1, "one_minus_beta1")
+    one_minus_beta2 = b.shared_const(1.0 - ADAM_BETA2, "one_minus_beta2")
 
     m_next = b.add(b.mul(beta1, m), b.mul(one_minus_beta1, grad))
     v_next = b.add(b.mul(beta2, v), b.mul(one_minus_beta2, b.mul(grad, grad)))
     m_hat = b.mul(m_next, m_correction)
     v_hat = b.mul(v_next, v_correction)
-    step = b.div(b.mul(lr, m_hat), b.add(b.sqrt(v_hat), b.const(eps)))
+    step = b.div(b.mul(lr, m_hat), b.add(b.sqrt(v_hat), b.shared_const(eps, "eps")))
     param_next = b.sub(param, step)
     return param_next, m_next, v_next
 
@@ -468,12 +500,13 @@ def sgd_momentum_update(
         param' = param - lr * mom'
 
     ``momentum`` is a plain Python float baked into the graph as a constant
-    with :meth:`GraphBuilder.const`, exactly like ``eps`` in :func:`adam_update`
-    -- not a per-step scalar input the way ``lr`` is. This is a real,
-    deliberate limitation rather than an oversight: a step graph built with
-    this function can anneal ``lr`` from one step to the next (it is fed
-    fresh every call to :func:`run_step_graph`), but ``momentum`` is fixed for
-    the life of the graph -- changing it means building a new step graph.
+    with :meth:`GraphBuilder.shared_const`, exactly like ``eps`` in
+    :func:`adam_update` -- not a per-step scalar input the way ``lr`` is.
+    This is a real, deliberate limitation rather than an oversight: a step
+    graph built with this function can anneal ``lr`` from one step to the
+    next (it is fed fresh every call to :func:`run_step_graph`), but
+    ``momentum`` is fixed for the life of the graph -- changing it means
+    building a new step graph.
     Nothing in this optimizer's current callers needs a per-step momentum
     schedule, and keeping it a constant keeps the graph one input smaller.
 
@@ -491,11 +524,11 @@ def sgd_momentum_update(
     same slow warm-up plain SGD momentum has always had rather than paying
     for a correction the algebra does not need.
 
-    Uses only :meth:`GraphBuilder.const`/:meth:`add`/:meth:`mul`/:meth:`sub` --
-    no ``div``/``sqrt``, since there is no second moment or epsilon-guarded
-    denominator to compute.
+    Uses only :meth:`GraphBuilder.shared_const`/:meth:`add`/:meth:`mul`/
+    :meth:`sub` -- no ``div``/``sqrt``, since there is no second moment or
+    epsilon-guarded denominator to compute.
     """
-    momentum_const = b.const(momentum)
+    momentum_const = b.shared_const(momentum, "momentum")
     mom_next = b.add(b.mul(momentum_const, mom), grad)
     step = b.mul(lr, mom_next)
     param_next = b.sub(param, step)

--- a/onnxsim/qat_graph_builder.cpp
+++ b/onnxsim/qat_graph_builder.cpp
@@ -156,6 +156,16 @@ std::string GraphBuilder::Const(const std::vector<float>& values,
   return name;
 }
 
+std::string GraphBuilder::SharedConst(float value, const std::string& hint) {
+  uint32_t key = 0;
+  std::memcpy(&key, &value, sizeof(key));
+  auto it = shared_consts_.find(key);
+  if (it != shared_consts_.end()) return it->second;
+  const std::string name = Const(value, hint);
+  shared_consts_.emplace(key, name);
+  return name;
+}
+
 std::string GraphBuilder::ConstInt64(const std::vector<int64_t>& values,
                                      const std::string& hint) {
   const std::string name = Name(hint);
@@ -313,12 +323,12 @@ AdamOutputs AdamUpdate(GraphBuilder& b, const std::string& param,
                        const std::string& v, const std::string& lr,
                        const std::string& m_correction,
                        const std::string& v_correction, float eps) {
-  const std::string beta1 = b.Const(kAdamBeta1);
-  const std::string beta2 = b.Const(kAdamBeta2);
+  const std::string beta1 = b.SharedConst(kAdamBeta1, "beta1");
+  const std::string beta2 = b.SharedConst(kAdamBeta2, "beta2");
   const std::string one_minus_beta1 =
-      b.Const(static_cast<float>(1.0 - kBeta1Double));
+      b.SharedConst(static_cast<float>(1.0 - kBeta1Double), "one_minus_beta1");
   const std::string one_minus_beta2 =
-      b.Const(static_cast<float>(1.0 - kBeta2Double));
+      b.SharedConst(static_cast<float>(1.0 - kBeta2Double), "one_minus_beta2");
 
   // Every nesting in adam_update is flattened here for the argument-order
   // reason above; the left-to-right order of these locals *is* the Python's.
@@ -336,7 +346,7 @@ AdamOutputs AdamUpdate(GraphBuilder& b, const std::string& param,
 
   const std::string numerator = b.Mul(lr, m_hat);
   const std::string root = b.Sqrt(v_hat);
-  const std::string epsilon = b.Const(eps);
+  const std::string epsilon = b.SharedConst(eps, "eps");
   const std::string denominator = b.Add(root, epsilon);
   const std::string step = b.Div(numerator, denominator);
 
@@ -347,7 +357,7 @@ SgdMomentumOutputs SgdMomentumUpdate(GraphBuilder& b, const std::string& param,
                                      const std::string& grad,
                                      const std::string& mom,
                                      const std::string& lr, float momentum) {
-  const std::string momentum_const = b.Const(momentum);
+  const std::string momentum_const = b.SharedConst(momentum, "momentum");
 
   // Sequenced in the Python's left-to-right order, as AdamUpdate's own locals
   // above are: `b.add(b.mul(momentum_const, mom), grad)`.

--- a/onnxsim/qat_graph_builder.h
+++ b/onnxsim/qat_graph_builder.h
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -98,6 +99,17 @@ class GraphBuilder {
   std::string Const(const std::vector<float>& values,
                     const std::vector<int64_t>& dims,
                     const std::string& hint = "c");
+
+  // Like Const(float, hint), but returns the same initializer for an
+  // identical value requested more than once on this builder. Matches
+  // qat_graph.GraphBuilder.shared_const exactly: AdamUpdate/
+  // SgdMomentumUpdate use it for their own fixed hyperparameters (beta1,
+  // beta2, eps, momentum), which every caller re-derives from the same
+  // float on every call, once per trained parameter. The parity fixture
+  // compares tensor names bit-for-bit (see this class's own comment
+  // above), so this side must dedup identically -- same key, same hint --
+  // or the two emitters would number their initializers differently.
+  std::string SharedConst(float value, const std::string& hint = "c");
   // An int64 initializer -- the shape/axes operand form Reshape and the
   // opset-13 Reduce ops take as a tensor input rather than an attribute.
   std::string ConstInt64(const std::vector<int64_t>& values,
@@ -184,6 +196,8 @@ class GraphBuilder {
   std::set<std::pair<std::string, std::string>> function_ids_;
   std::string prefix_;
   int64_t counter_ = 0;
+  // Keyed by the float's raw bit pattern -- see SharedConst.
+  std::unordered_map<uint32_t, std::string> shared_consts_;
 };
 
 // Appends one Adam step to `b` and returns (param', m', v').

--- a/onnxsim/qat_graph_builder_test.cpp
+++ b/onnxsim/qat_graph_builder_test.cpp
@@ -299,7 +299,8 @@ void AdamUpdateEmitsTheDocumentedArithmeticInTheDocumentedOrder() {
   CheckEqual(out.param_next, "sub_19",
              "p' = p - lr*m_hat / (sqrt(v_hat) + eps)");
 
-  CheckEqual(b.nodes()[0].input(0), "c_1", "beta1 scales the old first moment");
+  CheckEqual(b.nodes()[0].input(0), "beta1_1",
+             "beta1 scales the old first moment");
   CheckEqual(b.nodes()[0].input(1), "m", "...against the incoming m");
   CheckEqual(b.nodes()[4].input(0), "g",
              "the squared gradient is g*g, not Pow");
@@ -345,7 +346,7 @@ void SgdMomentumUpdateEmitsTheDocumentedArithmeticInTheDocumentedOrder() {
   CheckEqual(out.mom_next, "add_3", "mom' = momentum*mom + g");
   CheckEqual(out.param_next, "sub_5", "p' = p - lr*mom'");
 
-  CheckEqual(b.nodes()[0].input(0), "c_1",
+  CheckEqual(b.nodes()[0].input(0), "momentum_1",
              "momentum scales the old momentum buffer");
   CheckEqual(b.nodes()[0].input(1), "mom", "...against the incoming mom");
   CheckEqual(b.nodes()[1].input(1), "g",

--- a/onnxsim/qat_parity_fixtures.txt
+++ b/onnxsim/qat_parity_fixtures.txt
@@ -12,23 +12,23 @@ model_text   A = Relu(H)
 model_text   Y = MatMul(A, W2)
 model_text }
 case adam_update
-  init c_1 1 [] 0x3f666666
-  init c_2 1 [] 0x3f7fbe77
-  init c_3 1 [] 0x3dcccccd
-  init c_4 1 [] 0x3a83126f
-  init c_16 1 [] 0x322bcc77
-  node Mul [c_1,m] [mul_5] {}
-  node Mul [c_3,g] [mul_6] {}
+  init beta1_1 1 [] 0x3f666666
+  init beta2_2 1 [] 0x3f7fbe77
+  init one_minus_beta1_3 1 [] 0x3dcccccd
+  init one_minus_beta2_4 1 [] 0x3a83126f
+  init eps_16 1 [] 0x322bcc77
+  node Mul [beta1_1,m] [mul_5] {}
+  node Mul [one_minus_beta1_3,g] [mul_6] {}
   node Add [mul_5,mul_6] [add_7] {}
-  node Mul [c_2,v] [mul_8] {}
+  node Mul [beta2_2,v] [mul_8] {}
   node Mul [g,g] [mul_9] {}
-  node Mul [c_4,mul_9] [mul_10] {}
+  node Mul [one_minus_beta2_4,mul_9] [mul_10] {}
   node Add [mul_8,mul_10] [add_11] {}
   node Mul [add_7,mc] [mul_12] {}
   node Mul [add_11,vc] [mul_13] {}
   node Mul [lr,mul_12] [mul_14] {}
   node Sqrt [mul_13] [sqrt_15] {}
-  node Add [sqrt_15,c_16] [add_17] {}
+  node Add [sqrt_15,eps_16] [add_17] {}
   node Div [mul_14,add_17] [div_18] {}
   node Sub [p,div_18] [sub_19] {}
   result sub_19,add_7,add_11
@@ -80,11 +80,11 @@ case planner
   init qat__c_22 1 [] 0x40e00000
   init qat__c_27 1 [] 0x3c800000
   init qat__c_33 1 [] 0x00000000
-  init qat__c_42 1 [] 0x3f666666
-  init qat__c_43 1 [] 0x3f7fbe77
-  init qat__c_44 1 [] 0x3dcccccd
-  init qat__c_45 1 [] 0x3a83126f
-  init qat__c_57 1 [] 0x322bcc77
+  init qat__beta1_42 1 [] 0x3f666666
+  init qat__beta2_43 1 [] 0x3f7fbe77
+  init qat__one_minus_beta1_44 1 [] 0x3dcccccd
+  init qat__one_minus_beta2_45 1 [] 0x3a83126f
+  init qat__eps_57 1 [] 0x322bcc77
   node Reshape [qat__scale_1,qat__i64_2] [qat__reshape_3] {}
   node Mul [qat__reshape_3,qat__ones_4] [qat__mul_5] {}
   node Reshape [qat__mul_5,qat__i64_6] [qat__reshape_7] {}
@@ -119,18 +119,18 @@ case planner
   node Transpose [X] [qat__transpose_39] {perm=1,0}
   node MatMul [qat__transpose_39,qat__mul_36] [qat__matmul_40] {}
   node Mul [qat__matmul_40,qat__mul_25] [qat__mul_41] {}
-  node Mul [qat__c_42,qat__mw0] [qat__mul_46] {}
-  node Mul [qat__c_44,qat__mul_41] [qat__mul_47] {}
+  node Mul [qat__beta1_42,qat__mw0] [qat__mul_46] {}
+  node Mul [qat__one_minus_beta1_44,qat__mul_41] [qat__mul_47] {}
   node Add [qat__mul_46,qat__mul_47] [qat__add_48] {}
-  node Mul [qat__c_43,qat__vw0] [qat__mul_49] {}
+  node Mul [qat__beta2_43,qat__vw0] [qat__mul_49] {}
   node Mul [qat__mul_41,qat__mul_41] [qat__mul_50] {}
-  node Mul [qat__c_45,qat__mul_50] [qat__mul_51] {}
+  node Mul [qat__one_minus_beta2_45,qat__mul_50] [qat__mul_51] {}
   node Add [qat__mul_49,qat__mul_51] [qat__add_52] {}
   node Mul [qat__add_48,m_correction] [qat__mul_53] {}
   node Mul [qat__add_52,v_correction] [qat__mul_54] {}
   node Mul [qat__lr,qat__mul_53] [qat__mul_55] {}
   node Sqrt [qat__mul_54] [qat__sqrt_56] {}
-  node Add [qat__sqrt_56,qat__c_57] [qat__add_58] {}
+  node Add [qat__sqrt_56,qat__eps_57] [qat__add_58] {}
   node Div [qat__mul_55,qat__add_58] [qat__div_59] {}
   node Sub [qat__w0,qat__div_59] [qat__sub_60] {}
   node Mul [qat__sub_26,qat__sub_26] [qat__mul_61] {}
@@ -164,33 +164,33 @@ case round_to_nearest
   node Mul [sign_5,cast_6] [mul_7] {}
   result mul_7
 case sgd_momentum_update
-  init c_1 1 [] 0x3f666666
-  node Mul [c_1,mom] [mul_2] {}
+  init momentum_1 1 [] 0x3f666666
+  node Mul [momentum_1,mom] [mul_2] {}
   node Add [mul_2,g] [add_3] {}
   node Mul [lr,add_3] [mul_4] {}
   node Sub [p,mul_4] [sub_5] {}
   result sub_5,add_3
 case step_graph
-  init c_4 1 [] 0x3f666666
-  init c_5 1 [] 0x3f7fbe77
-  init c_6 1 [] 0x3dcccccd
-  init c_7 1 [] 0x3a83126f
-  init c_19 1 [] 0x322bcc77
+  init beta1_4 1 [] 0x3f666666
+  init beta2_5 1 [] 0x3f7fbe77
+  init one_minus_beta1_6 1 [] 0x3dcccccd
+  init one_minus_beta2_7 1 [] 0x3a83126f
+  init eps_19 1 [] 0x322bcc77
   node Sub [student,teacher] [sub_1] {}
   node Mul [sub_1,sub_1] [mul_2] {}
   node ReduceMean [mul_2] [reducemean_3] {keepdims=0}
-  node Mul [c_4,m] [mul_8] {}
-  node Mul [c_6,sub_1] [mul_9] {}
+  node Mul [beta1_4,m] [mul_8] {}
+  node Mul [one_minus_beta1_6,sub_1] [mul_9] {}
   node Add [mul_8,mul_9] [add_10] {}
-  node Mul [c_5,v] [mul_11] {}
+  node Mul [beta2_5,v] [mul_11] {}
   node Mul [sub_1,sub_1] [mul_12] {}
-  node Mul [c_7,mul_12] [mul_13] {}
+  node Mul [one_minus_beta2_7,mul_12] [mul_13] {}
   node Add [mul_11,mul_13] [add_14] {}
   node Mul [add_10,mc] [mul_15] {}
   node Mul [add_14,vc] [mul_16] {}
   node Mul [lr,mul_15] [mul_17] {}
   node Sqrt [mul_16] [sqrt_18] {}
-  node Add [sqrt_18,c_19] [add_20] {}
+  node Add [sqrt_18,eps_19] [add_20] {}
   node Div [mul_17,add_20] [div_21] {}
   node Sub [w,div_21] [sub_22] {}
   opset  17


### PR DESCRIPTION
## Summary
`adam_update()`/`sgd_momentum_update()` re-created their fixed hyperparameters (beta1, beta2, eps, momentum) as fresh ONNX initializers on every call, even though every caller passes the same Python floats to update every trained parameter against one `GraphBuilder`. A step graph training `N` parameters carried `N` duplicate copies of each constant, all left for `simplify()`'s CSE to merge back down afterward.

## Changes
- Added `GraphBuilder.shared_const()`, which interns by `(shape, value)` and returns an existing initializer instead of creating a duplicate.
- Switched `adam_update()`/`sgd_momentum_update()` to use it for their own fixed hyperparameters (not for `graph_grad`'s per-call constants, which still use plain `const()` as before).
- Updated the affected docstrings to reference `shared_const()`.

## Details
Measured on a synthetic 32-parameter step graph (forward MLP → `graph_grad.build_backward()` → Adam wiring): the raw (pre-simplify) graph carried 289 initializers, 257 of them scalar, collapsing to only 8 distinct values — beta1/beta2/(1-beta1)/(1-beta2)/eps each appeared exactly 32 times, once per parameter. After this change, the same graph carries 134 initializers, with each hyperparameter appearing exactly once.

This complements #1388 (skipping the unneeded custom-op schema scan): both reduce the amount of redundant work `simplify()` has to do on step graphs built in tight loops (adaround/adaquant's per-layer candidates, `compile_training`'s whole-network compile).

## Test plan
- [x] `pytest tests/test_qat_graph.py tests/test_qat.py tests/test_lora.py tests/test_graph_grad.py tests/test_adaround.py tests/test_adaquant.py tests/test_compile_training.py tests/test_distributed.py` — 367 passed, 2 skipped
- [x] Verified initializer counts directly (289 → 134 for a 32-parameter synthetic step graph), confirming each shared hyperparameter now appears exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ya4VApyoNqt52MAJeQruwF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ya4VApyoNqt52MAJeQruwF)_