### PR TITLE
Wire onnxsim.inline_local_functions into axera legalize's inlining rule

### DIFF
--- a/scripts/axera/legalize.py
+++ b/scripts/axera/legalize.py
@@ -560,35 +560,45 @@ def inline_local_functions(model):
     resnet18 training step, and they are eight residual connections' gradient
     accumulations, so they are not optional.
 
-    `onnx.inliner` expands them into what they always were -- here, `Identity`,
-    which the AX650 does support. Returns the number of function definitions
-    that were inlined away.
+    Delegates to `onnxsim.inline_local_functions` (added specifically for
+    this): it handles the same "a locally-defined function lives in its own
+    domain, and the model has to import that domain before anything --
+    checker or inliner -- will look at it" fixup this function used to do by
+    hand, uses onnx's own `convert_version=True` to reconcile an opset
+    mismatch (`graph_grad`'s functions declare opset 17; a graph built from a
+    modern export declares 18) rather than this module's old crude "just
+    overwrite the version number" hack, and -- the reason it is worth the
+    onnxsim dependency below -- raises if an `If`/`Loop`/`Scan` survives
+    inlining. A function whose body branches on a genuinely data-dependent
+    condition (not the compile-time-constant kind
+    `eliminate_if_with_const_cond` already collapses automatically) would
+    otherwise pass this rule silently and fail much later, opaquely, on
+    Pulsar2 or any other runtime that does not execute control flow.
+
+    `fuse_matmul_add_bias_into_gemm(_batched)`/`fuse_transpose_into_gemm` are
+    skipped in the simplify pass this runs: `gemm_to_matmul`/
+    `act_weight_conv_to_matmul`, later in `TRAINING_RULES`, exist specifically
+    to decompose `Gemm` away for this target, and would otherwise have to
+    undo a fusion this step just introduced.
+
+    Only imports `onnxsim` when there is actually a function to inline, so
+    `legalize.py in.onnx out.onnx`'s standalone (`onnx`-only) usage is
+    unaffected for the common case of a model with none. Returns the number
+    of function definitions that were inlined away.
     """
     if not model.functions:
         return 0
-    import onnx.inliner
+    import onnxsim
 
-    # A locally-defined function lives in its own domain, and the model has to
-    # import that domain before anything -- checker or inliner -- will look at
-    # it. A graph assembled by hand from `graph_grad`'s output does not have
-    # the import, so add it rather than failing on "No opset import for domain".
-    have = {entry.domain: entry for entry in model.opset_import}
-    for fn in model.functions:
-        if fn.domain not in have:
-            entry = helper.make_opsetid(fn.domain, 1)
-            model.opset_import.append(entry)
-            have[fn.domain] = entry
-        # The inliner silently declines a function whose standard-domain opset
-        # disagrees with the model's -- it inlined nothing and left eight
-        # GradAdd calls for Pulsar2 to reject with "dont support GradAdd opr".
-        # The functions `graph_grad` ships declare opset 17; a graph built from
-        # a modern export declares 18.
-        for imp in fn.opset_import:
-            standard = have.get(imp.domain or "")
-            if standard is not None and (imp.domain or "") == "":
-                imp.version = standard.version
     before = len(model.functions)
-    inlined = onnx.inliner.inline_local_functions(model)
+    inlined = onnxsim.inline_local_functions(
+        model,
+        skipped_optimizers=[
+            "fuse_matmul_add_bias_into_gemm",
+            "fuse_matmul_add_bias_into_gemm_batched",
+            "fuse_transpose_into_gemm",
+        ],
+    )
     model.CopyFrom(inlined)
     return before - len(model.functions)
 

--- a/tests/test_axera_training_legalize.py
+++ b/tests/test_axera_training_legalize.py
@@ -458,6 +458,43 @@ def test_inlining_a_graph_with_no_functions_is_a_no_op():
     assert legalize.inline_local_functions(model) == 0
 
 
+def test_a_function_with_real_control_flow_raises_instead_of_shipping_an_if():
+    """Not every function inlines down to plain ops: one whose body branches
+    on a genuinely data-dependent condition leaves an `If` behind, and
+    Pulsar2 (like most ONNX runtimes) does not execute one. This has to fail
+    right here, loudly, rather than pass this rule silently and break far
+    later on the compiler with an opaque "unsupported op" error."""
+    model = onnx.parser.parse_model(
+        """
+        <
+          ir_version: 10,
+          opset_import: ["": 18, "custom": 1]
+        >
+        agraph (float[4] X) => (float[4] Y) {
+          Y = custom.DynIdentity(X)
+        }
+        <
+          domain: "custom",
+          opset_import: ["": 18]
+        >
+        DynIdentity (x) => (y) {
+          summed = ReduceSum<keepdims=0>(x)
+          cond = Greater(summed, summed)
+          y = If<
+            then_branch = then_g () => (float[4] t) { t = Relu(x) },
+            else_branch = else_g () => (float[4] e) { e = Neg(x) }
+          >(cond)
+        }
+        """
+    )
+    try:
+        legalize.inline_local_functions(model)
+    except ValueError as error:
+        assert "If" in str(error)
+    else:
+        raise AssertionError("expected a ValueError naming the surviving If node")
+
+
 def test_training_rules_run_in_an_order_that_works():
     """`inline_local_functions` has to come first -- every later rule inspects
     op types and would look straight past a function call."""


### PR DESCRIPTION
## Summary
`scripts/axera/legalize.py`'s own `inline_local_functions` rule inlined `graph_grad`'s function calls raw, with no check that the result was actually free of control flow. A function whose body branches on a genuinely data-dependent condition would leave an `If` node behind — the rest of `TRAINING_RULES` has no reason to notice (they only look for op types they know), and Pulsar2, like most ONNX runtimes, doesn't execute one — so it would fail much later and far from the inlining call that produced it.

## Changes
- `inline_local_functions` now delegates to `onnxsim.inline_local_functions` (added in #1393 for exactly this), which raises right here if an `If`/`Loop`/`Scan` survives.
- Replaces this rule's old hand-rolled opset-import fixup and version-forcing hack with the same fixup generalized, plus onnx's own `convert_version=True` for the version mismatch instead of just overwriting the version number.
- Skips `fuse_matmul_add_bias_into_gemm(_batched)`/`fuse_transpose_into_gemm` in the simplify pass this runs, since `gemm_to_matmul`/`act_weight_conv_to_matmul` later in `TRAINING_RULES` exist specifically to decompose `Gemm` away for this target and would otherwise have to undo a fusion this step just introduced.
- `onnxsim` is only imported when there is actually a function to inline, so `legalize.py in.onnx out.onnx`'s standalone (`onnx`-only) usage is unaffected for the common case of a model with none.
- Added a test for the motivating case: a function with a real data-dependent `If` now raises instead of silently passing this rule.

## Test plan
- [x] `pytest tests/test_axera_training_legalize.py tests/test_axera_legalize.py` — 30 passed
- [x] Full test suite (excluding files needing optional deps not installed here — torch, timm): 4421 passed, 368 skipped, no regressions
- [x] `ruff format --check` / `ruff check` clean on the touched files
- [x] Confirmed the standalone (no local functions) path still never imports `onnxsim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ya4VApyoNqt52MAJeQruwF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ya4VApyoNqt52MAJeQruwF)_