### PR TITLE
axera: fix rank-1 Sub tiler crash generically -- bias tensors now trainable on real hardware

### DIFF
--- a/docs/axera-super-resolution-op-coverage.md
+++ b/docs/axera-super-resolution-op-coverage.md
@@ -123,25 +123,35 @@ trajectory actually used, `grad_seed` given real values near 1.0) and
 compiled the `tail` scope with real `pulsar2:7.0-lite`.
 
 **A new, real, generalizable Pulsar2 NPU-backend limitation, not an EDSR
-quirk**: compiling `tail`'s full 4-tensor scope (both `Conv` weights and
-both biases) fails -- `TileFailException("AxQuantizedSub, tuple index out
-of range")` on the in-graph SGD update (`w_next = w - lr * grad`, an
-ordinary `Sub`) for a **rank-1** operand. Confirmed on two different real
-compiles, isolating the trigger precisely: `tail.1.bias` (3 elements) and
-`tail.0.0.bias` (32 elements) both crash identically, so element count is
-not the cause -- rank is. Training only the two `Conv` **weights**
-(`--weights-only`, dropping both rank-1 biases) compiles successfully.
-**Every earlier real-hardware training in this project's history happened
-to only train rank>=2 weight tensors** -- resnet18/50's conv/fc weights,
-LSTM/GRU's per-gate weight matrices -- which is almost certainly why this
-was never found before EDSR's own survey put a bias tensor directly in a
-trainable scope for the first time. A reshape-to-rank-2-and-back
-workaround (wrap the `Sub` in `Reshape([1,N])`/`Sub`/`Reshape([N])`,
-sidestepping the crash entirely) was tried once, cleared the backend
-tiler issue, but hit a different, likely calibration/build-script-shaped
-error (`fetch_calibration_data`'s own `IndexError`) on a first attempt --
-untried further, a real, promising next step for whoever wants bias
-tensors trainable through this pipeline.
+quirk -- found, then fixed**: compiling `tail`'s full 4-tensor scope (both
+`Conv` weights and both biases) originally failed --
+`TileFailException("AxQuantizedSub, tuple index out of range")` on the
+in-graph SGD update (`w_next = w - lr * grad`, an ordinary `Sub`) for a
+**rank-1** operand. Confirmed on two different real compiles, isolating
+the trigger precisely: `tail.1.bias` (3 elements) and `tail.0.0.bias` (32
+elements) both crashed identically, so element count was not the cause --
+rank was. **Every earlier real-hardware training in this project's
+history happened to only train rank>=2 weight tensors** -- resnet18/50's
+conv/fc weights, LSTM/GRU's per-gate weight matrices -- which is almost
+certainly why this was never found before EDSR's own survey put a bias
+tensor directly in a trainable scope for the first time.
+
+**Fixed generically in `build_resident_step()` itself** (not an
+EDSR-specific patch): any rank-1 trainable tensor's whole per-step update
+now runs in rank-2 `[1, N]` space -- reshape in, `Mul`/`Sub`, reshape back
+-- transparent to the state tensor's own declared rank-1 shape at the
+step graph's I/O boundary, so calibration and every other caller see the
+exact same tensor shapes as before (the `fetch_calibration_data`
+`IndexError` an earlier attempt at this hit turned out to be an artifact
+of that attempt's own approach, not a real blocker of the reshape
+strategy itself -- calibrating the unchanged rank-1 I/O boundary directly,
+as `build_edsr_calib.py` already did, needed no special handling at all).
+Verified bit-exact against the un-reshaped math on host, and a dedicated
+regression test (`tests/test_build_resident_train_step.py`'s
+`test_rank1_state_update_is_reshaped_around_the_sub`) checks both the
+structural property (`Sub` never sees a bare rank-1 operand) and the
+numeric one (the implied gradient matches a central-difference check of
+the original graph, independent of `build_resident_step`'s own code).
 
 **Real numbers, `--scope tail --weights-only` (`tail.0.0.weight` +
 `tail.1.weight`, 58 nodes)**: compiles in **~30 seconds** (three real
@@ -156,6 +166,16 @@ mean `|grad|` for the two weights, measured directly) still rounds to
 zero under real INT8 quantization at that scale; `lr=10` diverges to NaN
 within a handful of real host SGD steps. `lr=1.0` is the confirmed
 working value, not a default guess.
+
+**With the rank-1 fix in place, `--scope tail` (all four tensors, both
+`Conv` weights and both biases, 72 nodes) now also compiles and trains on
+real hardware**: real `pulsar2:7.0-lite` build in **31.2s** (no
+compile-time cost from the extra reshapes), and real, monotonically
+decreasing loss at `lr=1.0` (`0.0914259 -> 0.0910601 -> 0.0906944 -> ... ->
+0.0895973` over 30 real steps, ~136 steps/s), confirmed genuinely
+gradient-driven via the same `lr=0` control (bit-identical loss across 10
+real steps). Bias tensors are trainable through this pipeline now, not
+just a documented future direction.
 
 **A second real gap found and fixed getting here, worth recording
 generically**: `export_edsr()`'s first version never seeded `torch`, so
@@ -176,9 +196,9 @@ EDSR does, so the same `DepthToSpace` coverage almost certainly transfers
 directly -- untried here, but a much smaller lift than EDSR's own first
 survey was, since the one real gap this domain has is now closed.
 
-The rank-1 `AxQuantizedSub` crash found above is not EDSR-specific --
+The rank-1 `AxQuantizedSub` crash found above was not EDSR-specific --
 any future domain training a bias tensor through this pipeline's in-graph
-SGD update will hit it. The reshape-to-rank-2-and-back workaround is the
-concrete next step for whoever wants bias tensors trainable generally,
-rather than working around it per-model as `trainable_scope`'s
-`weights_only` does here.
+SGD update would have hit it too. Already fixed generically in
+`build_resident_step()` itself (see "Real hardware" above), so no future
+domain needs its own per-model workaround the way `trainable_scope`'s
+`weights_only` flag did here before the fix.

--- a/scripts/axera/build_edsr_calib.py
+++ b/scripts/axera/build_edsr_calib.py
@@ -10,13 +10,16 @@ used, give `grad_seed` real values near 1.0) -- the same recipe that has
 turned every other "compiles but nothing moves" build in this project into
 "trains correctly."
 
-Defaults to `--scope tail --weights-only`, the one confirmed-compiling
-configuration on real hardware: `trainable_scope`'s own docstring has the
-full story, but in short, a rank-1 (bias) tensor's in-graph SGD update
-crashes Pulsar2's NPU backend tiler (`TileFailException("AxQuantizedSub,
-tuple index out of range")`), confirmed on two different bias shapes here.
-Pass `--scope tail` alone (without `--weights-only`) to reproduce that
-crash directly.
+Defaults to `--scope tail --weights-only`, the configuration confirmed
+first on real hardware. A rank-1 (bias) tensor's in-graph SGD update used
+to crash Pulsar2's NPU backend tiler (`TileFailException("AxQuantizedSub,
+tuple index out of range")`, confirmed on two different bias shapes here)
+-- **fixed generically in `build_resident_train_step.build_resident_step()`
+itself** (reshape the whole per-step update to rank-2 around the `Sub` and
+back), so `--scope tail --no-weights-only` (all four tensors, both `Conv`
+weights and both biases) now also compiles and trains correctly; see
+`docs/axera-super-resolution-op-coverage.md`'s real-hardware section for
+the numbers.
 
 A real, distinct calibration-degeneracy trap this domain's own input names
 surfaced (not present in any earlier model): `make_training_calib.

--- a/scripts/axera/build_edsr_train_step.py
+++ b/scripts/axera/build_edsr_train_step.py
@@ -154,21 +154,22 @@ def trainable_scope(
     fuller, harder-to-reach scope; `"all"`: every trainable tensor.
 
     `weights_only` (default `False`) drops every rank-1 (bias) tensor from
-    the result. **Real hardware finding, not a style preference**: a
-    resident training step's in-graph SGD update (`w_next = w - lr *
-    grad`, an ordinary `Sub`) crashes Pulsar2's own NPU backend tiler on a
-    rank-1 operand -- confirmed on two different real compiles here (a
-    3-element and a 32-element bias, both `TileFailException("
-    AxQuantizedSub, tuple index out of range")`), so size is not the
-    trigger, rank is. `scope="tail"`/`"head"`/`"all"` all include real
-    bias tensors and will hit this on real hardware; every earlier domain
-    in this project happened to only train rank>=2 weight tensors, which
-    is almost certainly why this was never found before EDSR's own survey.
-    See `docs/axera-super-resolution-op-coverage.md`'s real-hardware
-    section for the confirmed compile/train result this scope produces,
-    and for a reshape-to-rank-2-and-back workaround idea that hit a
-    different (calibration/build-script, not backend) error on a first
-    attempt -- untried further, a real next step.
+    the result. **Originally a real hardware finding, now fixed
+    generically, not a style preference to keep**: a resident training
+    step's in-graph SGD update (`w_next = w - lr * grad`, an ordinary
+    `Sub`) used to crash Pulsar2's own NPU backend tiler on a rank-1
+    operand -- confirmed on two different real compiles here (a 3-element
+    and a 32-element bias, both `TileFailException("AxQuantizedSub, tuple
+    index out of range")`), so size was not the trigger, rank was; every
+    earlier domain in this project happened to only train rank>=2 weight
+    tensors, which is almost certainly why this was never found before
+    EDSR's own survey. **Fixed in
+    `build_resident_train_step.build_resident_step()` itself**, which now
+    reshapes any rank-1 state tensor's update to rank-2 around the `Sub`
+    transparently -- `weights_only=True` is no longer required for a
+    real compile, kept only as an option for a smaller/faster scope. See
+    `docs/axera-super-resolution-op-coverage.md`'s real-hardware section
+    for the confirmed compile/train result with biases included.
     """
     float_inits = {
         i.name

--- a/scripts/axera/build_resident_train_step.py
+++ b/scripts/axera/build_resident_train_step.py
@@ -619,11 +619,40 @@ def build_resident_step(
         targets=list(params),
     )
 
+    def _int64_const(values, hint):
+        name = b.name(hint)
+        b.initializer.append(
+            numpy_helper.from_array(np.array(values, dtype=np.int64), name)
+        )
+        return name
+
     state: Dict[str, Tuple[Sequence[int], str]] = {}
     for p in params:
         w_shape = tuple(int(d) for d in shapes[p])
-        step = b.mul("lr", grads[p])
-        w_next = b.sub(p, step)
+        if len(w_shape) == 1:
+            # Pulsar2's NPU backend tiler crashes compiling a rank-1 `Sub`
+            # (`TileFailException("AxQuantizedSub, tuple index out of
+            # range")`, confirmed on real hardware for both a 3- and a
+            # 32-element bias -- it's the *rank*, not the size). Every
+            # trainable tensor in this project's history before EDSR's own
+            # bias tensors happened to be rank>=2 (conv/matmul weights),
+            # which is why this was never hit until now. Side-stepped by
+            # doing the whole per-step update in rank-2 `[1, N]` space --
+            # neither the SGD math nor Pulsar2's own tiler cares about a
+            # leading size-1 axis, only about a bare rank-1 tensor
+            # specifically -- then reshaping the result back to the state
+            # tensor's own declared rank-1 shape.
+            n = w_shape[0]
+            shape2d = _int64_const([1, n], f"{p}_2d_shape")
+            shape1d = _int64_const([n], f"{p}_1d_shape")
+            p_2d = b.op("Reshape", [p, shape2d], hint=f"{p}_2d")
+            grad_2d = b.op("Reshape", [grads[p], shape2d], hint=f"{p}_grad_2d")
+            step_2d = b.mul("lr", grad_2d)
+            w_next_2d = b.sub(p_2d, step_2d)
+            w_next = b.op("Reshape", [w_next_2d, shape1d], hint=f"{p}_next")
+        else:
+            step = b.mul("lr", grads[p])
+            w_next = b.sub(p, step)
         state[p] = (w_shape, w_next)
 
     constants: Dict[str, Tuple[Sequence[int], int]] = {}

--- a/tests/test_build_resident_train_step.py
+++ b/tests/test_build_resident_train_step.py
@@ -120,6 +120,101 @@ def test_state_output_is_sgd_update_of_the_input():
     assert np.array_equal(outs[state["gw"]], gw0)
 
 
+def test_rank1_state_update_is_reshaped_around_the_sub():
+    """A rank-1 trainable tensor's in-graph SGD `Sub` crashes Pulsar2's own
+    NPU backend tiler on real hardware (`TileFailException("AxQuantizedSub,
+    tuple index out of range")`, confirmed on two different real bias
+    shapes -- `docs/axera-super-resolution-op-coverage.md`'s real-hardware
+    section). Sidestepped by reshaping the whole per-step update to rank-2
+    around the `Sub` and back afterward -- transparent to the state
+    tensor's own declared rank-1 shape at the graph's I/O boundary, checked
+    both structurally (the `Reshape`s exist) and numerically (the update
+    computes the identical value a bare rank-1 `Sub` would)."""
+    forward = _forward_model()
+    with_loss = brts.add_mse_loss(forward, "logits", num_classes=10)
+    step_model, state = brts.build_resident_step(with_loss, params=["cw", "gw", "gb"])
+    onnx.checker.check_model(step_model)
+
+    gb_next = state["gb"]
+    reshape_out = next(n for n in step_model.graph.node if n.output[0] == gb_next)
+    assert reshape_out.op_type == "Reshape", "expected the final state back at rank 1"
+    sub_node = next(
+        n for n in step_model.graph.node if n.output[0] == reshape_out.input[0]
+    )
+    assert sub_node.op_type == "Sub"
+    # `simplify()` may fold away a reshape that turns out to be a no-op (a
+    # Gemm bias gradient's own "unbroadcast" step can already land at rank
+    # 2), so check the `Sub`'s *actual* operand ranks rather than assuming
+    # a specific intermediate reshape node survives -- the property this
+    # test cares about is that `Sub` itself never sees a bare rank-1
+    # tensor, not the exact node count it took to get there.
+    for operand in sub_node.input:
+        shape = next(
+            (
+                [d.dim_value for d in vi.type.tensor_type.shape.dim]
+                for vi in list(step_model.graph.value_info)
+                + list(step_model.graph.input)
+                if vi.name == operand
+            ),
+            None,
+        )
+        if shape is not None:
+            assert len(shape) != 1, f"{operand} feeds Sub as a bare rank-1 tensor"
+
+    initializers = {t.name: t for t in forward.graph.initializer}
+    cw0 = onnx.numpy_helper.to_array(initializers["cw"])
+    gw0 = onnx.numpy_helper.to_array(initializers["gw"])
+    gb0 = onnx.numpy_helper.to_array(initializers["gb"])
+
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal((1, 1, 4, 4)).astype(np.float32)
+    y = rng.standard_normal((1, 10)).astype(np.float32)
+    lr = 0.1
+
+    feeds = {
+        "x": x,
+        "y": y,
+        "lr": np.array([lr], np.float32),
+        "grad_seed": np.array([1.0], np.float32),
+        "cw": cw0,
+        "gw": gw0,
+        "gb": gb0,
+    }
+    out_names = [o.name for o in step_model.graph.output]
+    outs = dict(zip(out_names, _run(step_model, feeds, out_names)))
+
+    # The update's implied gradient (`grad = (gb0 - gb_next) / lr`) must
+    # match a central-difference gradient of the *original* forward+loss
+    # graph's own loss w.r.t. `gb` -- independent of this module's own
+    # graph-building code, and of exactly which nodes survived `simplify()`.
+    # `with_loss` still has `gb` as a fixed initializer, not a real input --
+    # promote it to one so the loss can be probed at an offset value.
+    gb_as_input = onnx.ModelProto()
+    gb_as_input.CopyFrom(with_loss)
+    kept = [t for t in gb_as_input.graph.initializer if t.name != "gb"]
+    del gb_as_input.graph.initializer[:]
+    gb_as_input.graph.initializer.extend(kept)
+    gb_as_input.graph.input.append(
+        onnx.helper.make_tensor_value_info("gb", onnx.TensorProto.FLOAT, [10])
+    )
+
+    implied_grad = (gb0 - outs[gb_next]) / lr
+
+    def loss_at(gb_value):
+        (loss,) = _run(gb_as_input, {"x": x, "y": y, "gb": gb_value}, ["loss"])
+        return float(loss)
+
+    eps = 1e-3
+    numeric_grad = np.zeros_like(gb0)
+    for i in range(gb0.shape[0]):
+        plus, minus = gb0.copy(), gb0.copy()
+        plus[i] += eps
+        minus[i] -= eps
+        numeric_grad[i] = (loss_at(plus) - loss_at(minus)) / (2 * eps)
+
+    assert np.allclose(implied_grad, numeric_grad, atol=1e-3)
+
+
 def test_grad_seed_is_a_runtime_input_that_linearly_scales_the_gradient():
     """`grad_seed` used to be `b.const(1.0)` -- baked in at build time, so no
     per-step loss-scaling controller could ever vary it (see


### PR DESCRIPTION
## Summary
- PR #1392 found a real, generalizable Pulsar2 NPU-backend bug: compiling the in-graph SGD update (`w_next = w - lr * grad`, an ordinary `Sub`) for a **rank-1** trainable tensor crashes with `TileFailException("AxQuantizedSub, tuple index out of range")`. Confirmed on two different bias shapes (3 and 32 elements) -- rank is the trigger, not size. Every earlier real-hardware training in this project's history happened to only train rank>=2 weight tensors, which is why this was never found until EDSR's own survey put a bias directly in a trainable scope.
- Fixed generically in `build_resident_step()` itself, not as an EDSR-specific patch: any rank-1 state tensor's whole per-step update now runs in rank-2 `[1, N]` space (reshape in, `Mul`/`Sub`, reshape back), transparent to the state tensor's own declared rank-1 shape at the step graph's I/O boundary -- so calibration and every other caller see the exact same tensor shapes as before. Verified bit-exact against the un-reshaped math on host.
- **Confirmed on real AX650N hardware**: the full EDSR `tail` scope (both `Conv` weights and both biases, 72 nodes) compiles in 31.2s and trains with real, monotonically decreasing loss at `lr=1.0` (`0.0914259 -> ... -> 0.0895973` over 30 real steps), confirmed genuinely gradient-driven via the standard `lr=0` frozen-loss control.
- New regression test checks both the structural property (`Sub` never sees a bare rank-1 operand) and the numeric one (the implied gradient matches a central-difference check of the original graph).

## Test plan
- [x] `pytest tests/ -q -k "resident or whisper or w2v2 or parakeet or gru or edsr or resnet or graph_grad or qat"` -- 535 passed, no regressions
- [x] Real `pulsar2:7.0-lite` compile + real AX650N run: full 4-tensor EDSR `tail` scope compiles (31.2s) and trains correctly, `lr=0` control confirms genuine gradient-driven training
- [x] `ruff format --check` / `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J8MPmSSFeyNx3SvsEaq8W